### PR TITLE
fix(components/systemd): fix non-existing service uptime checks

### DIFF
--- a/components/systemd/component_output.go
+++ b/components/systemd/component_output.go
@@ -177,12 +177,19 @@ func CreateGet(cfg Config) query.GetFunc {
 				}
 			}
 
-			now := time.Now().UTC()
+			uptimeSeconds := int64(0)
+			uptimeDescription := "n/a"
+			if uptime != nil {
+				uptimeSeconds = int64(uptime.Seconds())
+
+				now := time.Now().UTC()
+				uptimeDescription = humanize.RelTime(now.Add(-*uptime), now, "ago", "from now")
+			}
 			o.Units = append(o.Units, Unit{
 				Name:            unit,
 				Active:          active,
-				UptimeSeconds:   int64(uptime.Seconds()),
-				UptimeHumanized: humanize.RelTime(now.Add(-uptime), now, "ago", "from now"),
+				UptimeSeconds:   uptimeSeconds,
+				UptimeHumanized: uptimeDescription,
 			})
 		}
 

--- a/pkg/systemd/systemd_test.go
+++ b/pkg/systemd/systemd_test.go
@@ -82,6 +82,11 @@ func TestParseSystemdUnitUptime(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			name:        "Valid input - Saturday",
+			input:       "Sat 2024-11-02 13:51:36 UTC\n",
+			expectedErr: false,
+		},
+		{
 			name:        "Invalid input",
 			input:       "Invalid input",
 			expectedErr: true,


### PR DESCRIPTION
> Error: failed to get uptime for unit kubelet: parsing time "n/a" as "Mon 2006-01-02 15:04:05 MST": cannot parse "n/a" as "Mon"

e.g.,

```
# sudo systemctl show --property=InactiveExitTimestamp kubelet
InactiveExitTimestamp=Fri 2024-11-08 03:20:47 UTC

# sudo systemctl show --property=InactiveExitTimestamp gpud
InactiveExitTimestamp=Sat 2024-11-02 13:51:36 UTC

# sudo systemctl show --property=InactiveExitTimestamp g2
InactiveExitTimestamp=n/a
```