### PR TITLE
fix(nvidia): suggest reboot for Xid 45, async nvidia-smi checks to not be stuck

### DIFF
--- a/components/accelerator/nvidia/query/nvidia_smi_query.go
+++ b/components/accelerator/nvidia/query/nvidia_smi_query.go
@@ -30,8 +30,47 @@ func RunSMI(ctx context.Context, args ...string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("nvidia-smi not found (%w)", err)
 	}
+
 	cmd := exec.CommandContext(ctx, p, args...)
-	return cmd.Output()
+
+	// in case of driver issue, the nvidia-smi is stuck in "state:D" -- uninterruptible sleep state
+	// which may not handle the os kill signal from the context timeout/cancellation
+	//
+	// e.g.,
+	//
+	// [Sat Oct 12 18:35:32 2024] NVRM: Xid (PCI:0000:61:00): 45, pid=1496200, name=distprovers-gpu, Ch 0000000f
+	// [Sat Oct 12 18:38:44 2024] INFO: task cache_mgr_event:620917 blocked for more than 120 seconds.
+	// [Sat Oct 12 18:38:44 2024]       Tainted: P           OE     5.15.0-97-generic #107-Ubuntu
+	// [Sat Oct 12 18:38:44 2024] "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
+	// [Sat Oct 12 18:38:44 2024] task:cache_mgr_event state:D stack:    0 pid:620917 ppid:620571 flags:0x00000002
+	// [Sat Oct 12 18:38:44 2024] Call Trace:
+	// [Sat Oct 12 18:38:44 2024]  <TASK>
+	// [Sat Oct 12 18:38:44 2024]  __schedule+0x24e/0x590
+	// [Sat Oct 12 18:38:44 2024]  schedule+0x69/0x110
+	// [Sat Oct 12 18:38:44 2024]  rwsem_down_write_slowpath+0x230/0x3e0
+	// [Sat Oct 12 18:38:44 2024]  ? load_new_mm_cr3+0x76/0xe0
+	// [Sat Oct 12 18:38:44 2024]  down_write+0x47/0x60
+	// [Sat Oct 12 18:38:44 2024]  os_acquire_rwlock_write+0x35/0x50 [nvidia]
+	// [Sat Oct 12 18:38:44 2024]  _nv042330rm+0x10/0x40 [nvidia]
+	// [Sat Oct 12 18:38:44 2024]  ? _nv043429rm+0x23c/0x290
+	errc := make(chan error, 1)
+	var output []byte
+	go func() {
+		var err error
+		output, err = cmd.Output()
+		errc <- err
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+
+	case err := <-errc:
+		if err != nil {
+			return nil, fmt.Errorf("nvidia-smi command failed: %w", err)
+		}
+		return output, nil
+	}
 }
 
 // Make sure to call this with a timeout, as a broken GPU may block the command.

