### PR TITLE
ci(github): run uber-go/nilaway

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,0 +1,9 @@
+# https://github.com/uber-go/nilaway
+# https://github.com/golangci/golangci-lint/releases/tag/v1.61.0
+
+# This has to be >= v1.57.0 for module plugin system support.
+version: v1.61.0
+plugins:
+  - module: "go.uber.org/nilaway"
+    import: "go.uber.org/nilaway/cmd/gclplugin"
+    version: latest # Or a fixed version for reproducible builds.

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,11 +25,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
       - uses: actions/setup-go@v5
         with:
           cache: false
           go-version-file: go.mod
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           args: --config=.golangci.yml -v
+
+      - name: Build custom golangci-lint
+        run: golangci-lint custom
+
+      - name: Run custom golangci-lint
+        run: ./custom-gcl run

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -31,13 +31,11 @@ jobs:
           cache: false
           go-version-file: go.mod
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          args: --config=.golangci.yml -v
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
 
       - name: Build custom golangci-lint
         run: golangci-lint custom
 
-      - name: Run custom golangci-lint
-        run: ./custom-gcl run --verbose ./...
+      - name: Run golangci-lint
+        run: ./custom-gcl run --verbose --config=.golangci.yml ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -40,4 +40,4 @@ jobs:
         run: golangci-lint custom
 
       - name: Run custom golangci-lint
-        run: ./custom-gcl run
+        run: ./custom-gcl run --verbose ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,17 @@ linters-settings:
     # Setting locale to US will correct the British spelling of 'colour' to 'color'.
     locale: US
 
+  custom:
+
+    # ref. https://github.com/uber-go/nilaway
+    nilaway:
+      type: "module"
+      description: Static analysis tool to detect potential nil panics in Go code.
+      settings:
+        include-pkgs: "github.com/leptonai/gpud"
+        exclude-pkgs: "github.com/leptonai/gpud/third_party"
+        experimental-anonymous-function: "true"
+
 linters:
   fast: false
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,10 +10,12 @@ linters-settings:
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
+
   goimports:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
     local-prefixes: lepton.ai/lepton
+
   misspell:
     # Correct spellings using locale preferences for US or UK.
     # Default is to use a neutral variety of English.
@@ -21,7 +23,6 @@ linters-settings:
     locale: US
 
   custom:
-
     # ref. https://github.com/uber-go/nilaway
     nilaway:
       type: "module"


### PR DESCRIPTION
https://github.com/uber-go/nilaway

> level=info msg="golangci-lint has version v1.61.0-custom-gcl built with go1.23.1 from ? on 2024-11-09 05:32:32.785090935 +0000 UTC"
level=info msg="[config_reader] Used config file .golangci.yml"
level=info msg="Loaded : nilaway"
level=info msg="[lintersdb] Active 10 linters: [errcheck gofmt goimports gosimple govet ineffassign misspell staticcheck unconvert unused]"