### PR TITLE
fix(nvidia/query): poller to return error on nvidia-smi failure

### DIFF
--- a/components/accelerator/nvidia/query/nvidia_smi_query.go
+++ b/components/accelerator/nvidia/query/nvidia_smi_query.go
@@ -81,13 +81,18 @@ func RunSMI(ctx context.Context, args ...string) ([]byte, error) {
 		errc <- err
 	}()
 
+	partialOutputErr := ""
+	if len(lines) > 0 {
+		partialOutputErr = fmt.Sprintf("\n\n(partial) output:\n%s", strings.Join(lines, "\n"))
+	}
+
 	select {
 	case <-ctx.Done():
-		return nil, fmt.Errorf("nvidia-smi command timed out: %w\n\n(partial) output:\n%s", ctx.Err(), strings.Join(lines, "\n"))
+		return nil, fmt.Errorf("nvidia-smi command timed out: %w%s", ctx.Err(), partialOutputErr)
 
 	case err := <-errc:
 		if err != nil {
-			return nil, fmt.Errorf("nvidia-smi command failed: %w\n\n(partial) output:\n%s", err, strings.Join(lines, "\n"))
+			return nil, fmt.Errorf("nvidia-smi command failed: %w%s", err, partialOutputErr)
 		}
 		return []byte(strings.Join(lines, "\n")), nil
 	}

--- a/components/accelerator/nvidia/query/query.go
+++ b/components/accelerator/nvidia/query/query.go
@@ -281,6 +281,12 @@ func Get(ctx context.Context, db *sql.DB) (output any, err error) {
 				}
 			}
 		}
+
+		// fail the whole get operation if nvidia-smi check failed
+		// because nvidia-smi provides data for all GPU components
+		if len(o.SMIQueryErrors) > 0 {
+			return o, fmt.Errorf("nvidia-smi check failed with %d error(s); %v", len(o.SMIQueryErrors), o.SMIQueryErrors)
+		}
 	}
 
 	return o, nil


### PR DESCRIPTION
So, we can go back to the successful one