### PR TITLE
feat(components/file): initial commit for file status tracking

### DIFF
--- a/components/file/component.go
+++ b/components/file/component.go
@@ -1,0 +1,118 @@
+// Package file tracks the file status.
+package file
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/leptonai/gpud/components"
+	"github.com/leptonai/gpud/components/fd/metrics"
+	"github.com/leptonai/gpud/components/query"
+	"github.com/leptonai/gpud/log"
+)
+
+const Name = "file"
+
+func New(ctx context.Context, cfg Config) components.Component {
+	cfg.Query.SetDefaultsIfNotSet()
+	setDefaultPoller(cfg)
+
+	cctx, ccancel := context.WithCancel(ctx)
+	getDefaultPoller().Start(cctx, cfg.Query, Name)
+
+	return &component{
+		rootCtx: ctx,
+		cancel:  ccancel,
+		poller:  getDefaultPoller(),
+	}
+}
+
+var _ components.Component = (*component)(nil)
+
+type component struct {
+	rootCtx context.Context
+	cancel  context.CancelFunc
+	poller  query.Poller
+}
+
+func (c *component) Name() string { return Name }
+
+func (c *component) States(ctx context.Context) ([]components.State, error) {
+	last, err := c.poller.Last()
+	if err != nil {
+		return nil, err
+	}
+	if last == nil { // no data
+		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", Name)
+		return nil, nil
+	}
+	if last.Error != nil {
+		return []components.State{
+			{
+				Name:    Name,
+				Healthy: false,
+				Error:   last.Error.Error(),
+				Reason:  "last query failed",
+			},
+		}, nil
+	}
+	if last.Output == nil {
+		return []components.State{
+			{
+				Name:    Name,
+				Healthy: false,
+				Reason:  "no output",
+			},
+		}, nil
+	}
+
+	output, ok := last.Output.(*Output)
+	if !ok {
+		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	return output.States()
+}
+
+func (c *component) Events(ctx context.Context, since time.Time) ([]components.Event, error) {
+	return nil, nil
+}
+
+func (c *component) Metrics(ctx context.Context, since time.Time) ([]components.Metric, error) {
+	log.Logger.Debugw("querying metrics", "since", since)
+
+	runningPIDs, err := metrics.ReadRunningPIDs(ctx, since)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read running pids: %w", err)
+	}
+	limits, err := metrics.ReadLimits(ctx, since)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read limits: %w", err)
+	}
+	usedPercents, err := metrics.ReadUsedPercents(ctx, since)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read used percents: %w", err)
+	}
+
+	ms := make([]components.Metric, 0, len(runningPIDs)+len(limits)+len(usedPercents))
+	for _, m := range runningPIDs {
+		ms = append(ms, components.Metric{Metric: m})
+	}
+	for _, m := range limits {
+		ms = append(ms, components.Metric{Metric: m})
+	}
+	for _, m := range usedPercents {
+		ms = append(ms, components.Metric{Metric: m})
+	}
+
+	return ms, nil
+}
+
+func (c *component) Close() error {
+	log.Logger.Debugw("closing component")
+
+	// safe to call stop multiple times
+	c.poller.Stop(Name)
+
+	return nil
+}

