### PR TITLE
fix(k8s/pod): "gpud run --kubelet-ignore-connection-errors" to not mark unhealthy when read only port is not open (does not ignore by default)

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -43,6 +43,8 @@ var (
 
 	enableAutoUpdate bool
 	filesToCheck     cli.StringSlice
+
+	kubeletIgnoreConnectionErrors bool
 )
 
 const (
@@ -194,6 +196,11 @@ sudo rm /etc/systemd/system/gpud.service
 					Name:  "files-to-check",
 					Usage: "enable 'file' component that returns healthy if and only if all the files exist (default: [], use '--files-to-check=a --files-to-check=b' for multiple files)",
 					Value: &filesToCheck,
+				},
+				&cli.BoolFlag{
+					Name:        "kubelet-ignore-connection-errors",
+					Usage:       "ignore connection errors to kubelet read-only port, useful when kubelet readOnlyPort is disabled (default: false)",
+					Destination: &kubeletIgnoreConnectionErrors,
 				},
 			},
 		},

--- a/cmd/gpud/command/run.go
+++ b/cmd/gpud/command/run.go
@@ -37,8 +37,13 @@ func cmdRun(cliContext *cli.Context) error {
 		gin.SetMode(gin.DebugMode)
 	}
 
+	configOpts := []config.OpOption{
+		config.WithFilesToCheck(filesToCheck...),
+		config.WithKubeletIgnoreConnectionErrors(kubeletIgnoreConnectionErrors),
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	cfg, err := config.DefaultConfig(ctx, config.WithFilesToCheck(filesToCheck...))
+	cfg, err := config.DefaultConfig(ctx, configOpts...)
 	cancel()
 	if err != nil {
 		return err
@@ -88,7 +93,7 @@ func cmdRun(cliContext *cli.Context) error {
 	// we don't miss any signals during boot
 	signal.Notify(signals, handledSignals...)
 
-	server, err := lepServer.New(rootCtx, cfg, cliContext.String("endpoint"), uid)
+	server, err := lepServer.New(rootCtx, cfg, cliContext.String("endpoint"), uid, configOpts...)
 	if err != nil {
 		return err
 	}

--- a/components/k8s/pod/component.go
+++ b/components/k8s/pod/component.go
@@ -27,6 +27,7 @@ func New(ctx context.Context, cfg Config) components.Component {
 		rootCtx: ctx,
 		cancel:  ccancel,
 		poller:  GetDefaultPoller(),
+		cfg:     cfg,
 	}
 }
 
@@ -36,6 +37,8 @@ type component struct {
 	rootCtx context.Context
 	cancel  context.CancelFunc
 	poller  query.Poller
+
+	cfg Config
 }
 
 func (c *component) Name() string { return Name }
@@ -73,7 +76,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
 	}
-	return output.States()
+	return output.States(c.cfg)
 }
 
 func (c *component) Events(ctx context.Context, since time.Time) ([]components.Event, error) {

--- a/components/k8s/pod/component_output.go
+++ b/components/k8s/pod/component_output.go
@@ -23,6 +23,7 @@ type Output struct {
 	NodeName string      `json:"node_name,omitempty"`
 	Pods     []PodStatus `json:"pods,omitempty"`
 
+	ConnectionError        string `json:"connection_error,omitempty"`
 	ConnectionErrorIgnored bool   `json:"connection_error_ignored"`
 	Message                string `json:"message,omitempty"`
 }
@@ -130,6 +131,7 @@ func CreateGet(cfg Config) query.GetFunc {
 			if cfg.IgnoreConnectionErrors && connectionErr {
 				log.Logger.Warnw("failed to list pods from kubelet read-only port but ignoring since ignore_connection_errors is true", "error", err)
 				return &Output{
+					ConnectionError:        err.Error(),
 					ConnectionErrorIgnored: true,
 					Message:                "failed to list pods from kubelet read-only port but ignoring (maybe readOnlyPort not set in kubelet config file)",
 				}, nil

--- a/components/k8s/pod/component_output.go
+++ b/components/k8s/pod/component_output.go
@@ -78,11 +78,17 @@ func (o *Output) describeReason() string {
 	return fmt.Sprintf("total %d pods (node %s)", len(o.Pods), o.NodeName)
 }
 
-func (o *Output) States() ([]components.State, error) {
+func (o *Output) States(cfg Config) ([]components.State, error) {
+	healthy := o.ConnectionError == ""
+	if cfg.IgnoreConnectionErrors {
+		healthy = true
+	}
+
 	b, _ := o.JSON()
+
 	return []components.State{{
 		Name:    StateNamePod,
-		Healthy: true,
+		Healthy: healthy,
 		Reason:  o.describeReason(),
 		ExtraInfo: map[string]string{
 			StateKeyPodData:     string(b),

--- a/components/k8s/pod/component_output.go
+++ b/components/k8s/pod/component_output.go
@@ -22,7 +22,9 @@ import (
 type Output struct {
 	NodeName string      `json:"node_name,omitempty"`
 	Pods     []PodStatus `json:"pods,omitempty"`
-	Message  string      `json:"message,omitempty"`
+
+	ConnectionErrorIgnored bool   `json:"connection_error_ignored"`
+	Message                string `json:"message,omitempty"`
 }
 
 func (o *Output) JSON() ([]byte, error) {
@@ -128,7 +130,8 @@ func CreateGet(cfg Config) query.GetFunc {
 			if cfg.IgnoreConnectionErrors && connectionErr {
 				log.Logger.Warnw("failed to list pods from kubelet read-only port but ignoring since ignore_connection_errors is true", "error", err)
 				return &Output{
-					Message: "failed to list pods from kubelet read-only port but ignoring (maybe readOnlyPort not set in kubelet config file)",
+					ConnectionErrorIgnored: true,
+					Message:                "failed to list pods from kubelet read-only port but ignoring (maybe readOnlyPort not set in kubelet config file)",
 				}, nil
 			}
 			return nil, err

--- a/components/k8s/pod/config.go
+++ b/components/k8s/pod/config.go
@@ -11,6 +11,10 @@ import (
 type Config struct {
 	Query query_config.Config `json:"query"`
 	Port  int                 `json:"port"`
+
+	// In case the kubelet does not open the read-only port, we ignore such errors as
+	// 'Get "http://localhost:10255/pods": dial tcp 127.0.0.1:10255: connect: connection refused'.
+	IgnoreConnectionErrors bool `json:"ignore_connection_errors"`
 }
 
 func ParseConfig(b any, db *sql.DB) (*Config, error) {

--- a/config/default.go
+++ b/config/default.go
@@ -67,7 +67,7 @@ var (
 
 func DefaultConfig(ctx context.Context, opts ...OpOption) (*Config, error) {
 	options := &Op{}
-	if err := options.applyOpts(opts); err != nil {
+	if err := options.ApplyOpts(opts); err != nil {
 		return nil, err
 	}
 
@@ -104,8 +104,8 @@ func DefaultConfig(ctx context.Context, opts ...OpOption) (*Config, error) {
 		EnableAutoUpdate: true,
 	}
 
-	if len(options.filesToCheck) > 0 {
-		cfg.Components[file.Name] = options.filesToCheck
+	if len(options.FilesToCheck) > 0 {
+		cfg.Components[file.Name] = options.FilesToCheck
 	}
 
 	if cc, exists := DefaultDockerContainerComponent(ctx); exists {
@@ -114,7 +114,7 @@ func DefaultConfig(ctx context.Context, opts ...OpOption) (*Config, error) {
 	if cc, exists := DefaultContainerdComponent(ctx); exists {
 		cfg.Components[containerd_pod.Name] = cc
 	}
-	if cc, exists := DefaultK8sPodComponent(ctx); exists {
+	if cc, exists := DefaultK8sPodComponent(ctx, options.KubeletIgnoreConnectionErrors); exists {
 		cfg.Components[k8s_pod.Name] = cc
 	}
 
@@ -355,7 +355,7 @@ func DefaultDockerContainerComponent(ctx context.Context) (any, bool) {
 	return nil, false
 }
 
-func DefaultK8sPodComponent(ctx context.Context) (any, bool) {
+func DefaultK8sPodComponent(ctx context.Context, ignoreConnectionErrors bool) (any, bool) {
 	if runtime.GOOS != "linux" {
 		log.Logger.Debugw("ignoring default kubelet checking since it's not linux", "os", runtime.GOOS)
 		return nil, false
@@ -389,8 +389,9 @@ func DefaultK8sPodComponent(ctx context.Context) (any, bool) {
 			// "k8s_pod" requires kubelet read-only port
 			// assume if kubelet is running, it opens the most common read-only port 10255
 			return k8s_pod.Config{
-				Query: query_config.DefaultConfig(),
-				Port:  k8s_pod.DefaultKubeletReadOnlyPort,
+				Query:                  query_config.DefaultConfig(),
+				Port:                   k8s_pod.DefaultKubeletReadOnlyPort,
+				IgnoreConnectionErrors: ignoreConnectionErrors,
 			}, true
 		}
 	}

--- a/config/op_options.go
+++ b/config/op_options.go
@@ -1,12 +1,13 @@
 package config
 
 type Op struct {
-	filesToCheck []string
+	FilesToCheck                  []string
+	KubeletIgnoreConnectionErrors bool
 }
 
 type OpOption func(*Op)
 
-func (op *Op) applyOpts(opts []OpOption) error {
+func (op *Op) ApplyOpts(opts []OpOption) error {
 	for _, opt := range opts {
 		opt(op)
 	}
@@ -16,6 +17,12 @@ func (op *Op) applyOpts(opts []OpOption) error {
 
 func WithFilesToCheck(files ...string) OpOption {
 	return func(op *Op) {
-		op.filesToCheck = append(op.filesToCheck, files...)
+		op.FilesToCheck = append(op.FilesToCheck, files...)
+	}
+}
+
+func WithKubeletIgnoreConnectionErrors(b bool) OpOption {
+	return func(op *Op) {
+		op.KubeletIgnoreConnectionErrors = b
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -72,6 +72,7 @@ import (
 	"github.com/leptonai/gpud/components/state"
 	component_systemd "github.com/leptonai/gpud/components/systemd"
 	"github.com/leptonai/gpud/components/tailscale"
+	gpud_config "github.com/leptonai/gpud/config"
 	lepconfig "github.com/leptonai/gpud/config"
 	_ "github.com/leptonai/gpud/docs/apis"
 	"github.com/leptonai/gpud/internal/login"
@@ -90,7 +91,12 @@ type Server struct {
 	enableAutoUpdate      bool
 }
 
-func New(ctx context.Context, config *lepconfig.Config, endpoint string, cliUID string) (_ *Server, retErr error) {
+func New(ctx context.Context, config *lepconfig.Config, endpoint string, cliUID string, opts ...gpud_config.OpOption) (_ *Server, retErr error) {
+	options := &gpud_config.Op{}
+	if err := options.ApplyOpts(opts); err != nil {
+		return nil, err
+	}
+
 	if err := config.Validate(); err != nil {
 		return nil, fmt.Errorf("failed to validate config: %w", err)
 	}
@@ -933,7 +939,7 @@ func New(ctx context.Context, config *lepconfig.Config, endpoint string, cliUID 
 						componentsToAdd = append(componentsToAdd, docker_container.New(ctx, ccfg))
 					}
 
-					if cc, exists := lepconfig.DefaultK8sPodComponent(ctx); exists {
+					if cc, exists := lepconfig.DefaultK8sPodComponent(ctx, options.KubeletIgnoreConnectionErrors); exists {
 						ccfg := k8s_pod.Config{Query: defaultQueryCfg}
 						if cc != nil {
 							parsed, err := k8s_pod.ParseConfig(cc, db)


### PR DESCRIPTION

Fix

<img width="790" alt="Screenshot 2024-10-09 at 7 42 28 PM" src="https://github.com/user-attachments/assets/0524b10e-9796-486f-a830-c9b1996f5fbf">
