### PR TITLE
feat(nvidia): track "ECC mode" (enabled/disabled) using nvidia-smi and NVML

### DIFF
--- a/components/accelerator/nvidia/ecc/component_output.go
+++ b/components/accelerator/nvidia/ecc/component_output.go
@@ -36,6 +36,7 @@ func ToOutput(i *nvidia_query.Output) *Output {
 
 	if i.NVML != nil {
 		for _, dev := range i.NVML.DeviceInfos {
+			o.ECCModes = append(o.ECCModes, dev.ECCMode)
 			o.ErrorCountsNVML = append(o.ErrorCountsNVML, dev.ECCErrors)
 
 			if errs := dev.ECCErrors.Volatile.FindUncorrectedErrs(); len(errs) > 0 {
@@ -48,6 +49,8 @@ func ToOutput(i *nvidia_query.Output) *Output {
 }
 
 type Output struct {
+	ECCModes []nvidia_query_nvml.ECCMode `json:"ecc_modes"`
+
 	ErrorCountsSMI  []nvidia_query.SMIECCErrors   `json:"error_counts_smi"`
 	ErrorCountsNVML []nvidia_query_nvml.ECCErrors `json:"error_counts_nvml"`
 

--- a/components/accelerator/nvidia/ecc/component_output_test.go
+++ b/components/accelerator/nvidia/ecc/component_output_test.go
@@ -1,0 +1,75 @@
+package ecc
+
+import (
+	"reflect"
+	"testing"
+
+	nvidia_query "github.com/leptonai/gpud/components/accelerator/nvidia/query"
+	nvidia_query_nvml "github.com/leptonai/gpud/components/accelerator/nvidia/query/nvml"
+)
+
+func TestToOutputECCMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *nvidia_query.Output
+		expected *Output
+	}{
+		{
+			name:     "Nil input",
+			input:    nil,
+			expected: &Output{},
+		},
+		{
+			name: "Empty input",
+			input: &nvidia_query.Output{
+				SMI:  &nvidia_query.SMIOutput{},
+				NVML: &nvidia_query_nvml.Output{},
+			},
+			expected: &Output{},
+		},
+		{
+			name: "With ECC mode",
+			input: &nvidia_query.Output{
+				NVML: &nvidia_query_nvml.Output{
+					DeviceInfos: []*nvidia_query_nvml.DeviceInfo{
+						{
+							ECCMode: nvidia_query_nvml.ECCMode{
+								EnabledCurrent: true,
+							},
+						},
+					},
+				},
+			},
+			expected: &Output{
+				ECCModes: []nvidia_query_nvml.ECCMode{
+					{
+						EnabledCurrent: true,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ToOutput(tt.input)
+			if !reflect.DeepEqual(result.ECCModes, tt.expected.ECCModes) {
+				t.Errorf("ToOutput()\n%+v\n\nwant\n%+v", result.ECCModes, tt.expected.ECCModes)
+			}
+
+			b, err := result.JSON()
+			if err != nil {
+				t.Errorf("JSON()\n%+v", err)
+			}
+
+			parsed, err := ParseOutputJSON(b)
+			if err != nil {
+				t.Errorf("ParseOutputJSON()\n%+v", err)
+			}
+
+			if !reflect.DeepEqual(parsed.ECCModes, result.ECCModes) {
+				t.Errorf("ParseOutputJSON()\n%+v\n\nwant\n%+v", parsed.ECCModes, result.ECCModes)
+			}
+		})
+	}
+}

--- a/components/accelerator/nvidia/query/nvidia_smi_query_gpu.go
+++ b/components/accelerator/nvidia/query/nvidia_smi_query_gpu.go
@@ -26,6 +26,7 @@ type NvidiaSMIGPU struct {
 	GPUResetStatus    *SMIGPUResetStatus    `json:"GPU Reset Status,omitempty"`
 	ClockEventReasons *SMIClockEventReasons `json:"Clocks Event Reasons,omitempty"`
 
+	ECCMode      *SMIECCMode      `json:"ECC Mode,omitempty"`
 	ECCErrors    *SMIECCErrors    `json:"ECC Errors,omitempty"`
 	RemappedRows *SMIRemappedRows `json:"Remapped Rows,omitempty"`
 
@@ -48,6 +49,11 @@ type SMIClockEventReasons struct {
 	HWSlowdown           string `json:"HW Slowdown"`
 	HWThermalSlowdown    string `json:"HW Thermal Slowdown"`
 	HWPowerBrakeSlowdown string `json:"HW Power Brake Slowdown"`
+}
+
+type SMIECCMode struct {
+	Current string `json:"Current"`
+	Pending string `json:"Pending"`
 }
 
 type SMIECCErrors struct {

--- a/components/accelerator/nvidia/query/nvidia_smi_query_test.go
+++ b/components/accelerator/nvidia/query/nvidia_smi_query_test.go
@@ -44,6 +44,25 @@ func TestParseWithHWSlowdownActive(t *testing.T) {
 	}
 }
 
+func TestParseECCMode(t *testing.T) {
+	data, err := os.ReadFile("testdata/nvidia-smi-query.535.161.08.out.0.valid")
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	parsed, err := ParseSMIQueryOutput(data)
+	if err != nil {
+		t.Errorf("Parse returned an error: %v", err)
+	}
+	for _, gpu := range parsed.GPUs {
+		if gpu.ECCMode.Current != "Enabled" {
+			t.Errorf("ECCMode mismatch: %+v", gpu.ECCMode.Current)
+		}
+		if gpu.ECCMode.Pending != "Enabled" {
+			t.Errorf("ECCMode mismatch: %+v", gpu.ECCMode.Pending)
+		}
+	}
+}
+
 func TestParseWithProcesses(t *testing.T) {
 	data, err := os.ReadFile("testdata/nvidia-smi-query.535.154.05.out.0.valid")
 	if err != nil {

--- a/components/accelerator/nvidia/query/nvml/ecc_errors.go
+++ b/components/accelerator/nvidia/query/nvml/ecc_errors.go
@@ -123,7 +123,7 @@ func (allCounts AllECCErrorCounts) FindUncorrectedErrs() []string {
 	return errs
 }
 
-func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
+func GetECCErrors(uuid string, dev device.Device, eccModeEnabledCurrent bool) (ECCErrors, error) {
 	result := ECCErrors{
 		UUID:      uuid,
 		Aggregate: AllECCErrorCounts{},
@@ -164,185 +164,6 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 		}
 	}
 
-	// "GetDetailedEccErrors" is deprecated, use "nvmlDeviceGetMemoryErrorCounter"
-	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1ga14fc137726f6c34c3351d83e3812ed4
-	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
-	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceEnumvs.html#group__nvmlDeviceEnumvs_1g9bcbee49054a953d333d4aa11e8b9c25
-	result.Aggregate.L1Cache.Corrected, ret = dev.GetMemoryErrorCounter(
-		nvml.MEMORY_ERROR_TYPE_CORRECTED,
-		nvml.AGGREGATE_ECC,
-		nvml.MEMORY_LOCATION_L1_CACHE,
-	)
-	if ret != nvml.SUCCESS {
-		if ret == nvml.ERROR_NOT_SUPPORTED {
-			log.Logger.Debugw("(aggregate, corrected) get l1 cache ecc errors not supported", "error", nvml.ErrorString(ret))
-		} else {
-			return result, fmt.Errorf("(aggregate, corrected) failed to get l1 cache ecc errors: %s", nvml.ErrorString(ret))
-		}
-	}
-	result.Aggregate.L1Cache.Uncorrected, ret = dev.GetMemoryErrorCounter(
-		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
-		nvml.AGGREGATE_ECC,
-		nvml.MEMORY_LOCATION_L1_CACHE,
-	)
-	if ret != nvml.SUCCESS {
-		if ret == nvml.ERROR_NOT_SUPPORTED {
-			log.Logger.Debugw("(aggregate, uncorrected) get l1 cache ecc errors not supported", "error", nvml.ErrorString(ret))
-		} else {
-			return result, fmt.Errorf("(aggregate, uncorrected) failed to get l1 cache ecc errors: %s", nvml.ErrorString(ret))
-		}
-	}
-
-	result.Aggregate.L2Cache.Corrected, ret = dev.GetMemoryErrorCounter(
-		nvml.MEMORY_ERROR_TYPE_CORRECTED,
-		nvml.AGGREGATE_ECC,
-		nvml.MEMORY_LOCATION_L2_CACHE,
-	)
-	if ret != nvml.SUCCESS {
-		if ret == nvml.ERROR_NOT_SUPPORTED {
-			log.Logger.Debugw("(aggregate, corrected) get l2 cache ecc errors not supported", "error", nvml.ErrorString(ret))
-		} else {
-			return result, fmt.Errorf("(aggregate, corrected) failed to get l2 cache ecc errors: %s", nvml.ErrorString(ret))
-		}
-	}
-	result.Aggregate.L2Cache.Uncorrected, ret = dev.GetMemoryErrorCounter(
-		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
-		nvml.AGGREGATE_ECC,
-		nvml.MEMORY_LOCATION_L2_CACHE,
-	)
-	if ret != nvml.SUCCESS {
-		if ret == nvml.ERROR_NOT_SUPPORTED {
-			log.Logger.Debugw("(aggregate, uncorrected) get l2 cache ecc errors not supported", "error", nvml.ErrorString(ret))
-		} else {
-			return result, fmt.Errorf("(aggregate, uncorrected) failed to get l2 cache ecc errors: %s", nvml.ErrorString(ret))
-		}
-	}
-
-	result.Aggregate.DRAM.Corrected, ret = dev.GetMemoryErrorCounter(
-		nvml.MEMORY_ERROR_TYPE_CORRECTED,
-		nvml.AGGREGATE_ECC,
-		nvml.MEMORY_LOCATION_DRAM,
-	)
-	if ret != nvml.SUCCESS {
-		if ret == nvml.ERROR_NOT_SUPPORTED {
-			log.Logger.Debugw("(aggregate, corrected) get dram cache ecc errors not supported", "error", nvml.ErrorString(ret))
-		} else {
-			return result, fmt.Errorf("(aggregate, corrected) failed to get dram cache ecc errors: %s", nvml.ErrorString(ret))
-		}
-	}
-	result.Aggregate.DRAM.Uncorrected, ret = dev.GetMemoryErrorCounter(
-		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
-		nvml.AGGREGATE_ECC,
-		nvml.MEMORY_LOCATION_DRAM,
-	)
-	if ret != nvml.SUCCESS {
-		if ret == nvml.ERROR_NOT_SUPPORTED {
-			log.Logger.Debugw("(aggregate, uncorrected) get dram cache ecc errors not supported", "error", nvml.ErrorString(ret))
-		} else {
-			return result, fmt.Errorf("(aggregate, uncorrected) failed to get dram cache ecc errors: %s", nvml.ErrorString(ret))
-		}
-	}
-
-	result.Aggregate.SRAM.Corrected, ret = dev.GetMemoryErrorCounter(
-		nvml.MEMORY_ERROR_TYPE_CORRECTED,
-		nvml.AGGREGATE_ECC,
-		nvml.MEMORY_LOCATION_SRAM,
-	)
-	if ret != nvml.SUCCESS {
-		if ret == nvml.ERROR_NOT_SUPPORTED {
-			log.Logger.Debugw("(aggregate, corrected) get sram ecc errors not supported", "error", nvml.ErrorString(ret))
-		} else {
-			return result, fmt.Errorf("(aggregate, corrected) failed to get sram ecc errors: %s", nvml.ErrorString(ret))
-		}
-	}
-	result.Aggregate.SRAM.Uncorrected, ret = dev.GetMemoryErrorCounter(
-		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
-		nvml.AGGREGATE_ECC,
-		nvml.MEMORY_LOCATION_SRAM,
-	)
-	if ret != nvml.SUCCESS {
-		if ret == nvml.ERROR_NOT_SUPPORTED {
-			log.Logger.Debugw("(aggregate, uncorrected) get sram ecc errors not supported", "error", nvml.ErrorString(ret))
-		} else {
-			return result, fmt.Errorf("(aggregate, uncorrected) failed to get sram ecc errors: %s", nvml.ErrorString(ret))
-		}
-	}
-
-	result.Aggregate.GPUDeviceMemory.Corrected, ret = dev.GetMemoryErrorCounter(
-		nvml.MEMORY_ERROR_TYPE_CORRECTED,
-		nvml.AGGREGATE_ECC,
-		nvml.MEMORY_LOCATION_DEVICE_MEMORY,
-	)
-	if ret != nvml.SUCCESS {
-		if ret == nvml.ERROR_NOT_SUPPORTED {
-			log.Logger.Debugw("(aggregate, corrected) get gpu device memory ecc errors not supported", "error", nvml.ErrorString(ret))
-		} else {
-			return result, fmt.Errorf("(aggregate, corrected) failed to get gpu device memory ecc errors: %s", nvml.ErrorString(ret))
-		}
-	}
-	result.Aggregate.GPUDeviceMemory.Uncorrected, ret = dev.GetMemoryErrorCounter(
-		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
-		nvml.AGGREGATE_ECC,
-		nvml.MEMORY_LOCATION_DEVICE_MEMORY,
-	)
-	if ret != nvml.SUCCESS {
-		if ret == nvml.ERROR_NOT_SUPPORTED {
-			log.Logger.Debugw("(aggregate, uncorrected) get gpu device memory ecc errors not supported", "error", nvml.ErrorString(ret))
-		} else {
-			return result, fmt.Errorf("(aggregate, uncorrected) failed to get gpu device memory ecc errors: %s", nvml.ErrorString(ret))
-		}
-	}
-
-	result.Aggregate.GPUTextureMemory.Corrected, ret = dev.GetMemoryErrorCounter(
-		nvml.MEMORY_ERROR_TYPE_CORRECTED,
-		nvml.AGGREGATE_ECC,
-		nvml.MEMORY_LOCATION_TEXTURE_MEMORY,
-	)
-	if ret != nvml.SUCCESS {
-		if ret == nvml.ERROR_NOT_SUPPORTED {
-			log.Logger.Debugw("(aggregate, corrected) get gpu texture memory ecc errors not supported", "error", nvml.ErrorString(ret))
-		} else {
-			return result, fmt.Errorf("(aggregate, corrected) failed to get gpu texture memory ecc errors: %s", nvml.ErrorString(ret))
-		}
-	}
-	result.Aggregate.GPUTextureMemory.Uncorrected, ret = dev.GetMemoryErrorCounter(
-		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
-		nvml.AGGREGATE_ECC,
-		nvml.MEMORY_LOCATION_TEXTURE_MEMORY,
-	)
-	if ret != nvml.SUCCESS {
-		if ret == nvml.ERROR_NOT_SUPPORTED {
-			log.Logger.Debugw("(aggregate, uncorrected) get gpu texture memory ecc errors not supported", "error", nvml.ErrorString(ret))
-		} else {
-			return result, fmt.Errorf("(aggregate, uncorrected) failed to get gpu texture memory ecc errors: %s", nvml.ErrorString(ret))
-		}
-	}
-
-	result.Aggregate.SharedMemory.Corrected, ret = dev.GetMemoryErrorCounter(
-		nvml.MEMORY_ERROR_TYPE_CORRECTED,
-		nvml.AGGREGATE_ECC,
-		nvml.MEMORY_LOCATION_TEXTURE_SHM,
-	)
-	if ret != nvml.SUCCESS {
-		if ret == nvml.ERROR_NOT_SUPPORTED {
-			log.Logger.Debugw("(aggregate, corrected) get shared memory ecc errors not supported", "error", nvml.ErrorString(ret))
-		} else {
-			return result, fmt.Errorf("(aggregate, corrected) failed to get shared memory ecc errors: %s", nvml.ErrorString(ret))
-		}
-	}
-	result.Aggregate.SharedMemory.Uncorrected, ret = dev.GetMemoryErrorCounter(
-		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
-		nvml.AGGREGATE_ECC,
-		nvml.MEMORY_LOCATION_TEXTURE_SHM,
-	)
-	if ret != nvml.SUCCESS {
-		if ret == nvml.ERROR_NOT_SUPPORTED {
-			log.Logger.Debugw("(aggregate, uncorrected) get shared memory ecc errors not supported", "error", nvml.ErrorString(ret))
-		} else {
-			return result, fmt.Errorf("(aggregate, uncorrected) failed to get shared memory ecc errors: %s", nvml.ErrorString(ret))
-		}
-	}
-
 	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g9748430b6aa6cdbb2349c5e835d70b0f
 	result.Volatile.Total.Corrected, ret = dev.GetTotalEccErrors(
 		// A memory error that was correctedFor ECC errors, these are single bit errors.
@@ -375,6 +196,227 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 		}
 	}
 
+	if !eccModeEnabledCurrent {
+		log.Logger.Debugw("ecc mode is not enabled -- skipping fetching memory error counts using 'nvmlDeviceGetMemoryErrorCounter'", "uuid", uuid)
+		return result, nil
+	}
+
+	// "GetDetailedEccErrors" is deprecated, use "nvmlDeviceGetMemoryErrorCounter"
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1ga14fc137726f6c34c3351d83e3812ed4
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceEnumvs.html#group__nvmlDeviceEnumvs_1g9bcbee49054a953d333d4aa11e8b9c25
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
+	result.Aggregate.L1Cache.Corrected, ret = dev.GetMemoryErrorCounter(
+		nvml.MEMORY_ERROR_TYPE_CORRECTED,
+		nvml.AGGREGATE_ECC,
+		nvml.MEMORY_LOCATION_L1_CACHE,
+	)
+	if ret != nvml.SUCCESS {
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			log.Logger.Debugw("(aggregate, corrected) get l1 cache ecc errors not supported", "error", nvml.ErrorString(ret))
+		} else {
+			return result, fmt.Errorf("(aggregate, corrected) failed to get l1 cache ecc errors: %s", nvml.ErrorString(ret))
+		}
+	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
+	result.Aggregate.L1Cache.Uncorrected, ret = dev.GetMemoryErrorCounter(
+		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
+		nvml.AGGREGATE_ECC,
+		nvml.MEMORY_LOCATION_L1_CACHE,
+	)
+	if ret != nvml.SUCCESS {
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			log.Logger.Debugw("(aggregate, uncorrected) get l1 cache ecc errors not supported", "error", nvml.ErrorString(ret))
+		} else {
+			return result, fmt.Errorf("(aggregate, uncorrected) failed to get l1 cache ecc errors: %s", nvml.ErrorString(ret))
+		}
+	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
+	result.Aggregate.L2Cache.Corrected, ret = dev.GetMemoryErrorCounter(
+		nvml.MEMORY_ERROR_TYPE_CORRECTED,
+		nvml.AGGREGATE_ECC,
+		nvml.MEMORY_LOCATION_L2_CACHE,
+	)
+	if ret != nvml.SUCCESS {
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			log.Logger.Debugw("(aggregate, corrected) get l2 cache ecc errors not supported", "error", nvml.ErrorString(ret))
+		} else {
+			return result, fmt.Errorf("(aggregate, corrected) failed to get l2 cache ecc errors: %s", nvml.ErrorString(ret))
+		}
+	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
+	result.Aggregate.L2Cache.Uncorrected, ret = dev.GetMemoryErrorCounter(
+		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
+		nvml.AGGREGATE_ECC,
+		nvml.MEMORY_LOCATION_L2_CACHE,
+	)
+	if ret != nvml.SUCCESS {
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			log.Logger.Debugw("(aggregate, uncorrected) get l2 cache ecc errors not supported", "error", nvml.ErrorString(ret))
+		} else {
+			return result, fmt.Errorf("(aggregate, uncorrected) failed to get l2 cache ecc errors: %s", nvml.ErrorString(ret))
+		}
+	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
+	result.Aggregate.DRAM.Corrected, ret = dev.GetMemoryErrorCounter(
+		nvml.MEMORY_ERROR_TYPE_CORRECTED,
+		nvml.AGGREGATE_ECC,
+		nvml.MEMORY_LOCATION_DRAM,
+	)
+	if ret != nvml.SUCCESS {
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			log.Logger.Debugw("(aggregate, corrected) get dram cache ecc errors not supported", "error", nvml.ErrorString(ret))
+		} else {
+			return result, fmt.Errorf("(aggregate, corrected) failed to get dram cache ecc errors: %s", nvml.ErrorString(ret))
+		}
+	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
+	result.Aggregate.DRAM.Uncorrected, ret = dev.GetMemoryErrorCounter(
+		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
+		nvml.AGGREGATE_ECC,
+		nvml.MEMORY_LOCATION_DRAM,
+	)
+	if ret != nvml.SUCCESS {
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			log.Logger.Debugw("(aggregate, uncorrected) get dram cache ecc errors not supported", "error", nvml.ErrorString(ret))
+		} else {
+			return result, fmt.Errorf("(aggregate, uncorrected) failed to get dram cache ecc errors: %s", nvml.ErrorString(ret))
+		}
+	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
+	result.Aggregate.SRAM.Corrected, ret = dev.GetMemoryErrorCounter(
+		nvml.MEMORY_ERROR_TYPE_CORRECTED,
+		nvml.AGGREGATE_ECC,
+		nvml.MEMORY_LOCATION_SRAM,
+	)
+	if ret != nvml.SUCCESS {
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			log.Logger.Debugw("(aggregate, corrected) get sram ecc errors not supported", "error", nvml.ErrorString(ret))
+		} else {
+			return result, fmt.Errorf("(aggregate, corrected) failed to get sram ecc errors: %s", nvml.ErrorString(ret))
+		}
+	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
+	result.Aggregate.SRAM.Uncorrected, ret = dev.GetMemoryErrorCounter(
+		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
+		nvml.AGGREGATE_ECC,
+		nvml.MEMORY_LOCATION_SRAM,
+	)
+	if ret != nvml.SUCCESS {
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			log.Logger.Debugw("(aggregate, uncorrected) get sram ecc errors not supported", "error", nvml.ErrorString(ret))
+		} else {
+			return result, fmt.Errorf("(aggregate, uncorrected) failed to get sram ecc errors: %s", nvml.ErrorString(ret))
+		}
+	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
+	result.Aggregate.GPUDeviceMemory.Corrected, ret = dev.GetMemoryErrorCounter(
+		nvml.MEMORY_ERROR_TYPE_CORRECTED,
+		nvml.AGGREGATE_ECC,
+		nvml.MEMORY_LOCATION_DEVICE_MEMORY,
+	)
+	if ret != nvml.SUCCESS {
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			log.Logger.Debugw("(aggregate, corrected) get gpu device memory ecc errors not supported", "error", nvml.ErrorString(ret))
+		} else {
+			return result, fmt.Errorf("(aggregate, corrected) failed to get gpu device memory ecc errors: %s", nvml.ErrorString(ret))
+		}
+	}
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
+	result.Aggregate.GPUDeviceMemory.Uncorrected, ret = dev.GetMemoryErrorCounter(
+		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
+		nvml.AGGREGATE_ECC,
+		nvml.MEMORY_LOCATION_DEVICE_MEMORY,
+	)
+	if ret != nvml.SUCCESS {
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			log.Logger.Debugw("(aggregate, uncorrected) get gpu device memory ecc errors not supported", "error", nvml.ErrorString(ret))
+		} else {
+			return result, fmt.Errorf("(aggregate, uncorrected) failed to get gpu device memory ecc errors: %s", nvml.ErrorString(ret))
+		}
+	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
+	result.Aggregate.GPUTextureMemory.Corrected, ret = dev.GetMemoryErrorCounter(
+		nvml.MEMORY_ERROR_TYPE_CORRECTED,
+		nvml.AGGREGATE_ECC,
+		nvml.MEMORY_LOCATION_TEXTURE_MEMORY,
+	)
+	if ret != nvml.SUCCESS {
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			log.Logger.Debugw("(aggregate, corrected) get gpu texture memory ecc errors not supported", "error", nvml.ErrorString(ret))
+		} else {
+			return result, fmt.Errorf("(aggregate, corrected) failed to get gpu texture memory ecc errors: %s", nvml.ErrorString(ret))
+		}
+	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
+	result.Aggregate.GPUTextureMemory.Uncorrected, ret = dev.GetMemoryErrorCounter(
+		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
+		nvml.AGGREGATE_ECC,
+		nvml.MEMORY_LOCATION_TEXTURE_MEMORY,
+	)
+	if ret != nvml.SUCCESS {
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			log.Logger.Debugw("(aggregate, uncorrected) get gpu texture memory ecc errors not supported", "error", nvml.ErrorString(ret))
+		} else {
+			return result, fmt.Errorf("(aggregate, uncorrected) failed to get gpu texture memory ecc errors: %s", nvml.ErrorString(ret))
+		}
+	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
+	result.Aggregate.SharedMemory.Corrected, ret = dev.GetMemoryErrorCounter(
+		nvml.MEMORY_ERROR_TYPE_CORRECTED,
+		nvml.AGGREGATE_ECC,
+		nvml.MEMORY_LOCATION_TEXTURE_SHM,
+	)
+	if ret != nvml.SUCCESS {
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			log.Logger.Debugw("(aggregate, corrected) get shared memory ecc errors not supported", "error", nvml.ErrorString(ret))
+		} else {
+			return result, fmt.Errorf("(aggregate, corrected) failed to get shared memory ecc errors: %s", nvml.ErrorString(ret))
+		}
+	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
+	result.Aggregate.SharedMemory.Uncorrected, ret = dev.GetMemoryErrorCounter(
+		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
+		nvml.AGGREGATE_ECC,
+		nvml.MEMORY_LOCATION_TEXTURE_SHM,
+	)
+	if ret != nvml.SUCCESS {
+		if ret == nvml.ERROR_NOT_SUPPORTED {
+			log.Logger.Debugw("(aggregate, uncorrected) get shared memory ecc errors not supported", "error", nvml.ErrorString(ret))
+		} else {
+			return result, fmt.Errorf("(aggregate, uncorrected) failed to get shared memory ecc errors: %s", nvml.ErrorString(ret))
+		}
+	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.L1Cache.Corrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_CORRECTED,
 		nvml.VOLATILE_ECC,
@@ -387,6 +429,9 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 			return result, fmt.Errorf("(volatile, corrected) failed to get l1 cache ecc errors: %s", nvml.ErrorString(ret))
 		}
 	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.L1Cache.Uncorrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
 		nvml.VOLATILE_ECC,
@@ -400,6 +445,8 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 		}
 	}
 
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.L2Cache.Corrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_CORRECTED,
 		nvml.VOLATILE_ECC,
@@ -412,6 +459,9 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 			return result, fmt.Errorf("(volatile, corrected) failed to get l2 cache ecc errors: %s", nvml.ErrorString(ret))
 		}
 	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.L2Cache.Uncorrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
 		nvml.VOLATILE_ECC,
@@ -425,6 +475,8 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 		}
 	}
 
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.DRAM.Corrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_CORRECTED,
 		nvml.VOLATILE_ECC,
@@ -437,6 +489,9 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 			return result, fmt.Errorf("(volatile, corrected) failed to get dram cache ecc errors: %s", nvml.ErrorString(ret))
 		}
 	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.DRAM.Uncorrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
 		nvml.VOLATILE_ECC,
