### PR TITLE
fix(docs): pkg.go.dev links, add Makefile CGO_ENABLED=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ FORCE:
 
 define BUILD_BINARY
 @echo "$(WHALE) $@"
-@$(GO) build ${GO_BUILD_FLAGS} ${DEBUG_GO_GCFLAGS} -o $@ ${GO_TAGS}  ./$<
+@CGO_ENABLED=1 $(GO) build ${GO_BUILD_FLAGS} ${DEBUG_GO_GCFLAGS} -o $@ ${GO_TAGS}  ./$<
 endef
 
 # Build a binary from a cmd.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@ Each component implements its own collector to be called by the shared poller, a
 
 ## Code structure
 
-- Each component implements the [`Component`](./components/components.go) interface (see [file descriptor](./components/fd/component.go) for an example).
+- Each component implements the [`Component`](../components/components.go) interface (see [file descriptor](../components/fd/component.go) for an example).
 - Each component has a unique name, description, and tags.
 - Each component defines its own configuration.
 - Each component implements its own "get" function to collect data.

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -2,6 +2,7 @@
 
 ## GPU components
 
+- [**`accelerator-nvidia-clock`**](https://pkg.go.dev/github.com/leptonai/gpud/components/accelerator/nvidia/clock): Monitors NVIDIA GPU clock events of all GPUs, such as HW Slowdown events.
 - [**`accelerator-nvidia-clock-speed`**](https://pkg.go.dev/github.com/leptonai/gpud/components/accelerator/nvidia/clock-speed): Tracks the per-GPU clock speed.
 - [**`accelerator-nvidia-ecc`**](https://pkg.go.dev/github.com/leptonai/gpud/components/accelerator/nvidia/ecc): Tracks the NVIDIA per-GPU ECC errors.
 - [**`accelerator-nvidia-error`**](https://pkg.go.dev/github.com/leptonai/gpud/components/accelerator/nvidia/error): Tracks NVIDIA GPU errors real-time in the SMI queries -- likely requires host restarts.

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -2,7 +2,6 @@
 
 ## GPU components
 
-- [**`accelerator-nvidia-clock`**](https://pkg.go.dev/github.com/leptonai/gpud/components/accelerator/nvidia/clock-event): Monitors NVIDIA GPU clock events of all GPUs, such as HW Slowdown events.
 - [**`accelerator-nvidia-clock-speed`**](https://pkg.go.dev/github.com/leptonai/gpud/components/accelerator/nvidia/clock-speed): Tracks the per-GPU clock speed.
 - [**`accelerator-nvidia-ecc`**](https://pkg.go.dev/github.com/leptonai/gpud/components/accelerator/nvidia/ecc): Tracks the NVIDIA per-GPU ECC errors.
 - [**`accelerator-nvidia-error`**](https://pkg.go.dev/github.com/leptonai/gpud/components/accelerator/nvidia/error): Tracks NVIDIA GPU errors real-time in the SMI queries -- likely requires host restarts.


### PR DESCRIPTION
Fix invalid document links, delete invalid document content, and add `CGO_ENABLED=1` configuration when compiling `gpud` in Makefile.