### PR TITLE
feat(nvidia/ibstat): check "Physical state" as fallback

### DIFF
--- a/components/accelerator/nvidia/infiniband/component_output.go
+++ b/components/accelerator/nvidia/infiniband/component_output.go
@@ -4,11 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/leptonai/gpud/components"
 	nvidia_query "github.com/leptonai/gpud/components/accelerator/nvidia/query"
-
-	"sigs.k8s.io/yaml"
 )
 
 // ToOutput converts nvidia_query.Output to Output.
@@ -84,11 +83,7 @@ func ParseStatesToOutput(states ...components.State) (*Output, error) {
 // Returns the output evaluation reason and its healthy-ness.
 func (o *Output) Evaluate() (string, bool, error) {
 	if len(o.Ibstat.Errors) > 0 {
-		yb, err := yaml.Marshal(o.Ibstat.Errors)
-		if err != nil {
-			return "", false, err
-		}
-		return fmt.Sprintf("ibstat errors found:\n\n%s", string(yb)), false, nil
+		return fmt.Sprintf("ibstat errors found: %s", strings.Join(o.Ibstat.Errors, ", ")), false, nil
 	}
 	return "no ibstat error found", true, nil
 }

--- a/components/accelerator/nvidia/query/ibstat.go
+++ b/components/accelerator/nvidia/query/ibstat.go
@@ -42,8 +42,8 @@ func RunIbstat(ctx context.Context) (*IbstatOutput, error) {
 }
 
 var (
-	ErrIbstatOutputBrokenStateDown        = errors.New("ibstat output unexpected; found State: Down")
-	ErrIbstatOutputBrokenPhysicalDisabled = errors.New("ibstat output unexpected; found Physical state: Disabled")
+	ErrIbstatOutputBrokenStateDown        = errors.New("ibstat output unexpected; found State: Down (check the physical switch)")
+	ErrIbstatOutputBrokenPhysicalDisabled = errors.New("ibstat output unexpected; found Physical state: Disabled (check the physical switch)")
 )
 
 func ValidateIbstatOutput(s string) error {

--- a/components/accelerator/nvidia/query/ibstat.go
+++ b/components/accelerator/nvidia/query/ibstat.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -40,10 +41,22 @@ func RunIbstat(ctx context.Context) (*IbstatOutput, error) {
 	return o, nil
 }
 
+var (
+	ErrIbstatOutputBrokenStateDown        = errors.New("ibstat output seems broken; found State: Down")
+	ErrIbstatOutputBrokenPhysicalDisabled = errors.New("ibstat output seems broken; found Physical state: Disabled")
+)
+
 func ValidateIbstatOutput(s string) error {
 	if strings.Contains(s, "State: Down") {
-		return fmt.Errorf("ibstat output seems broken; found State: Down")
+		return ErrIbstatOutputBrokenStateDown
 	}
+
+	// needs
+	// "ip link set <dev> up"
+	if strings.Contains(s, "Physical state: Disabled") {
+		return ErrIbstatOutputBrokenPhysicalDisabled
+	}
+
 	return nil
 }
 

--- a/components/accelerator/nvidia/query/ibstat.go
+++ b/components/accelerator/nvidia/query/ibstat.go
@@ -43,7 +43,7 @@ func RunIbstat(ctx context.Context) (*IbstatOutput, error) {
 
 var (
 	ErrIbstatOutputBrokenStateDown        = errors.New("ibstat output unexpected; found State: Down")
-	ErrIbstatOutputBrokenPhysicalDisabled = errors.New("ibstat output seems broken; found Physical state: Disabled")
+	ErrIbstatOutputBrokenPhysicalDisabled = errors.New("ibstat output unexpected; found Physical state: Disabled")
 )
 
 func ValidateIbstatOutput(s string) error {

--- a/components/accelerator/nvidia/query/ibstat.go
+++ b/components/accelerator/nvidia/query/ibstat.go
@@ -42,7 +42,7 @@ func RunIbstat(ctx context.Context) (*IbstatOutput, error) {
 }
 
 var (
-	ErrIbstatOutputBrokenStateDown        = errors.New("ibstat output seems broken; found State: Down")
+	ErrIbstatOutputBrokenStateDown        = errors.New("ibstat output unexpected; found State: Down")
 	ErrIbstatOutputBrokenPhysicalDisabled = errors.New("ibstat output seems broken; found Physical state: Disabled")
 )
 

--- a/components/accelerator/nvidia/query/ibstat_test.go
+++ b/components/accelerator/nvidia/query/ibstat_test.go
@@ -2,10 +2,9 @@ package query
 
 import "testing"
 
-func TestValidateIbstatOutputBrokenCase(t *testing.T) {
+func TestValidateIbstatOutputErrIbstatOutputBrokenStateDown(t *testing.T) {
 	t.Parallel()
 
-	// This case was found in https://github.com/leptonai/lepton/issues/7521
 	outputWithErr := `
 
 CA 'mlx5_11'
@@ -27,8 +26,37 @@ CA 'mlx5_11'
 		Link layer: Ethernet
 	`
 	err := ValidateIbstatOutput(outputWithErr)
-	if err == nil {
-		t.Errorf("broken ibstat output passed validation")
+	if err != ErrIbstatOutputBrokenStateDown {
+		t.Errorf("ibstat output did not pass validation")
+	}
+}
+
+func TestValidateIbstatOutputErrIbstatOutputBrokenPhysicalDisabled(t *testing.T) {
+	t.Parallel()
+
+	outputWithErr := `
+
+CA 'mlx5_11'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300bb3514
+	System image GUID: 0xa088c20300bb3514
+	Port 1:
+		State: Active
+		Physical state: Disabled
+		Rate: 40
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+	`
+	err := ValidateIbstatOutput(outputWithErr)
+	if err != ErrIbstatOutputBrokenPhysicalDisabled {
+		t.Errorf("ibstat output did not pass validation")
 	}
 }
 


### PR DESCRIPTION
Should not happen... but in case our hard-coded ibstat "State" string match fails (e.g., breaking API changes), we fallback to "Physical state" for link status checking.

```
CA 'mlx5_8'
	CA type: MT4125
	Number of ports: 1
	Firmware version: 22.39.1002
	Hardware version: 0
	Node GUID: 0xe8ebd303003307df
	System image GUID: 0xe8ebd303003307de
	Port 1:
		State: Down
		Physical state: Disabled
```