### PR TITLE
fix(session): close writer goroutine

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -115,9 +115,7 @@ func (s *Session) startWriter() {
 		}
 
 		log.Logger.Debugf("session writer: unexpected closed, resp: %v %v, reconnecting...", resp.Status, resp.StatusCode)
-
-		// no need to close goroutineCloseCh
-		// to ensure only one pair of read/write connection is there
+		close(goroutineCloseCh)
 	}
 }
 


### PR DESCRIPTION
revert #7 
still need to close write channel, when control plane is restarting and 504 is thrown, http is disconnected and goroutine will be leak. There will be multiple consumers of s.writer and the old goroutine will keep consuming the data to be written back to control plane and control plane will never get response back.
![image](https://github.com/user-attachments/assets/488a6121-c424-4fa0-a6f9-1d9de2682917)
