### PR TITLE
feat(network/latency): track latency in metrics per region

### DIFF
--- a/components/network/latency/component.go
+++ b/components/network/latency/component.go
@@ -11,6 +11,7 @@ import (
 	"github.com/leptonai/gpud/components/network/latency/metrics"
 	"github.com/leptonai/gpud/components/query"
 	"github.com/leptonai/gpud/log"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/components/network/latency/component.go
+++ b/components/network/latency/component.go
@@ -3,12 +3,15 @@ package latency
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"time"
 
 	"github.com/leptonai/gpud/components"
+	"github.com/leptonai/gpud/components/network/latency/metrics"
 	"github.com/leptonai/gpud/components/query"
 	"github.com/leptonai/gpud/log"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const Name = "network-latency"
@@ -31,10 +34,11 @@ func New(ctx context.Context, cfg Config) components.Component {
 var _ components.Component = (*component)(nil)
 
 type component struct {
-	rootCtx context.Context
-	cancel  context.CancelFunc
-	poller  query.Poller
-	cfg     Config
+	rootCtx  context.Context
+	cancel   context.CancelFunc
+	poller   query.Poller
+	gatherer prometheus.Gatherer
+	cfg      Config
 }
 
 func (c *component) Name() string { return Name }
@@ -78,7 +82,17 @@ func (c *component) Events(ctx context.Context, since time.Time) ([]components.E
 func (c *component) Metrics(ctx context.Context, since time.Time) ([]components.Metric, error) {
 	log.Logger.Debugw("querying metrics", "since", since)
 
-	return nil, nil
+	edgeLatencies, err := metrics.ReadEdgeInMilliseconds(ctx, since)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read running pids: %w", err)
+	}
+
+	ms := make([]components.Metric, 0, len(edgeLatencies))
+	for _, m := range edgeLatencies {
+		ms = append(ms, components.Metric{Metric: m})
+	}
+
+	return ms, nil
 }
 
 func (c *component) Close() error {
@@ -88,4 +102,11 @@ func (c *component) Close() error {
 	c.poller.Stop(Name)
 
 	return nil
+}
+
+var _ components.PromRegisterer = (*component)(nil)
+
+func (c *component) RegisterCollectors(reg *prometheus.Registry, db *sql.DB, tableName string) error {
+	c.gatherer = reg
+	return metrics.Register(reg, db, tableName)
 }

--- a/components/network/latency/metrics/metrics.go
+++ b/components/network/latency/metrics/metrics.go
@@ -1,0 +1,75 @@
+// Package metrics implements the network latency metrics collection and reporting.
+package metrics
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	components_metrics "github.com/leptonai/gpud/components/metrics"
+	components_metrics_state "github.com/leptonai/gpud/components/metrics/state"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const SubSystem = "network_latency"
+
+var (
+	lastUpdateUnixSeconds = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: SubSystem,
+			Name:      "last_update_unix_seconds",
+			Help:      "tracks the last update time in unix seconds",
+		},
+	)
+
+	edgeInMilliseconds = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: SubSystem,
+			Name:      "edge_in_milliseconds",
+			Help:      "tracks the edge latency in milliseconds",
+		},
+		[]string{"provider_region"},
+	)
+	edgeInMillisecondsAverager = components_metrics.NewNoOpAverager()
+)
+
+func InitAveragers(db *sql.DB, tableName string) {
+	edgeInMillisecondsAverager = components_metrics.NewAverager(db, tableName, SubSystem+"_edge_in_milliseconds")
+}
+
+func ReadEdgeInMilliseconds(ctx context.Context, since time.Time) (components_metrics_state.Metrics, error) {
+	return edgeInMillisecondsAverager.Read(ctx, components_metrics.WithSince(since))
+}
+
+func SetLastUpdateUnixSeconds(unixSeconds float64) {
+	lastUpdateUnixSeconds.Set(unixSeconds)
+}
+
+func SetEdgeInMilliseconds(ctx context.Context, providerRegion string, latencyInMilliseconds float64, currentTime time.Time) error {
+	edgeInMilliseconds.WithLabelValues(providerRegion).Set(latencyInMilliseconds)
+
+	if err := edgeInMillisecondsAverager.Observe(
+		ctx,
+		latencyInMilliseconds,
+		components_metrics.WithMetricSecondaryName(providerRegion),
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Register(reg *prometheus.Registry, db *sql.DB, tableName string) error {
+	InitAveragers(db, tableName)
+
+	if err := reg.Register(lastUpdateUnixSeconds); err != nil {
+		return err
+	}
+	if err := reg.Register(edgeInMilliseconds); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
```
# TYPE network_latency_edge_in_milliseconds gauge
network_latency_edge_in_milliseconds{provider_region="Amsterdam (tailscale-derp)"} 251
network_latency_edge_in_milliseconds{provider_region="Bangalore (tailscale-derp)"} 322
network_latency_edge_in_milliseconds{provider_region="Chicago (tailscale-derp)"} 185
network_latency_edge_in_milliseconds{provider_region="Dallas (tailscale-derp)"} 176
network_latency_edge_in_milliseconds{provider_region="Denver (tailscale-derp)"} 172
network_latency_edge_in_milliseconds{provider_region="Dubai (tailscale-derp)"} 380
network_latency_edge_in_milliseconds{provider_region="Frankfurt (tailscale-derp)"} 285
network_latency_edge_in_milliseconds{provider_region="Hong Kong (tailscale-derp)"} 66
network_latency_edge_in_milliseconds{provider_region="Honolulu (tailscale-derp)"} 187
network_latency_edge_in_milliseconds{provider_region="Johannesburg (tailscale-derp)"} 461
network_latency_edge_in_milliseconds{provider_region="London (tailscale-derp)"} 265
network_latency_edge_in_milliseconds{provider_region="Los Angeles (tailscale-derp)"} 154
network_latency_edge_in_milliseconds{provider_region="Madrid (tailscale-derp)"} 273
network_latency_edge_in_milliseconds{provider_region="Miami (tailscale-derp)"} 200
network_latency_edge_in_milliseconds{provider_region="New York City (tailscale-derp)"} 205
network_latency_edge_in_milliseconds{provider_region="Paris (tailscale-derp)"} 276
network_latency_edge_in_milliseconds{provider_region="San Francisco (tailscale-derp)"} 139
network_latency_edge_in_milliseconds{provider_region="Seattle (tailscale-derp)"} 151
network_latency_edge_in_milliseconds{provider_region="Singapore (tailscale-derp)"} 84
network_latency_edge_in_milliseconds{provider_region="Sydney (tailscale-derp)"} 173
network_latency_edge_in_milliseconds{provider_region="São Paulo (tailscale-derp)"} 312
network_latency_edge_in_milliseconds{provider_region="Tokyo (tailscale-derp)"} 41
network_latency_edge_in_milliseconds{provider_region="Toronto (tailscale-derp)"} 195
network_latency_edge_in_milliseconds{provider_region="Warsaw (tailscale-derp)"} 313
```