### PR TITLE
feat(tail/log): dedup same log string in scanner

### DIFF
--- a/cmd/gpud/command/logs.go
+++ b/cmd/gpud/command/logs.go
@@ -26,6 +26,7 @@ func cmdLogs(cliContext *cli.Context) error {
 	lines := make([]string, 0, tailLines)
 	_, err := tail.Scan(
 		rootCtx,
+		tail.WithDedup(true),
 		tail.WithFile(logFile),
 		tail.WithLinesToTail(tailLines),
 		tail.WithPerLineFunc(func(line []byte) {

--- a/components/diagnose/diagnose.go
+++ b/components/diagnose/diagnose.go
@@ -146,6 +146,7 @@ func run(ctx context.Context, dir string, opts ...OpOption) error {
 	}
 	matched, err := query_log_tail.Scan(
 		ctx,
+		query_log_tail.WithDedup(true),
 		query_log_tail.WithCommands(defaultDmesgCfg.Log.Scan.Commands),
 		query_log_tail.WithLinesToTail(5000),
 		query_log_tail.WithSelectFilter(defaultDmesgCfg.Log.SelectFilters...),

--- a/components/diagnose/scan.go
+++ b/components/diagnose/scan.go
@@ -182,6 +182,7 @@ func Scan(ctx context.Context, opts ...OpOption) error {
 	}
 	matched, err := query_log_tail.Scan(
 		ctx,
+		query_log_tail.WithDedup(true),
 		query_log_tail.WithCommands(defaultDmesgCfg.Log.Scan.Commands),
 		query_log_tail.WithLinesToTail(op.lines),
 		query_log_tail.WithSelectFilter(defaultDmesgCfg.Log.SelectFilters...),

--- a/components/dmesg/component.go
+++ b/components/dmesg/component.go
@@ -55,6 +55,7 @@ func (c *Component) TailScan() (*State, error) {
 	if c.cfg != nil && c.cfg.Log.Scan != nil {
 		items, err := c.logPoller.TailScan(
 			c.rootCtx,
+			query_log_tail.WithDedup(true),
 			query_log_tail.WithFile(c.cfg.Log.Scan.File),
 			query_log_tail.WithCommands(c.cfg.Log.Scan.Commands),
 			query_log_tail.WithLinesToTail(c.cfg.Log.Scan.LinesToTail),

--- a/components/query/log/tail/options.go
+++ b/components/query/log/tail/options.go
@@ -12,6 +12,7 @@ type Op struct {
 	commands [][]string
 
 	linesToTail int
+	dedup       bool
 
 	perLineFunc func([]byte)
 
@@ -80,6 +81,15 @@ func WithCommands(commands [][]string) OpOption {
 func WithLinesToTail(n int) OpOption {
 	return func(op *Op) {
 		op.linesToTail = n
+	}
+}
+
+// If true, dedup lines by the log line string.
+// This is useful for logs that have the same message
+// repeated multiple times with the same timestamp.
+func WithDedup(dedup bool) OpOption {
+	return func(op *Op) {
+		op.dedup = dedup
 	}
 }
 

--- a/components/query/log/tail/scan.go
+++ b/components/query/log/tail/scan.go
@@ -78,6 +78,29 @@ func Scan(ctx context.Context, opts ...OpOption) (int, error) {
 	scannedLines := 0
 	matchedLines := 0
 
+	processLine := func(buf []byte) error {
+		reverse(buf)
+		scannedLines++
+
+		if op.perLineFunc != nil {
+			op.perLineFunc(buf)
+		}
+
+		shouldInclude, matchedFilter, err := op.applyFilter(buf)
+		if err != nil {
+			return err
+		}
+		if shouldInclude {
+			matchedLines++
+			parsedTime, err := op.parseTime(buf)
+			if err != nil {
+				return err
+			}
+			op.processMatched(buf, parsedTime, matchedFilter)
+		}
+		return nil
+	}
+
 	defer func() {
 		log.Logger.Debugw("scanned lines", "lines", scannedLines, "matched", matchedLines)
 	}()
@@ -96,60 +119,32 @@ func Scan(ctx context.Context, opts ...OpOption) (int, error) {
 		}
 
 		for i := chunkSize - 1; i >= 0; i-- {
-			if chunkBuf[i] == '\n' {
-				if len(lineBuf) > 0 {
-					reverse(lineBuf)
-					scannedLines++
-
-					if op.perLineFunc != nil {
-						op.perLineFunc(lineBuf)
-					}
-
-					shouldInclude, matchedFilter, err := op.applyFilter(lineBuf)
-					if err != nil {
-						return 0, err
-					}
-					if shouldInclude {
-						matchedLines++
-
-						parsedTime, err := op.parseTime(lineBuf)
-						if err != nil {
-							return 0, err
-						}
-						op.processMatched(lineBuf, parsedTime, matchedFilter)
-					}
-
-					lineBuf = lineBuf[:0]
-				}
-			} else {
-				lineBuf = append(lineBuf, chunkBuf[i])
-			}
-
 			if scannedLines == op.linesToTail {
 				return matchedLines, nil
 			}
+
+			// still processing a line
+			if chunkBuf[i] != '\n' {
+				lineBuf = append(lineBuf, chunkBuf[i])
+				continue
+			}
+
+			// end of a line but no content
+			if len(lineBuf) == 0 {
+				continue
+			}
+
+			if err := processLine(lineBuf); err != nil {
+				return 0, err
+			}
+
+			lineBuf = lineBuf[:0]
 		}
 	}
 
 	if len(lineBuf) > 0 && scannedLines < op.linesToTail {
-		reverse(lineBuf)
-
-		if op.perLineFunc != nil {
-			op.perLineFunc(lineBuf)
-		}
-
-		shouldInclude, matchedFilter, err := op.applyFilter(lineBuf)
-		if err != nil {
+		if err := processLine(lineBuf); err != nil {
 			return 0, err
-		}
-		if shouldInclude {
-			matchedLines++
-
-			parsedTime, err := op.parseTime(lineBuf)
-			if err != nil {
-				return 0, err
-			}
-			op.processMatched(lineBuf, parsedTime, matchedFilter)
 		}
 	}
 

--- a/components/query/log/tail/scan_benchmark_test.go
+++ b/components/query/log/tail/scan_benchmark_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	query_log_filter "github.com/leptonai/gpud/components/query/log/filter"
+	query_log_common "github.com/leptonai/gpud/components/query/log/common"
 
 	"k8s.io/utils/ptr"
 )
@@ -41,11 +41,11 @@ func BenchmarkScan_DmesgLog(b *testing.B) {
 				WithParseTime(func(line []byte) (time.Time, error) {
 					return time.Time{}, nil
 				}),
-				WithProcessMatched(func(line []byte, _ time.Time, _ *query_log_filter.Filter) {}),
+				WithProcessMatched(func(line []byte, _ time.Time, _ *query_log_common.Filter) {}),
 			)
 
 			if bm.withFilter {
-				opts = append(opts, WithSelectFilter(&query_log_filter.Filter{
+				opts = append(opts, WithSelectFilter(&query_log_common.Filter{
 					Substring: ptr.To("error"),
 				}))
 			}
@@ -92,11 +92,11 @@ func BenchmarkScan_KubeletLog(b *testing.B) {
 				WithParseTime(func(line []byte) (time.Time, error) {
 					return time.Time{}, nil
 				}),
-				WithProcessMatched(func(line []byte, _ time.Time, _ *query_log_filter.Filter) {}),
+				WithProcessMatched(func(line []byte, _ time.Time, _ *query_log_common.Filter) {}),
 			)
 
 			if bm.withFilter {
-				opts = append(opts, WithSelectFilter(&query_log_filter.Filter{
+				opts = append(opts, WithSelectFilter(&query_log_common.Filter{
 					Substring: ptr.To("error"),
 				}))
 			}

--- a/components/query/log/tail/scan_benchmark_test.go
+++ b/components/query/log/tail/scan_benchmark_test.go
@@ -1,0 +1,112 @@
+package tail
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	query_log_filter "github.com/leptonai/gpud/components/query/log/filter"
+	"k8s.io/utils/ptr"
+)
+
+// go test -bench=BenchmarkScan -benchmem
+// go test -bench=BenchmarkScan_DmesgLog -benchmem
+func BenchmarkScan_DmesgLog(b *testing.B) {
+	ctx := context.Background()
+
+	benchmarks := []struct {
+		name        string
+		linesToTail int
+		withFilter  bool
+		dedup       bool
+	}{
+		{"Tail100NoFilter", 100, false, false},
+		{"Tail1000NoFilter", 1000, false, false},
+		{"Tail100WithFilter", 100, true, false},
+		{"Tail1000WithFilter", 1000, true, false},
+
+		{"Tail100NoFilterWithDedup", 100, false, true},
+		{"Tail1000NoFilterWithDedup", 1000, false, true},
+		{"Tail100WithFilterWithDedup", 100, true, true},
+		{"Tail1000WithFilterWithDedup", 1000, true, true},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			var opts []OpOption
+			opts = append(opts,
+				WithFile("testdata/dmesg.0.log"),
+				WithLinesToTail(bm.linesToTail),
+				WithParseTime(func(line []byte) (time.Time, error) {
+					return time.Time{}, nil
+				}),
+				WithProcessMatched(func(line []byte, _ time.Time, _ *query_log_filter.Filter) {}),
+			)
+
+			if bm.withFilter {
+				opts = append(opts, WithSelectFilter(&query_log_filter.Filter{
+					Substring: ptr.To("error"),
+				}))
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := Scan(ctx, opts...)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// go test -bench=BenchmarkScan -benchmem
+// go test -bench=BenchmarkScan_KubeletLog -benchmem
+func BenchmarkScan_KubeletLog(b *testing.B) {
+	ctx := context.Background()
+
+	benchmarks := []struct {
+		name        string
+		linesToTail int
+		withFilter  bool
+		dedup       bool
+	}{
+		{"Tail100NoFilter", 100, false, false},
+		{"Tail1000NoFilter", 1000, false, false},
+		{"Tail100WithFilter", 100, true, false},
+		{"Tail1000WithFilter", 1000, true, false},
+
+		{"Tail100NoFilterWithDedup", 100, false, true},
+		{"Tail1000NoFilterWithDedup", 1000, false, true},
+		{"Tail100WithFilterWithDedup", 100, true, true},
+		{"Tail1000WithFilterWithDedup", 1000, true, true},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			var opts []OpOption
+			opts = append(opts,
+				WithFile("testdata/kubelet.0.log"),
+				WithLinesToTail(bm.linesToTail),
+				WithParseTime(func(line []byte) (time.Time, error) {
+					return time.Time{}, nil
+				}),
+				WithProcessMatched(func(line []byte, _ time.Time, _ *query_log_filter.Filter) {}),
+			)
+
+			if bm.withFilter {
+				opts = append(opts, WithSelectFilter(&query_log_filter.Filter{
+					Substring: ptr.To("error"),
+				}))
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := Scan(ctx, opts...)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/components/query/log/tail/scan_benchmark_test.go
+++ b/components/query/log/tail/scan_benchmark_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	query_log_filter "github.com/leptonai/gpud/components/query/log/filter"
+
 	"k8s.io/utils/ptr"
 )
 

--- a/components/query/log/tail/scan_test.go
+++ b/components/query/log/tail/scan_test.go
@@ -243,7 +243,7 @@ func TestScan_LastLineWithoutNewline(t *testing.T) {
 	tests := []struct {
 		name          string
 		linesToTail   int
-		selectFilters []*query_log_filter.Filter
+		selectFilters []*query_log_common.Filter
 		want          []string
 	}{
 		{
@@ -259,7 +259,7 @@ func TestScan_LastLineWithoutNewline(t *testing.T) {
 		{
 			name:        "tail with filter matching last line",
 			linesToTail: 5,
-			selectFilters: []*query_log_filter.Filter{
+			selectFilters: []*query_log_common.Filter{
 				{Substring: ptr.To("final")},
 			},
 			want: []string{"final_line_no_newline"},
@@ -277,7 +277,7 @@ func TestScan_LastLineWithoutNewline(t *testing.T) {
 				WithParseTime(func(line []byte) (time.Time, error) {
 					return time.Time{}, nil
 				}),
-				WithProcessMatched(func(line []byte, time time.Time, filter *query_log_filter.Filter) {
+				WithProcessMatched(func(line []byte, time time.Time, filter *query_log_common.Filter) {
 					got = append(got, string(line))
 				}),
 			)
@@ -394,7 +394,7 @@ func TestScan_Dedup(t *testing.T) {
 				WithParseTime(func(line []byte) (time.Time, error) {
 					return time.Time{}, nil
 				}),
-				WithProcessMatched(func(line []byte, time time.Time, filter *query_log_filter.Filter) {
+				WithProcessMatched(func(line []byte, time time.Time, filter *query_log_common.Filter) {
 					got = append(got, string(line))
 				}),
 			)
@@ -446,7 +446,7 @@ func TestScan_DedupWithFilters(t *testing.T) {
 		name          string
 		linesToTail   int
 		dedup         bool
-		selectFilters []*query_log_filter.Filter
+		selectFilters []*query_log_common.Filter
 		want          []string
 		wantCount     int
 	}{
@@ -454,7 +454,7 @@ func TestScan_DedupWithFilters(t *testing.T) {
 			name:        "filter without dedup",
 			linesToTail: 100,
 			dedup:       false,
-			selectFilters: []*query_log_filter.Filter{
+			selectFilters: []*query_log_common.Filter{
 				{Substring: ptr.To("error")},
 			},
 			want: []string{
@@ -469,7 +469,7 @@ func TestScan_DedupWithFilters(t *testing.T) {
 			name:        "filter with dedup",
 			linesToTail: 100,
 			dedup:       true,
-			selectFilters: []*query_log_filter.Filter{
+			selectFilters: []*query_log_common.Filter{
 				{Substring: ptr.To("error")},
 			},
 			want: []string{
@@ -492,7 +492,7 @@ func TestScan_DedupWithFilters(t *testing.T) {
 				WithParseTime(func(line []byte) (time.Time, error) {
 					return time.Time{}, nil
 				}),
-				WithProcessMatched(func(line []byte, time time.Time, filter *query_log_filter.Filter) {
+				WithProcessMatched(func(line []byte, time time.Time, filter *query_log_common.Filter) {
 					got = append(got, string(line))
 				}),
 			)
@@ -590,7 +590,7 @@ func TestScan_EmptyAndSmallFiles(t *testing.T) {
 				WithParseTime(func(line []byte) (time.Time, error) {
 					return time.Time{}, nil
 				}),
-				WithProcessMatched(func(line []byte, _ time.Time, _ *query_log_filter.Filter) {
+				WithProcessMatched(func(line []byte, _ time.Time, _ *query_log_common.Filter) {
 					got = append(got, string(line))
 				}),
 			)
@@ -683,7 +683,7 @@ func TestScan_LongLines(t *testing.T) {
 				WithParseTime(func(line []byte) (time.Time, error) {
 					return time.Time{}, nil
 				}),
-				WithProcessMatched(func(line []byte, _ time.Time, _ *query_log_filter.Filter) {
+				WithProcessMatched(func(line []byte, _ time.Time, _ *query_log_common.Filter) {
 					got = append(got, string(line))
 				}),
 			)
@@ -757,7 +757,7 @@ func TestScan_CommandOutput(t *testing.T) {
 				WithParseTime(func(line []byte) (time.Time, error) {
 					return time.Time{}, nil
 				}),
-				WithProcessMatched(func(line []byte, _ time.Time, _ *query_log_filter.Filter) {
+				WithProcessMatched(func(line []byte, _ time.Time, _ *query_log_common.Filter) {
 					got = append(got, string(line))
 				}),
 			)


### PR DESCRIPTION
There's no reason to catch all these logs with same timestamps:

> [Thu Sep 19 02:29:46 2024] nvidia-peermem nv_get_p2p_free_callback:127 ERROR detected invalid context, skipping further processing
> [Thu Sep 19 02:29:46 2024] nvidia-peermem nv_get_p2p_free_callback:127 ERROR detected invalid context, skipping further processing
> [Thu Sep 19 02:29:46 2024] nvidia-peermem nv_get_p2p_free_callback:127 ERROR detected invalid context, skipping further processing

Break https://github.com/leptonai/gpud/pull/157 into smaller PRs.