### PR TITLE
feat(nvidia): parse infiniband ibstat for error checking based on GPU card counts

### DIFF
--- a/components/accelerator/nvidia/infiniband/component.go
+++ b/components/accelerator/nvidia/infiniband/component.go
@@ -26,6 +26,7 @@ func New(ctx context.Context, cfg Config) components.Component {
 		rootCtx: ctx,
 		cancel:  ccancel,
 		poller:  nvidia_query.GetDefaultPoller(),
+		cfg:     cfg,
 	}
 }
 
@@ -35,6 +36,7 @@ type component struct {
 	rootCtx context.Context
 	cancel  context.CancelFunc
 	poller  query.Poller
+	cfg     Config
 }
 
 func (c *component) Name() string { return Name }
@@ -78,7 +80,7 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	}
 
 	output := ToOutput(allOutput)
-	return output.States()
+	return output.States(c.cfg)
 }
 
 func (c *component) Events(ctx context.Context, since time.Time) ([]components.Event, error) {

--- a/components/accelerator/nvidia/infiniband/component_output.go
+++ b/components/accelerator/nvidia/infiniband/component_output.go
@@ -101,7 +101,7 @@ func (o *Output) Evaluate() (string, bool, error) {
 		if len(o.Ibstat.Errors) > 0 {
 			return fmt.Sprintf("infiniband suppported but ibstat errors found: %s", strings.Join(o.Ibstat.Errors, ", ")), false, nil
 		}
-		if o.Ibstat.Parsed != nil && len(o.Ibstat.Parsed) > 0 {
+		if len(o.Ibstat.Parsed) > 0 {
 			upCards := o.Ibstat.Parsed.CountByRates(o.GPUCount, "Active", "LinkUp")
 			if upCards != o.GPUCount {
 				return fmt.Sprintf("only %d out of %d ibstat cards are active and link up", upCards, o.GPUCount), false, nil

--- a/components/accelerator/nvidia/infiniband/component_output.go
+++ b/components/accelerator/nvidia/infiniband/component_output.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/leptonai/gpud/components"
 	nvidia_query "github.com/leptonai/gpud/components/accelerator/nvidia/query"
+	"github.com/leptonai/gpud/components/accelerator/nvidia/query/infiniband"
 	"github.com/leptonai/gpud/components/common"
 )
 
@@ -35,9 +36,9 @@ type Output struct {
 	// Useful to ignore infiniband states for non-infiniband supported GPUs (e.g., GTX 4090).
 	GPUProductName string `json:"gpu_product_name"`
 
-	InfinibandClassExists bool                      `json:"infiniband_class_exists"`
-	IbstatExists          bool                      `json:"ibstat_exists"`
-	Ibstat                nvidia_query.IbstatOutput `json:"ibstat"`
+	InfinibandClassExists bool                    `json:"infiniband_class_exists"`
+	IbstatExists          bool                    `json:"ibstat_exists"`
+	Ibstat                infiniband.IbstatOutput `json:"ibstat"`
 }
 
 func (o *Output) JSON() ([]byte, error) {
@@ -88,7 +89,7 @@ func ParseStatesToOutput(states ...components.State) (*Output, error) {
 
 // Returns the output evaluation reason and its healthy-ness.
 func (o *Output) Evaluate() (string, bool, error) {
-	if !nvidia_query.SupportsInfinibandProduct(o.GPUProductName) {
+	if !infiniband.SupportsInfinibandProduct(o.GPUProductName) {
 		return fmt.Sprintf("%q GPUs do not support infiniband", o.GPUProductName), true, nil
 	}
 	if o.InfinibandClassExists && o.IbstatExists && len(o.Ibstat.Errors) > 0 {

--- a/components/accelerator/nvidia/infiniband/component_output_test.go
+++ b/components/accelerator/nvidia/infiniband/component_output_test.go
@@ -57,6 +57,29 @@ func TestOutputStates(t *testing.T) {
 			expectedHealthy: true,
 			expectedReason:  "no infiniband class found or no ibstat exists or no ibstat error found",
 		},
+		{
+			name: "Not all cards active and up",
+			o: &Output{
+				GPUProductName:        "NVIDIA H100",
+				GPUCount:              8,
+				InfinibandClassExists: true,
+				IbstatExists:          true,
+				Ibstat: infiniband.IbstatOutput{
+					Parsed: infiniband.IBStatCards{
+						{Port1: infiniband.IBStatPort{State: "Active", PhysicalState: "LinkUp", Rate: 400}},
+						{Port1: infiniband.IBStatPort{State: "Active", PhysicalState: "LinkUp", Rate: 400}},
+						{Port1: infiniband.IBStatPort{State: "Down", PhysicalState: "Disabled", Rate: 400}},
+						{Port1: infiniband.IBStatPort{State: "Active", PhysicalState: "LinkUp", Rate: 400}},
+						{Port1: infiniband.IBStatPort{State: "Active", PhysicalState: "LinkUp", Rate: 400}},
+						{Port1: infiniband.IBStatPort{State: "Active", PhysicalState: "LinkUp", Rate: 400}},
+						{Port1: infiniband.IBStatPort{State: "Active", PhysicalState: "LinkUp", Rate: 400}},
+						{Port1: infiniband.IBStatPort{State: "Down", PhysicalState: "Disabled", Rate: 400}},
+					},
+				},
+			},
+			expectedHealthy: false,
+			expectedReason:  "only 6 out of 8 ibstat cards are active and link up",
+		},
 	}
 
 	for _, tt := range tests {

--- a/components/accelerator/nvidia/infiniband/component_output_test.go
+++ b/components/accelerator/nvidia/infiniband/component_output_test.go
@@ -11,12 +11,17 @@ import (
 func TestOutputStates(t *testing.T) {
 	tests := []struct {
 		name            string
+		cfg             Config
 		o               *Output
 		expectedHealthy bool
 		expectedReason  string
 	}{
 		{
 			name: "GTX 4090 state",
+			cfg: Config{
+				ExpectedPortCount: 1,
+				ExpectedRate:      400,
+			},
 			o: &Output{
 				GPUProductName: "NVIDIA GeForce RTX 4090",
 			},
@@ -25,6 +30,10 @@ func TestOutputStates(t *testing.T) {
 		},
 		{
 			name: "Healthy state",
+			cfg: Config{
+				ExpectedPortCount: 1,
+				ExpectedRate:      400,
+			},
 			o: &Output{
 				GPUProductName:        "NVIDIA A100",
 				InfinibandClassExists: true,
@@ -36,6 +45,10 @@ func TestOutputStates(t *testing.T) {
 		},
 		{
 			name: "Unhealthy state",
+			cfg: Config{
+				ExpectedPortCount: 0,
+				ExpectedRate:      400,
+			},
 			o: &Output{
 				GPUProductName:        "NVIDIA H100",
 				InfinibandClassExists: true,
@@ -49,6 +62,10 @@ func TestOutputStates(t *testing.T) {
 		},
 		{
 			name: "No ibstat state",
+			cfg: Config{
+				ExpectedPortCount: 0,
+				ExpectedRate:      400,
+			},
 			o: &Output{
 				GPUProductName:        "NVIDIA H100",
 				InfinibandClassExists: false,
@@ -59,6 +76,10 @@ func TestOutputStates(t *testing.T) {
 		},
 		{
 			name: "Not all cards active and up",
+			cfg: Config{
+				ExpectedPortCount: 0,
+				ExpectedRate:      400,
+			},
 			o: &Output{
 				GPUProductName:        "NVIDIA H100",
 				GPUCount:              8,
@@ -84,7 +105,7 @@ func TestOutputStates(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			states, err := tt.o.States()
+			states, err := tt.o.States(tt.cfg)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/components/accelerator/nvidia/infiniband/component_output_test.go
+++ b/components/accelerator/nvidia/infiniband/component_output_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	nvidia_query "github.com/leptonai/gpud/components/accelerator/nvidia/query"
+	"github.com/leptonai/gpud/components/accelerator/nvidia/query/infiniband"
 	"github.com/leptonai/gpud/components/common"
 )
 
@@ -28,7 +29,7 @@ func TestOutputStates(t *testing.T) {
 				GPUProductName:        "NVIDIA A100",
 				InfinibandClassExists: true,
 				IbstatExists:          true,
-				Ibstat:                nvidia_query.IbstatOutput{},
+				Ibstat:                infiniband.IbstatOutput{},
 			},
 			expectedHealthy: true,
 			expectedReason:  "no infiniband class found or no ibstat exists or no ibstat error found",
@@ -39,7 +40,7 @@ func TestOutputStates(t *testing.T) {
 				GPUProductName:        "NVIDIA H100",
 				InfinibandClassExists: true,
 				IbstatExists:          true,
-				Ibstat: nvidia_query.IbstatOutput{
+				Ibstat: infiniband.IbstatOutput{
 					Errors: []string{"Error 1", "Error 2"},
 				},
 			},

--- a/components/accelerator/nvidia/infiniband/config.go
+++ b/components/accelerator/nvidia/infiniband/config.go
@@ -7,8 +7,20 @@ import (
 	query_config "github.com/leptonai/gpud/components/query/config"
 )
 
+const (
+	DefaultExpectedRate = 400
+)
+
 type Config struct {
 	Query query_config.Config `json:"query"`
+
+	// The number of ports expected to be "Active" and "LinkUp".
+	// If not set, it defaults to the number of GPUs.
+	ExpectedPortCount int `json:"expected_port_count"`
+
+	// The rate expected to be "Active" and "LinkUp".
+	// If not set, it defaults to 400.
+	ExpectedRate int `json:"expected_rate"`
 }
 
 func ParseConfig(b any, db *sql.DB) (*Config, error) {
@@ -27,6 +39,9 @@ func ParseConfig(b any, db *sql.DB) (*Config, error) {
 	return cfg, nil
 }
 
-func (cfg Config) Validate() error {
+func (cfg *Config) Validate() error {
+	if cfg.ExpectedRate == 0 {
+		cfg.ExpectedRate = DefaultExpectedRate
+	}
 	return nil
 }

--- a/components/accelerator/nvidia/infiniband/config_test.go
+++ b/components/accelerator/nvidia/infiniband/config_test.go
@@ -1,0 +1,98 @@
+package infiniband
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]interface{}
+		wantErr bool
+		want    Config
+	}{
+		{
+			name: "valid config",
+			input: map[string]interface{}{
+				"expected_port_count": 4,
+				"expected_rate":       200,
+			},
+			wantErr: false,
+			want: Config{
+				ExpectedPortCount: 4,
+				ExpectedRate:      200,
+			},
+		},
+		{
+			name:    "empty config",
+			input:   map[string]interface{}{},
+			wantErr: false,
+			want:    Config{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseConfig(tt.input, nil)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseConfig() error = nil, wantErr = true")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ParseConfig() error = %v, wantErr = false", err)
+				return
+			}
+			if !reflect.DeepEqual(*got, tt.want) {
+				t.Errorf("ParseConfig() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     Config
+		wantError  bool
+		wantConfig Config
+	}{
+		{
+			name:   "zero expected rate should set default",
+			config: Config{ExpectedRate: 0},
+			wantConfig: Config{
+				ExpectedRate: DefaultExpectedRate,
+			},
+			wantError: false,
+		},
+		{
+			name:   "non-zero expected rate should remain unchanged",
+			config: Config{ExpectedRate: 200},
+			wantConfig: Config{
+				ExpectedRate: 200,
+			},
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("Validate() error = nil, wantErr = true")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Validate() error = %v, wantErr = false", err)
+				return
+			}
+			if tt.config.ExpectedRate != tt.wantConfig.ExpectedRate {
+				t.Errorf("ExpectedRate = %v, want %v", tt.config.ExpectedRate, tt.wantConfig.ExpectedRate)
+			}
+		})
+	}
+}

--- a/components/accelerator/nvidia/peermem/component_output.go
+++ b/components/accelerator/nvidia/peermem/component_output.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/leptonai/gpud/components"
 	nvidia_query "github.com/leptonai/gpud/components/accelerator/nvidia/query"
+	"github.com/leptonai/gpud/components/accelerator/nvidia/query/peermem"
 )
 
 // ToOutput converts nvidia_query.Output to Output.
@@ -29,8 +30,8 @@ type Output struct {
 	// This is used to determine if ibcore may be expected to use peermem module.
 	GPUCount int `json:"gpu_count"`
 
-	ProductName  string                                `json:"product_name"`
-	LsmodPeermem nvidia_query.LsmodPeermemModuleOutput `json:"lsmod_peermem"`
+	ProductName  string                           `json:"product_name"`
+	LsmodPeermem peermem.LsmodPeermemModuleOutput `json:"lsmod_peermem"`
 }
 
 func (o *Output) JSON() ([]byte, error) {

--- a/components/accelerator/nvidia/query/infiniband/infiniband.go
+++ b/components/accelerator/nvidia/query/infiniband/infiniband.go
@@ -1,4 +1,5 @@
-package query
+// Package infiniband provides utilities to query infiniband status.
+package infiniband
 
 import (
 	"context"

--- a/components/accelerator/nvidia/query/infiniband/infiniband.go
+++ b/components/accelerator/nvidia/query/infiniband/infiniband.go
@@ -59,24 +59,6 @@ func RunIbstat(ctx context.Context) (*IbstatOutput, error) {
 			o.Errors = append(o.Errors, err.Error())
 		}
 	}
-	if len(o.Parsed) > 0 {
-		for _, card := range o.Parsed {
-			// "State: Active"
-			if card.Port1.State == "Active" {
-				continue
-			}
-			// "Physical state: LinkUp"
-			if card.Port1.PhysicalState == "LinkUp" {
-				continue
-			}
-
-			// TODO: implement more checks
-			// some providers have
-			// "State: Down"
-			// "Physical state: Disabled"
-			// "Rate: 40"
-		}
-	}
 
 	return o, nil
 }

--- a/components/accelerator/nvidia/query/infiniband/infiniband_test.go
+++ b/components/accelerator/nvidia/query/infiniband/infiniband_test.go
@@ -1,4 +1,4 @@
-package query
+package infiniband
 
 import "testing"
 

--- a/components/accelerator/nvidia/query/infiniband/parse.go
+++ b/components/accelerator/nvidia/query/infiniband/parse.go
@@ -13,7 +13,7 @@ type IBStatCards []IBStatCard
 // than the specified rate (e.g., count all the cards whose rate is >= 400).
 // If `expectedState` is not empty, it only counts the cards whose "Port 1"."State" is equal to the expected state.
 // If `expectedPhysicalState` is not empty, it only counts the cards whose "Port 1"."Physical state" is equal to the expected physical state.
-func (cards IBStatCards) CountRates(rate int, expectedState string, expectedPhysicalState string) int {
+func (cards IBStatCards) CountByRates(rate int, expectedState string, expectedPhysicalState string) int {
 	cnt := 0
 	for _, card := range cards {
 		if card.Port1.Rate < rate {

--- a/components/accelerator/nvidia/query/infiniband/parse.go
+++ b/components/accelerator/nvidia/query/infiniband/parse.go
@@ -1,0 +1,136 @@
+package infiniband
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+type IBStatCards []IBStatCard
+
+type IBStatCard struct {
+	Name            string     `yaml:"CA name"`
+	Type            string     `yaml:"CA type"`
+	NumPorts        string     `yaml:"Number of ports"`
+	FirmwareVersion string     `yaml:"Firmware version"`
+	HardwareVersion string     `yaml:"Hardware version"`
+	NodeGUID        string     `yaml:"Node GUID"`
+	SystemImageGUID string     `yaml:"System image GUID"`
+	Port1           IBStatPort `yaml:"Port 1"`
+}
+
+type IBStatPort struct {
+	State         string `yaml:"State"`
+	PhysicalState string `yaml:"Physical state"`
+	Rate          int    `yaml:"Rate"`
+	BaseLid       int    `yaml:"Base lid"`
+	LinkLayer     string `yaml:"Link layer"`
+}
+
+// ParseIBStat parses ibstat output and returns YAML representation
+func ParseIBStat(input string) (IBStatCards, error) {
+	scanner := bufio.NewScanner(strings.NewReader(input))
+
+	lines := make([]string, 0)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		// CA 'mlx5_9'
+		// should be
+		// - CA name: mlx5_9
+		// with the indentation
+		// but we convert them at the end
+		if strings.HasPrefix(line, "CA '") && !strings.HasPrefix(strings.TrimSpace(line), "CA type:") {
+			line = strings.TrimSpace(line)
+			line = strings.TrimPrefix(line, "CA '")
+			line = strings.TrimSuffix(line, "'")
+			lines = append(lines, "- CA name: "+line)
+			continue
+		}
+
+		// CA type: MT4125
+		if strings.HasPrefix(strings.TrimSpace(line), "CA type:") {
+			lines = append(lines, "  "+strings.TrimSpace(line))
+			continue
+		}
+
+		// Number of ports: 1
+		if strings.HasPrefix(strings.TrimSpace(line), "Number of ports:") {
+			lines = append(lines, "  "+strings.TrimSpace(line))
+			continue
+		}
+
+		// Firmware version: 28.39.1002
+		if strings.HasPrefix(strings.TrimSpace(line), "Firmware version:") {
+			lines = append(lines, "  "+strings.TrimSpace(line))
+			continue
+		}
+
+		// Hardware version: 0
+		if strings.HasPrefix(strings.TrimSpace(line), "Hardware version:") {
+			lines = append(lines, "  "+strings.TrimSpace(line))
+			continue
+		}
+
+		// Node GUID: 0xa088c20300e3142a
+		if strings.HasPrefix(strings.TrimSpace(line), "Node GUID:") {
+			lines = append(lines, "  "+strings.TrimSpace(line))
+			continue
+		}
+
+		// System image GUID: 0xa088c20300e3142a
+		if strings.HasPrefix(strings.TrimSpace(line), "System image GUID:") {
+			lines = append(lines, "  "+strings.TrimSpace(line))
+			continue
+		}
+
+		// Port 1:
+		if strings.HasPrefix(strings.TrimSpace(line), "Port 1:") {
+			lines = append(lines, "  "+strings.TrimSpace(line))
+			continue
+		}
+
+		// Port 1:
+		//    State: ...
+		if strings.HasPrefix(strings.TrimSpace(line), "State:") {
+			lines = append(lines, "    "+strings.TrimSpace(line))
+			continue
+		}
+
+		// Port 1:
+		//    Physical state: ...
+		if strings.HasPrefix(strings.TrimSpace(line), "Physical state:") {
+			lines = append(lines, "    "+strings.TrimSpace(line))
+			continue
+		}
+
+		// Port 1:
+		//    Rate: ...
+		if strings.HasPrefix(strings.TrimSpace(line), "Rate:") {
+			lines = append(lines, "    "+strings.TrimSpace(line))
+			continue
+		}
+
+		// Port 1:
+		//    Link layer: ...
+		if strings.HasPrefix(strings.TrimSpace(line), "Link layer:") {
+			lines = append(lines, "    "+strings.TrimSpace(line))
+			continue
+		}
+	}
+
+	txt := strings.Join(lines, "\n")
+	fmt.Printf("txt:\n\n%s\n\n", txt)
+
+	// Convert to YAML
+	cards := IBStatCards{}
+	if err := yaml.Unmarshal([]byte(txt), &cards); err != nil {
+		return nil, err
+	}
+	return cards, nil
+}

--- a/components/accelerator/nvidia/query/infiniband/parse_test.go
+++ b/components/accelerator/nvidia/query/infiniband/parse_test.go
@@ -43,10 +43,63 @@ func TestParseIBStatFiles(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to read file %s: %v", file, err)
 		}
-		parsed, err := ParseIBStat(string(content))
-		if err != nil {
+		if _, err := ParseIBStat(string(content)); err != nil {
 			t.Fatalf("Failed to parse ibstat file %s: %v", file, err)
 		}
-		t.Logf("parsed:\n%+v", parsed)
+	}
+}
+
+func TestParseIBStatCountRates(t *testing.T) {
+	tt := []struct {
+		fileName              string
+		rate                  int
+		expectedState         string
+		expectedPhysicalState string
+		expectedCount         int
+	}{
+		{
+			fileName:              "testdata/ibstat.47.0.all.active.0",
+			rate:                  400,
+			expectedState:         "Active",
+			expectedPhysicalState: "LinkUp",
+			expectedCount:         8,
+		},
+		{
+			fileName:              "testdata/ibstat.47.0.all.active.1",
+			rate:                  400,
+			expectedState:         "Active",
+			expectedPhysicalState: "LinkUp",
+			expectedCount:         8,
+		},
+		{
+			fileName:              "testdata/ibstat.47.0.some.down.0",
+			rate:                  400,
+			expectedState:         "Active",
+			expectedPhysicalState: "LinkUp",
+			expectedCount:         8,
+		},
+		{
+			fileName:              "testdata/ibstat.47.0.some.down.1",
+			rate:                  400,
+			expectedState:         "Active",
+			expectedPhysicalState: "LinkUp",
+			expectedCount:         6,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.fileName, func(t *testing.T) {
+			content, err := os.ReadFile(tc.fileName)
+			if err != nil {
+				t.Fatalf("Failed to read file %s: %v", tc.fileName, err)
+			}
+			parsed, err := ParseIBStat(string(content))
+			if err != nil {
+				t.Fatalf("Failed to parse ibstat file %s: %v", tc.fileName, err)
+			}
+			count := parsed.CountRates(tc.rate, tc.expectedState, tc.expectedPhysicalState)
+			if count != tc.expectedCount {
+				t.Errorf("Expected %d cards, got %d", tc.expectedCount, count)
+			}
+		})
 	}
 }

--- a/components/accelerator/nvidia/query/infiniband/parse_test.go
+++ b/components/accelerator/nvidia/query/infiniband/parse_test.go
@@ -1,0 +1,52 @@
+package infiniband
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseIBStat(t *testing.T) {
+	input := `CA 'mlx5_0'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e3142a
+	System image GUID: 0xa088c20300e3142a
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee3142a
+		Link layer: Ethernet`
+
+	parsed, err := ParseIBStat(input)
+	if err != nil {
+		t.Fatalf("Failed to parse ibstat output: %v", err)
+	}
+	t.Logf("parsed:\n%+v", parsed)
+}
+
+func TestParseIBStatFiles(t *testing.T) {
+	files, err := filepath.Glob("testdata/ibstat.*")
+	if err != nil {
+		t.Fatalf("Failed to get ibstat files: %v", err)
+	}
+	for _, file := range files {
+		t.Logf("file: %s", file)
+		content, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("Failed to read file %s: %v", file, err)
+		}
+		parsed, err := ParseIBStat(string(content))
+		if err != nil {
+			t.Fatalf("Failed to parse ibstat file %s: %v", file, err)
+		}
+		t.Logf("parsed:\n%+v", parsed)
+	}
+}

--- a/components/accelerator/nvidia/query/infiniband/parse_test.go
+++ b/components/accelerator/nvidia/query/infiniband/parse_test.go
@@ -49,7 +49,7 @@ func TestParseIBStatFiles(t *testing.T) {
 	}
 }
 
-func TestParseIBStatCountRates(t *testing.T) {
+func TestParseIBStatCountByRates(t *testing.T) {
 	tt := []struct {
 		fileName              string
 		rate                  int
@@ -96,7 +96,7 @@ func TestParseIBStatCountRates(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to parse ibstat file %s: %v", tc.fileName, err)
 			}
-			count := parsed.CountRates(tc.rate, tc.expectedState, tc.expectedPhysicalState)
+			count := parsed.CountByRates(tc.rate, tc.expectedState, tc.expectedPhysicalState)
 			if count != tc.expectedCount {
 				t.Errorf("Expected %d cards, got %d", tc.expectedCount, count)
 			}

--- a/components/accelerator/nvidia/query/infiniband/testdata/ibstat.47.0.all.active.0
+++ b/components/accelerator/nvidia/query/infiniband/testdata/ibstat.47.0.all.active.0
@@ -1,0 +1,204 @@
+CA 'mlx5_0'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e3142a
+	System image GUID: 0xa088c20300e3142a
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee3142a
+		Link layer: Ethernet
+CA 'mlx5_1'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xe8ebd303003307da
+	System image GUID: 0xe8ebd303003307da
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_10'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e313fa
+	System image GUID: 0xa088c20300e313fa
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee313fa
+		Link layer: Ethernet
+CA 'mlx5_11'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e0478e
+	System image GUID: 0xa088c20300e0478e
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee0478e
+		Link layer: Ethernet
+CA 'mlx5_2'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xe8ebd303003307db
+	System image GUID: 0xe8ebd303003307da
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_3'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e312f2
+	System image GUID: 0xa088c20300e312f2
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee312f2
+		Link layer: Ethernet
+CA 'mlx5_4'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e31372
+	System image GUID: 0xa088c20300e31372
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee31372
+		Link layer: Ethernet
+CA 'mlx5_5'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e04776
+	System image GUID: 0xa088c20300e04776
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee04776
+		Link layer: Ethernet
+CA 'mlx5_6'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e0476e
+	System image GUID: 0xa088c20300e0476e
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee0476e
+		Link layer: Ethernet
+CA 'mlx5_7'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xe8ebd303003308d6
+	System image GUID: 0xe8ebd303003308d6
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_8'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xe8ebd303003308d7
+	System image GUID: 0xe8ebd303003308d6
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_9'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e313f2
+	System image GUID: 0xa088c20300e313f2
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee313f2
+		Link layer: Ethernet

--- a/components/accelerator/nvidia/query/infiniband/testdata/ibstat.47.0.all.active.1
+++ b/components/accelerator/nvidia/query/infiniband/testdata/ibstat.47.0.all.active.1
@@ -1,0 +1,204 @@
+CA 'mlx5_0'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e3142a
+	System image GUID: 0xa088c20300e3142a
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee3142a
+		Link layer: Ethernet
+CA 'mlx5_1'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xe8ebd303003307da
+	System image GUID: 0xe8ebd303003307da
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_10'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e313fa
+	System image GUID: 0xa088c20300e313fa
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee313fa
+		Link layer: Ethernet
+CA 'mlx5_11'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e0478e
+	System image GUID: 0xa088c20300e0478e
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee0478e
+		Link layer: Ethernet
+CA 'mlx5_2'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xe8ebd303003307db
+	System image GUID: 0xe8ebd303003307da
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_3'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e312f2
+	System image GUID: 0xa088c20300e312f2
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee312f2
+		Link layer: Ethernet
+CA 'mlx5_4'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e31372
+	System image GUID: 0xa088c20300e31372
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee31372
+		Link layer: Ethernet
+CA 'mlx5_5'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e04776
+	System image GUID: 0xa088c20300e04776
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee04776
+		Link layer: Ethernet
+CA 'mlx5_6'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e0476e
+	System image GUID: 0xa088c20300e0476e
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee0476e
+		Link layer: Ethernet
+CA 'mlx5_7'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xe8ebd303003308d6
+	System image GUID: 0xe8ebd303003308d6
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_8'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xe8ebd303003308d7
+	System image GUID: 0xe8ebd303003308d6
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_9'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300e313f2
+	System image GUID: 0xa088c20300e313f2
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffee313f2
+		Link layer: Ethernet

--- a/components/accelerator/nvidia/query/infiniband/testdata/ibstat.47.0.some.down.0
+++ b/components/accelerator/nvidia/query/infiniband/testdata/ibstat.47.0.some.down.0
@@ -1,0 +1,204 @@
+CA 'mlx5_0'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0x946dae0300cde72c
+	System image GUID: 0x946dae0300cde72c
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 75
+		LMC: 0
+		SM lid: 334
+		Capability mask: 0xa751e848
+		Port GUID: 0x946dae0300cde72c
+		Link layer: InfiniBand
+CA 'mlx5_1'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.38.1002
+	Hardware version: 0
+	Node GUID: 0x946dae0300c2b690
+	System image GUID: 0x946dae0300c2b690
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x966daefffec2b690
+		Link layer: Ethernet
+CA 'mlx5_10'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0x946dae0300cde884
+	System image GUID: 0x946dae0300cde884
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 828
+		LMC: 0
+		SM lid: 334
+		Capability mask: 0xa751e848
+		Port GUID: 0x946dae0300cde884
+		Link layer: InfiniBand
+CA 'mlx5_11'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0x946dae0300cdea00
+	System image GUID: 0x946dae0300cdea00
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 944
+		LMC: 0
+		SM lid: 334
+		Capability mask: 0xa751e848
+		Port GUID: 0x946dae0300cdea00
+		Link layer: InfiniBand
+CA 'mlx5_2'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.38.1002
+	Hardware version: 0
+	Node GUID: 0x946dae0300c2b691
+	System image GUID: 0x946dae0300c2b690
+	Port 1:
+		State: Down
+		Physical state: Disabled
+		Rate: 40
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x966daefffec2b691
+		Link layer: Ethernet
+CA 'mlx5_3'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0x946dae0300cde728
+	System image GUID: 0x946dae0300cde728
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 143
+		LMC: 0
+		SM lid: 334
+		Capability mask: 0xa751e848
+		Port GUID: 0x946dae0300cde728
+		Link layer: InfiniBand
+CA 'mlx5_4'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0x946dae0300cde78c
+	System image GUID: 0x946dae0300cde78c
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 343
+		LMC: 0
+		SM lid: 334
+		Capability mask: 0xa751e848
+		Port GUID: 0x946dae0300cde78c
+		Link layer: InfiniBand
+CA 'mlx5_5'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0x946dae0300cde780
+	System image GUID: 0x946dae0300cde780
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 454
+		LMC: 0
+		SM lid: 334
+		Capability mask: 0xa751e848
+		Port GUID: 0x946dae0300cde780
+		Link layer: InfiniBand
+CA 'mlx5_6'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0x946dae0300cde8ac
+	System image GUID: 0x946dae0300cde8ac
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 597
+		LMC: 0
+		SM lid: 334
+		Capability mask: 0xa751e848
+		Port GUID: 0x946dae0300cde8ac
+		Link layer: InfiniBand
+CA 'mlx5_7'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.38.1002
+	Hardware version: 0
+	Node GUID: 0x946dae0300c2b648
+	System image GUID: 0x946dae0300c2b648
+	Port 1:
+		State: Down
+		Physical state: Disabled
+		Rate: 40
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x966daefffec2b648
+		Link layer: Ethernet
+CA 'mlx5_8'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.38.1002
+	Hardware version: 0
+	Node GUID: 0x946dae0300c2b649
+	System image GUID: 0x946dae0300c2b648
+	Port 1:
+		State: Down
+		Physical state: Disabled
+		Rate: 40
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x966daefffec2b649
+		Link layer: Ethernet
+CA 'mlx5_9'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0x946dae0300cde9c8
+	System image GUID: 0x946dae0300cde9c8
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 771
+		LMC: 0
+		SM lid: 334
+		Capability mask: 0xa751e848
+		Port GUID: 0x946dae0300cde9c8
+		Link layer: InfiniBand

--- a/components/accelerator/nvidia/query/infiniband/testdata/ibstat.47.0.some.down.1
+++ b/components/accelerator/nvidia/query/infiniband/testdata/ibstat.47.0.some.down.1
@@ -1,0 +1,204 @@
+CA 'mlx5_0'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300adeab8
+	System image GUID: 0xa088c20300adeab8
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffeadeab8
+		Link layer: Ethernet
+CA 'mlx5_1'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xb83fd203002a1a1c
+	System image GUID: 0xb83fd203002a1a1c
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_10'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300bb98b4
+	System image GUID: 0xa088c20300bb98b4
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffebb98b4
+		Link layer: Ethernet
+CA 'mlx5_11'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300bb3514
+	System image GUID: 0xa088c20300bb3514
+	Port 1:
+		State: Down
+		Physical state: Disabled
+		Rate: 40
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_2'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xb83fd203002a1a1d
+	System image GUID: 0xb83fd203002a1a1c
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_3'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300adeaa8
+	System image GUID: 0xa088c20300adeaa8
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffeadeaa8
+		Link layer: Ethernet
+CA 'mlx5_4'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300adeb88
+	System image GUID: 0xa088c20300adeb88
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffeadeb88
+		Link layer: Ethernet
+CA 'mlx5_5'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300adeb20
+	System image GUID: 0xa088c20300adeb20
+	Port 1:
+		State: Down
+		Physical state: Disabled
+		Rate: 40
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_6'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300bb9804
+	System image GUID: 0xa088c20300bb9804
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffebb9804
+		Link layer: Ethernet
+CA 'mlx5_7'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xe8ebd303003307a2
+	System image GUID: 0xe8ebd303003307a2
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_8'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xe8ebd303003307a3
+	System image GUID: 0xe8ebd303003307a2
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_9'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300adeb60
+	System image GUID: 0xa088c20300adeb60
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffeadeb60
+		Link layer: Ethernet

--- a/components/accelerator/nvidia/query/peermem/peermem.go
+++ b/components/accelerator/nvidia/query/peermem/peermem.go
@@ -1,4 +1,4 @@
-package query
+package peermem
 
 import (
 	"bufio"
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/leptonai/gpud/components/accelerator/nvidia/query/infiniband"
 	"github.com/leptonai/gpud/log"
 	"github.com/leptonai/gpud/pkg/process"
 )
@@ -75,8 +76,8 @@ func CheckLsmodPeermemModule(ctx context.Context) (*LsmodPeermemModuleOutput, er
 	}
 
 	o := &LsmodPeermemModuleOutput{
-		IbstatExists:          IbstatExists(),
-		InfinibandClassExists: InfinibandClassExists(),
+		IbstatExists:          infiniband.IbstatExists(),
+		InfinibandClassExists: infiniband.InfinibandClassExists(),
 		Raw:                   strings.Join(lines, "\n"),
 	}
 	o.IbcoreUsingPeermemModule = HasLsmodInfinibandPeerMem(o.Raw)

--- a/components/accelerator/nvidia/query/peermem/peermem_test.go
+++ b/components/accelerator/nvidia/query/peermem/peermem_test.go
@@ -1,4 +1,4 @@
-package query
+package peermem
 
 import "testing"
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -800,7 +800,13 @@ func New(ctx context.Context, config *lepconfig.Config, endpoint string, cliUID 
 			allComponents = append(allComponents, nvidia_gsp_firmware_mode.New(ctx, cfg))
 
 		case nvidia_infiniband.Name:
-			cfg := nvidia_infiniband.Config{Query: defaultQueryCfg}
+			cfg := nvidia_infiniband.Config{
+				Query: defaultQueryCfg,
+
+				// TODO: make these configurable
+				ExpectedPortCount: 0,
+				ExpectedRate:      nvidia_infiniband.DefaultExpectedRate,
+			}
 			if configValue != nil {
 				parsed, err := nvidia_infiniband.ParseConfig(configValue, db)
 				if err != nil {


### PR DESCRIPTION
To handle the machines with

```
CA 'mlx5_2'
	CA type: MT4125
	Number of ports: 1
	Firmware version: 22.38.1002
	Hardware version: 0
	Node GUID: 0x946dae0300c2b691
	System image GUID: 0x946dae0300c2b690
	Port 1:
		State: Down
		Physical state: Disabled
		Rate: 40
		Base lid: 0
```