### PR TITLE
fix(nvidia): skip clock events NVML check if not supported by old drivers

### DIFF
--- a/components/accelerator/nvidia/clock/component_output.go
+++ b/components/accelerator/nvidia/clock/component_output.go
@@ -13,9 +13,11 @@ import (
 )
 
 func ToOutput(i *nvidia_query.Output) *Output {
-	clockEvents := make([]nvidia_query_nvml.ClockEvents, len(i.NVML.DeviceInfos))
-	for idx, devInfo := range i.NVML.DeviceInfos {
-		clockEvents[idx] = devInfo.ClockEvents
+	var clockEvents []nvidia_query_nvml.ClockEvents = nil
+	for _, devInfo := range i.NVML.DeviceInfos {
+		if devInfo.ClockEvents != nil {
+			clockEvents = append(clockEvents, *devInfo.ClockEvents)
+		}
 	}
 	return &Output{
 		HWSlowdownSMI: HWSlowdownSMI{

--- a/components/accelerator/nvidia/query/nvml/nvml.go
+++ b/components/accelerator/nvidia/query/nvml/nvml.go
@@ -43,6 +43,9 @@ var _ Instance = (*instance)(nil)
 type instance struct {
 	mu sync.RWMutex
 
+	driverVersion        string
+	clockEventsSupported bool
+
 	rootCtx    context.Context
 	rootCancel context.CancelFunc
 
@@ -91,17 +94,51 @@ type DeviceInfo struct {
 	// Set true if the device supports GPM metrics.
 	GPMMetricsSupported bool `json:"gpm_metrics_supported"`
 
-	ClockEvents ClockEvents `json:"clock_events"`
-	ClockSpeed  ClockSpeed  `json:"clock_speed"`
-	Memory      Memory      `json:"memory"`
-	NVLink      NVLink      `json:"nvlink"`
-	Power       Power       `json:"power"`
-	Temperature Temperature `json:"temperature"`
-	Utilization Utilization `json:"utilization"`
-	Processes   Processes   `json:"processes"`
-	ECCErrors   ECCErrors   `json:"ecc_errors"`
+	ClockEvents *ClockEvents `json:"clock_events,omitempty"`
+	ClockSpeed  ClockSpeed   `json:"clock_speed"`
+	Memory      Memory       `json:"memory"`
+	NVLink      NVLink       `json:"nvlink"`
+	Power       Power        `json:"power"`
+	Temperature Temperature  `json:"temperature"`
+	Utilization Utilization  `json:"utilization"`
+	Processes   Processes    `json:"processes"`
+	ECCErrors   ECCErrors    `json:"ecc_errors"`
 
 	device device.Device `json:"-"`
+}
+
+func GetDriverVersion() (string, error) {
+	nvmlLib := nvml.New()
+	if ret := nvmlLib.Init(); ret != nvml.SUCCESS {
+		return "", fmt.Errorf("failed to initialize NVML: %v", nvml.ErrorString(ret))
+	}
+
+	ver, ret := nvmlLib.SystemGetDriverVersion()
+	if ret != nvml.SUCCESS {
+		return "", fmt.Errorf("failed to get driver version: %v", nvml.ErrorString(ret))
+	}
+
+	// e.g.,
+	// 525.85.12  == does not support clock events
+	// 535.161.08 == supports clock events
+	return ver, nil
+}
+
+func ParseDriverVersion(version string) (major, minor, patch int, err error) {
+	var parsed [3]int
+	if _, err = fmt.Sscanf(version, "%d.%d.%d", &parsed[0], &parsed[1], &parsed[2]); err != nil {
+		return 0, 0, 0, fmt.Errorf("failed to parse driver version: %v", err)
+	}
+
+	major, minor, patch = parsed[0], parsed[1], parsed[2]
+	return major, minor, patch, nil
+}
+
+// clock events are supported in versions 535 and above
+// otherwise, CGO call just exits with
+// undefined symbol: nvmlDeviceGetCurrentClocksEventReasons
+func ClockEventsSupportedVersion(major, minor, patch int) bool {
+	return major >= 535
 }
 
 func NewInstance(ctx context.Context, opts ...OpOption) (Instance, error) {
@@ -118,7 +155,20 @@ func NewInstance(ctx context.Context, opts ...OpOption) (Instance, error) {
 	if ret := nvmlLib.Init(); ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("failed to initialize NVML: %v", nvml.ErrorString(ret))
 	}
-	log.Logger.Debugw("successfully initialized NVML")
+	driverVersion, err := GetDriverVersion()
+	if err != nil {
+		return nil, err
+	}
+	major, minor, patch, err := ParseDriverVersion(driverVersion)
+	if err != nil {
+		return nil, err
+	}
+	clockEventsSupported := ClockEventsSupportedVersion(major, minor, patch)
+	if !clockEventsSupported {
+		log.Logger.Warnw("old nvidia driver -- skipping clock events, see https://github.com/NVIDIA/go-nvml/pull/123", "version", driverVersion)
+	}
+
+	log.Logger.Debugw("successfully initialized NVML", "driverVersion", driverVersion)
 
 	deviceLib := device.New(nvmlLib)
 	infoLib := nvinfo.New(
@@ -140,6 +190,9 @@ func NewInstance(ctx context.Context, opts ...OpOption) (Instance, error) {
 	return &instance{
 		rootCtx:    rootCtx,
 		rootCancel: rootCancel,
+
+		driverVersion:        driverVersion,
+		clockEventsSupported: clockEventsSupported,
 
 		nvmlLib:   nvmlLib,
 		deviceLib: deviceLib,
@@ -345,12 +398,15 @@ func (inst *instance) Get() (*Output, error) {
 		}
 		st.DeviceInfos = append(st.DeviceInfos, latestInfo)
 
-		var err error
-		latestInfo.ClockEvents, err = GetClockEvents(devInfo.UUID, devInfo.device)
-		if err != nil {
-			return st, err
+		if inst.clockEventsSupported {
+			clockEvents, err := GetClockEvents(devInfo.UUID, devInfo.device)
+			if err != nil {
+				return st, err
+			}
+			latestInfo.ClockEvents = &clockEvents
 		}
 
+		var err error
 		latestInfo.ClockSpeed, err = GetClockSpeed(devInfo.UUID, devInfo.device)
 		if err != nil {
 			return st, err

--- a/components/accelerator/nvidia/query/nvml/nvml.go
+++ b/components/accelerator/nvidia/query/nvml/nvml.go
@@ -137,7 +137,7 @@ func ParseDriverVersion(version string) (major, minor, patch int, err error) {
 // clock events are supported in versions 535 and above
 // otherwise, CGO call just exits with
 // undefined symbol: nvmlDeviceGetCurrentClocksEventReasons
-func ClockEventsSupportedVersion(major, minor, patch int) bool {
+func ClockEventsSupportedVersion(major int) bool {
 	return major >= 535
 }
 
@@ -159,11 +159,11 @@ func NewInstance(ctx context.Context, opts ...OpOption) (Instance, error) {
 	if err != nil {
 		return nil, err
 	}
-	major, minor, patch, err := ParseDriverVersion(driverVersion)
+	major, _, _, err := ParseDriverVersion(driverVersion)
 	if err != nil {
 		return nil, err
 	}
-	clockEventsSupported := ClockEventsSupportedVersion(major, minor, patch)
+	clockEventsSupported := ClockEventsSupportedVersion(major)
 	if !clockEventsSupported {
 		log.Logger.Warnw("old nvidia driver -- skipping clock events, see https://github.com/NVIDIA/go-nvml/pull/123", "version", driverVersion)
 	}

--- a/components/accelerator/nvidia/query/nvml/nvml_test.go
+++ b/components/accelerator/nvidia/query/nvml/nvml_test.go
@@ -1,0 +1,55 @@
+package nvml
+
+import "testing"
+
+func TestParseDriverVersion(t *testing.T) {
+	testCases := []struct {
+		version    string
+		wantMajor  int
+		wantMinor  int
+		wantPatch  int
+		wantErrNil bool
+	}{
+		{
+			version:    "525.85.12",
+			wantMajor:  525,
+			wantMinor:  85,
+			wantPatch:  12,
+			wantErrNil: true,
+		},
+		{
+			version:    "535.161.08",
+			wantMajor:  535,
+			wantMinor:  161,
+			wantPatch:  8,
+			wantErrNil: true,
+		},
+		{
+			version:    "invalid.version",
+			wantErrNil: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.version, func(t *testing.T) {
+			major, minor, patch, err := ParseDriverVersion(tc.version)
+
+			if (err == nil) != tc.wantErrNil {
+				t.Errorf("ParseDriverVersion(%q) error = %v, wantErrNil %v", tc.version, err, tc.wantErrNil)
+				return
+			}
+
+			if err == nil {
+				if major != tc.wantMajor {
+					t.Errorf("ParseDriverVersion(%q) major = %d, want %d", tc.version, major, tc.wantMajor)
+				}
+				if minor != tc.wantMinor {
+					t.Errorf("ParseDriverVersion(%q) minor = %d, want %d", tc.version, minor, tc.wantMinor)
+				}
+				if patch != tc.wantPatch {
+					t.Errorf("ParseDriverVersion(%q) patch = %d, want %d", tc.version, patch, tc.wantPatch)
+				}
+			}
+		})
+	}
+}

--- a/config/default.go
+++ b/config/default.go
@@ -221,14 +221,14 @@ func DefaultConfig(ctx context.Context) (*Config, error) {
 			if err != nil {
 				return nil, err
 			}
-			major, minor, patch, err := nvidia_query_nvml.ParseDriverVersion(driverVersion)
+			major, _, _, err := nvidia_query_nvml.ParseDriverVersion(driverVersion)
 			if err != nil {
 				return nil, err
 			}
 
 			log.Logger.Debugw("auto-detected nvidia -- configuring nvidia components")
 
-			if nvidia_query_nvml.ClockEventsSupportedVersion(major, minor, patch) {
+			if nvidia_query_nvml.ClockEventsSupportedVersion(major) {
 				clockEventsSupported, err := nvidia_query_nvml.ClockEventsSupported()
 				if err == nil {
 					if clockEventsSupported {


### PR DESCRIPTION
Reported by @cardyok:

![image](https://github.com/user-attachments/assets/0da288d7-0157-48d3-b147-e7515f21c776)

Not all NVIDIA drivers support this symbol. And if we don't do this, the CGO call just exits the whole process.

(ref. https://github.com/NVIDIA/go-nvml/pull/123)