### PR TITLE
feat(nvidia/info): report GPU device count from "/dev" (`DCGM_FR_DEVICE_COUNT_MISMATCH` DCGM)

### DIFF
--- a/components/accelerator/nvidia/query/device_count.go
+++ b/components/accelerator/nvidia/query/device_count.go
@@ -1,0 +1,51 @@
+package query
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+func CountAllDevicesFromDevDir() (int, error) {
+	return countAllDevicesFromDir("/dev")
+}
+
+// "checkPermissions" in "nvvs/plugin_src/software/Software.cpp"
+// ref. https://github.com/NVIDIA/DCGM/blob/903d745504f50153be8293f8566346f9de3b3c93/nvvs/plugin_src/software/Software.cpp#L220-L249
+func countAllDevicesFromDir(dir string) (int, error) {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, err
+	}
+
+	count := 0
+	for _, file := range files {
+		if countDevEntry(file.Name()) && canRead(filepath.Join(dir, file.Name())) {
+			count++
+		}
+	}
+
+	return count, nil
+}
+
+// countDevEntry checks if the entry name matches "nvidia" followed by a number
+// ref. "CountDevEntry" in "nvvs/plugin_src/software/Software.cpp"
+// ref. https://github.com/NVIDIA/DCGM/blob/903d745504f50153be8293f8566346f9de3b3c93/nvvs/plugin_src/software/Software.cpp#L220-L249
+func countDevEntry(entryName string) bool {
+	lastElement := filepath.Base(entryName)
+
+	// check if the entry name ends with "nvidia" followed by a number
+	match, _ := regexp.MatchString(`^nvidia\d+$`, lastElement)
+	return match
+}
+
+// "nvvs/plugin_src/software/Software.cpp"
+// ref. https://github.com/NVIDIA/DCGM/blob/903d745504f50153be8293f8566346f9de3b3c93/nvvs/plugin_src/software/Software.cpp#L220-L249
+func canRead(file string) bool {
+	f, err := os.OpenFile(file, os.O_RDONLY, 0)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	return true
+}

