### PR TITLE
fix(pkg/systemd): handle "n/a" in uptime with trailing characters

### DIFF
--- a/components/systemd/component_output.go
+++ b/components/systemd/component_output.go
@@ -161,7 +161,7 @@ func CreateGet(cfg Config) query.GetFunc {
 		for _, unit := range cfg.Units {
 			uptime, err := systemd.GetUptime(unit)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get uptime for unit %s: %w", unit, err)
+				return nil, fmt.Errorf("failed to get uptime for unit %q: %w", unit, err)
 			}
 
 			active := false
@@ -173,7 +173,7 @@ func CreateGet(cfg Config) query.GetFunc {
 			if defaultConn == nil || err != nil {
 				active, err = systemd.IsActive(unit)
 				if err != nil {
-					return nil, fmt.Errorf("failed to check active status for unit %s: %w", unit, err)
+					return nil, fmt.Errorf("failed to check active status for unit %q: %w", unit, err)
 				}
 			}
 

--- a/pkg/systemd/systemd.go
+++ b/pkg/systemd/systemd.go
@@ -120,15 +120,21 @@ func GetUptime(service string) (*time.Duration, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// e.g.,
+	// systemctl show --property=InactiveExitTimestamp abc
+	// InactiveExitTimestamp=n/a
 	val := strings.Split(string(b), "=")
 	if len(val) < 2 {
 		return nil, errors.New("could not parse the service uptime time correctly")
 	}
-	if val[1] == "" || val[1] == "n/a" {
+
+	uptimeRaw := strings.TrimSpace(strings.Trim(val[1], "\x0a"))
+	if uptimeRaw == "" || uptimeRaw == "n/a" {
 		return nil, nil
 	}
 
-	uptime, err := parseSystemdUnitUptime(val[1])
+	uptime, err := parseSystemdUnitUptime(uptimeRaw)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To handle the case with trailing "\x0a"

Fix

> Error: failed to get uptime for unit network.target: parsing time "n/a" as "Mon 2006-01-02 15:04:05 MST": cannot parse "n/a" as "Mon"