### PR TITLE
fix(nvidia/query): skip xid=0 event

### DIFF
--- a/components/accelerator/nvidia/query/nvml/xid.go
+++ b/components/accelerator/nvidia/query/nvml/xid.go
@@ -121,7 +121,7 @@ func (inst *instance) pollXidEvents() {
 		xid := e.EventData
 
 		if xid == 0 {
-			log.Logger.Warnw("received xid 0 as an event -- skipping", "return", ret)
+			log.Logger.Debugw("received xid 0 as an event -- skipping", "return", ret)
 			continue
 		}
 

--- a/components/accelerator/nvidia/query/nvml/xid.go
+++ b/components/accelerator/nvidia/query/nvml/xid.go
@@ -121,7 +121,7 @@ func (inst *instance) pollXidEvents() {
 		xid := e.EventData
 
 		if xid == 0 {
-			log.Logger.Warnw("received xid 0 as an event -- skipping")
+			log.Logger.Warnw("received xid 0 as an event -- skipping", "return", ret)
 			continue
 		}
 

--- a/components/accelerator/nvidia/query/nvml/xid.go
+++ b/components/accelerator/nvidia/query/nvml/xid.go
@@ -120,14 +120,15 @@ func (inst *instance) pollXidEvents() {
 
 		xid := e.EventData
 
-		var xidDetail *nvidia_query_xid.Detail
-		msg := "received event but xid unknown"
-		if xid > 0 {
-			var ok bool
-			xidDetail, ok = nvidia_query_xid.GetDetail(int(xid))
-			if ok {
-				msg = "received event with a known xid"
-			}
+		if xid == 0 {
+			log.Logger.Warnw("received xid 0 as an event -- skipping")
+			continue
+		}
+
+		msg := "received event with a known xid"
+		xidDetail, ok := nvidia_query_xid.GetDetail(int(xid))
+		if !ok {
+			msg = "received event but xid unknown"
 		}
 
 		var deviceUUID string
@@ -162,7 +163,7 @@ func (inst *instance) pollXidEvents() {
 			Error: deviceUUIDErr,
 		}
 
-		log.Logger.Warnw("detected xid event", "event", event)
+		log.Logger.Warnw("detected xid event", "xid", xid, "event", event)
 		select {
 		case <-inst.rootCtx.Done():
 			return


### PR DESCRIPTION
> {"level":"warn","ts":"2024-11-08T04:24:24Z","caller":"nvml/xid.go:170","msg":"notified xid event","event":{"time":"2024-11-08T04:24:24Z","sample_duration":"5s","device_uuid":"GPU-e3038df4-dc48-27c8-a48a-36956600f1c2","xid":0,"nvml_event_type":16,"nvml_event_type_single_bit_ecc_error":false,"nvml_event_type_double_bit_ecc_error":false,"nvml_event_type_p_state":false,"nvml_event_type_xid_critical_error":false,"nvml_event_type_clock":true,"nvml_event_type_power_source_change":false,"nvml_event_type_mig_config_change":false,"detail":null,"message":"received event but xid unknown"}}

![image (2)](https://github.com/user-attachments/assets/089a7865-a0cc-4e68-8d37-78b1f8725910)

