### PR TITLE
fix(accelerator/nvidia/gpm): add missing Healthy: true field

### DIFF
--- a/components/accelerator/nvidia/gpm/component_output.go
+++ b/components/accelerator/nvidia/gpm/component_output.go
@@ -76,7 +76,8 @@ func ParseStatesToOutput(states ...components.State) (*Output, error) {
 func (o *Output) States() ([]components.State, error) {
 	b, _ := o.JSON()
 	state := components.State{
-		Name: StateNameGPM,
+		Name:    StateNameGPM,
+		Healthy: true,
 		ExtraInfo: map[string]string{
 			StateKeyGPMData:     string(b),
 			StateKeyGPMEncoding: StateValueGPMEncodingJSON,


### PR DESCRIPTION
```json
  {
    "component": "accelerator-nvidia-gpm",
    "states": [
      {
        "name": "gpm",
        "healthy": true,
        "extra_info": {
          "data": "{}",
          "encoding": "json"
        }
      }
    ]
  },
```