### PR TITLE
fix(nvidia): remove init func for nvidia packages (do not check nvidia if not needed)

### DIFF
--- a/cmd/gpud/main.go
+++ b/cmd/gpud/main.go
@@ -5,9 +5,16 @@ import (
 	"os"
 
 	"github.com/leptonai/gpud/cmd/gpud/command"
+	"github.com/leptonai/gpud/version"
 )
 
 func main() {
+	// check for version flag before initializing the full app
+	if len(os.Args) == 2 && (os.Args[1] == "version" || os.Args[1] == "--version" || os.Args[1] == "-v") {
+		fmt.Println("gpud version", version.Version)
+		return
+	}
+
 	app := command.App()
 	if err := app.Run(os.Args); err != nil {
 		fmt.Fprintf(os.Stderr, "gpud: %s\n", err)

--- a/cmd/gpud/main.go
+++ b/cmd/gpud/main.go
@@ -5,16 +5,9 @@ import (
 	"os"
 
 	"github.com/leptonai/gpud/cmd/gpud/command"
-	"github.com/leptonai/gpud/version"
 )
 
 func main() {
-	// check for version flag before initializing the full app
-	if len(os.Args) == 2 && (os.Args[1] == "version" || os.Args[1] == "--version" || os.Args[1] == "-v") {
-		fmt.Println("gpud version", version.Version)
-		return
-	}
-
 	app := command.App()
 	if err := app.Run(os.Args); err != nil {
 		fmt.Fprintf(os.Stderr, "gpud: %s\n", err)

--- a/components/diagnose/diagnose.go
+++ b/components/diagnose/diagnose.go
@@ -139,7 +139,10 @@ func run(ctx context.Context, dir string, opts ...OpOption) error {
 	}
 
 	fmt.Printf("%s scanning dmesg with regexes\n", inProgress)
-	defaultDmesgCfg := dmesg.DefaultConfig()
+	defaultDmesgCfg, err := dmesg.DefaultConfig(ctx)
+	if err != nil {
+		return err
+	}
 	matched, err := query_log_tail.Scan(
 		ctx,
 		query_log_tail.WithCommands(defaultDmesgCfg.Log.Scan.Commands),

--- a/components/diagnose/scan.go
+++ b/components/diagnose/scan.go
@@ -163,7 +163,10 @@ func Scan(ctx context.Context, opts ...OpOption) error {
 	println()
 
 	fmt.Printf("%s scanning dmesg for %d lines\n", inProgress, op.lines)
-	defaultDmesgCfg := dmesg.DefaultConfig()
+	defaultDmesgCfg, err := dmesg.DefaultConfig(ctx)
+	if err != nil {
+		return err
+	}
 	matched, err := query_log_tail.Scan(
 		ctx,
 		query_log_tail.WithCommands(defaultDmesgCfg.Log.Scan.Commands),

--- a/components/dmesg/config.go
+++ b/components/dmesg/config.go
@@ -1,6 +1,7 @@
 package dmesg
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"os"
@@ -47,7 +48,12 @@ func DmesgExists() bool {
 
 const DefaultDmesgFile = "/var/log/dmesg"
 
-func DefaultConfig() Config {
+func DefaultConfig(ctx context.Context) (Config, error) {
+	defaultFilters, err := DefaultLogFilters(ctx)
+	if err != nil {
+		return Config{}, err
+	}
+
 	scanCommands := [][]string{
 		{"cat", DefaultDmesgFile},
 
@@ -78,9 +84,9 @@ func DefaultConfig() Config {
 				Commands:    scanCommands,
 				LinesToTail: 10000,
 			},
+
+			SelectFilters: defaultFilters,
 		},
 	}
-	cfg.Log.SelectFilters = append(cfg.Log.SelectFilters, defaultFilters...)
-
-	return cfg
+	return cfg, nil
 }

--- a/components/dmesg/filters_nvidia.go
+++ b/components/dmesg/filters_nvidia.go
@@ -1,13 +1,9 @@
 package dmesg
 
 import (
-	"context"
-	"time"
-
 	nvidia_error "github.com/leptonai/gpud/components/accelerator/nvidia/error"
 	nvidia_nccl_id "github.com/leptonai/gpud/components/accelerator/nvidia/nccl/id"
 	nvidia_peermem_id "github.com/leptonai/gpud/components/accelerator/nvidia/peermem/id"
-	nvidia_query "github.com/leptonai/gpud/components/accelerator/nvidia/query"
 	nvidia_query_nccl "github.com/leptonai/gpud/components/accelerator/nvidia/query/nccl"
 	nvidia_query_peermem "github.com/leptonai/gpud/components/accelerator/nvidia/query/peermem"
 	nvidia_query_sxid "github.com/leptonai/gpud/components/accelerator/nvidia/query/sxid"
@@ -16,25 +12,6 @@ import (
 
 	"k8s.io/utils/ptr"
 )
-
-func init() {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	nvidiaInstalled, err := nvidia_query.GPUsInstalled(ctx)
-	if err != nil {
-		return
-	}
-
-	if nvidiaInstalled {
-		defaultFilters = append(defaultFilters, DefaultDmesgFiltersForNvidia()...)
-	}
-	for i := range defaultFilters {
-		if err := defaultFilters[i].Compile(); err != nil {
-			panic(err)
-		}
-	}
-}
 
 const (
 	// e.g.,


### PR DESCRIPTION
When nvidia driver/device is broken, `gpud --version` blocks including others. This fixes the gpud initialization problem.

> strace gpud --version

Before

```
execve("/usr/sbin/gpud", ["gpud", "--version"], 0x7fff8bc31358 /* 24 vars */) = 0
brk(NULL)                               = 0x3b43000

rt_sigreturn({mask=[]})                 = 824646017024
--- SIGURG {si_signo=SIGURG, si_code=SI_TKILL, si_pid=220181, si_uid=0} ---
rt_sigreturn({mask=[]})                 = 824646017024
--- SIGURG {si_signo=SIGURG, si_code=SI_TKILL, si_pid=220181, si_uid=0} ---
rt_sigreturn({mask=[]})                 = 824646017024
--- SIGURG {si_signo=SIGURG, si_code=SI_TKILL, si_pid=220181, si_uid=0} ---
rt_sigreturn({mask=[]})                 = 824646017024
futex(0x315e7a0, FUTEX_WAIT_PRIVATE, 0, NULL) = 0
--- SIGURG {si_signo=SIGURG, si_code=SI_TKILL, si_pid=220181, si_uid=0} ---
rt_sigreturn({mask=[]})                 = 0
sched_yield()                           = 0
futex(0x3160eb8, FUTEX_WAIT_PRIVATE, 2, NULL) = -1 EAGAIN (Resource temporarily unavailable)
futex(0x3160eb8, FUTEX_WAKE_PRIVATE, 1) = 0
futex(0xc000600848, FUTEX_WAKE_PRIVATE, 1) = 1
futex(0x3160fb8, FUTEX_WAKE_PRIVATE, 1) = 1
futex(0x3160eb8, FUTEX_WAKE_PRIVATE, 1) = 1
sched_yield()                           = 0
futex(0x3160eb8, FUTEX_WAKE_PRIVATE, 1) = 0
--- SIGURG {si_signo=SIGURG, si_code=SI_TKILL, si_pid=220181, si_uid=0} ---
rt_sigreturn({mask=[]})                 = 128
futex(0xc000680848, FUTEX_WAKE_PRIVATE, 1) = 1
futex(0x3160fb8, FUTEX_WAKE_PRIVATE, 1) = 0
futex(0x3160eb8, FUTEX_WAKE_PRIVATE, 1) = 1
sched_yield()                           = 0
futex(0x3160eb8, FUTEX_WAIT_PRIVATE, 2, NULL) = -1 EAGAIN (Resource temporarily unavailable)
futex(0x3160eb8, FUTEX_WAKE_PRIVATE, 1) = 0

mkdir("/dev/nvidia-caps", 0755)         = -1 EEXIST (File exists)
openat(AT_FDCWD, "/proc/driver/nvidia/capabilities/mig/monitor", O_RDONLY) = 15
newfstatat(15, "", {st_mode=S_IFREG|0444, st_size=0, ...}, AT_EMPTY_PATH) = 0
read(15, "DeviceFileMinor: 2\nDeviceFileMod"..., 1024) = 59
read(15, "", 1024)                      = 0
close(15)                               = 0
stat("/dev/nvidia-caps/nvidia-cap2", {st_mode=S_IFCHR|0666, st_rdev=makedev(0x1fe, 0x1), ...}) = 0
unlink("/dev/nvidia-caps/nvidia-cap2")  = -1 EBUSY (Device or resource busy)
stat("/usr/bin/nvidia-modprobe", {st_mode=S_IFREG|S_ISUID|S_ISGID|0755, st_size=51416, ...}) = 0
geteuid()                               = 0
openat(AT_FDCWD, "/proc/devices", O_RDONLY) = 15
newfstatat(15, "", {st_mode=S_IFREG|0444, st_size=0, ...}, AT_EMPTY_PATH) = 0
read(15, "Character devices:\n  1 mem\n  4 /"..., 1024) = 855
close(15)                               = 0
openat(AT_FDCWD, "/proc/driver/nvidia/capabilities/mig/monitor", O_RDONLY) = 15
newfstatat(15, "", {st_mode=S_IFREG|0444, st_size=0, ...}, AT_EMPTY_PATH) = 0
read(15, "DeviceFileMinor: 2\nDeviceFileMod"..., 1024) = 59
close(15)                               = 0
openat(AT_FDCWD, "/proc/driver/nvidia/capabilities/mig/monitor", O_RDONLY) = 15
newfstatat(15, "", {st_mode=S_IFREG|0444, st_size=0, ...}, AT_EMPTY_PATH) = 0
read(15, "DeviceFileMinor: 2\nDeviceFileMod"..., 1024) = 59
read(15, "", 1024)                      = 0
close(15)                               = 0
stat("/dev/nvidia-caps/nvidia-cap2", {st_mode=S_IFCHR|0666, st_rdev=makedev(0x1fe, 0x1), ...}) = 0
ioctl(6, _IOC(_IOC_READ|_IOC_WRITE, 0x46, 0x2a, 0x20), 0x7ffd86f3cbb0) = 0
```

After

No syscalls to any nvidia related components
