### PR TITLE
feat(nvidia/xid, sxid): support query by event type

### DIFF
--- a/components/accelerator/nvidia/query/xid-sxid-state/options.go
+++ b/components/accelerator/nvidia/query/xid-sxid-state/options.go
@@ -8,6 +8,7 @@ import (
 var ErrInvalidLimit = errors.New("limit must be greater than or equal to 0")
 
 type Op struct {
+	eventType               string
 	sinceUnixSeconds        int64
 	beforeUnixSeconds       int64
 	sortUnixSecondsAscOrder bool
@@ -26,6 +27,12 @@ func (op *Op) applyOpts(opts []OpOption) error {
 	}
 
 	return nil
+}
+
+func WithEventType(eventType string) OpOption {
+	return func(op *Op) {
+		op.eventType = eventType
+	}
 }
 
 // WithSince sets the since timestamp for the select queries.

--- a/components/accelerator/nvidia/query/xid-sxid-state/state.go
+++ b/components/accelerator/nvidia/query/xid-sxid-state/state.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	nvidia_query_sxid "github.com/leptonai/gpud/components/accelerator/nvidia/query/sxid"
@@ -215,6 +216,16 @@ FROM %s`,
 		selectStatement += "\nWHERE "
 		selectStatement += fmt.Sprintf("%s >= ?", ColumnUnixSeconds)
 		args = append(args, op.sinceUnixSeconds)
+	}
+
+	if op.eventType != "" {
+		if !strings.Contains(selectStatement, "WHERE") {
+			selectStatement += "\nWHERE "
+		} else {
+			selectStatement += " AND "
+		}
+		selectStatement += fmt.Sprintf("%s = ?", ColumnEventType)
+		args = append(args, op.eventType)
 	}
 
 	if op.sortUnixSecondsAscOrder {

--- a/components/accelerator/nvidia/query/xid-sxid-state/state_test.go
+++ b/components/accelerator/nvidia/query/xid-sxid-state/state_test.go
@@ -115,6 +115,26 @@ LIMIT 10`,
 			wantArgs: []any{int64(1234)},
 			wantErr:  false,
 		},
+		{
+			name: "with since unix seconds and event type",
+			opts: []OpOption{WithSince(time.Unix(1234, 0)), WithEventType("xid")},
+			want: fmt.Sprintf(`SELECT %s, %s, %s, %s, %s
+FROM %s
+WHERE %s >= ? AND %s = ?
+ORDER BY %s DESC`,
+				ColumnUnixSeconds,
+				ColumnDataSource,
+				ColumnEventType,
+				ColumnEventID,
+				ColumnEventDetails,
+				TableNameXidSXidEventHistory,
+				ColumnUnixSeconds,
+				ColumnEventType,
+				ColumnUnixSeconds,
+			),
+			wantArgs: []any{int64(1234), "xid"},
+			wantErr:  false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Preparing the code cleanups in xid and sxid components:
1. switch to this shared database to query the latest xid/sxid events
2. remove redundant polling logic in xid + sxid components
3. remove xid-sxid component