### PR TITLE
fix(pkg/disk): skip usage table output render if unmounted

### DIFF
--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -124,14 +124,23 @@ func (parts Partitions) RenderTable(wr io.Writer) {
 	table.SetHeader([]string{"Device", "Fstype", "Mount Point", "Mounted", "Total", "Used", "Free"})
 
 	for _, part := range parts {
+		total := "n/a"
+		used := "n/a"
+		free := "n/a"
+		if part.Usage != nil {
+			total = part.Usage.TotalHumanized
+			used = part.Usage.UsedHumanized
+			free = part.Usage.FreeHumanized
+		}
+
 		table.Append([]string{
 			part.Device,
 			part.Fstype,
 			part.MountPoint,
 			strconv.FormatBool(part.Mounted),
-			part.Usage.TotalHumanized,
-			part.Usage.UsedHumanized,
-			part.Usage.FreeHumanized,
+			total,
+			used,
+			free,
 		})
 	}
 


### PR DESCRIPTION
```
partitions have total mounted size 141 TB
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xe6be70]

goroutine 1 [running]:
github.com/leptonai/gpud/pkg/disk.Partitions.RenderTable({0xc000451508, 0xf, 0x1a2ae96?}, {0x1c97080?, 0xc00019c038?})
	/home/runner/work/gpud/gpud/pkg/disk/disk.go:132 +0x1d0
github.com/leptonai/gpud/components/diagnose.Scan({0x1cae600, 0xc000701c00}, {0xc0000537b0, 0x5, 0x0?})
	/home/runner/work/gpud/gpud/components/diagnose/scan.go:281 +0x1538
github.com/leptonai/gpud/cmd/gpud/command.cmdScan(0xc0006bc120?)
	/home/runner/work/gpud/gpud/cmd/gpud/command/scan.go:40 +0x337
github.com/urfave/cli.HandleAction({0x1734200?, 0x1aeaf18?}, 0x4?)
	/home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.15/app.go:524 +0x50
github.com/urfave/cli.Command.Run({{0x19da5f5, 0x4}, {0x0, 0x0}, {0xc000346ec0, 0x2, 0x2}, {0x1a2ee0f, 0x29}, {0x0, ...}, ...}, ...)
	/home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.15/command.go:175 +0x67c
github.com/urfave/cli.(*App).Run(0xc0002fd6c0, {0xc000040040, 0x2, 0x2})
	/home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.15/app.go:277 +0xb3b
main.main()
	/home/runner/work/gpud/gpud/cmd/gpud/main.go:12 +0x2d
```