### PR TITLE
feat(dmesg): log watch command only up to 1 hour

### DIFF
--- a/components/dmesg/config.go
+++ b/components/dmesg/config.go
@@ -73,8 +73,8 @@ func DefaultConfig(ctx context.Context) (Config, error) {
 
 			Commands: [][]string{
 				// run last commands as fallback, in case dmesg flag only works in some machines
-				{"dmesg --time-format=iso --nopager --buffer-size 163920 -w || true"},
-				{"dmesg --time-format=iso --nopager --buffer-size 163920 -W"},
+				{"dmesg --time-format=iso --nopager --buffer-size 163920 --since '1 hour ago' -w || dmesg --time-format=iso --nopager --buffer-size 163920 -w || true"},
+				{"dmesg --time-format=iso --nopager --buffer-size 163920 --since '1 hour ago' -W || dmesg --time-format=iso --nopager --buffer-size 163920 -W"},
 			},
 
 			Scan: &query_log_config.Scan{


### PR DESCRIPTION
dmesg -w outputs all the logs in the buffer, we should only watch up to 1 hour