### PR TITLE
fix(accelerator/nvidia): panic when ibstat command fails, when recording errors

### DIFF
--- a/components/accelerator/nvidia/query/query.go
+++ b/components/accelerator/nvidia/query/query.go
@@ -103,6 +103,9 @@ func Get(ctx context.Context) (output any, err error) {
 	if o.IbstatExists {
 		o.Ibstat, err = RunIbstat(cctx)
 		if err != nil {
+			if o.Ibstat == nil {
+				o.Ibstat = &IbstatOutput{}
+			}
 			o.Ibstat.Errors = append(o.Ibstat.Errors, err.Error())
 		}
 	}


### PR DESCRIPTION
Fix

```
⌛ scanning nvidia accelerators
{"level":"warn","ts":"2024-09-08T04:35:57Z","caller":"nvml/nvml.go:322","msg":"gpm metrics not supported"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xc414e2]

goroutine 1 [running]:
github.com/leptonai/gpud/components/accelerator/nvidia/query.Get({0x19b3a18, 0xc000880850})
	/home/ubuntu/leptonai/gpud/components/accelerator/nvidia/query/query.go:106 +0x7c2
github.com/leptonai/gpud/components/diagnose.Scan({0x19b3a18, 0xc000880850}, {0xc0000537b8, 0x4, 0xc0000536b0?})
	/home/ubuntu/leptonai/gpud/components/diagnose/scan.go:42 +0x214
github.com/leptonai/gpud/cmd/gpud/command.cmdScan(0xc000336440?)
	/home/ubuntu/leptonai/gpud/cmd/gpud/command/scan.go:15 +0xff
github.com/urfave/cli.HandleAction({0x14f36a0?, 0x1827e20?}, 0x4?)
	/home/ubuntu/go/pkg/mod/github.com/urfave/cli@v1.22.15/app.go:524 +0x50
github.com/urfave/cli.Command.Run({{0x172f06f, 0x4}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0x17798c8, 0x29}, {0x0, ...}, ...}, ...)
	/home/ubuntu/go/pkg/mod/github.com/urfave/cli@v1.22.15/command.go:175 +0x67c
github.com/urfave/cli.(*App).Run(0xc000552e00, {0xc0002be000, 0x2, 0x2})
	/home/ubuntu/go/pkg/mod/github.com/urfave/cli@v1.22.15/app.go:277 +0xb3b
main.main()
	/home/ubuntu/leptonai/gpud/cmd/gpud/main.go:12 +0x2d
```