### PR TITLE
feat(query/log/tail): log stream with deduper

### DIFF
--- a/components/os/component_test.go
+++ b/components/os/component_test.go
@@ -25,7 +25,7 @@ func TestComponent(t *testing.T) {
 		},
 	)
 
-	time.Sleep(time.Second)
+	time.Sleep(2 * time.Second)
 
 	states, err := component.States(ctx)
 	if err != nil {

--- a/components/query/log/poller.go
+++ b/components/query/log/poller.go
@@ -96,6 +96,7 @@ func newPoller(ctx context.Context, cfg query_log_config.Config, parseTime query
 	cfg.SetDefaultsIfNotSet()
 
 	options := []query_log_tail.OpOption{
+		query_log_tail.WithDedup(true),
 		query_log_tail.WithSelectFilter(cfg.SelectFilters...),
 		query_log_tail.WithRejectFilter(cfg.RejectFilters...),
 		query_log_tail.WithParseTime(parseTime),
@@ -104,7 +105,7 @@ func newPoller(ctx context.Context, cfg query_log_config.Config, parseTime query
 	var tailLogger query_log_tail.Streamer
 	var err error
 	if cfg.File != "" {
-		tailLogger, err = query_log_tail.NewFromFile(cfg.File, cfg.SeekInfo, options...)
+		tailLogger, err = query_log_tail.NewFromFile(ctx, cfg.File, cfg.SeekInfo, options...)
 	} else {
 		tailLogger, err = query_log_tail.NewFromCommand(ctx, cfg.Commands, options...)
 	}

--- a/components/query/log/tail/streamer.go
+++ b/components/query/log/tail/streamer.go
@@ -1,6 +1,8 @@
 package tail
 
 import (
+	"sync"
+
 	query_log_common "github.com/leptonai/gpud/components/query/log/common"
 	"github.com/nxadm/tail"
 )
@@ -19,4 +21,17 @@ type Streamer interface {
 type Line struct {
 	*tail.Line
 	MatchedFilter *query_log_common.Filter
+}
+
+type streamDeduper struct {
+	seen map[string]struct{}
+	mu   sync.Mutex
+}
+
+var seenPool = sync.Pool{
+	New: func() interface{} {
+		return &streamDeduper{
+			seen: make(map[string]struct{}, 1000),
+		}
+	},
 }

--- a/components/query/log/tail/streamer_command.go
+++ b/components/query/log/tail/streamer_command.go
@@ -41,11 +41,17 @@ func NewFromCommand(ctx context.Context, commands [][]string, opts ...OpOption) 
 	stderrScanner := bufio.NewScanner(p.StderrReader())
 
 	streamer := &commandStreamer{
-		op:    op,
-		ctx:   ctx,
-		proc:  p,
-		lineC: make(chan Line, 200),
+		op:           op,
+		ctx:          ctx,
+		proc:         p,
+		lineC:        make(chan Line, 200),
+		dedupEnabled: op.dedup,
 	}
+
+	if op.dedup {
+		streamer.dedup = seenPool.Get().(*streamDeduper)
+	}
+
 	go streamer.pollLoops(stdoutScanner)
 	go streamer.pollLoops(stderrScanner)
 	go streamer.waitCommand()
@@ -60,6 +66,9 @@ type commandStreamer struct {
 	ctx   context.Context
 	proc  process.Process
 	lineC chan Line
+
+	dedupEnabled bool
+	dedup        *streamDeduper
 }
 
 func (sr *commandStreamer) File() string {
@@ -91,6 +100,18 @@ func (sr *commandStreamer) pollLoops(scanner *bufio.Scanner) {
 		}
 
 		s = scanner.Text()
+
+		if sr.dedupEnabled {
+			sr.dedup.mu.Lock()
+			_, exists := sr.dedup.seen[s]
+			if exists {
+				sr.dedup.mu.Unlock()
+				continue
+			}
+			sr.dedup.seen[s] = struct{}{}
+			sr.dedup.mu.Unlock()
+		}
+
 		ts, err = sr.op.parseTime([]byte(s))
 		if err != nil {
 			log.Logger.Warnw("error parsing time", "error", err)
@@ -109,22 +130,38 @@ func (sr *commandStreamer) pollLoops(scanner *bufio.Scanner) {
 			continue
 		}
 
-		select {
-		case sr.lineC <- Line{
+		lineToSend := Line{
 			Line: &tail.Line{
 				Text: s,
 				Time: ts,
 			},
 			MatchedFilter: matchedFilter,
-		}:
+		}
+
+		select {
+		case <-sr.ctx.Done():
+			return
+
+		case sr.lineC <- lineToSend:
+
 		default:
-			log.Logger.Debugw("channel is full -- dropped output", "pid", sr.proc.PID())
+			log.Logger.Warnw("channel is full -- dropped output", "pid", sr.proc.PID())
 		}
 	}
 }
 
 func (sr *commandStreamer) waitCommand() {
-	defer close(sr.lineC)
+	defer func() {
+		close(sr.lineC)
+
+		sr.dedup.mu.Lock()
+		for k := range sr.dedup.seen {
+			delete(sr.dedup.seen, k)
+		}
+		sr.dedup.mu.Unlock()
+		seenPool.Put(sr.dedup)
+	}()
+
 	select {
 	case <-sr.ctx.Done():
 	case <-sr.proc.Wait():

--- a/components/query/log/tail/streamer_command.go
+++ b/components/query/log/tail/streamer_command.go
@@ -154,12 +154,14 @@ func (sr *commandStreamer) waitCommand() {
 	defer func() {
 		close(sr.lineC)
 
-		sr.dedup.mu.Lock()
-		for k := range sr.dedup.seen {
-			delete(sr.dedup.seen, k)
+		if sr.dedupEnabled {
+			sr.dedup.mu.Lock()
+			for k := range sr.dedup.seen {
+				delete(sr.dedup.seen, k)
+			}
+			sr.dedup.mu.Unlock()
+			seenPool.Put(sr.dedup)
 		}
-		sr.dedup.mu.Unlock()
-		seenPool.Put(sr.dedup)
 	}()
 
 	select {

--- a/components/query/log/tail/streamer_command_test.go
+++ b/components/query/log/tail/streamer_command_test.go
@@ -106,6 +106,57 @@ func TestCommandStreamerDmesg(t *testing.T) {
 	t.Logf("%+v\n", streamer.Commands())
 }
 
+func TestCommandStreamerWithDedup(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	tmpf, err := os.CreateTemp("", "test*.txt")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpf.Name())
+
+	streamer, err := NewFromCommand(
+		ctx,
+		[][]string{{"tail", "-f", tmpf.Name()}},
+		WithDedup(true),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Second)
+
+	// Write same line multiple times
+	testLine := "duplicate line"
+	for i := 0; i < 10; i++ {
+		if _, err := tmpf.WriteString(testLine + "\n"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Should only receive one line despite writing multiple
+	select {
+	case line := <-streamer.Line():
+		t.Logf("received %q", line.Text)
+		if line.Text != testLine {
+			t.Fatalf("expected %q, got %q", testLine, line.Text)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for first line")
+	}
+
+	// Verify no more lines are received (as they should be deduped)
+	select {
+	case line := <-streamer.Line():
+		t.Fatalf("unexpected line received: %q", line.Text)
+	case <-time.After(2 * time.Second):
+		// This is the expected path - no additional lines should be received
+	}
+
+	t.Logf("%+v\n", streamer.Commands())
+}
+
 func readFileToLines(t *testing.T, path string) []string {
 	file, err := os.Open(path)
 	if err != nil {

--- a/components/query/log/tail/streamer_file.go
+++ b/components/query/log/tail/streamer_file.go
@@ -112,12 +112,14 @@ func (sr *fileStreamer) pollLoops() {
 		case <-sr.ctx.Done():
 			sr.file.Done()
 
-			sr.dedup.mu.Lock()
-			for k := range sr.dedup.seen {
-				delete(sr.dedup.seen, k)
+			if sr.dedupEnabled {
+				sr.dedup.mu.Lock()
+				for k := range sr.dedup.seen {
+					delete(sr.dedup.seen, k)
+				}
+				sr.dedup.mu.Unlock()
+				seenPool.Put(sr.dedup)
 			}
-			sr.dedup.mu.Unlock()
-			seenPool.Put(sr.dedup)
 			return
 
 		case sr.lineC <- lineToSend:

--- a/components/query/log/tail/streamer_file_test.go
+++ b/components/query/log/tail/streamer_file_test.go
@@ -1,6 +1,7 @@
 package tail
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -14,7 +15,9 @@ func TestFileStreamer(t *testing.T) {
 	}
 	defer os.Remove(tmpf.Name())
 
-	streamer, err := NewFromFile(tmpf.Name(), nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	streamer, err := NewFromFile(ctx, tmpf.Name(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,5 +39,49 @@ func TestFileStreamer(t *testing.T) {
 		case <-time.After(3 * time.Second):
 			t.Fatal("timeout")
 		}
+	}
+}
+
+func TestFileStreamerWithDedup(t *testing.T) {
+	tmpf, err := os.CreateTemp("", "test*.txt")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpf.Name())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	streamer, err := NewFromFile(ctx, tmpf.Name(), nil, WithDedup(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Second)
+
+	// Write same line multiple times
+	testLine := "duplicate line"
+	for i := 0; i < 10; i++ {
+		if _, err := tmpf.WriteString(testLine + "\n"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Should only receive one line despite writing three
+	select {
+	case line := <-streamer.Line():
+		t.Logf("received %q (%v, %+v)", line.Text, line.Time, line.SeekInfo)
+		if line.Text != testLine {
+			t.Fatalf("expected %q, got %q", testLine, line.Text)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for first line")
+	}
+
+	// Verify no more lines are received (as they should be deduped)
+	select {
+	case line := <-streamer.Line():
+		t.Fatalf("unexpected line received: %q", line.Text)
+	case <-time.After(2 * time.Second):
+		// This is the expected path - no additional lines should be received
 	}
 }


### PR DESCRIPTION
Will be useful to dedup the same messages from dmesg:

![image (1)](https://github.com/user-attachments/assets/2fcfdfed-aa66-4594-a1b3-191c6e81b95d)
