### PR TITLE
feat(components): add accelerator detect func, "gpud accelerator" subcommand

### DIFF
--- a/cmd/gpud/command/accelerator.go
+++ b/cmd/gpud/command/accelerator.go
@@ -1,0 +1,23 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/leptonai/gpud/components/accelerator"
+
+	"github.com/urfave/cli"
+)
+
+func cmdAccelerator(cliContext *cli.Context) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	acceleratorType, productName, err := accelerator.DetectTypeAndProductName(ctx)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("accelerator type: %s\nproduct name: %s\n", acceleratorType, productName)
+	return nil
+}

--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -330,12 +330,16 @@ sudo rm /etc/systemd/system/gpud.service
 
 		// for checking gpud status
 		{
-			Name:   "status",
+			Name:    "status",
+			Aliases: []string{"st"},
+
 			Usage:  "checks the status of gpud",
 			Action: cmdStatus,
 		},
 		{
-			Name:   "logs",
+			Name:    "logs",
+			Aliases: []string{"l"},
+
 			Usage:  "checks the gpud logs",
 			Action: cmdLogs,
 			Flags: []cli.Flag{
@@ -348,9 +352,19 @@ sudo rm /etc/systemd/system/gpud.service
 			},
 		},
 
+		{
+			Name:    "accelerator",
+			Aliases: []string{"a"},
+
+			Usage:  "quick scans the currently installed accelerator",
+			Action: cmdAccelerator,
+		},
+
 		// for diagnose + quick scanning
 		{
-			Name:  "diagnose",
+			Name:    "diagnose",
+			Aliases: []string{"d"},
+
 			Usage: "collects diagnose information",
 			UsageText: `# to collect diagnose information
 sudo gpud diagnose
@@ -358,8 +372,7 @@ sudo gpud diagnose
 # check the auto-generated summary file
 cat summary.txt
 `,
-			Action:  cmdDiagnose,
-			Aliases: []string{"d"},
+			Action: cmdDiagnose,
 			Flags: []cli.Flag{
 				&cli.BoolTFlag{
 					Name:        "create-archive (default: true)",
@@ -369,7 +382,9 @@ cat summary.txt
 			},
 		},
 		{
-			Name:   "scan",
+			Name:    "scan",
+			Aliases: []string{"s"},
+
 			Usage:  "quick scans the host for any major issues",
 			Action: cmdScan,
 			Flags: []cli.Flag{

--- a/components/accelerator/detect.go
+++ b/components/accelerator/detect.go
@@ -1,0 +1,67 @@
+package accelerator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/leptonai/gpud/pkg/file"
+
+	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	nvinfo "github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+type Type string
+
+const (
+	TypeUnknown Type = "unknown"
+	TypeNVIDIA  Type = "nvidia"
+)
+
+// Returns the GPU type (e.g., "NVIDIA") and product name (e.g., "A100")
+func DetectTypeAndProductName(ctx context.Context) (Type, string, error) {
+	if p, err := file.LocateExecutable("nvidia-smi"); p != "" && err == nil {
+		productName, err := LoadNVIDIAProductName(ctx)
+		if err != nil {
+			return TypeNVIDIA, "unknown", err
+		}
+		return TypeNVIDIA, productName, nil
+	}
+
+	return TypeUnknown, "unknown", nil
+}
+
+func LoadNVIDIAProductName(ctx context.Context) (string, error) {
+	nvmlLib := nvml.New()
+	if ret := nvmlLib.Init(); ret != nvml.SUCCESS {
+		return "", fmt.Errorf("failed to initialize NVML: %v", nvml.ErrorString(ret))
+	}
+
+	deviceLib := device.New(nvmlLib)
+	infoLib := nvinfo.New(
+		nvinfo.WithNvmlLib(nvmlLib),
+		nvinfo.WithDeviceLib(deviceLib),
+	)
+
+	nvmlExists, nvmlExistsMsg := infoLib.HasNvml()
+	if !nvmlExists {
+		return "", fmt.Errorf("NVML not found: %s", nvmlExistsMsg)
+	}
+
+	devices, err := deviceLib.GetDevices()
+	if err != nil {
+		return "", err
+	}
+
+	for _, d := range devices {
+		name, ret := d.GetName()
+		if ret != nvml.SUCCESS {
+			return "", fmt.Errorf("failed to get device name: %v", nvml.ErrorString(ret))
+		}
+		if name != "" {
+			return name, nil
+		}
+	}
+
+	return "", nil
+}

--- a/components/accelerator/nvidia/query/nvidia_smi_query.go
+++ b/components/accelerator/nvidia/query/nvidia_smi_query.go
@@ -10,13 +10,15 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/leptonai/gpud/pkg/file"
+
 	"sigs.k8s.io/yaml"
 )
 
 // Returns true if the local machine runs on Nvidia GPU
 // by running "nvidia-smi".
 func SMIExists() bool {
-	p, err := exec.LookPath("nvidia-smi")
+	p, err := file.LocateExecutable("nvidia-smi")
 	if err != nil {
 		return false
 	}
@@ -24,7 +26,7 @@ func SMIExists() bool {
 }
 
 func RunSMI(ctx context.Context, args ...string) ([]byte, error) {
-	p, err := exec.LookPath("nvidia-smi")
+	p, err := file.LocateExecutable("nvidia-smi")
 	if err != nil {
 		return nil, fmt.Errorf("nvidia-smi not found (%w)", err)
 	}


### PR DESCRIPTION
```
gpud -h
NAME:
   gpud -
# to quick scan for your machine health status
gpud scan

# to start gpud as a systemd unit
sudo gpud up


USAGE:
   gpud [global options] command [command options] [arguments...]

VERSION:
   a1f836a

DESCRIPTION:
   monitor your GPU/CPU machines and run workloads

COMMANDS:
   login           login gpud to lepton.ai (called automatically in gpud up with non-empty --token)
   up              initialize and start gpud in a daemon mode (systemd)
   down            stop gpud systemd unit
   run             starts gpud without any login/checkin ('gpud up' is recommended for linux)
   update          update gpud
   release         release gpud
   status, st      checks the status of gpud
   logs, l         checks the gpud logs
   accelerator, a  quick scans the currently installed accelerator
   diagnose, d     collects diagnose information
   scan, s         quick scans the host for any major issues
   help, h         Shows a list of commands or help for one command
```

```
gpud a
accelerator type: nvidia
product name: NVIDIA H100 80GB HBM3
```

when `nvidia-smi` returns:

```
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.161.08             Driver Version: 535.161.08   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA H100 80GB HBM3          On  | 00000000:19:00.0 Off |                    0 |
| N/A   38C    P0             301W / 700W |  53847MiB / 81559MiB |    100%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
```