### PR TITLE
fix(components/dmesg): do not read raw dmesg file with unix time

### DIFF
--- a/components/dmesg/config.go
+++ b/components/dmesg/config.go
@@ -55,8 +55,6 @@ func DefaultConfig(ctx context.Context) (Config, error) {
 	}
 
 	scanCommands := [][]string{
-		{"cat", DefaultDmesgFile},
-
 		// some old dmesg versions don't support --since, thus fall back to the one without --since and tail the last 200 lines
 		// ref. https://github.com/leptonai/gpud/issues/32
 		{"dmesg --ctime --nopager --buffer-size 163920 --since '1 hour ago' || dmesg --ctime --nopager --buffer-size 163920 | tail -n 200"},


### PR DESCRIPTION
Which makes wrong event detection with inconsistent timestamps than dmesg --ctime outputs:

> [1105056.784211] kernel: nvidia-peermem nv_get_p2p_free_callback:127 ERROR detected invalid context, skipping further processing
[1105056.804136] kernel: nvidia-peermem nv_get_p2p_free_callback:127 ERROR detected invalid context, skipping further processing
[1105056.824136] kernel: nvidia-peermem nv_get_p2p_free_callback:127 ERROR detected invalid context, skipping further processing