### PR TITLE
feat(pkg/process): initial commit, fix dmesg scan on non-root

### DIFF
--- a/components/dmesg/config.go
+++ b/components/dmesg/config.go
@@ -64,8 +64,9 @@ func DefaultConfig() Config {
 			BufferSize: query_log_config.DefaultBufferSize,
 
 			Commands: [][]string{
-				{"dmesg", "--ctime", "--nopager", "--buffer-size", "163920", "-w"},
-				{"dmesg", "--ctime", "--nopager", "--buffer-size", "163920", "-W"},
+				// run last commands as fallback, in case dmesg flag only works in some machines
+				{"dmesg --ctime --nopager --buffer-size 163920 -w || true"},
+				{"dmesg --ctime --nopager --buffer-size 163920 -W"},
 			},
 
 			Scan: &query_log_config.Scan{

--- a/components/query/log/tail/options.go
+++ b/components/query/log/tail/options.go
@@ -2,8 +2,6 @@ package tail
 
 import (
 	"errors"
-	"io"
-	"strings"
 	"time"
 
 	query_log_filter "github.com/leptonai/gpud/components/query/log/filter"
@@ -75,41 +73,6 @@ func WithCommands(commands [][]string) OpOption {
 	return func(op *Op) {
 		op.commands = commands
 	}
-}
-
-const bashScriptHeader = `
-#!/bin/bash
-
-# do not mask errors in a pipeline
-set -o pipefail
-
-# treat unset variables as an error
-set -o nounset
-
-# exit script whenever it errs
-set -o errexit
-
-`
-
-func (op *Op) writeCommands(w io.Writer) error {
-	if _, err := w.Write([]byte(bashScriptHeader)); err != nil {
-		return err
-	}
-	for i, args := range op.commands {
-		if _, err := w.Write([]byte(strings.Join(args, " "))); err != nil {
-			return err
-		}
-		if i < len(op.commands)-1 {
-			// run last commands as fallback, in case dmesg flag only works in some machines
-			if _, err := w.Write([]byte(" || true")); err != nil {
-				return err
-			}
-		}
-		if _, err := w.Write([]byte("\n")); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // Sets the number of lines to tail.

--- a/config/default.go
+++ b/config/default.go
@@ -60,6 +60,8 @@ var (
 )
 
 func DefaultConfig(ctx context.Context) (*Config, error) {
+	asRoot := stdos.Geteuid() == 0 // running as root
+
 	cfg := &Config{
 		APIVersion: DefaultAPIVersion,
 
@@ -163,8 +165,12 @@ func DefaultConfig(ctx context.Context) (*Config, error) {
 
 	if runtime.GOOS == "linux" {
 		if dmesg.DmesgExists() {
-			log.Logger.Debugw("auto-detected dmesg -- configuring dmesg component")
-			cfg.Components[dmesg.Name] = dmesg.DefaultConfig()
+			if asRoot {
+				log.Logger.Debugw("auto-detected dmesg -- configuring dmesg component")
+				cfg.Components[dmesg.Name] = dmesg.DefaultConfig()
+			} else {
+				log.Logger.Debugw("auto-detected dmesg but running as root -- skipping")
+			}
 		}
 	} else {
 		log.Logger.Debugw("auto-detect dmesg not supported -- skipping", "os", runtime.GOOS)

--- a/pkg/process/options.go
+++ b/pkg/process/options.go
@@ -1,0 +1,75 @@
+package process
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+type OpOption func(*Op)
+
+type Op struct {
+	envs            []string
+	outputFile      *os.File
+	runAsBashScript bool
+
+	restartConfig *RestartConfig
+}
+
+func (op *Op) applyOpts(opts []OpOption) error {
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	foundEnvs := make(map[string]any)
+	for _, env := range op.envs {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid environment variable format: %s", env)
+		}
+		if _, ok := foundEnvs[parts[0]]; ok {
+			return fmt.Errorf("duplicate environment variable: %s", parts[0])
+		}
+		foundEnvs[parts[0]] = parts[1]
+	}
+
+	if op.restartConfig != nil && op.restartConfig.Interval == 0 {
+		op.restartConfig.Interval = 5 * time.Second
+	}
+
+	return nil
+}
+
+// Add a new environment variable to the process
+// in the format of `KEY=VALUE`.
+func WithEnvs(envs ...string) OpOption {
+	return func(op *Op) {
+		op.envs = append(op.envs, envs...)
+	}
+}
+
+// Sets the file to which stderr and stdout will be written.
+// For instance, you can set it to os.Stderr to pipe all the sub-process
+// stderr and stdout to the parent process's stderr.
+// Default is to set the os.Pipe to forward its output via io.ReadCloser.
+func WithOutputFile(file *os.File) OpOption {
+	return func(op *Op) {
+		op.outputFile = file
+	}
+}
+
+// Set true to run commands as a bash script.
+// This is useful for running multiple/complicated commands.
+func WithRunAsBashScript() OpOption {
+	return func(op *Op) {
+		op.runAsBashScript = true
+	}
+}
+
+// Configures the process restart behavior.
+func WithRestartConfig(config RestartConfig) OpOption {
+	return func(op *Op) {
+		op.restartConfig = &config
+	}
+}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -1,0 +1,336 @@
+// Package process provides the process runner implementation on the host.
+package process
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/leptonai/gpud/log"
+)
+
+type Process interface {
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+
+	// Waits for the process to exit and returns the error, if any.
+	// If the command completes successfully, the error will be nil.
+	Wait() <-chan error
+
+	PID() int32
+
+	StdoutReader() io.Reader
+	StderrReader() io.Reader
+}
+
+// RestartConfig is the configuration for the process restart.
+type RestartConfig struct {
+	// Set true to restart the process on error exit.
+	OnError bool
+	// Set the maximum number of restarts.
+	Limit int
+	// Set the interval between restarts.
+	Interval time.Duration
+}
+
+type process struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	cmdMu       sync.RWMutex
+	cmd         *exec.Cmd
+	errc        chan error
+	pid         int32
+	commandArgs []string
+	envs        []string
+	runBashFile *os.File
+
+	outputFile   *os.File
+	stdoutReader io.ReadCloser
+	stderrReader io.ReadCloser
+
+	wg sync.WaitGroup
+
+	restartConfig *RestartConfig
+}
+
+func New(commands [][]string, opts ...OpOption) (Process, error) {
+	op := &Op{}
+	if err := op.applyOpts(opts); err != nil {
+		return nil, err
+	}
+	if len(commands) == 0 {
+		return nil, errors.New("no commands provided")
+	}
+	if len(commands) > 1 && !op.runAsBashScript {
+		return nil, errors.New("cannot run multiple commands without a bash script mode")
+	}
+	for _, args := range commands {
+		cmd := strings.Split(args[0], " ")[0]
+		if !commandExists(cmd) {
+			return nil, fmt.Errorf("command not found: %q", cmd)
+		}
+	}
+
+	var cmdArgs []string
+	var bashFile *os.File
+	if op.runAsBashScript {
+		var err error
+		bashFile, err = os.CreateTemp(os.TempDir(), "tmpbash*.bash")
+		if err != nil {
+			return nil, err
+		}
+		if _, err := bashFile.Write([]byte(bashScriptHeader)); err != nil {
+			return nil, err
+		}
+		defer func() {
+			_ = bashFile.Sync()
+		}()
+		cmdArgs = []string{"bash", bashFile.Name()}
+	}
+
+	for _, args := range commands {
+		if bashFile == nil {
+			cmdArgs = args
+			continue
+		}
+
+		if _, err := bashFile.Write([]byte(strings.Join(args, " "))); err != nil {
+			return nil, err
+		}
+		if _, err := bashFile.Write([]byte("\n")); err != nil {
+			return nil, err
+		}
+	}
+
+	errcBuffer := 1
+	if op.restartConfig != nil && op.restartConfig.OnError && op.restartConfig.Limit > 0 {
+		errcBuffer = op.restartConfig.Limit
+	}
+	return &process{
+		cmd:         nil,
+		errc:        make(chan error, errcBuffer),
+		commandArgs: cmdArgs,
+		envs:        op.envs,
+		runBashFile: bashFile,
+		outputFile:  op.outputFile,
+
+		restartConfig: op.restartConfig,
+	}, nil
+}
+
+func (p *process) Start(ctx context.Context) error {
+	p.cmdMu.Lock()
+	defer p.cmdMu.Unlock()
+
+	if p.cmd != nil {
+		return errors.New("process already started")
+	}
+
+	cctx, ccancel := context.WithCancel(ctx)
+	p.ctx = cctx
+	p.cancel = ccancel
+
+	if err := p.startCommand(); err != nil {
+		return err
+	}
+
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		p.cmdWait()
+	}()
+
+	return nil
+}
+
+func (p *process) startCommand() error {
+	log.Logger.Debugw("starting command", "command", p.commandArgs)
+	p.cmd = exec.CommandContext(p.ctx, p.commandArgs[0], p.commandArgs[1:]...)
+	p.cmd.Env = p.envs
+
+	switch {
+	case p.outputFile != nil:
+		p.cmd.Stdout = p.outputFile
+		p.cmd.Stderr = p.outputFile
+
+	default:
+		var err error
+		p.stdoutReader, err = p.cmd.StdoutPipe()
+		if err != nil {
+			return fmt.Errorf("failed to get stdout pipe: %w", err)
+		}
+		p.stderrReader, err = p.cmd.StderrPipe()
+		if err != nil {
+			return fmt.Errorf("failed to get stderr pipe: %w", err)
+		}
+	}
+
+	if err := p.cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start command: %w", err)
+	}
+	atomic.StoreInt32(&p.pid, int32(p.cmd.Process.Pid))
+
+	return nil
+}
+
+func (p *process) Wait() <-chan error {
+	return p.errc
+}
+
+func (p *process) cmdWait() {
+	restartCount := 0
+	for {
+		errc := make(chan error)
+		go func() {
+			errc <- p.cmd.Wait()
+		}()
+
+		select {
+		case <-p.ctx.Done():
+			// command aborted (e.g., Stop called)
+			// cmd.Wait will return error
+			err := <-errc
+			p.errc <- err
+			return
+
+		case err := <-errc:
+			p.errc <- err
+
+			if err == nil {
+				log.Logger.Debugw("process exited successfully")
+				return
+			}
+
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				if exitErr.ExitCode() == -1 {
+					if p.ctx.Err() != nil {
+						log.Logger.Debugw("command was terminated (exit code -1) by the root context cancellation", "cmd", p.cmd.String(), "contextError", p.ctx.Err())
+					} else {
+						log.Logger.Warnw("command was terminated (exit code -1) for unknown reasons", "cmd", p.cmd.String())
+					}
+				} else {
+					log.Logger.Warnw("command exited with non-zero status", "error", err, "cmd", p.cmd.String(), "exitCode", exitErr.ExitCode())
+				}
+			} else {
+				log.Logger.Warnw("error waiting for command to finish", "error", err, "cmd", p.cmd.String())
+			}
+
+			if p.restartConfig == nil || !p.restartConfig.OnError {
+				log.Logger.Warnw("process exited with error", "error", err)
+				return
+			}
+
+			if p.restartConfig.Limit > 0 && restartCount >= p.restartConfig.Limit {
+				log.Logger.Warnw("process exited with error, but restart limits reached", "restartCount", restartCount, "error", err)
+				return
+			}
+		}
+
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-time.After(p.restartConfig.Interval):
+		}
+
+		if err := p.startCommand(); err != nil {
+			log.Logger.Warnw("failed to restart command", "error", err)
+			return
+		}
+
+		restartCount++
+	}
+}
+
+func (p *process) Stop(ctx context.Context) error {
+	p.cmdMu.Lock()
+	defer p.cmdMu.Unlock()
+
+	if p.cmd == nil {
+		return errors.New("process not started")
+	}
+
+	p.cancel()
+
+	finished := false
+	if err := p.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		if err.Error() == "os: process already finished" {
+			finished = true
+		} else {
+			log.Logger.Warnw("failed to send SIGTERM to process", "error", err)
+		}
+	}
+
+	if !finished {
+		select {
+		case <-p.ctx.Done():
+			return ctx.Err()
+		case <-time.After(3 * time.Second):
+			if err := p.cmd.Process.Kill(); err != nil {
+				log.Logger.Warnw("failed to send SIGKILL to process", "error", err)
+			}
+		}
+	}
+
+	if p.runBashFile != nil {
+		_ = p.runBashFile.Sync()
+		_ = p.runBashFile.Close()
+		return os.RemoveAll(p.runBashFile.Name())
+	}
+
+	p.cmd = nil
+	return nil
+}
+
+func (p *process) PID() int32 {
+	return atomic.LoadInt32(&p.pid)
+}
+
+func (p *process) StdoutReader() io.Reader {
+	p.cmdMu.RLock()
+	defer p.cmdMu.RUnlock()
+
+	if p.outputFile != nil {
+		return p.outputFile
+	}
+	return p.stdoutReader
+}
+
+func (p *process) StderrReader() io.Reader {
+	p.cmdMu.RLock()
+	defer p.cmdMu.RUnlock()
+
+	if p.outputFile != nil {
+		return p.outputFile
+	}
+	return p.stderrReader
+}
+
+const bashScriptHeader = `#!/bin/bash
+
+# do not mask errors in a pipeline
+set -o pipefail
+
+# treat unset variables as an error
+set -o nounset
+
+# exit script whenever it errs
+set -o errexit
+
+`
+
+func commandExists(name string) bool {
+	p, err := exec.LookPath(name)
+	if err != nil {
+		return false
+	}
+	return p != ""
+}

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -1,0 +1,360 @@
+package process
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProcess(t *testing.T) {
+	t.Parallel()
+
+	p, err := New(
+		[][]string{
+			{"echo", "hello"},
+		},
+		WithOutputFile(os.Stderr),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := p.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("pid: %d", p.PID())
+
+	select {
+	case err := <-p.Wait():
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	if err := p.Stop(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProcessWithBash(t *testing.T) {
+	t.Parallel()
+
+	p, err := New(
+		[][]string{
+			{"echo", "hello"},
+			{"echo hello && echo 111 | grep 1"},
+		},
+		WithOutputFile(os.Stderr),
+		WithRunAsBashScript(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := p.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("pid: %d", p.PID())
+
+	select {
+	case err := <-p.Wait():
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	if err := p.Stop(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProcessWithTempFile(t *testing.T) {
+	t.Parallel()
+
+	// create a temporary file
+	tmpFile, err := os.CreateTemp("", "process-test-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	p, err := New(
+		[][]string{
+			{"echo", "hello"},
+		},
+		WithOutputFile(tmpFile),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := p.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("pid: %d", p.PID())
+
+	select {
+	case err := <-p.Wait():
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	if err := p.Stop(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the content of the temporary file
+	content, err := os.ReadFile(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedContent := "hello\n"
+	if string(content) != expectedContent {
+		t.Fatalf("Expected content %q, but got %q", expectedContent, string(content))
+	}
+}
+
+func TestProcessWithStdoutReader(t *testing.T) {
+	t.Parallel()
+
+	p, err := New(
+		[][]string{
+			{"echo hello && sleep 1000"},
+		},
+		WithRunAsBashScript(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := p.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("pid: %d", p.PID())
+
+	select {
+	case err := <-p.Wait():
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+	}
+
+	rd := p.StdoutReader()
+	buf := make([]byte, 1024)
+	n, err := rd.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := string(buf[:n])
+	expectedOutput := "hello\n"
+	if output != expectedOutput {
+		t.Fatalf("expected output %q, but got %q", expectedOutput, output)
+	}
+	t.Logf("stdout: %q", output)
+
+	if err := p.Stop(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProcessWithStdoutReaderUntilEOF(t *testing.T) {
+	t.Parallel()
+
+	p, err := New(
+		[][]string{
+			{"echo hello 1 && sleep 1"},
+			{"echo hello 2 && sleep 1"},
+			{"echo hello 3 && sleep 1"},
+		},
+		WithRunAsBashScript(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := p.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("pid: %d", p.PID())
+
+	rd := p.StdoutReader()
+	scanner := bufio.NewScanner(rd)
+	var output string
+	for scanner.Scan() {
+		output += scanner.Text() + "\n"
+	}
+	expectedOutput := "hello 1\nhello 2\nhello 3\n"
+	if output != expectedOutput {
+		t.Fatalf("expected output %q, but got %q", expectedOutput, output)
+	}
+	t.Logf("stdout: %q", output)
+
+	select {
+	case err := <-p.Wait():
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+	}
+
+	if err := p.Stop(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProcessWithRestarts(t *testing.T) {
+	t.Parallel()
+
+	p, err := New(
+		[][]string{
+			{"echo hello"},
+			{"echo 111 && exit 1"},
+		},
+		WithOutputFile(os.Stderr),
+		WithRunAsBashScript(),
+		WithRestartConfig(RestartConfig{
+			OnError:  true,
+			Limit:    3,
+			Interval: 100 * time.Millisecond,
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := p.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("pid: %d", p.PID())
+
+	for i := 0; i < 3; i++ {
+		select {
+		case err := <-p.Wait():
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if strings.Contains(err.Error(), "exit status 1") {
+				t.Log(err)
+				continue
+			}
+			t.Fatal(err)
+
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout")
+		}
+	}
+
+	if err := p.Stop(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProcessSleep(t *testing.T) {
+	t.Parallel()
+
+	p, err := New(
+		[][]string{
+			{"sleep", "9999"},
+		},
+		WithOutputFile(os.Stderr),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := p.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("pid: %d", p.PID())
+
+	if err := p.Stop(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-p.Wait():
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		t.Log(err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestProcessStream(t *testing.T) {
+	t.Parallel()
+
+	cmds := make([][]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		cmds = append(cmds, []string{fmt.Sprintf("echo hello %d && sleep 1", i)})
+	}
+
+	p, err := New(cmds, WithRunAsBashScript())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := p.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("pid: %d", p.PID())
+
+	rd := p.StdoutReader()
+	buf := make([]byte, 1024)
+	for i := 0; i < 3; i++ {
+		n, err := rd.Read(buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		output := string(buf[:n])
+		expectedOutput := fmt.Sprintf("hello %d\n", i)
+		if output != expectedOutput {
+			t.Fatalf("expected output %q, but got %q", expectedOutput, output)
+		}
+		t.Logf("stdout: %q", output)
+	}
+
+	if err := p.Stop(ctx); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
We run external commands as an external process within gpud everything (e.g., dmesg, dmesg -w, gpud diagnosis for nvidia* commands). We should have a shared package that runs those commands. (optiona) Will be useful for next phase of GPUd where we can maintain the on-host components.