--- a/components/accelerator/nvidia/query/xid/xid.go
+++ b/components/accelerator/nvidia/query/xid/xid.go
@@ -714,9 +714,11 @@ var details = map[int]Detail{
 		// ref. https://www.reddit.com/r/pop_os/comments/joq8zn/nvrm_nvidia_xid_45_error_intermittent/
 		SuggestedActions: &common.SuggestedActions{
 			RepairActions: []common.RepairActionType{
+				common.RepairActionTypeRebootSystem,
 				common.RepairActionTypeCheckUserAppAndGPU,
 			},
 			Descriptions: []string{
+				"System reboot is recommended as Xid 45 often blocks nvidia-smi, sometimes indicating a deeper GPU issue.",
 				"Software-related issue affecting code and data segments, possibly GPU memory issue (Xid 45) -- check user applications and GPUs.",
 			},
 		},


### PR DESCRIPTION
nvidia-smi may get stuck with Xid 45, and in such case, the existing nvidia-smi may get stuck forever, when the nvidia-smi process goes into D (uninterruptible) state.

For example,

```
[Sat Oct 12 18:35:32 2024] NVRM: Xid (PCI:0000:61:00): 45, pid=1496200, name=distprovers-gpu, Ch 0000000a
[Sat Oct 12 18:35:32 2024] NVRM: Xid (PCI:0000:61:00): 45, pid=1496200, name=distprovers-gpu, Ch 0000000b
[Sat Oct 12 18:35:32 2024] NVRM: Xid (PCI:0000:61:00): 45, pid=1496200, name=distprovers-gpu, Ch 0000000c
[Sat Oct 12 18:35:32 2024] NVRM: Xid (PCI:0000:61:00): 45, pid=1496200, name=distprovers-gpu, Ch 0000000d
[Sat Oct 12 18:35:32 2024] NVRM: Xid (PCI:0000:61:00): 45, pid=1496200, name=distprovers-gpu, Ch 0000000e
[Sat Oct 12 18:35:32 2024] NVRM: Xid (PCI:0000:61:00): 45, pid=1496200, name=distprovers-gpu, Ch 0000000f
[Sat Oct 12 18:38:44 2024] INFO: task cache_mgr_event:620917 blocked for more than 120 seconds.
[Sat Oct 12 18:38:44 2024]       Tainted: P           OE     5.15.0-97-generic #107-Ubuntu
[Sat Oct 12 18:38:44 2024] "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
[Sat Oct 12 18:38:44 2024] task:cache_mgr_event state:D stack:    0 pid:620917 ppid:620571 flags:0x00000002
[Sat Oct 12 18:38:44 2024] Call Trace:
[Sat Oct 12 18:38:44 2024]  <TASK>
[Sat Oct 12 18:38:44 2024]  __schedule+0x24e/0x590
[Sat Oct 12 18:38:44 2024]  schedule+0x69/0x110
[Sat Oct 12 18:38:44 2024]  rwsem_down_write_slowpath+0x230/0x3e0
[Sat Oct 12 18:38:44 2024]  ? load_new_mm_cr3+0x76/0xe0
[Sat Oct 12 18:38:44 2024]  down_write+0x47/0x60
[Sat Oct 12 18:38:44 2024]  os_acquire_rwlock_write+0x35/0x50 [nvidia]
[Sat Oct 12 18:38:44 2024]  _nv042330rm+0x10/0x40 [nvidia]
[Sat Oct 12 18:38:44 2024]  ? _nv043429rm+0x23c/0x290 [nvidia]
[Sat Oct 12 18:38:44 2024]  ? _nv043348rm+0x25/0xe0 [nvidia]
[Sat Oct 12 18:38:44 2024]  ? _nv000716rm+0x5e3/0xe70 [nvidia]
[Sat Oct 12 18:38:44 2024]  ? rm_ioctl+0x58/0xb0 [nvidia]
[Sat Oct 12 18:38:44 2024]  ? nvidia_ioctl+0x61d/0x840 [nvidia]
[Sat Oct 12 18:38:44 2024]  ? nvidia_frontend_unlocked_ioctl+0x58/0x90 [nvidia]
[Sat Oct 12 18:38:44 2024]  ? __x64_sys_ioctl+0x95/0xd0
[Sat Oct 12 18:38:44 2024]  ? do_syscall_64+0x5c/0xc0
[Sat Oct 12 18:38:44 2024]  ? exit_to_user_mode_prepare+0x37/0xb0
[Sat Oct 12 18:38:44 2024]  ? irqentry_exit_to_user_mode+0x17/0x20
[Sat Oct 12 18:38:44 2024]  ? irqentry_exit+0x1d/0x30
[Sat Oct 12 18:38:44 2024]  ? exc_page_fault+0x89/0x170
[Sat Oct 12 18:38:44 2024]  ? entry_SYSCALL_64_after_hwframe+0x62/0xcc
[Sat Oct 12 18:38:44 2024]  </TASK>
[Sat Oct 12 18:38:44 2024] INFO: task cache_mgr_main:620919 blocked for more than 120 seconds.
[Sat Oct 12 18:38:44 2024]       Tainted: P           OE     5.15.0-97-generic #107-Ubuntu
[Sat Oct 12 18:38:44 2024] "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
[Sat Oct 12 18:38:44 2024] task:cache_mgr_main  state:D stack:    0 pid:620919 ppid:620571 flags:0x00000002
[Sat Oct 12 18:38:44 2024] Call Trace:
[Sat Oct 12 18:38:44 2024]  <TASK>
[Sat Oct 12 18:38:44 2024]  __schedule+0x24e/0x590
[Sat Oct 12 18:38:44 2024]  schedule+0x69/0x110
[Sat Oct 12 18:38:44 2024]  rwsem_down_write_slowpath+0x230/0x3e0
[Sat Oct 12 18:38:44 2024]  down_write+0x47/0x60
[Sat Oct 12 18:38:44 2024]  os_acquire_rwlock_write+0x35/0x50 [nvidia]
[Sat Oct 12 18:38:44 2024]  _nv042330rm+0x10/0x40 [nvidia]
```