--- a/components/file/component_output.go
+++ b/components/file/component_output.go
@@ -1,0 +1,148 @@
+package file
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/leptonai/gpud/components"
+	components_metrics "github.com/leptonai/gpud/components/metrics"
+	"github.com/leptonai/gpud/components/query"
+
+	"github.com/dustin/go-humanize"
+)
+
+type Output struct {
+	Files []File `json:"files"`
+}
+
+func (o *Output) JSON() ([]byte, error) {
+	return json.Marshal(o)
+}
+
+func ParseOutputJSON(data []byte) (*Output, error) {
+	o := new(Output)
+	if err := json.Unmarshal(data, o); err != nil {
+		return nil, err
+	}
+	return o, nil
+}
+
+const (
+	StateNameFile = "file"
+
+	StateNameFileData          = "data"
+	StateNameFileEncoding      = "encoding"
+	StateValueFileEncodingJSON = "json"
+)
+
+func ParseStateFile(m map[string]string) (*Output, error) {
+	o := &Output{}
+	data := m[StateNameFileData]
+	if err := json.Unmarshal([]byte(data), o); err != nil {
+		return nil, err
+	}
+	return o, nil
+}
+
+func ParseStatesToOutput(states ...components.State) (*Output, error) {
+	for _, state := range states {
+		switch state.Name {
+		case StateNameFile:
+			return ParseStateFile(state.ExtraInfo)
+
+		default:
+			return nil, fmt.Errorf("unknown state name: %s", state.Name)
+		}
+	}
+	return nil, fmt.Errorf("no state found")
+}
+
+func (o *Output) States() ([]components.State, error) {
+	b, _ := o.JSON()
+	state := components.State{
+		Name:    StateNameFile,
+		Healthy: true,
+		Reason:  fmt.Sprintf("checked %d files", len(o.Files)),
+		ExtraInfo: map[string]string{
+			StateNameFileData:     string(b),
+			StateNameFileEncoding: StateValueFileEncodingJSON,
+		},
+	}
+
+	errs := []string{}
+	for _, file := range o.Files {
+		if file.RequireExists && !file.Exists {
+			errs = append(errs, fmt.Sprintf("file %s does not exist", file.Path))
+		}
+	}
+	if len(errs) > 0 {
+		state.Healthy = false
+		state.Reason += fmt.Sprintf("-- %s", strings.Join(errs, ", "))
+	}
+
+	return []components.State{state}, nil
+}
+
+var (
+	defaultPollerOnce sync.Once
+	defaultPoller     query.Poller
+)
+
+// only set once since it relies on the kube client and specific port
+func setDefaultPoller(cfg Config) {
+	defaultPollerOnce.Do(func() {
+		defaultPoller = query.New(Name, cfg.Query, CreateGet(cfg))
+	})
+}
+
+func getDefaultPoller() query.Poller {
+	return defaultPoller
+}
+
+func CreateGet(cfg Config) query.GetFunc {
+	return func(ctx context.Context) (_ any, e error) {
+		defer func() {
+			if e != nil {
+				components_metrics.SetGetFailed(Name)
+			} else {
+				components_metrics.SetGetSuccess(Name)
+			}
+		}()
+
+		o := &Output{}
+		for _, file := range cfg.Files {
+			f, err := checkFile(file.Path, file.RequireExists)
+			if err != nil {
+				return nil, err
+			}
+			o.Files = append(o.Files, f)
+		}
+
+		return o, nil
+	}
+}
+
+func checkFile(path string, requireExists bool) (File, error) {
+	f := File{
+		Path:          path,
+		RequireExists: requireExists,
+	}
+
+	stat, err := os.Stat(path)
+	f.Exists = err == nil
+
+	if err != nil && !os.IsNotExist(err) {
+		return f, err
+	}
+
+	if f.Exists {
+		f.Size = stat.Size()
+		f.SizeHumanized = humanize.Bytes(uint64(f.Size))
+	}
+
+	return f, nil
+}

