### PR TITLE
fix(dmesg): add fallback dmesg watch command, remove confusing log message

### DIFF
--- a/components/dmesg/config.go
+++ b/components/dmesg/config.go
@@ -64,8 +64,8 @@ func DefaultConfig() Config {
 			BufferSize: query_log_config.DefaultBufferSize,
 
 			Commands: [][]string{
-				{"dmesg", "--ctime", "--nopager", "--buffer-size", "163920", "-w"},
 				{"dmesg", "--ctime", "--nopager", "--buffer-size", "163920", "-W"},
+				{"dmesg", "--ctime", "--nopager", "--buffer-size", "163920", "-w"},
 			},
 
 			Scan: &query_log_config.Scan{

--- a/components/dmesg/config.go
+++ b/components/dmesg/config.go
@@ -65,6 +65,7 @@ func DefaultConfig() Config {
 
 			Commands: [][]string{
 				{"dmesg", "--ctime", "--nopager", "--buffer-size", "163920", "-w"},
+				{"dmesg", "--ctime", "--nopager", "--buffer-size", "163920", "-W"},
 			},
 
 			Scan: &query_log_config.Scan{

--- a/components/dmesg/config.go
+++ b/components/dmesg/config.go
@@ -64,8 +64,8 @@ func DefaultConfig() Config {
 			BufferSize: query_log_config.DefaultBufferSize,
 
 			Commands: [][]string{
-				{"dmesg", "--ctime", "--nopager", "--buffer-size", "163920", "-W"},
 				{"dmesg", "--ctime", "--nopager", "--buffer-size", "163920", "-w"},
+				{"dmesg", "--ctime", "--nopager", "--buffer-size", "163920", "-W"},
 			},
 
 			Scan: &query_log_config.Scan{

--- a/components/query/log/tail/options.go
+++ b/components/query/log/tail/options.go
@@ -95,9 +95,15 @@ func (op *Op) writeCommands(w io.Writer) error {
 	if _, err := w.Write([]byte(bashScriptHeader)); err != nil {
 		return err
 	}
-	for _, args := range op.commands {
+	for i, args := range op.commands {
 		if _, err := w.Write([]byte(strings.Join(args, " "))); err != nil {
 			return err
+		}
+		if i < len(op.commands)-1 {
+			// run last commands as fallback, in case dmesg flag only works in some machines
+			if _, err := w.Write([]byte(" || true")); err != nil {
+				return err
+			}
 		}
 		if _, err := w.Write([]byte("\n")); err != nil {
 			return err

--- a/components/query/log/tail/streamer_command.go
+++ b/components/query/log/tail/streamer_command.go
@@ -137,7 +137,7 @@ func (sr *commandStreamer) waitCommand() {
 	if err := sr.cmd.Wait(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			if exitErr.ExitCode() == -1 {
-				log.Logger.Infow("command was terminated", "cmd", sr.cmd.String())
+				log.Logger.Infow("command was terminated (exit code -1)", "cmd", sr.cmd.String())
 			} else {
 				log.Logger.Warnw("command exited with non-zero status", "error", err, "cmd", sr.cmd.String(), "exitCode", exitErr.ExitCode())
 			}

--- a/components/query/log/tail/streamer_command.go
+++ b/components/query/log/tail/streamer_command.go
@@ -31,7 +31,7 @@ func NewFromCommand(ctx context.Context, commands [][]string, opts ...OpOption) 
 		return nil, err
 	}
 
-	cmd := exec.CommandContext(ctx, "bash", file)
+	cmd := exec.Command("bash", file)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
`Commands [][]string` run in sequence, so in case `-w` is not supported in some machines, we should continue to the next commands.

> log.Logger.Debugw("command was terminated (exit code -1) by the root context cancellation", "cmd", sr.cmd.String(), "contextError", sr.ctx.Err())

to clarify the logging (this is expected when we run `gpud down`)

Previous logging was confusing:

> {"level":"warn","ts":"2024-08-19T18:20:17Z","caller":"tail/streamer_command.go:138","msg":"error waiting for command to finish","error":"signal: terminated","cmd":"/usr/bin/bash /tmp/streamer-from-command2548997474.txt"}
{"level":"warn","ts":"2024-08-19T18:27:11Z","caller":"tail/streamer_command.go:138","msg":"error waiting for command to finish","error":"signal: terminated","cmd":"/usr/bin/bash /tmp/streamer-from-command4028497856.txt"}

