### PR TITLE
fix(pkg/process): skip without log for no such file

### DIFF
--- a/components/diagnose/scan.go
+++ b/components/diagnose/scan.go
@@ -44,6 +44,7 @@ func Scan(ctx context.Context, opts ...OpOption) error {
 
 	fmt.Printf("\n\n%s scanning the host\n\n", inProgress)
 
+	fmt.Printf("%s scanning the process counts\n", inProgress)
 	processCountsByStatus, err := process.CountProcessesByStatus(ctx)
 	if err != nil {
 		log.Logger.Warnw("error counting processes by status", "error", err)

--- a/pkg/process/pids.go
+++ b/pkg/process/pids.go
@@ -27,8 +27,15 @@ func CountProcessesByStatus(ctx context.Context) (map[string][]*procs.Process, e
 
 		status, err := p.Status()
 		if err != nil {
+			ee := strings.ToLower(err.Error())
+
 			// e.g., Not Found
-			if strings.Contains(strings.ToLower(err.Error()), "not found") {
+			if strings.Contains(ee, "not found") {
+				continue
+			}
+
+			// e.g., "open /proc/2342816/status: no such file or directory"
+			if strings.Contains(ee, "no such file") {
 				continue
 			}
 


### PR DESCRIPTION
We shouldn't see logs like these:

> {"level":"warn","ts":"2024-11-09T04:52:34Z","caller":"process/pids.go:35","msg":"failed to get status","error":"open /proc/2331227/status: no such file or directory"}
{"level":"warn","ts":"2024-11-09T04:52:34Z","caller":"process/pids.go:35","msg":"failed to get status","error":"open /proc/2331228/status: no such file or directory"}
{"level":"warn","ts":"2024-11-09T04:52:34Z","caller":"process/pids.go:35","msg":"failed to get status","error":"open /proc/2331232/status: no such file or directory"}
{"level":"warn","ts":"2024-11-09T04:52:34Z","caller":"process/pids.go:35","msg":"failed to get status","error":"open /proc/2337970/status: no such file or directory"}
{"level":"warn","ts":"2024-11-09T04:52:34Z","caller":"process/pids.go:35","msg":"failed to get status","error":"open /proc/2342816/status: no such file or directory"}

Break https://github.com/leptonai/gpud/pull/157 into smaller PRs.