@@ -450,6 +505,8 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 		}
 	}
 
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.SRAM.Corrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_CORRECTED,
 		nvml.VOLATILE_ECC,
@@ -462,6 +519,9 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 			return result, fmt.Errorf("(volatile, corrected) failed to get sram ecc errors: %s", nvml.ErrorString(ret))
 		}
 	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.SRAM.Uncorrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
 		nvml.VOLATILE_ECC,
@@ -475,6 +535,8 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 		}
 	}
 
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.GPUDeviceMemory.Corrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_CORRECTED,
 		nvml.VOLATILE_ECC,
@@ -487,6 +549,9 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 			return result, fmt.Errorf("(volatile, corrected) failed to get gpu device memory ecc errors: %s", nvml.ErrorString(ret))
 		}
 	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.GPUDeviceMemory.Uncorrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
 		nvml.VOLATILE_ECC,
@@ -500,6 +565,8 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 		}
 	}
 
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.GPUTextureMemory.Corrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_CORRECTED,
 		nvml.VOLATILE_ECC,
@@ -512,6 +579,9 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 			return result, fmt.Errorf("(volatile, corrected) failed to get gpu texture memory ecc errors: %s", nvml.ErrorString(ret))
 		}
 	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.GPUTextureMemory.Uncorrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
 		nvml.VOLATILE_ECC,
