### PR TITLE
fix(components): separate timeout for poller get function calls

### DIFF
--- a/components/accelerator/nvidia/query/query.go
+++ b/components/accelerator/nvidia/query/query.go
@@ -70,7 +70,12 @@ func GetSuccessOnce() <-chan any {
 
 func CreateGet(db *sql.DB) query.GetFunc {
 	return func(ctx context.Context) (_ any, e error) {
-		return Get(ctx, db)
+		// "ctx" here is the root level, create one with shorter timeouts
+		// to not block on this checks
+		cctx, ccancel := context.WithTimeout(ctx, 3*time.Minute)
+		defer ccancel()
+
+		return Get(cctx, db)
 	}
 }
 

--- a/components/containerd/pod/component_output.go
+++ b/components/containerd/pod/component_output.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/leptonai/gpud/components"
 	components_metrics "github.com/leptonai/gpud/components/metrics"
@@ -118,10 +119,15 @@ func CreateGet(cfg Config) query.GetFunc {
 			}
 		}()
 
-		ss, err := ListSandboxStatus(ctx, cfg.Endpoint)
+		// "ctx" here is the root level, create one with shorter timeouts
+		// to not block on this checks
+		cctx, ccancel := context.WithTimeout(ctx, 15*time.Second)
+		ss, err := ListSandboxStatus(cctx, cfg.Endpoint)
+		ccancel()
 		if err != nil {
 			return nil, err
 		}
+
 		pods := make([]PodSandbox, 0)
 		for _, s := range ss {
 			pods = append(pods, ConvertToPodSandbox(s))

--- a/components/docker/container/component_output.go
+++ b/components/docker/container/component_output.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/leptonai/gpud/components"
 	components_metrics "github.com/leptonai/gpud/components/metrics"
@@ -150,7 +151,11 @@ func CreateGet(cfg Config) query.GetFunc {
 			log.Logger.Warnw("docker process not found, assuming docker is not running", "error", err)
 		}
 
-		dockerContainers, err := ListContainers(ctx)
+		// "ctx" here is the root level, create one with shorter timeouts
+		// to not block on this checks
+		cctx, ccancel := context.WithTimeout(ctx, 15*time.Second)
+		dockerContainers, err := ListContainers(cctx)
+		ccancel()
 		if err != nil {
 			if IsErrDockerClientVersionNewerThanDaemon(err) {
 				return &Output{

--- a/components/k8s/pod/component_output.go
+++ b/components/k8s/pod/component_output.go
@@ -140,7 +140,11 @@ func CreateGet(cfg Config) query.GetFunc {
 			log.Logger.Warnw("kubelet process not found, assuming kubelet is not running", "error", err)
 		}
 
-		pods, err := ListFromKubeletReadOnlyPort(ctx, cfg.Port)
+		// "ctx" here is the root level, create one with shorter timeouts
+		// to not block on this checks
+		cctx, ccancel := context.WithTimeout(ctx, 15*time.Second)
+		pods, err := ListFromKubeletReadOnlyPort(cctx, cfg.Port)
+		ccancel()
 		if err != nil {
 			o := &Output{
 				KubeletPidFound: kubeletRunning,

--- a/components/network/latency/component_output.go
+++ b/components/network/latency/component_output.go
@@ -139,8 +139,8 @@ func createGetFunc(cfg Config) query.GetFunc {
 
 		// "ctx" here is the root level, create one with shorter timeouts
 		// to not block on this checks
-		cctx, cancel := context.WithTimeout(ctx, timeout)
-		defer cancel()
+		cctx, ccancel := context.WithTimeout(ctx, timeout)
+		defer ccancel()
 
 		var err error
 		o.EgressLatencies, err = latency_edge.Measure(cctx)
@@ -150,7 +150,7 @@ func createGetFunc(cfg Config) query.GetFunc {
 
 		for _, latency := range o.EgressLatencies {
 			if err := metrics.SetEdgeInMilliseconds(
-				ctx,
+				cctx,
 				fmt.Sprintf("%s (%s)", latency.RegionName, latency.Provider),
 				float64(latency.LatencyMilliseconds),
 				now,


### PR DESCRIPTION
Otherwise, blocks on the root context (which can block forever).

Fix when containerd down, poller hangs