### PR TITLE
feat(dmesg): add oom-kill:constraint regex for cri-containerd events

### DIFF
--- a/components/dmesg/filters.go
+++ b/components/dmesg/filters.go
@@ -14,6 +14,11 @@ const (
 	EventOOMKillRegex = `Out of memory:`
 
 	// e.g.,
+	// oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),
+	EventOOMKillConstraint      = "oom_kill_constraint"
+	EventOOMKillConstraintRegex = `oom-kill:constraint=`
+
+	// e.g.,
 	// postgres invoked oom-killer: gfp_mask=0x201d2, order=0, oomkilladj=0
 	EventOOMKiller      = "oom_killer"
 	EventOOMKillerRegex = `(?i)\b(invoked|triggered) oom-killer\b`
@@ -28,6 +33,11 @@ var defaultFilters = []*query_log_filter.Filter{
 	{
 		Name:            EventOOMKill,
 		Regex:           ptr.To(EventOOMKillRegex),
+		OwnerReferences: []string{memory.Name},
+	},
+	{
+		Name:            EventOOMKillConstraint,
+		Regex:           ptr.To(EventOOMKillConstraintRegex),
 		OwnerReferences: []string{memory.Name},
 	},
 	{

--- a/components/dmesg/filters_test.go
+++ b/components/dmesg/filters_test.go
@@ -27,12 +27,25 @@ func TestOOMRegexes(t *testing.T) {
 			},
 		},
 		{
+			name:  "OOMConstraint",
+			regex: EventOOMKillConstraintRegex,
+			matches: []string{
+				"oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),cpuset=cri-containerd-3fc28fa1c647ceede9f6b340d0b16c9f1f663698972d22a52e296f291638e014.scope,mems_allowed=0-1,oom_memcg=/lxc.payload.ny2g2r5hh3-lxc/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-poda8697f49_441d_4d4f_90d2_6d8e1fa3bbe7.slice,task_memcg=/lxc.payload.ny2g2r5hh3-lxc/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-poda8697f49_441d_4d4f_90d2_6d8e1fa3bbe7.slice/cri-containerd-3fc28fa1c647ceede9f6b340d0b16c9f1f663698972d22a52e296f291638e014.scope,task=node,pid=863987,uid=0",
+				"oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),cpuset=cri-containerd-3fc28fa1c647ceede9f6b340d0b16c9f1f663698972d22a52e296f291638e014.scope,mems_allowed=0-1,oom_memcg=/lxc.payload.ny2g2r5hh3-lxc/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-poda8697f49_441d_4d4f_90d2_6d8e1fa3bbe7.slice,task_memcg=/lxc.payload.ny2g2r5hh3-lxc/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-poda8697f49_441d_4d4f_90d2_6d8e1fa3bbe7.slice/cri-containerd-3fc28fa1c647ceede9f6b340d0b16c9f1f663698972d22a52e296f291638e014.scope,task=pt_main_thread,pid=1483257,uid=0",
+			},
+			notMatch: []string{
+				"oom-kill:abc=OTHER_CONSTRAINT",
+				"Memory constraint reached",
+			},
+		},
+		{
 			name:  "OOMKiller",
 			regex: EventOOMKillerRegex,
 			matches: []string{
 				"postgres invoked oom-killer: gfp_mask=0x201d2, order=0, oomkilladj=0",
 				"java triggered oom-killer: gfp_mask=0x14200ca, order=0, oom_score_adj=0",
 				"PROCESS INVOKED OOM-KILLER: details here",
+				"pt_main_thread invoked oom-killer: gfp_mask=0x400dc0(GFP_KERNEL_ACCOUNT|__GFP_ZERO), order=0, oom_score_adj=893",
 			},
 			notMatch: []string{
 				"System killed process due to low memory",
@@ -45,6 +58,8 @@ func TestOOMRegexes(t *testing.T) {
 			matches: []string{
 				"Memory cgroup out of memory: Killed process 123, UID 48, (httpd).",
 				"Memory cgroup out of memory: Kill process 789 (nginx) score 1000 or sacrifice child",
+				"Memory cgroup out of memory: Killed process 863987 (node) total-vm:42779752kB, anon-rss:41545760kB, file-rss:2836kB, shmem-rss:0kB, UID:0 pgtables:82636kB oom_score_adj:893",
+				"Memory cgroup out of memory: Killed process 1483257 (pt_main_thread) total-vm:48979828kB, anon-rss:23167252kB, file-rss:83700kB, shmem-rss:20kB, UID:0 pgtables:46968kB oom_score_adj:893",
 			},
 			notMatch: []string{
 				"Cgroup memory limit reached",


### PR DESCRIPTION
e.g.,

> Aug 30 06:58:55.050705 ... kernel: oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),cpuset=cri-containerd-ec9ee26695deb4cc72bc665efff1cf3a03fdfb12f1303e02fe9252985e084a95.scope,mems_allowed=0-1,oom_memcg=/lxc.payload....-lxc/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podeded8c65_6e8e_4c6e_a889_3e427565c740.slice,task_memcg=/lxc.payload.ny2g2r5hh3-lxc/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podeded8c65_6e8e_4c6e_a889_3e427565c740.slice/cri-containerd-ec9ee26695deb4cc72bc665efff1cf3a03fdfb12f1303e02fe9252985e084a95.scope,task=pt_main_thread,pid=461754,uid=0