### PR TITLE
feat(nvidia/ecc): rename state name key to "ecc" (from ecc_errors)

### DIFF
--- a/components/accelerator/nvidia/ecc/component.go
+++ b/components/accelerator/nvidia/ecc/component.go
@@ -1,4 +1,4 @@
-// Package ecc tracks the NVIDIA per-GPU ECC errors.
+// Package ecc tracks the NVIDIA per-GPU ECC errors and other ECC related information.
 package ecc
 
 import (

--- a/components/accelerator/nvidia/ecc/component_output.go
+++ b/components/accelerator/nvidia/ecc/component_output.go
@@ -78,22 +78,22 @@ func ParseOutputJSON(data []byte) (*Output, error) {
 }
 
 const (
-	StateNameECCErrors = "ecc_errors"
+	StateNameECC = "ecc"
 
-	StateKeyECCErrorsData           = "data"
-	StateKeyECCErrorsEncoding       = "encoding"
-	StateValueECCErrorsEncodingJSON = "json"
+	StateKeyECCData           = "data"
+	StateKeyECCEncoding       = "encoding"
+	StateValueECCEncodingJSON = "json"
 )
 
 func ParseStateECCErrors(m map[string]string) (*Output, error) {
-	data := m[StateKeyECCErrorsData]
+	data := m[StateKeyECCData]
 	return ParseOutputJSON([]byte(data))
 }
 
 func ParseStatesToOutput(states ...components.State) (*Output, error) {
 	for _, state := range states {
 		switch state.Name {
-		case StateNameECCErrors:
+		case StateNameECC:
 			o, err := ParseStateECCErrors(state.ExtraInfo)
 			if err != nil {
 				return nil, err
@@ -121,12 +121,12 @@ func (o *Output) States() ([]components.State, error) {
 
 	b, _ := o.JSON()
 	state := components.State{
-		Name:    StateNameECCErrors,
+		Name:    StateNameECC,
 		Healthy: len(o.VolatileUncorrectedErrors) == 0,
 		Reason:  reasons,
 		ExtraInfo: map[string]string{
-			StateKeyECCErrorsData:     string(b),
-			StateKeyECCErrorsEncoding: StateValueECCErrorsEncodingJSON,
+			StateKeyECCData:     string(b),
+			StateKeyECCEncoding: StateValueECCEncodingJSON,
 		},
 	}
 	return []components.State{state}, nil

--- a/components/accelerator/nvidia/ecc/component_output_test.go
+++ b/components/accelerator/nvidia/ecc/component_output_test.go
@@ -8,6 +8,109 @@ import (
 	nvidia_query_nvml "github.com/leptonai/gpud/components/accelerator/nvidia/query/nvml"
 )
 
+func TestToOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *nvidia_query.Output
+		expected *Output
+	}{
+		{
+			name:     "Nil input",
+			input:    nil,
+			expected: &Output{},
+		},
+		{
+			name: "Empty input",
+			input: &nvidia_query.Output{
+				SMI:  &nvidia_query.SMIOutput{},
+				NVML: &nvidia_query_nvml.Output{},
+			},
+			expected: &Output{},
+		},
+		{
+			name: "SMI data only",
+			input: &nvidia_query.Output{
+				SMI: &nvidia_query.SMIOutput{
+					GPUs: []nvidia_query.NvidiaSMIGPU{
+						{
+							ID: "GPU-1",
+							ECCErrors: &nvidia_query.SMIECCErrors{
+								Volatile: &nvidia_query.SMIECCErrorVolatile{
+									DRAMUncorrectable: "6",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &Output{
+				ErrorCountsSMI: []nvidia_query.SMIECCErrors{
+					{
+						Volatile: &nvidia_query.SMIECCErrorVolatile{
+							DRAMUncorrectable: "6",
+						},
+					},
+				},
+				VolatileUncorrectedErrors: []string{"[GPU-1] GPU : Volatile DRAMUncorrectable: 6"},
+			},
+		},
+		{
+			name: "NVML data only",
+			input: &nvidia_query.Output{
+				NVML: &nvidia_query_nvml.Output{
+					DeviceInfos: []*nvidia_query_nvml.DeviceInfo{
+						{
+							UUID: "GPU-2",
+							ECCErrors: nvidia_query_nvml.ECCErrors{
+								Volatile: nvidia_query_nvml.AllECCErrorCounts{
+									Total: nvidia_query_nvml.ECCErrorCounts{
+										Uncorrected: 20,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &Output{
+				ErrorCountsNVML: []nvidia_query_nvml.ECCErrors{
+					{
+						Volatile: nvidia_query_nvml.AllECCErrorCounts{
+							Total: nvidia_query_nvml.ECCErrorCounts{
+								Uncorrected: 20,
+							},
+						},
+					},
+				},
+				VolatileUncorrectedErrors: []string{"[GPU-2] total uncorrected 20 errors"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ToOutput(tt.input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("ToOutput()\n%+v\n\nwant\n%+v", result.VolatileUncorrectedErrors, tt.expected.VolatileUncorrectedErrors)
+			}
+
+			b, err := result.JSON()
+			if err != nil {
+				t.Errorf("JSON()\n%+v", err)
+			}
+
+			parsed, err := ParseOutputJSON(b)
+			if err != nil {
+				t.Errorf("ParseOutputJSON()\n%+v", err)
+			}
+
+			if !reflect.DeepEqual(parsed, result) {
+				t.Errorf("ParseOutputJSON()\n%+v\n\nwant\n%+v", parsed, result)
+			}
+		})
+	}
+}
+
 func TestToOutputECCMode(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/components/accelerator/nvidia/ecc/component_output_test.go
+++ b/components/accelerator/nvidia/ecc/component_output_test.go
@@ -73,6 +73,9 @@ func TestToOutput(t *testing.T) {
 				},
 			},
 			expected: &Output{
+				ECCModes: []nvidia_query_nvml.ECCMode{
+					{},
+				},
 				ErrorCountsNVML: []nvidia_query_nvml.ECCErrors{
 					{
 						Volatile: nvidia_query_nvml.AllECCErrorCounts{
@@ -91,7 +94,7 @@ func TestToOutput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := ToOutput(tt.input)
 			if !reflect.DeepEqual(result, tt.expected) {
-				t.Errorf("ToOutput()\n%+v\n\nwant\n%+v", result.VolatileUncorrectedErrors, tt.expected.VolatileUncorrectedErrors)
+				t.Errorf("ToOutput()\n%+v\n\nwant\n%+v", result, tt.expected)
 			}
 
 			b, err := result.JSON()

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -4,7 +4,7 @@
 
 - [**`accelerator-nvidia-clock`**](https://pkg.go.dev/github.com/leptonai/gpud/components/accelerator/nvidia/clock): Monitors NVIDIA GPU clock events of all GPUs, such as HW Slowdown events.
 - [**`accelerator-nvidia-clock-speed`**](https://pkg.go.dev/github.com/leptonai/gpud/components/accelerator/nvidia/clock-speed): Tracks the per-GPU clock speed.
-- [**`accelerator-nvidia-ecc`**](https://pkg.go.dev/github.com/leptonai/gpud/components/accelerator/nvidia/ecc): Tracks the NVIDIA per-GPU ECC errors.
+- [**`accelerator-nvidia-ecc`**](https://pkg.go.dev/github.com/leptonai/gpud/components/accelerator/nvidia/ecc): Tracks the NVIDIA per-GPU ECC errors and other ECC related information.
 - [**`accelerator-nvidia-error`**](https://pkg.go.dev/github.com/leptonai/gpud/components/accelerator/nvidia/error): Tracks NVIDIA GPU errors real-time in the SMI queries -- likely requires host restarts.
 - [**`accelerator-nvidia-error-sxid`**](https://pkg.go.dev/github.com/leptonai/gpud/components/accelerator/nvidia/error/sxid): Tracks the NVIDIA GPU SXid errors scanning the dmesg -- see [fabric manager documentation](https://docs.nvidia.com/datacenter/tesla/pdf/fabric-manager-user-guide.pdf).
 - [**`accelerator-nvidia-error-xid`**](https://pkg.go.dev/github.com/leptonai/gpud/components/accelerator/nvidia/error/xid): Tracks the NVIDIA GPU Xid errors scanning the dmesg and using the NVIDIA Management Library (NVML) -- see [Xid messages](https://docs.nvidia.com/deploy/gpu-debug-guidelines/index.html#xid-messages).


### PR DESCRIPTION
https://github.com/leptonai/gpud/pull/86 is now tracking "ECC Mode", regardless of its error counts.

Thus, renaming the state key to "ecc", not "ecc-errors".