### PR TITLE
fix(components/accelerator-nvidia-ecc): do not unhealthy when driver recovers uncorrectable ecc errors

### DIFF
--- a/components/accelerator/nvidia/ecc/component_output.go
+++ b/components/accelerator/nvidia/ecc/component_output.go
@@ -115,16 +115,14 @@ func (o *Output) States() ([]components.State, error) {
 	// as aggregate counts persist across reboots
 	// ignore it for settings the healthy
 	if len(o.VolatileUncorrectedErrorsFromSMI) > 0 {
-		reasons = append(reasons, fmt.Sprintf("%d volatile errors found (from nvidia-smi): %s",
+		reasons = append(reasons, fmt.Sprintf("%d volatile errors found (from nvidia-smi)",
 			len(o.VolatileUncorrectedErrorsFromSMI),
-			strings.Join(o.VolatileUncorrectedErrorsFromSMI, ", "),
 		))
 	}
 
 	if len(o.VolatileUncorrectedErrorsFromNVML) > 0 {
-		reasons = append(reasons, fmt.Sprintf("%d volatile errors found (from nvml): %s",
+		reasons = append(reasons, fmt.Sprintf("%d volatile errors found (from nvml)",
 			len(o.VolatileUncorrectedErrorsFromNVML),
-			strings.Join(o.VolatileUncorrectedErrorsFromNVML, ", "),
 		))
 	}
 
@@ -132,7 +130,7 @@ func (o *Output) States() ([]components.State, error) {
 	if len(reason) == 0 {
 		reason = "no issue detected"
 	} else {
-		reason = fmt.Sprintf("note that when an uncorrectable ECC error is detected, the NVIDIA driver software will perform error recovery -- details of ecc status are: %s", reason)
+		reason = fmt.Sprintf("note that when an uncorrectable ECC error is detected, the NVIDIA driver software will perform error recovery -- %s", reason)
 	}
 
 	b, _ := o.JSON()

--- a/components/accelerator/nvidia/ecc/component_output.go
+++ b/components/accelerator/nvidia/ecc/component_output.go
@@ -29,7 +29,7 @@ func ToOutput(i *nvidia_query.Output) *Output {
 			o.ErrorCountsSMI = append(o.ErrorCountsSMI, *g.ECCErrors)
 
 			if errs := g.ECCErrors.FindVolatileUncorrectableErrs(); len(errs) > 0 {
-				o.VolatileUncorrectedErrors = append(o.VolatileUncorrectedErrors, fmt.Sprintf("[%s] %s", g.ID, strings.Join(errs, ", ")))
+				o.VolatileUncorrectedErrorsFromSMI = append(o.VolatileUncorrectedErrorsFromSMI, fmt.Sprintf("[%s] %s", g.ID, strings.Join(errs, ", ")))
 			}
 		}
 	}
@@ -40,7 +40,7 @@ func ToOutput(i *nvidia_query.Output) *Output {
 			o.ErrorCountsNVML = append(o.ErrorCountsNVML, dev.ECCErrors)
 
 			if errs := dev.ECCErrors.Volatile.FindUncorrectedErrs(); len(errs) > 0 {
-				o.VolatileUncorrectedErrors = append(o.VolatileUncorrectedErrors, fmt.Sprintf("[%s] %s", dev.UUID, strings.Join(errs, ", ")))
+				o.VolatileUncorrectedErrorsFromNVML = append(o.VolatileUncorrectedErrorsFromNVML, fmt.Sprintf("[%s] %s", dev.UUID, strings.Join(errs, ", ")))
 			}
 		}
 	}
@@ -56,13 +56,15 @@ type Output struct {
 
 	// Volatile counts are reset each time the driver loads.
 	// As aggregate counts persist across reboots (i.e. for the lifetime of the device),
-	// do not track separately.
+	// we do not track separately.
 	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceEnumvs.html#group__nvmlDeviceEnumvs_1g08978d1c4fb52b6a4c72b39de144f1d9
 	//
-	// A memory error that was not correctedFor ECC errors, these are double bit errors.
+	// A memory error that was not corrected.
+	// For ECC errors, these are double bit errors.
 	// For Texture memory, these are errors where the resend fails.
 	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceEnumvs.html#group__nvmlDeviceEnumvs_1gc5469bd68b9fdcf78734471d86becb24
-	VolatileUncorrectedErrors []string `json:"volatile_uncorrected_errors"`
+	VolatileUncorrectedErrorsFromSMI  []string `json:"volatile_uncorrected_errors_from_smi"`
+	VolatileUncorrectedErrorsFromNVML []string `json:"volatile_uncorrected_errors_from_nvml"`
 }
 
 func (o *Output) JSON() ([]byte, error) {
@@ -108,22 +110,41 @@ func ParseStatesToOutput(states ...components.State) (*Output, error) {
 }
 
 func (o *Output) States() ([]components.State, error) {
-	reasons := ""
+	reasons := []string{}
 
 	// as aggregate counts persist across reboots
 	// ignore it for settings the healthy
-	if len(o.VolatileUncorrectedErrors) > 0 {
-		reasons = fmt.Sprintf("%d volatile errors found (from nvidia-smi and nvml): %s",
-			len(o.VolatileUncorrectedErrors),
-			strings.Join(o.VolatileUncorrectedErrors, ", "),
-		)
+	if len(o.VolatileUncorrectedErrorsFromSMI) > 0 {
+		reasons = append(reasons, fmt.Sprintf("%d volatile errors found (from nvidia-smi): %s",
+			len(o.VolatileUncorrectedErrorsFromSMI),
+			strings.Join(o.VolatileUncorrectedErrorsFromSMI, ", "),
+		))
+	}
+
+	if len(o.VolatileUncorrectedErrorsFromNVML) > 0 {
+		reasons = append(reasons, fmt.Sprintf("%d volatile errors found (from nvml): %s",
+			len(o.VolatileUncorrectedErrorsFromNVML),
+			strings.Join(o.VolatileUncorrectedErrorsFromNVML, ", "),
+		))
+	}
+
+	reason := strings.Join(reasons, "; ")
+	if len(reason) == 0 {
+		reason = "no issue detected"
+	} else {
+		reason = fmt.Sprintf("note that when an uncorrectable ECC error is detected, the NVIDIA driver software will perform error recovery -- details of ecc status are: %s", reason)
 	}
 
 	b, _ := o.JSON()
 	state := components.State{
-		Name:    StateNameECC,
-		Healthy: len(o.VolatileUncorrectedErrors) == 0,
-		Reason:  reasons,
+		Name: StateNameECC,
+
+		// no reason to mark this unhealthy as "when an uncorrectable ECC error is detected, the NVIDIA driver software will perform error recovery."
+		// we only mark this unhealthy when the pending row remapping is >0 (which requires GPU reset)
+		// ref. https://docs.nvidia.com/deploy/a100-gpu-mem-error-mgmt/index.html
+		Healthy: true,
+
+		Reason: reason,
 		ExtraInfo: map[string]string{
 			StateKeyECCData:     string(b),
 			StateKeyECCEncoding: StateValueECCEncodingJSON,

--- a/components/accelerator/nvidia/ecc/component_output_test.go
+++ b/components/accelerator/nvidia/ecc/component_output_test.go
@@ -51,7 +51,7 @@ func TestToOutput(t *testing.T) {
 						},
 					},
 				},
-				VolatileUncorrectedErrors: []string{"[GPU-1] GPU : Volatile DRAMUncorrectable: 6"},
+				VolatileUncorrectedErrorsFromSMI: []string{"[GPU-1] GPU : Volatile DRAMUncorrectable: 6"},
 			},
 		},
 		{
@@ -85,7 +85,7 @@ func TestToOutput(t *testing.T) {
 						},
 					},
 				},
-				VolatileUncorrectedErrors: []string{"[GPU-2] total uncorrected 20 errors"},
+				VolatileUncorrectedErrorsFromNVML: []string{"[GPU-2] total uncorrected 20 errors"},
 			},
 		},
 	}

--- a/components/accelerator/nvidia/query/nvml/ecc_errors.go
+++ b/components/accelerator/nvidia/query/nvml/ecc_errors.go
@@ -80,7 +80,8 @@ type ECCErrorCounts struct {
 	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceEnumvs.html#group__nvmlDeviceEnumvs_1gc5469bd68b9fdcf78734471d86becb24
 	Corrected uint64 `json:"corrected"`
 
-	// A memory error that was not correctedFor ECC errors, these are double bit errors.
+	// A memory error that was not corrected.
+	// For ECC errors, these are double bit errors.
 	// For Texture memory, these are errors where the resend fails.
 	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceEnumvs.html#group__nvmlDeviceEnumvs_1gc5469bd68b9fdcf78734471d86becb24
 	Uncorrected uint64 `json:"uncorrected"`
@@ -150,7 +151,8 @@ func GetECCErrors(uuid string, dev device.Device, eccModeEnabledCurrent bool) (E
 
 	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g9748430b6aa6cdbb2349c5e835d70b0f
 	result.Aggregate.Total.Uncorrected, ret = dev.GetTotalEccErrors(
-		// A memory error that was not correctedFor ECC errors, these are double bit errors.
+		// A memory error that was not corrected.
+		// For ECC errors, these are double bit errors.
 		// For Texture memory, these are errors where the resend fails.
 		// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceEnumvs.html#group__nvmlDeviceEnumvs_1gc5469bd68b9fdcf78734471d86becb24
 		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,
@@ -182,7 +184,8 @@ func GetECCErrors(uuid string, dev device.Device, eccModeEnabledCurrent bool) (E
 
 	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g9748430b6aa6cdbb2349c5e835d70b0f
 	result.Volatile.Total.Uncorrected, ret = dev.GetTotalEccErrors(
-		// A memory error that was not correctedFor ECC errors, these are double bit errors.
+		// A memory error that was not corrected.
+		// For ECC errors, these are double bit errors.
 		// For Texture memory, these are errors where the resend fails.
 		// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceEnumvs.html#group__nvmlDeviceEnumvs_1gc5469bd68b9fdcf78734471d86becb24
 		nvml.MEMORY_ERROR_TYPE_UNCORRECTED,


### PR DESCRIPTION
> when an uncorrectable ECC error is detected, the NVIDIA driver software will perform error recovery.

Meaning, as long as NVIDIA performs row remapping, we don't need to mark this unhealthy. Instead, we monitor remapping-rows component for potential system reboot or gpu reset suggested actions

ref. https://docs.nvidia.com/deploy/a100-gpu-mem-error-mgmt/index.html

Fix

<img width="520" alt="Screenshot 2024-10-09 at 4 52 55 PM" src="https://github.com/user-attachments/assets/8c453447-eb09-49e2-9749-4c34f413e505">

<img width="614" alt="Screenshot 2024-10-09 at 7 13 07 PM" src="https://github.com/user-attachments/assets/4c4221be-b785-40b8-8c16-4d5083011a0a">
