### PR TITLE
feat(nvidia/query): check lsmod output with retries

### DIFF
--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -229,6 +229,9 @@ func TestProcessWithStdoutReaderUntilEOF(t *testing.T) {
 	if err := p.Stop(ctx); err != nil {
 		t.Fatal(err)
 	}
+	if scanner.Err() != nil {
+		t.Fatal(scanner.Err())
+	}
 }
 
 func TestProcessWithRestarts(t *testing.T) {


### PR DESCRIPTION
Tested and worked:

```
fabric_manager:
  active: true
  version: 535.161.08
fabric_manager_exists: true
ibstat:
  raw: ""
ibstat_exists: true
infiniband_class_exists: true
lsmod_peermem:
  ibcore_using_peermem_module: true
  ibstat_exists: true
  infiniband_class_exists: true
  raw: |-
    nvidia_peermem         16384  0
    ib_core               434176  9 rdma_cm,ib_ipoib,nvidia_peermem,iw_cm,ib_umad,rdma_ucm,ib_uverbs,mlx5_ib,ib_cm
    nvidia              56717312  550 nvidia_uvm,nvidia_peermem,nvidia_modeset
```