### PR TITLE
fix(components): do not attempt register if already registered

### DIFF
--- a/components/components.go
+++ b/components/components.go
@@ -109,6 +109,14 @@ var (
 	defaultSet   = make(map[string]Component)
 )
 
+func IsComponentRegistered(name string) bool {
+	defaultSetMu.RLock()
+	defer defaultSetMu.RUnlock()
+
+	_, ok := defaultSet[name]
+	return ok
+}
+
 func RegisterComponent(name string, comp Component) error {
 	defaultSetMu.Lock()
 	defer defaultSetMu.Unlock()


### PR DESCRIPTION
Fix all the noisy logs

> {"level":"warn","ts":"2024-11-02T00:03:34Z","caller":"server/server.go:1040","msg":"failed to register component","name":"k8s-pod","error":"component k8s-pod already registered: already exists"}
{"level":"warn","ts":"2024-11-02T00:04:34Z","caller":"server/server.go:1040","msg":"failed to register component","name":"containerd-pod","error":"component containerd-pod already registered: already exists"}
{"level":"warn","ts":"2024-11-02T00:04:34Z","caller":"server/server.go:1040","msg":"failed to register component","name":"k8s-pod","error":"component k8s-pod already registered: already exists"}
{"level":"warn","ts":"2024-11-02T00:05:34Z","caller":"server/server.go:1040","msg":"failed to register component","name":"containerd-pod","error":"component containerd-pod already registered: already exists"}
{"level":"warn","ts":"2024-11-02T00:05:34Z","caller":"server/server.go:1040","msg":"failed to register component","name":"k8s-pod","error":"component k8s-pod already registered: already exists"}
{"level":"warn","ts":"2024-11-02T00:06:34Z","caller":"server/server.go:1040","msg":"failed to register component","name":"containerd-pod","error":"component containerd-pod already registered: already exists"}
{"level":"warn","ts":"2024-11-02T00:06:34Z","caller":"server/server.go:1040","msg":"failed to register component","name":"k8s-pod","error":"component k8s-pod already registered: already exists"}