### PR TITLE
fix(components): scan panic error, docker-container error handling by converting state.error to string

### DIFF
--- a/cmd/gpud/command/up.go
+++ b/cmd/gpud/command/up.go
@@ -20,7 +20,7 @@ func cmdUp(cliContext *cli.Context) (retErr error) {
 				retErr = err
 			}
 		} else {
-			fmt.Printf("visit https://localhost:15132 to view the dashboard")
+			fmt.Printf("\nvisit https://localhost:15132 to view the dashboard\n\n")
 		}
 	}()
 

--- a/components/accelerator/nvidia/clock-speed/component.go
+++ b/components/accelerator/nvidia/clock-speed/component.go
@@ -4,7 +4,6 @@ package clockspeed
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"time"
 
@@ -56,7 +55,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 		return []components.State{
 			{
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil
@@ -80,7 +79,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			cs = append(cs, components.State{
 				Name:    Name,
 				Healthy: false,
-				Error:   errors.New(e),
+				Error:   e,
 				Reason:  "nvidia-smi query failed with " + e,
 				ExtraInfo: map[string]string{
 					nvidia_query.StateKeySMIExists: fmt.Sprintf("%v", allOutput.SMIExists),

--- a/components/accelerator/nvidia/clock/component.go
+++ b/components/accelerator/nvidia/clock/component.go
@@ -4,7 +4,6 @@ package clock
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"time"
 
@@ -56,7 +55,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 		return []components.State{
 			{
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil
@@ -80,7 +79,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			cs = append(cs, components.State{
 				Name:    Name,
 				Healthy: false,
-				Error:   errors.New(e),
+				Error:   e,
 				Reason:  "nvidia-smi query failed with " + e,
 				ExtraInfo: map[string]string{
 					nvidia_query.StateKeySMIExists: fmt.Sprintf("%v", allOutput.SMIExists),

--- a/components/accelerator/nvidia/clock/component_output.go
+++ b/components/accelerator/nvidia/clock/component_output.go
@@ -115,7 +115,6 @@ func (o *Output) States() ([]components.State, error) {
 			{
 				Name:    StateNameHWSlowdown,
 				Healthy: true,
-				Error:   nil,
 				Reason:  rm,
 				ExtraInfo: map[string]string{
 					StateKeyHWSlowdownData:     string(b),

--- a/components/accelerator/nvidia/ecc/component.go
+++ b/components/accelerator/nvidia/ecc/component.go
@@ -4,7 +4,6 @@ package ecc
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"time"
 
@@ -56,7 +55,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 		return []components.State{
 			{
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil
@@ -80,7 +79,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			cs = append(cs, components.State{
 				Name:    Name,
 				Healthy: false,
-				Error:   errors.New(e),
+				Error:   e,
 				Reason:  "nvidia-smi query failed with " + e,
 				ExtraInfo: map[string]string{
 					nvidia_query.StateKeySMIExists: fmt.Sprintf("%v", allOutput.SMIExists),

--- a/components/accelerator/nvidia/error/component.go
+++ b/components/accelerator/nvidia/error/component.go
@@ -3,7 +3,6 @@ package error
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -51,7 +50,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 		return []components.State{
 			{
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil
@@ -75,7 +74,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			cs = append(cs, components.State{
 				Name:    Name,
 				Healthy: false,
-				Error:   errors.New(e),
+				Error:   e,
 				Reason:  "nvidia-smi query failed with " + e,
 				ExtraInfo: map[string]string{
 					nvidia_query.StateKeySMIExists: fmt.Sprintf("%v", allOutput.SMIExists),

--- a/components/accelerator/nvidia/fabric-manager/component.go
+++ b/components/accelerator/nvidia/fabric-manager/component.go
@@ -4,7 +4,6 @@ package fabricmanager
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -68,7 +67,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 		return []components.State{
 			{
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil
@@ -101,7 +100,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			cs = append(cs, components.State{
 				Name:    Name,
 				Healthy: false,
-				Error:   errors.New(e),
+				Error:   e,
 				Reason:  "fabric manager query failed with " + e,
 				ExtraInfo: map[string]string{
 					nvidia_query.StateKeyFabricManagerExists: fmt.Sprintf("%v", allOutput.FabricManagerExists),

--- a/components/accelerator/nvidia/infiniband/component.go
+++ b/components/accelerator/nvidia/infiniband/component.go
@@ -52,7 +52,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 		return []components.State{
 			{
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil

--- a/components/accelerator/nvidia/info/component.go
+++ b/components/accelerator/nvidia/info/component.go
@@ -3,7 +3,6 @@ package info
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -51,7 +50,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 		return []components.State{
 			{
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil
@@ -75,7 +74,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			cs = append(cs, components.State{
 				Name:    Name,
 				Healthy: false,
-				Error:   errors.New(e),
+				Error:   e,
 				Reason:  "nvidia-smi query failed with " + e,
 				ExtraInfo: map[string]string{
 					nvidia_query.StateKeySMIExists: fmt.Sprintf("%v", allOutput.SMIExists),

--- a/components/accelerator/nvidia/memory/component.go
+++ b/components/accelerator/nvidia/memory/component.go
@@ -4,7 +4,6 @@ package memory
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"time"
 
@@ -56,7 +55,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 		return []components.State{
 			{
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil
@@ -80,7 +79,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			cs = append(cs, components.State{
 				Name:    Name,
 				Healthy: false,
-				Error:   errors.New(e),
+				Error:   e,
 				Reason:  "nvidia-smi query failed with " + e,
 				ExtraInfo: map[string]string{
 					nvidia_query.StateKeySMIExists: fmt.Sprintf("%v", allOutput.SMIExists),

--- a/components/accelerator/nvidia/nvlink/component.go
+++ b/components/accelerator/nvidia/nvlink/component.go
@@ -55,7 +55,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 		return []components.State{
 			{
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil

--- a/components/accelerator/nvidia/peermem/component.go
+++ b/components/accelerator/nvidia/peermem/component.go
@@ -4,7 +4,6 @@ package peermem
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -52,7 +51,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 		return []components.State{
 			{
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil
@@ -76,7 +75,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			cs = append(cs, components.State{
 				Name:    Name,
 				Healthy: false,
-				Error:   errors.New(e),
+				Error:   e,
 				Reason:  "lsmod peermem query failed with " + e,
 			})
 		}

--- a/components/accelerator/nvidia/power/component.go
+++ b/components/accelerator/nvidia/power/component.go
@@ -4,7 +4,6 @@ package power
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"time"
 
@@ -56,7 +55,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 		return []components.State{
 			{
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil
@@ -80,7 +79,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			cs = append(cs, components.State{
 				Name:    Name,
 				Healthy: false,
-				Error:   errors.New(e),
+				Error:   e,
 				Reason:  "nvidia-smi query failed with " + e,
 				ExtraInfo: map[string]string{
 					nvidia_query.StateKeySMIExists: fmt.Sprintf("%v", allOutput.SMIExists),

--- a/components/accelerator/nvidia/processes/component.go
+++ b/components/accelerator/nvidia/processes/component.go
@@ -4,7 +4,6 @@ package processes
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"time"
 
@@ -56,7 +55,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 		return []components.State{
 			{
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil
@@ -80,7 +79,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			cs = append(cs, components.State{
 				Name:    Name,
 				Healthy: false,
-				Error:   errors.New(e),
+				Error:   e,
 				Reason:  "nvidia-smi query failed with " + e,
 				ExtraInfo: map[string]string{
 					nvidia_query.StateKeySMIExists: fmt.Sprintf("%v", allOutput.SMIExists),

--- a/components/accelerator/nvidia/query/query.go
+++ b/components/accelerator/nvidia/query/query.go
@@ -326,13 +326,15 @@ func (o *Output) PrintInfo(debug bool) {
 		fmt.Printf("%s successfully checked fabric manager\n", checkMark)
 	}
 
-	if len(o.Ibstat.Errors) > 0 {
-		fmt.Printf("%s ibstat check failed with %d error(s)\n", warningSign, len(o.Ibstat.Errors))
-		for _, err := range o.Ibstat.Errors {
-			fmt.Println(err)
+	if o.IbstatExists {
+		if o.Ibstat != nil && len(o.Ibstat.Errors) > 0 {
+			fmt.Printf("%s ibstat check failed with %d error(s)\n", warningSign, len(o.Ibstat.Errors))
+			for _, err := range o.Ibstat.Errors {
+				fmt.Println(err)
+			}
+		} else {
+			fmt.Printf("%s successfully checked ibstat\n", checkMark)
 		}
-	} else {
-		fmt.Printf("%s successfully checked ibstat\n", checkMark)
 	}
 
 	if len(o.LsmodPeermemErrors) > 0 {

--- a/components/accelerator/nvidia/temperature/component.go
+++ b/components/accelerator/nvidia/temperature/component.go
@@ -4,7 +4,6 @@ package temperature
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"time"
 
@@ -56,7 +55,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 		return []components.State{
 			{
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil
@@ -80,7 +79,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			cs = append(cs, components.State{
 				Name:    Name,
 				Healthy: false,
-				Error:   errors.New(e),
+				Error:   e,
 				Reason:  "nvidia-smi query failed with " + e,
 				ExtraInfo: map[string]string{
 					nvidia_query.StateKeySMIExists: fmt.Sprintf("%v", allOutput.SMIExists),

--- a/components/accelerator/nvidia/utilization/component.go
+++ b/components/accelerator/nvidia/utilization/component.go
@@ -4,7 +4,6 @@ package utilization
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
 	"time"
 
@@ -56,7 +55,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 		return []components.State{
 			{
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil
@@ -80,7 +79,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			cs = append(cs, components.State{
 				Name:    Name,
 				Healthy: false,
-				Error:   errors.New(e),
+				Error:   e,
 				Reason:  "nvidia-smi query failed with " + e,
 				ExtraInfo: map[string]string{
 					nvidia_query.StateKeySMIExists: fmt.Sprintf("%v", allOutput.SMIExists),

--- a/components/components.go
+++ b/components/components.go
@@ -68,7 +68,7 @@ type State struct {
 	Name      string            `json:"name,omitempty"`
 	Healthy   bool              `json:"healthy,omitempty"`
 	Reason    string            `json:"reason,omitempty"`     // a detailed and processed reason on why the component is not healthy
-	Error     error             `json:"error,omitempty"`      // the unprocessed error returned from the component
+	Error     string            `json:"error,omitempty"`      // the unprocessed error returned from the component
 	ExtraInfo map[string]string `json:"extra_info,omitempty"` // any extra information the component may want to expose
 }
 

--- a/components/containerd/pod/component.go
+++ b/components/containerd/pod/component.go
@@ -51,7 +51,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			{
 				Name:    Name,
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil

--- a/components/cpu/component.go
+++ b/components/cpu/component.go
@@ -56,7 +56,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			{
 				Name:    Name,
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil

--- a/components/disk/component.go
+++ b/components/disk/component.go
@@ -56,7 +56,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			{
 				Name:    Name,
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil

--- a/components/docker/container/component.go
+++ b/components/docker/container/component.go
@@ -51,7 +51,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			{
 				Name:    Name,
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil

--- a/components/fd/component.go
+++ b/components/fd/component.go
@@ -56,7 +56,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			{
 				Name:    Name,
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil

--- a/components/k8s/pod/component.go
+++ b/components/k8s/pod/component.go
@@ -54,7 +54,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			{
 				Name:    Name,
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil

--- a/components/memory/component.go
+++ b/components/memory/component.go
@@ -56,7 +56,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			{
 				Name:    Name,
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil

--- a/components/network/latency/component.go
+++ b/components/network/latency/component.go
@@ -47,7 +47,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			{
 				Name:    Name,
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil

--- a/components/os/component.go
+++ b/components/os/component.go
@@ -51,7 +51,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			{
 				Name:    Name,
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil

--- a/components/power-supply/component.go
+++ b/components/power-supply/component.go
@@ -51,7 +51,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			{
 				Name:    Name,
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil

--- a/components/query/poller.go
+++ b/components/query/poller.go
@@ -110,7 +110,8 @@ func pollLoops(ctx context.Context, id string, ch chan<- Item, interval time.Dur
 				Time:  metav1.Time{Time: time.Now().UTC()},
 				Error: ctx.Err(),
 			}:
-			default: // channel is full, skip this result and continue
+			default:
+				log.Logger.Debugw("channel is full, skip this result and continue")
 			}
 			return
 
@@ -122,6 +123,7 @@ func pollLoops(ctx context.Context, id string, ch chan<- Item, interval time.Dur
 
 		output, err := get(ctx)
 		if err != nil {
+			log.Logger.Debugw("polling error", "id", id, "error", err)
 			select {
 			case <-ctx.Done():
 				return
@@ -129,7 +131,8 @@ func pollLoops(ctx context.Context, id string, ch chan<- Item, interval time.Dur
 				Time:  metav1.Time{Time: time.Now().UTC()},
 				Error: err,
 			}:
-			default: // channel is full, skip this result and continue
+			default:
+				log.Logger.Debugw("channel is full, skip this result and continue")
 			}
 			continue
 		}
@@ -146,7 +149,8 @@ func pollLoops(ctx context.Context, id string, ch chan<- Item, interval time.Dur
 			Time:   metav1.Time{Time: time.Now().UTC()},
 			Output: output,
 		}:
-		default: // channel is full, skip this result and continue
+		default:
+			log.Logger.Debugw("channel is full, skip this result and continue")
 		}
 	}
 }

--- a/components/systemd/component.go
+++ b/components/systemd/component.go
@@ -55,7 +55,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			{
 				Name:    Name,
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil

--- a/components/tailscale/component.go
+++ b/components/tailscale/component.go
@@ -51,7 +51,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 			{
 				Name:    Name,
 				Healthy: false,
-				Error:   last.Error,
+				Error:   last.Error.Error(),
 				Reason:  "last query failed",
 			},
 		}, nil


### PR DESCRIPTION
Before:

Cannot handle error like

> {"level":"debug","ts":"2024-08-17T01:53:44Z","caller":"query/poller.go:134","msg":"polling error","id":"docker-container","error":"Error response from daemon: client version 1.44 is too new. Maximum supported API version is 1.43"}

<img width="320" alt="Screenshot 2024-08-17 at 10 04 37 AM" src="https://github.com/user-attachments/assets/f05726d7-ee70-432f-8bff-98750b7bf10f">

<img width="498" alt="Screenshot 2024-08-17 at 10 02 07 AM" src="https://github.com/user-attachments/assets/4856b090-3115-4801-aea3-afef9a2685da">

After:

<img width="592" alt="Screenshot 2024-08-17 at 10 04 51 AM" src="https://github.com/user-attachments/assets/8a948a33-a1d1-4837-a151-3fd4e05b9611">
