### PR TITLE
feat(reboot): support optional delay reboot (reboot immediately by default)

### DIFF
--- a/internal/session/serve.go
+++ b/internal/session/serve.go
@@ -41,19 +41,19 @@ func (s *Session) serve() {
 			continue
 		}
 
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		if payload.Method == "reboot" {
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-			rerr := reboot.Reboot(ctx, reboot.WithDelaySeconds(3))
-			cancel()
+			rerr := reboot.Reboot(ctx, reboot.WithDelaySeconds(0))
 
 			if rerr != nil {
 				log.Logger.Errorf("failed to trigger reboot machine: %v", rerr)
 			}
+
+			cancel()
 			continue
 		}
 
 		response := &Response{}
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 		switch payload.Method {
 		case "metrics":
 			metrics, err := s.getMetrics(ctx, payload)

--- a/pkg/reboot/reboot.go
+++ b/pkg/reboot/reboot.go
@@ -116,7 +116,10 @@ func Reboot(ctx context.Context, opts ...OpOption) error {
 			return
 		}
 
-		rebootFunc()
+		rerr := rebootFunc()
+
+		// actually, this should not print if reboot worked
+		log.Logger.Warnw("successfully rebooted", "command", cmd, "error", rerr)
 	}()
 
 	log.Logger.Infow(

--- a/pkg/reboot/reboot.go
+++ b/pkg/reboot/reboot.go
@@ -8,12 +8,14 @@ import (
 	"fmt"
 	stdos "os"
 	"strings"
+	"time"
 
 	"github.com/leptonai/gpud/log"
 	"github.com/leptonai/gpud/pkg/process"
 )
 
 type Op struct {
+	delaySeconds int
 	useSystemctl bool
 }
 
@@ -25,6 +27,14 @@ func (op *Op) applyOpts(opts []OpOption) error {
 	}
 
 	return nil
+}
+
+// Specifies the delay seconds before rebooting.
+// Useful for the remote server to get the response from a GPUd daemon.
+func WithDelaySeconds(delaySeconds int) OpOption {
+	return func(op *Op) {
+		op.delaySeconds = delaySeconds
+	}
 }
 
 // Set true to run "systemctl reboot".
@@ -62,32 +72,57 @@ func Reboot(ctx context.Context, opts ...OpOption) error {
 		return err
 	}
 
-	log.Logger.Warnw("rebooting", "command", cmd)
-	if err := proc.Start(ctx); err != nil {
-		return err
-	}
-	// actually, this should not print if reboot worked
-	log.Logger.Infow("successfully rebooted", "command", cmd)
+	rebootFunc := func() error {
+		if err := proc.Start(ctx); err != nil {
+			return err
+		}
 
-	scanner := bufio.NewScanner(proc.StdoutReader())
-	for scanner.Scan() { // returns false at the end of the output
-		line := scanner.Text()
-		fmt.Println("stdout:", line)
-		select {
-		case err := <-proc.Wait():
-			if err != nil {
+		scanner := bufio.NewScanner(proc.StdoutReader())
+		for scanner.Scan() { // returns false at the end of the output
+			line := scanner.Text()
+			fmt.Println("stdout:", line)
+			select {
+			case err := <-proc.Wait():
+				if err != nil {
+					return err
+				}
+			default:
+			}
+		}
+		if serr := scanner.Err(); serr != nil {
+			// process already dead, thus ignore
+			// e.g., "read |0: file already closed"
+			if !strings.Contains(serr.Error(), "file already closed") {
 				return err
 			}
-		default:
 		}
-	}
-	if serr := scanner.Err(); serr != nil {
-		// process already dead, thus ignore
-		// e.g., "read |0: file already closed"
-		if !strings.Contains(serr.Error(), "file already closed") {
-			panic(serr)
-		}
+
+		// actually, this should not print if reboot worked
+		log.Logger.Infow("successfully rebooted", "command", cmd)
+		return nil
 	}
 
+	if options.delaySeconds == 0 {
+		log.Logger.Infow("rebooting immediately", "command", cmd)
+		return rebootFunc()
+	}
+
+	go func() {
+		select {
+		case <-time.After(time.Duration(options.delaySeconds) * time.Second):
+			log.Logger.Infow("delay expired, rebooting now", "command", cmd)
+		case <-ctx.Done():
+			log.Logger.Warnw("context done, aborting reboot", "command", cmd)
+			return
+		}
+
+		rebootFunc()
+	}()
+
+	log.Logger.Infow(
+		"triggering reboot after delay",
+		"delaySeconds", options.delaySeconds,
+		"command", cmd,
+	)
 	return nil
 }


### PR DESCRIPTION
To address issues like:

> [FIRING] reboot request failed for dedicated node group
Error: unexpected status code: 500,
body: {"message":"no active session for machine"} (read error: <nil>)