@@ -525,6 +595,8 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 		}
 	}
 
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.SharedMemory.Corrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_CORRECTED,
 		nvml.VOLATILE_ECC,
@@ -537,6 +609,9 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 			return result, fmt.Errorf("(volatile, corrected) failed to get shared memory ecc errors: %s", nvml.ErrorString(ret))
 		}
 	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.SharedMemory.Uncorrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
 		nvml.VOLATILE_ECC,
@@ -550,6 +625,8 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 		}
 	}
 
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.GPURegisterFile.Corrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_CORRECTED,
 		nvml.VOLATILE_ECC,
@@ -562,6 +639,9 @@ func GetECCErrors(uuid string, dev device.Device) (ECCErrors, error) {
 			return result, fmt.Errorf("(volatile, corrected) failed to get register file ecc errors: %s", nvml.ErrorString(ret))
 		}
 	}
+
+	// "Requires ECC Mode to be enabled."
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1
 	result.Volatile.GPURegisterFile.Uncorrected, ret = dev.GetMemoryErrorCounter(
 		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
 		nvml.VOLATILE_ECC,

--- a/components/accelerator/nvidia/query/nvml/ecc_mode.go
+++ b/components/accelerator/nvidia/query/nvml/ecc_mode.go
@@ -1,0 +1,37 @@
+package nvml
+
+import (
+	"fmt"
+
+	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+// Returns the current and pending ECC modes.
+// "pending" ECC mode refers to the target mode following the next reboot.
+func GetECCModeEnabled(uuid string, dev device.Device) (ECCMode, error) {
+	result := ECCMode{
+		UUID: uuid,
+	}
+
+	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1gbf6a8f2d0ed49e920e8ec20365381100
+	current, pending, ret := dev.GetEccMode()
+	if ret != nvml.SUCCESS {
+		return ECCMode{}, fmt.Errorf("failed to get current/pending ecc mode: %s", nvml.ErrorString(ret))
+	}
+
+	result.EnabledCurrent = current == nvml.FEATURE_ENABLED
+	result.EnabledPending = pending == nvml.FEATURE_ENABLED
+
+	return result, nil
+}
+
+type ECCMode struct {
+	// Represents the GPU UUID.
+	UUID string `json:"uuid"`
+
+	EnabledCurrent bool `json:"enabled_current"`
+
+	// "pending" ECC mode refers to the target mode following the next reboot.
+	EnabledPending bool `json:"enabled_pending"`
+}

--- a/components/accelerator/nvidia/query/nvml/nvml.go
+++ b/components/accelerator/nvidia/query/nvml/nvml.go
@@ -102,6 +102,7 @@ type DeviceInfo struct {
 	Temperature  Temperature  `json:"temperature"`
 	Utilization  Utilization  `json:"utilization"`
 	Processes    Processes    `json:"processes"`
+	ECCMode      ECCMode      `json:"ecc_mode"`
 	ECCErrors    ECCErrors    `json:"ecc_errors"`
 	RemappedRows RemappedRows `json:"remapped_rows"`
 
@@ -445,7 +446,12 @@ func (inst *instance) Get() (*Output, error) {
 			return st, err
 		}
 
-		latestInfo.ECCErrors, err = GetECCErrors(devInfo.UUID, devInfo.device)
+		latestInfo.ECCMode, err = GetECCModeEnabled(devInfo.UUID, devInfo.device)
+		if err != nil {
+			return st, err
+		}
+
+		latestInfo.ECCErrors, err = GetECCErrors(devInfo.UUID, devInfo.device, latestInfo.ECCMode.EnabledCurrent)
 		if err != nil {
 			return st, err
 		}


### PR DESCRIPTION
Especially, `nvmlDeviceGetMemoryErrorCounter` requires "ECC mode" to be enabled.

See https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g30900e951fe44f1f952f0e6c89b0e2c1.