--- a/components/file/component_test.go
+++ b/components/file/component_test.go
@@ -1,0 +1,68 @@
+package file
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	query_config "github.com/leptonai/gpud/components/query/config"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestComponent(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// create test files
+	testFile1 := "/tmp/test.txt"
+	testFile2 := "/tmp/1231232131.txt"
+
+	// create the first test file
+	if err := os.WriteFile(testFile1, []byte("test content"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+	defer os.Remove(testFile1)
+
+	component := New(
+		ctx,
+		Config{
+			Query: query_config.Config{
+				Interval: metav1.Duration{Duration: 5 * time.Second},
+			},
+			Files: []File{
+				{
+					Path:          testFile1,
+					RequireExists: true,
+				},
+				{
+					Path:          testFile2,
+					RequireExists: true,
+				},
+			},
+		},
+	)
+
+	time.Sleep(time.Second)
+
+	states, err := component.States(ctx)
+	if err != nil {
+		t.Fatalf("failed to get state: %v", err)
+	}
+	t.Logf("states: %+v", states)
+	if len(states) != 1 {
+		t.Fatalf("expected 1 states, got %d", len(states))
+	}
+	if states[0].Healthy {
+		t.Fatalf("expected unhealthy state, got healthy")
+	}
+
+	parsedOutput, err := ParseStatesToOutput(states...)
+	if err != nil {
+		t.Fatalf("failed to parse states: %v", err)
+	}
+	t.Logf("parsed output: %+v", parsedOutput)
+}

--- a/components/file/config.go
+++ b/components/file/config.go
@@ -1,0 +1,54 @@
+package file
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+
+	query_config "github.com/leptonai/gpud/components/query/config"
+)
+
+type Config struct {
+	Query query_config.Config `json:"query"`
+
+	Files []File `json:"files"`
+}
+
+type File struct {
+	Path string `json:"path"`
+
+	// State.Healthy is set to false if the file does not exist.
+	RequireExists bool `json:"require_exists"`
+
+	Exists        bool   `json:"exists"`
+	Size          int64  `json:"size"`
+	SizeHumanized string `json:"size_humanized"`
+}
+
+func ParseConfig(b any, db *sql.DB) (*Config, error) {
+	raw, err := json.Marshal(b)
+	if err != nil {
+		return nil, err
+	}
+	cfg := new(Config)
+	err = json.Unmarshal(raw, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Query.State != nil {
+		cfg.Query.State.DB = db
+	}
+	return cfg, nil
+}
+
+func (cfg Config) Validate() error {
+	if len(cfg.Files) == 0 {
+		return errors.New("files is empty")
+	}
+	for _, f := range cfg.Files {
+		if f.Path == "" {
+			return errors.New("file path is empty")
+		}
+	}
+	return nil
+}

--- a/config/default.go
+++ b/config/default.go
@@ -205,6 +205,7 @@ func DefaultConfig(ctx context.Context) (*Config, error) {
 		log.Logger.Debugw("auto-detect tailscale not supported -- skipping", "os", runtime.GOOS)
 	}
 
+	// TODO: auto-fill "file" components for nvidia lib files
 	if runtime.GOOS == "linux" {
 		if nvidia_query.SMIExists() {
 			log.Logger.Debugw("auto-detected nvidia -- configuring nvidia components")

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -34,6 +34,7 @@
 - [**`systemd`**](https://pkg.go.dev/github.com/leptonai/gpud/components/systemd): Tracks the systemd state and unit files.
 - [**`dmesg`**](https://pkg.go.dev/github.com/leptonai/gpud/components/dmesg): Scans and watches dmesg outputs for errors,, as specified in the configuration (e.g., regex match NVIDIA GPU errors).
 - [**`file-descriptor`**](https://pkg.go.dev/github.com/leptonai/gpud/components/fd): Tracks the number of file descriptors used on the host.
+- [**`file`**](https://pkg.go.dev/github.com/leptonai/gpud/components/file): Tracks the file status.
 
 ## Misc. components
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,6 +55,7 @@ import (
 	"github.com/leptonai/gpud/components/dmesg"
 	docker_container "github.com/leptonai/gpud/components/docker/container"
 	"github.com/leptonai/gpud/components/fd"
+	"github.com/leptonai/gpud/components/file"
 	"github.com/leptonai/gpud/components/info"
 	k8s_pod "github.com/leptonai/gpud/components/k8s/pod"
 	"github.com/leptonai/gpud/components/memory"
@@ -266,6 +267,20 @@ func New(ctx context.Context, config *lepconfig.Config, endpoint string) (_ *Ser
 				return nil, fmt.Errorf("failed to validate component %s config: %w", k, err)
 			}
 			allComponents = append(allComponents, fd.New(ctx, cfg))
+
+		case file.Name:
+			cfg := file.Config{Query: defaultQueryCfg}
+			if configValue != nil {
+				parsed, err := file.ParseConfig(configValue, db)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse component %s config: %w", k, err)
+				}
+				cfg = *parsed
+			}
+			if err := cfg.Validate(); err != nil {
+				return nil, fmt.Errorf("failed to validate component %s config: %w", k, err)
+			}
+			allComponents = append(allComponents, file.New(ctx, cfg))
 
 		case info.Name:
 			allComponents = append(allComponents, info.New(config.Annotations))


### PR DESCRIPTION
Will be useful to periodically check the nvidia lib files like nvidia-container-toolkit.

Much easier to debug (vs., looking nvidia operator error logs).

c.f.,

```go
var nvmlOpts []nvml.LibraryOption
candidates, err := l.driver.Libraries().Locate("libnvidia-ml.so.1")
if err != nil ...
```

- https://github.com/NVIDIA/nvidia-container-toolkit/blob/ff2ba2bbc50b6402237e7d689bf9b8da68234bb0/pkg/nvcdi/lib.go#L98-L104
- https://github.com/NVIDIA/nvidia-container-toolkit/blob/ff2ba2bbc50b6402237e7d689bf9b8da68234bb0/internal/dxcore/dxcore.c#L25-L35
- https://github.com/NVIDIA/nvidia-container-toolkit/blob/ff2ba2bbc50b6402237e7d689bf9b8da68234bb0/pkg/nvcdi/driver-wsl.go#L29-L38
