### PR TITLE
feat(nvidia): use last successful data in shared poller, shared nvidia-smi/nvml poller to still return data if one operation fails

### DIFF
--- a/components/accelerator/nvidia/bad-envs/component.go
+++ b/components/accelerator/nvidia/bad-envs/component.go
@@ -53,27 +53,13 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Error:   last.Error.Error(),
-				Reason:  "last query failed",
-			},
-		}, nil
-	}
-	if last.Output == nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Reason:  "no output",
-			},
-		}, nil
-	}
 
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
 	}
 	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
 	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
@@ -114,16 +100,18 @@ func (c *component) Output() (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return nil, last.Error
-	}
-	if last.Output == nil {
-		return nil, nil
-	}
 
-	output, ok := last.Output.(*nvidia_query.Output)
+	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T, expected *nvidia_query.Output", last.Output)
 	}
-	return ToOutput(output), nil
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
+	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	}
+
+	return ToOutput(allOutput), nil
 }

--- a/components/accelerator/nvidia/clock-speed/component.go
+++ b/components/accelerator/nvidia/clock-speed/component.go
@@ -43,7 +43,7 @@ type component struct {
 func (c *component) Name() string { return nvidia_clock_speed_id.Name }
 
 func (c *component) States(ctx context.Context) ([]components.State, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err == query.ErrNoData { // no data
 		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", nvidia_clock_speed_id.Name)
 		return []components.State{
@@ -79,6 +79,11 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
 	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	}
+
 	if allOutput.SMIExists && len(allOutput.SMIQueryErrors) > 0 {
 		cs := make([]components.State, 0)
 		for _, e := range allOutput.SMIQueryErrors {

--- a/components/accelerator/nvidia/ecc/component.go
+++ b/components/accelerator/nvidia/ecc/component.go
@@ -43,7 +43,7 @@ type component struct {
 func (c *component) Name() string { return nvidia_ecc_id.Name }
 
 func (c *component) States(ctx context.Context) ([]components.State, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err == query.ErrNoData { // no data
 		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", nvidia_ecc_id.Name)
 		return []components.State{
@@ -79,6 +79,11 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
 	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	}
+
 	if allOutput.SMIExists && len(allOutput.SMIQueryErrors) > 0 {
 		cs := make([]components.State, 0)
 		for _, e := range allOutput.SMIQueryErrors {

--- a/components/accelerator/nvidia/error/component.go
+++ b/components/accelerator/nvidia/error/component.go
@@ -53,27 +53,13 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Error:   last.Error.Error(),
-				Reason:  "last query failed",
-			},
-		}, nil
-	}
-	if last.Output == nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Reason:  "no output",
-			},
-		}, nil
-	}
 
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
 	}
 	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
 	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {

--- a/components/accelerator/nvidia/error/component.go
+++ b/components/accelerator/nvidia/error/component.go
@@ -39,7 +39,7 @@ type component struct {
 func (c *component) Name() string { return Name }
 
 func (c *component) States(ctx context.Context) ([]components.State, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err == query.ErrNoData { // no data
 		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", Name)
 		return []components.State{
@@ -75,6 +75,11 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
 	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	}
+
 	if allOutput.SMIExists && len(allOutput.SMIQueryErrors) > 0 {
 		cs := make([]components.State, 0)
 		for _, e := range allOutput.SMIQueryErrors {

--- a/components/accelerator/nvidia/error/sxid/component_output.go
+++ b/components/accelerator/nvidia/error/sxid/component_output.go
@@ -131,11 +131,11 @@ func (o *Output) getEvents(since time.Time) []components.Event {
 	des := make([]components.Event, 0)
 	for i, sxidErr := range reason.Errors {
 		if sxidErr.Time.IsZero() {
-			log.Logger.Warnw("skipping event because it's too old", "sxid", sxidErr.SXid, "since", since, "event_time", sxidErr.Time.Time)
+			log.Logger.Debugw("skipping event because it's too old", "sxid", sxidErr.SXid, "since", since, "event_time", sxidErr.Time.Time)
 			continue
 		}
 		if sxidErr.Time.Time.Before(since) {
-			log.Logger.Warnw("skipping event because it's too old", "sxid", sxidErr.SXid, "since", since, "event_time", sxidErr.Time.Time)
+			log.Logger.Debugw("skipping event because it's too old", "sxid", sxidErr.SXid, "since", since, "event_time", sxidErr.Time.Time)
 			continue
 		}
 

--- a/components/accelerator/nvidia/error/xid/component.go
+++ b/components/accelerator/nvidia/error/xid/component.go
@@ -43,30 +43,6 @@ func (c *component) Name() string { return nvidia_component_error_xid_id.Name }
 
 // Just checks if the xid poller is working.
 func (c *component) States(_ context.Context) ([]components.State, error) {
-	last, err := c.poller.LastSuccess()
-
-	// no data yet from realtime xid poller
-	// just return whatever we got from dmesg
-	if err == query.ErrNoData {
-		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", nvidia_component_error_xid_id.Name)
-		return []components.State{
-			{
-				Name:    StateNameErrorXid,
-				Healthy: true,
-				Reason:  "no xid error event",
-			},
-		}, nil
-	}
-
-	// something went wrong in the poller
-	// just return an error to surface the issue
-	if err != nil {
-		return nil, err
-	}
-	if last.Error != nil {
-		return nil, last.Error
-	}
-
 	return []components.State{
 		{
 			Name:    StateNameErrorXid,
@@ -132,15 +108,6 @@ func (c *component) tailScan() (*Output, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return nil, last.Error
-	}
-
-	// no output from the poller
-	// just return whatever we got from dmesg
-	if last.Output == nil {
-		return o, nil
-	}
 
 	ev, ok := last.Output.(*nvidia_query_nvml.XidEvent)
 	if !ok { // shoild never happen
@@ -148,6 +115,10 @@ func (c *component) tailScan() (*Output, error) {
 	}
 	if ev != nil && ev.Xid > 0 {
 		o.NVMLXidEvent = ev
+
+		if lerr := c.poller.LastError(); lerr != nil {
+			log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
+		}
 
 		lastSuccessPollElapsed := time.Now().UTC().Sub(ev.Time.Time)
 		if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {

--- a/components/accelerator/nvidia/error/xid/component_output.go
+++ b/components/accelerator/nvidia/error/xid/component_output.go
@@ -188,11 +188,11 @@ func (o *Output) getEvents(since time.Time) []components.Event {
 	des := make([]components.Event, 0)
 	for i, xidErr := range reason.Errors {
 		if xidErr.Time.IsZero() {
-			log.Logger.Warnw("skipping event because it's too old", "xid", xidErr.Xid, "since", since, "event_time", xidErr.Time.Time)
+			log.Logger.Debugw("skipping event because it's too old", "xid", xidErr.Xid, "since", since, "event_time", xidErr.Time.Time)
 			continue
 		}
 		if xidErr.Time.Time.Before(since) {
-			log.Logger.Warnw("skipping event because it's too old", "xid", xidErr.Xid, "since", since, "event_time", xidErr.Time.Time)
+			log.Logger.Debugw("skipping event because it's too old", "xid", xidErr.Xid, "since", since, "event_time", xidErr.Time.Time)
 			continue
 		}
 

--- a/components/accelerator/nvidia/fabric-manager/component.go
+++ b/components/accelerator/nvidia/fabric-manager/component.go
@@ -70,27 +70,13 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Error:   last.Error.Error(),
-				Reason:  "last query failed",
-			},
-		}, nil
-	}
-	if last.Output == nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Reason:  "no output",
-			},
-		}, nil
-	}
 
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
 	}
 	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
 	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {

--- a/components/accelerator/nvidia/fabric-manager/component.go
+++ b/components/accelerator/nvidia/fabric-manager/component.go
@@ -56,7 +56,7 @@ type component struct {
 func (c *component) Name() string { return Name }
 
 func (c *component) States(ctx context.Context) ([]components.State, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err == query.ErrNoData { // no data
 		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", Name)
 		return []components.State{
@@ -92,6 +92,11 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
 	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	}
+
 	if !allOutput.FabricManagerExists {
 		return []components.State{
 			{

--- a/components/accelerator/nvidia/gpm/component.go
+++ b/components/accelerator/nvidia/gpm/component.go
@@ -81,9 +81,11 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T, expected nvidia_query_nvml.GPMEvent", last.Output)
 	}
-	lastSuccessPollElapsed := time.Now().UTC().Sub(gpmEvent.Time.Time)
-	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
-		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	if gpmEvent != nil {
+		lastSuccessPollElapsed := time.Now().UTC().Sub(gpmEvent.Time.Time)
+		if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+			log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+		}
 	}
 
 	o := &Output{}

--- a/components/accelerator/nvidia/gpm/component.go
+++ b/components/accelerator/nvidia/gpm/component.go
@@ -81,15 +81,14 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T, expected nvidia_query_nvml.GPMEvent", last.Output)
 	}
-	if gpmEvent != nil {
+
+	o := &Output{}
+	if gpmEvent != nil && len(gpmEvent.Metrics) > 0 {
 		lastSuccessPollElapsed := time.Now().UTC().Sub(gpmEvent.Time.Time)
 		if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
 			log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
 		}
-	}
 
-	o := &Output{}
-	if gpmEvent != nil && len(gpmEvent.Metrics) > 0 {
 		o.NVMLGPMEvent = gpmEvent
 	}
 	return o.States()

--- a/components/accelerator/nvidia/gsp-firmware-mode/component.go
+++ b/components/accelerator/nvidia/gsp-firmware-mode/component.go
@@ -53,27 +53,13 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Error:   last.Error.Error(),
-				Reason:  "last query failed",
-			},
-		}, nil
-	}
-	if last.Output == nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Reason:  "no output",
-			},
-		}, nil
-	}
 
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
 	}
 	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
 	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {

--- a/components/accelerator/nvidia/infiniband/component.go
+++ b/components/accelerator/nvidia/infiniband/component.go
@@ -41,7 +41,7 @@ type component struct {
 func (c *component) Name() string { return nvidia_infiniband_id.Name }
 
 func (c *component) States(ctx context.Context) ([]components.State, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err == query.ErrNoData { // no data
 		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", nvidia_infiniband_id.Name)
 		return []components.State{
@@ -76,6 +76,10 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
 	}
 
 	output := ToOutput(allOutput)

--- a/components/accelerator/nvidia/infiniband/component.go
+++ b/components/accelerator/nvidia/infiniband/component.go
@@ -55,27 +55,13 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Error:   last.Error.Error(),
-				Reason:  "last query failed",
-			},
-		}, nil
-	}
-	if last.Output == nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Reason:  "no output",
-			},
-		}, nil
-	}
 
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
 	}
 	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
 	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {

--- a/components/accelerator/nvidia/info/component.go
+++ b/components/accelerator/nvidia/info/component.go
@@ -39,7 +39,7 @@ type component struct {
 func (c *component) Name() string { return Name }
 
 func (c *component) States(ctx context.Context) ([]components.State, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err == query.ErrNoData { // no data
 		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", Name)
 		return []components.State{
@@ -75,6 +75,11 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
 	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	}
+
 	if allOutput.SMIExists && len(allOutput.SMIQueryErrors) > 0 {
 		cs := make([]components.State, 0)
 		for _, e := range allOutput.SMIQueryErrors {
@@ -116,7 +121,7 @@ func (c *component) Close() error {
 var _ components.OutputProvider = (*component)(nil)
 
 func (c *component) Output() (any, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err != nil {
 		return nil, err
 	}

--- a/components/accelerator/nvidia/info/component.go
+++ b/components/accelerator/nvidia/info/component.go
@@ -53,27 +53,13 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Error:   last.Error.Error(),
-				Reason:  "last query failed",
-			},
-		}, nil
-	}
-	if last.Output == nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Reason:  "no output",
-			},
-		}, nil
-	}
 
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
 	}
 	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
 	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
@@ -122,23 +108,21 @@ var _ components.OutputProvider = (*component)(nil)
 
 func (c *component) Output() (any, error) {
 	last, err := c.poller.LastSuccess()
-	if err != nil {
-		return nil, err
-	}
 	if err == query.ErrNoData { // no data
 		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", Name)
 		return nil, query.ErrNoData
 	}
-	if last.Error != nil {
-		return nil, last.Error
-	}
-	if last.Output == nil {
-		return nil, nil
-	}
 
-	output, ok := last.Output.(*nvidia_query.Output)
+	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T, expected *nvidia_query.Output", last.Output)
 	}
-	return ToOutput(output), nil
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
+	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	}
+	return ToOutput(allOutput), nil
 }

--- a/components/accelerator/nvidia/memory/component.go
+++ b/components/accelerator/nvidia/memory/component.go
@@ -58,27 +58,13 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Error:   last.Error.Error(),
-				Reason:  "last query failed",
-			},
-		}, nil
-	}
-	if last.Output == nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Reason:  "no output",
-			},
-		}, nil
-	}
 
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
 	}
 	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
 	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {

--- a/components/accelerator/nvidia/memory/component.go
+++ b/components/accelerator/nvidia/memory/component.go
@@ -44,7 +44,7 @@ type component struct {
 func (c *component) Name() string { return Name }
 
 func (c *component) States(ctx context.Context) ([]components.State, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err == query.ErrNoData { // no data
 		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", Name)
 		return []components.State{
@@ -80,6 +80,11 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
 	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	}
+
 	if allOutput.SMIExists && len(allOutput.SMIQueryErrors) > 0 {
 		cs := make([]components.State, 0)
 		for _, e := range allOutput.SMIQueryErrors {

--- a/components/accelerator/nvidia/nvlink/component.go
+++ b/components/accelerator/nvidia/nvlink/component.go
@@ -58,27 +58,13 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Error:   last.Error.Error(),
-				Reason:  "last query failed",
-			},
-		}, nil
-	}
-	if last.Output == nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Reason:  "no output",
-			},
-		}, nil
-	}
 
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
 	}
 	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
 	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {

--- a/components/accelerator/nvidia/nvlink/component.go
+++ b/components/accelerator/nvidia/nvlink/component.go
@@ -44,7 +44,7 @@ type component struct {
 func (c *component) Name() string { return Name }
 
 func (c *component) States(ctx context.Context) ([]components.State, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err == query.ErrNoData { // no data
 		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", Name)
 		return []components.State{
@@ -80,6 +80,11 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
 	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	}
+
 	if allOutput.NVML == nil {
 		return []components.State{
 			{

--- a/components/accelerator/nvidia/peermem/component.go
+++ b/components/accelerator/nvidia/peermem/component.go
@@ -56,27 +56,13 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Error:   last.Error.Error(),
-				Reason:  "last query failed",
-			},
-		}, nil
-	}
-	if last.Output == nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Reason:  "no output",
-			},
-		}, nil
-	}
 
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
 	}
 	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
 	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {

--- a/components/accelerator/nvidia/peermem/component.go
+++ b/components/accelerator/nvidia/peermem/component.go
@@ -41,7 +41,7 @@ type component struct {
 func (c *component) Name() string { return nvidia_peermem_id.Name }
 
 func (c *component) States(ctx context.Context) ([]components.State, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err == query.ErrNoData { // no data
 		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", nvidia_peermem_id.Name)
 		return []components.State{
@@ -78,6 +78,11 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
 	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	}
+
 	if len(allOutput.LsmodPeermemErrors) > 0 {
 		cs := make([]components.State, 0)
 		for _, e := range allOutput.LsmodPeermemErrors {

--- a/components/accelerator/nvidia/persistence-mode/component.go
+++ b/components/accelerator/nvidia/persistence-mode/component.go
@@ -53,27 +53,13 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Error:   last.Error.Error(),
-				Reason:  "last query failed",
-			},
-		}, nil
-	}
-	if last.Output == nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Reason:  "no output",
-			},
-		}, nil
-	}
 
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
 	}
 	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
 	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {

--- a/components/accelerator/nvidia/persistence-mode/component.go
+++ b/components/accelerator/nvidia/persistence-mode/component.go
@@ -38,7 +38,7 @@ type component struct {
 func (c *component) Name() string { return nvidia_persistence_mode_id.Name }
 
 func (c *component) States(ctx context.Context) ([]components.State, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err == query.ErrNoData { // no data
 		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", nvidia_persistence_mode_id.Name)
 		return []components.State{
@@ -74,6 +74,10 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
 	}
 
 	output := ToOutput(allOutput)

--- a/components/accelerator/nvidia/power/component.go
+++ b/components/accelerator/nvidia/power/component.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/leptonai/gpud/components"
+	nvidia_power_id "github.com/leptonai/gpud/components/accelerator/nvidia/power/id"
 	nvidia_query "github.com/leptonai/gpud/components/accelerator/nvidia/query"
 	nvidia_query_metrics_power "github.com/leptonai/gpud/components/accelerator/nvidia/query/metrics/power"
 	"github.com/leptonai/gpud/components/query"
@@ -16,14 +17,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const Name = "accelerator-nvidia-power"
-
 func New(ctx context.Context, cfg Config) components.Component {
 	cfg.Query.SetDefaultsIfNotSet()
 
 	cctx, ccancel := context.WithCancel(ctx)
 	nvidia_query.SetDefaultPoller(cfg.Query.State.DB)
-	nvidia_query.GetDefaultPoller().Start(cctx, cfg.Query, Name)
+	nvidia_query.GetDefaultPoller().Start(cctx, cfg.Query, nvidia_power_id.Name)
 
 	return &component{
 		rootCtx: ctx,
@@ -41,15 +40,15 @@ type component struct {
 	gatherer prometheus.Gatherer
 }
 
-func (c *component) Name() string { return Name }
+func (c *component) Name() string { return nvidia_power_id.Name }
 
 func (c *component) States(ctx context.Context) ([]components.State, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err == query.ErrNoData { // no data
-		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", Name)
+		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", nvidia_power_id.Name)
 		return []components.State{
 			{
-				Name:    Name,
+				Name:    nvidia_power_id.Name,
 				Healthy: true,
 				Reason:  query.ErrNoData.Error(),
 			},
@@ -80,11 +79,16 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
 	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	}
+
 	if allOutput.SMIExists && len(allOutput.SMIQueryErrors) > 0 {
 		cs := make([]components.State, 0)
 		for _, e := range allOutput.SMIQueryErrors {
 			cs = append(cs, components.State{
-				Name:    Name,
+				Name:    nvidia_power_id.Name,
 				Healthy: false,
 				Error:   e,
 				Reason:  "nvidia-smi query failed with " + e,
@@ -152,7 +156,7 @@ func (c *component) Close() error {
 	log.Logger.Debugw("closing component")
 
 	// safe to call stop multiple times
-	_ = c.poller.Stop(Name)
+	_ = c.poller.Stop(nvidia_power_id.Name)
 
 	return nil
 }

--- a/components/accelerator/nvidia/power/id/id.go
+++ b/components/accelerator/nvidia/power/id/id.go
@@ -1,0 +1,4 @@
+// Package id defines the power component ID.
+package id
+
+const Name = "accelerator-nvidia-power"

--- a/components/accelerator/nvidia/processes/component.go
+++ b/components/accelerator/nvidia/processes/component.go
@@ -58,27 +58,13 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Error:   last.Error.Error(),
-				Reason:  "last query failed",
-			},
-		}, nil
-	}
-	if last.Output == nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Reason:  "no output",
-			},
-		}, nil
-	}
 
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
 	}
 	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
 	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {

--- a/components/accelerator/nvidia/processes/component.go
+++ b/components/accelerator/nvidia/processes/component.go
@@ -44,7 +44,7 @@ type component struct {
 func (c *component) Name() string { return Name }
 
 func (c *component) States(ctx context.Context) ([]components.State, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err == query.ErrNoData { // no data
 		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", Name)
 		return []components.State{
@@ -80,6 +80,11 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
 	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	}
+
 	if allOutput.SMIExists && len(allOutput.SMIQueryErrors) > 0 {
 		cs := make([]components.State, 0)
 		for _, e := range allOutput.SMIQueryErrors {

--- a/components/accelerator/nvidia/query/nvml/gpm.go
+++ b/components/accelerator/nvidia/query/nvml/gpm.go
@@ -46,6 +46,7 @@ func GPMSupported() (bool, error) {
 }
 
 type GPMEvent struct {
+	Time    metav1.Time  `json:"time"`
 	Metrics []GPMMetrics `json:"metrics"`
 	Error   error        `json:"error"`
 }
@@ -99,6 +100,7 @@ func (inst *instance) pollGPMEvents() {
 		case <-inst.rootCtx.Done():
 			return
 		case inst.gpmEventCh <- &GPMEvent{
+			Time:    metav1.NewTime(time.Now().UTC()),
 			Metrics: mss,
 			Error:   err,
 		}:

--- a/components/accelerator/nvidia/query/query.go
+++ b/components/accelerator/nvidia/query/query.go
@@ -100,6 +100,7 @@ func Get(ctx context.Context, db *sql.DB) (output any, err error) {
 	}
 
 	o := &Output{
+		Time:                  time.Now().UTC(),
 		SMIExists:             SMIExists(),
 		FabricManagerExists:   FabricManagerExists(),
 		InfinibandClassExists: infiniband.CountInfinibandClass() > 0,
@@ -196,7 +197,7 @@ func Get(ctx context.Context, db *sql.DB) (output any, err error) {
 	log.Logger.Debugw("waiting for default nvml instance")
 	select {
 	case <-ctx.Done():
-		return nil, fmt.Errorf("context canceled waiting for nvml instance: %w", ctx.Err())
+		return o, fmt.Errorf("context canceled waiting for nvml instance: %w", ctx.Err())
 	case <-nvml.DefaultInstanceReady():
 		log.Logger.Debugw("default nvml instance ready")
 	}
@@ -226,7 +227,7 @@ func Get(ctx context.Context, db *sql.DB) (output any, err error) {
 
 		for _, dev := range o.NVML.DeviceInfos {
 			if err := setMetricsForDevice(ctx, dev, now, o); err != nil {
-				return nil, fmt.Errorf("failed to set metrics for device %s: %w", dev.UUID, err)
+				return o, fmt.Errorf("failed to set metrics for device %s: %w", dev.UUID, err)
 			}
 		}
 	}
@@ -293,6 +294,9 @@ const (
 )
 
 type Output struct {
+	// Time is the time when the query is executed.
+	Time time.Time `json:"time"`
+
 	// GPU device count from the /dev directory.
 	GPUDeviceCount int `json:"gpu_device_count"`
 

--- a/components/accelerator/nvidia/remapped-rows/component.go
+++ b/components/accelerator/nvidia/remapped-rows/component.go
@@ -58,27 +58,13 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Error:   last.Error.Error(),
-				Reason:  "last query failed",
-			},
-		}, nil
-	}
-	if last.Output == nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Reason:  "no output",
-			},
-		}, nil
-	}
 
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
 	}
 	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
 	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {

--- a/components/accelerator/nvidia/remapped-rows/component.go
+++ b/components/accelerator/nvidia/remapped-rows/component.go
@@ -44,7 +44,7 @@ type component struct {
 func (c *component) Name() string { return Name }
 
 func (c *component) States(ctx context.Context) ([]components.State, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err == query.ErrNoData { // no data
 		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", Name)
 		return []components.State{
@@ -80,6 +80,11 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
 	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	}
+
 	if allOutput.SMIExists && len(allOutput.SMIQueryErrors) > 0 {
 		cs := make([]components.State, 0)
 		for _, e := range allOutput.SMIQueryErrors {

--- a/components/accelerator/nvidia/temperature/component.go
+++ b/components/accelerator/nvidia/temperature/component.go
@@ -58,27 +58,13 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Error:   last.Error.Error(),
-				Reason:  "last query failed",
-			},
-		}, nil
-	}
-	if last.Output == nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Reason:  "no output",
-			},
-		}, nil
-	}
 
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
 	}
 	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
 	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {

--- a/components/accelerator/nvidia/temperature/component.go
+++ b/components/accelerator/nvidia/temperature/component.go
@@ -44,7 +44,7 @@ type component struct {
 func (c *component) Name() string { return Name }
 
 func (c *component) States(ctx context.Context) ([]components.State, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err == query.ErrNoData { // no data
 		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", Name)
 		return []components.State{
@@ -80,6 +80,11 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
 	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	}
+
 	if allOutput.SMIExists && len(allOutput.SMIQueryErrors) > 0 {
 		cs := make([]components.State, 0)
 		for _, e := range allOutput.SMIQueryErrors {

--- a/components/accelerator/nvidia/utilization/component.go
+++ b/components/accelerator/nvidia/utilization/component.go
@@ -58,27 +58,13 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if err != nil {
 		return nil, err
 	}
-	if last.Error != nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Error:   last.Error.Error(),
-				Reason:  "last query failed",
-			},
-		}, nil
-	}
-	if last.Output == nil {
-		return []components.State{
-			{
-				Healthy: false,
-				Reason:  "no output",
-			},
-		}, nil
-	}
 
 	allOutput, ok := last.Output.(*nvidia_query.Output)
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
+	}
+	if lerr := c.poller.LastError(); lerr != nil {
+		log.Logger.Warnw("last query failed -- returning cached, possibly stale data", "error", lerr)
 	}
 	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
 	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {

--- a/components/accelerator/nvidia/utilization/component.go
+++ b/components/accelerator/nvidia/utilization/component.go
@@ -44,7 +44,7 @@ type component struct {
 func (c *component) Name() string { return Name }
 
 func (c *component) States(ctx context.Context) ([]components.State, error) {
-	last, err := c.poller.Last()
+	last, err := c.poller.LastSuccess()
 	if err == query.ErrNoData { // no data
 		log.Logger.Debugw("nothing found in last state (no data collected yet)", "component", Name)
 		return []components.State{
@@ -80,6 +80,11 @@ func (c *component) States(ctx context.Context) ([]components.State, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid output type: %T", last.Output)
 	}
+	lastSuccessPollElapsed := time.Now().UTC().Sub(allOutput.Time)
+	if lastSuccessPollElapsed > 2*c.poller.Config().Interval.Duration {
+		log.Logger.Warnw("last poll is too old", "elapsed", lastSuccessPollElapsed, "interval", c.poller.Config().Interval.Duration)
+	}
+
 	if allOutput.SMIExists && len(allOutput.SMIQueryErrors) > 0 {
 		cs := make([]components.State, 0)
 		for _, e := range allOutput.SMIQueryErrors {

--- a/components/query/poller.go
+++ b/components/query/poller.go
@@ -294,6 +294,7 @@ func (pl *poller) readLast(requireNoErr bool) (*Item, error) {
 	for i := len(pl.lastItems) - 1; i >= 0; i-- {
 		item := pl.lastItems[i]
 		if requireNoErr && item.Error != nil {
+			log.Logger.Warnw("skipping item due to error", "id", pl.id, "error", item.Error)
 			continue
 		}
 		return &item, nil

--- a/config/default.go
+++ b/config/default.go
@@ -27,7 +27,7 @@ import (
 	nvidia_nvlink "github.com/leptonai/gpud/components/accelerator/nvidia/nvlink"
 	nvidia_peermem_id "github.com/leptonai/gpud/components/accelerator/nvidia/peermem/id"
 	nvidia_persistence_mode_id "github.com/leptonai/gpud/components/accelerator/nvidia/persistence-mode/id"
-	nvidia_power "github.com/leptonai/gpud/components/accelerator/nvidia/power"
+	nvidia_power_id "github.com/leptonai/gpud/components/accelerator/nvidia/power/id"
 	nvidia_processes "github.com/leptonai/gpud/components/accelerator/nvidia/processes"
 	nvidia_query "github.com/leptonai/gpud/components/accelerator/nvidia/query"
 	nvidia_query_nvml "github.com/leptonai/gpud/components/accelerator/nvidia/query/nvml"
@@ -278,7 +278,7 @@ func DefaultConfig(ctx context.Context, opts ...OpOption) (*Config, error) {
 		}
 
 		cfg.Components[nvidia_nvlink.Name] = nil
-		cfg.Components[nvidia_power.Name] = nil
+		cfg.Components[nvidia_power_id.Name] = nil
 		cfg.Components[nvidia_temperature.Name] = nil
 		cfg.Components[nvidia_utilization.Name] = nil
 		cfg.Components[nvidia_processes.Name] = nil

--- a/internal/server/handlers_root.go
+++ b/internal/server/handlers_root.go
@@ -16,7 +16,7 @@ import (
 	nvidia_hw_slowdown_id "github.com/leptonai/gpud/components/accelerator/nvidia/hw-slowdown/id"
 	nvidia_info "github.com/leptonai/gpud/components/accelerator/nvidia/info"
 	nvidia_memory "github.com/leptonai/gpud/components/accelerator/nvidia/memory"
-	nvidia_power "github.com/leptonai/gpud/components/accelerator/nvidia/power"
+	nvidia_power_id "github.com/leptonai/gpud/components/accelerator/nvidia/power/id"
 	nvidia_query "github.com/leptonai/gpud/components/accelerator/nvidia/query"
 	nvidia_temperature "github.com/leptonai/gpud/components/accelerator/nvidia/temperature"
 	nvidia_utilization "github.com/leptonai/gpud/components/accelerator/nvidia/utilization"
@@ -114,7 +114,7 @@ func createRootHandler(handlerDescs []componentHandlerDescription, webConfig con
 		if c, err := components.GetComponent(nvidia_temperature.Name); c != nil && err == nil {
 			nvidiaTemperatureChart = true
 		}
-		if c, err := components.GetComponent(nvidia_power.Name); c != nil && err == nil {
+		if c, err := components.GetComponent(nvidia_power_id.Name); c != nil && err == nil {
 			nvidiaPowerChart = true
 		}
 		if c, err := components.GetComponent(nvidia_clock_speed_id.Name); c != nil && err == nil {
@@ -151,7 +151,7 @@ func createRootHandler(handlerDescs []componentHandlerDescription, webConfig con
 		components = append(components, nvidia_temperature.Name)
 	}
 	if nvidiaPowerChart {
-		components = append(components, nvidia_power.Name)
+		components = append(components, nvidia_power_id.Name)
 	}
 	if nvidiaClockSpeedChart {
 		components = append(components, nvidia_clock_speed_id.Name)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -61,6 +61,7 @@ import (
 	nvidia_persistence_mode "github.com/leptonai/gpud/components/accelerator/nvidia/persistence-mode"
 	nvidia_persistence_mode_id "github.com/leptonai/gpud/components/accelerator/nvidia/persistence-mode/id"
 	nvidia_power "github.com/leptonai/gpud/components/accelerator/nvidia/power"
+	nvidia_power_id "github.com/leptonai/gpud/components/accelerator/nvidia/power/id"
 	nvidia_processes "github.com/leptonai/gpud/components/accelerator/nvidia/processes"
 	nvidia_query "github.com/leptonai/gpud/components/accelerator/nvidia/query"
 	nvidia_clock_events_state "github.com/leptonai/gpud/components/accelerator/nvidia/query/clock-events-state"
@@ -800,7 +801,7 @@ func New(ctx context.Context, config *lepconfig.Config, endpoint string, cliUID 
 			}
 			allComponents = append(allComponents, nvidia_nvlink.New(ctx, cfg))
 
-		case nvidia_power.Name:
+		case nvidia_power_id.Name:
 			cfg := nvidia_power.Config{Query: defaultQueryCfg}
 			if configValue != nil {
 				parsed, err := nvidia_power.ParseConfig(configValue, db)


### PR DESCRIPTION
If one operation fails, the shared poller should still return the data so that each component that consumes the shared data can evaluate their own healthiness.