--- a/components/accelerator/nvidia/query/device_count_test.go
+++ b/components/accelerator/nvidia/query/device_count_test.go
@@ -1,0 +1,86 @@
+package query
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCountDevEntry(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "Valid device with /dev prefix",
+			input:    "/dev/nvidia0",
+			expected: true,
+		},
+		{
+			name:     "Valid device with /dev prefix and different number",
+			input:    "/dev/nvidia1",
+			expected: true,
+		},
+		{
+			name:     "Valid device without /dev prefix",
+			input:    "/nvidia2",
+			expected: true,
+		},
+		{
+			name:     "Valid device without /dev prefix and different number",
+			input:    "/nvidia3",
+			expected: true,
+		},
+		{
+			name:     "Invalid device without number",
+			input:    "nvidia",
+			expected: false,
+		},
+		{
+			name:     "Invalid device with non-numeric suffix",
+			input:    "nvidiax",
+			expected: false,
+		},
+		{
+			name:     "Invalid device with prefix",
+			input:    "my_nvidia0",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := countDevEntry(tc.input)
+			if result != tc.expected {
+				t.Errorf("countDevEntry(%q) = %v, want %v", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestCountAllDevicesFromDir(t *testing.T) {
+	testDir := t.TempDir()
+	defer t.Cleanup(func() {
+		_ = os.RemoveAll(testDir)
+	})
+
+	devCnt := 8
+	for i := 0; i < devCnt; i++ {
+		fileName := filepath.Join(testDir, fmt.Sprintf("nvidia%d", i))
+		_, err := os.Create(fileName)
+		if err != nil {
+			t.Fatalf("Failed to create test file %s: %v", fileName, err)
+		}
+	}
+
+	count, err := countAllDevicesFromDir(testDir)
+	if err != nil {
+		t.Fatalf("countAllDevicesFromDir returned an error: %v", err)
+	}
+
+	if count != devCnt {
+		t.Errorf("expected %d devices, but got %d", devCnt, count)
+	}
+}

--- a/components/accelerator/nvidia/query/query.go
+++ b/components/accelerator/nvidia/query/query.go
@@ -62,6 +62,11 @@ func Get(ctx context.Context) (output any, err error) {
 		IbstatExists:          IbstatExists(),
 	}
 
+	o.GPUDeviceCount, err = CountAllDevicesFromDevDir()
+	if err != nil {
+		log.Logger.Warnw("failed to count gpu devices", "error", err)
+	}
+
 	defer func() {
 		getSuccessOnceCloseOnce.Do(func() {
 			close(getSuccessOnce)
@@ -309,6 +314,9 @@ const (
 )
 
 type Output struct {
+	// GPU device count from the /dev directory.
+	GPUDeviceCount int `json:"gpu_device_count"`
+
 	SMIExists      bool       `json:"smi_exists"`
 	SMI            *SMIOutput `json:"smi,omitempty"`
 	SMIQueryErrors []string   `json:"smi_query_errors,omitempty"`

--- a/components/accelerator/nvidia/query/query.go
+++ b/components/accelerator/nvidia/query/query.go
@@ -360,16 +360,6 @@ func (o *Output) GPUCount() int {
 	return cnts
 }
 
-func (o *Output) GPUCountFromSMI() int {
-	if o == nil {
-		return 0
-	}
-	if o.SMI == nil {
-		return 0
-	}
-	return o.SMI.AttachedGPUs
-}
-
 func (o *Output) GPUCountFromNVML() int {
 	if o == nil {
 		return 0
@@ -422,7 +412,6 @@ func (o *Output) PrintInfo(debug bool) {
 	}
 
 	fmt.Printf("%s GPU device count '%d' (from /dev)\n", checkMark, o.GPUDeviceCount)
-	fmt.Printf("%s GPU count '%d' (from nvidia-smi)\n", checkMark, o.GPUCountFromSMI())
 	fmt.Printf("%s GPU count '%d' (from NVML)\n", checkMark, o.GPUCountFromNVML())
 	fmt.Printf("%s GPU product name '%s' (from NVML)\n", checkMark, o.GPUProductNameFromNVML())
 

--- a/components/accelerator/nvidia/query/query.go
+++ b/components/accelerator/nvidia/query/query.go
@@ -393,16 +393,8 @@ func (o *Output) GPUProductName() string {
 	return ""
 }
 
-func (o *Output) GPUProductNameFromSMI() string {
-	if o == nil || o.SMI == nil || len(o.SMI.GPUs) == 0 {
-		return ""
-	}
-	if o.SMI.GPUs[0].ProductName != "" {
-		return o.SMI.GPUs[0].ProductName
-	}
-	return ""
-}
-
+// This is the same product name in nvidia-smi outputs.
+// ref. https://developer.nvidia.com/management-library-nvml
 func (o *Output) GPUProductNameFromNVML() string {
 	if o == nil {
 		return ""
@@ -432,7 +424,6 @@ func (o *Output) PrintInfo(debug bool) {
 	fmt.Printf("%s GPU device count '%d' (from /dev)\n", checkMark, o.GPUDeviceCount)
 	fmt.Printf("%s GPU count '%d' (from nvidia-smi)\n", checkMark, o.GPUCountFromSMI())
 	fmt.Printf("%s GPU count '%d' (from NVML)\n", checkMark, o.GPUCountFromNVML())
-	fmt.Printf("%s GPU product name '%s' (from nvidia-smi)\n", checkMark, o.GPUProductNameFromSMI())
 	fmt.Printf("%s GPU product name '%s' (from NVML)\n", checkMark, o.GPUProductNameFromNVML())
 
 	if o.SMI != nil {


### PR DESCRIPTION
Implementing `DCGM_FR_DEVICE_COUNT_MISMATCH` logic.

Tested

> ⌛ scanning nvidia accelerators
✔ successfully checked nvidia-smi
✔ GPU device count '8' (from /dev)
✔ GPU count '8' (from nvidia-smi)
✔ GPU count '8' (from NVML)
✔ GPU product name 'NVIDIA H100 80GB HBM3' (from nvidia-smi)
✔ GPU product name 'NVIDIA H100 80GB HBM3' (from NVML)