### PR TITLE
feat(nvidia/peermem): explicitly skip "invalid context" errors

### DIFF
--- a/components/accelerator/nvidia/peermem/component.go
+++ b/components/accelerator/nvidia/peermem/component.go
@@ -116,6 +116,10 @@ func (c *component) Events(ctx context.Context, since time.Time) ([]components.E
 		return nil, err
 	}
 
+	return c.getEvents(ctx, since, dmesgTailResults)
+}
+
+func (c *component) getEvents(ctx context.Context, since time.Time, dmesgTailResults *dmesg.State) ([]components.Event, error) {
 	// dedup by minute level
 	seenMinute := make(map[int64]struct{})
 	events := make([]components.Event, 0)

--- a/components/accelerator/nvidia/peermem/component.go
+++ b/components/accelerator/nvidia/peermem/component.go
@@ -11,7 +11,6 @@ import (
 	"github.com/leptonai/gpud/components"
 	nvidia_peermem_id "github.com/leptonai/gpud/components/accelerator/nvidia/peermem/id"
 	nvidia_query "github.com/leptonai/gpud/components/accelerator/nvidia/query"
-	nvidia_query_peermem "github.com/leptonai/gpud/components/accelerator/nvidia/query/peermem"
 	"github.com/leptonai/gpud/components/dmesg"
 	"github.com/leptonai/gpud/components/query"
 	"github.com/leptonai/gpud/log"
@@ -140,8 +139,7 @@ func (c *component) Events(ctx context.Context, since time.Time) ([]components.E
 		//
 		// ref. https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-535-129-03/index.html
 		// ref. https://github.com/Mellanox/nv_peer_memory/issues/120
-		line := logItem.Line
-		if nvidia_query_peermem.HasInvalidContext(line) {
+		if logItem.Matched.Name == dmesg.EventNvidiaPeermemInvalidContext {
 			continue
 		}
 

--- a/components/accelerator/nvidia/peermem/component.go
+++ b/components/accelerator/nvidia/peermem/component.go
@@ -11,6 +11,7 @@ import (
 	"github.com/leptonai/gpud/components"
 	nvidia_peermem_id "github.com/leptonai/gpud/components/accelerator/nvidia/peermem/id"
 	nvidia_query "github.com/leptonai/gpud/components/accelerator/nvidia/query"
+	nvidia_query_peermem "github.com/leptonai/gpud/components/accelerator/nvidia/query/peermem"
 	"github.com/leptonai/gpud/components/dmesg"
 	"github.com/leptonai/gpud/components/query"
 	"github.com/leptonai/gpud/log"
@@ -127,6 +128,10 @@ func (c *component) Events(ctx context.Context, since time.Time) ([]components.E
 			continue
 		}
 
+		if logItem.Matched.Name != dmesg.EventNvidiaPeermemInvalidContext {
+			continue
+		}
+
 		// skip this for now as the latest driver https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-560-35-03/index.html#abstract fixes this issue
 		// "4272659 – A design defect has been identified and mitigated in the GPU kernel-mode driver, related to the GPUDirect RDMA support
 		// in MLNX_OFED and some Ubuntu kernels, commonly referred to as the PeerDirect technology, i.e. the one using the peer-memory kernel
@@ -135,7 +140,8 @@ func (c *component) Events(ctx context.Context, since time.Time) ([]components.E
 		//
 		// ref. https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-535-129-03/index.html
 		// ref. https://github.com/Mellanox/nv_peer_memory/issues/120
-		if logItem.Matched.Name == dmesg.EventNvidiaPeermemInvalidContext {
+		line := logItem.Line
+		if nvidia_query_peermem.HasInvalidContext(line) {
 			continue
 		}
 

--- a/components/accelerator/nvidia/peermem/component.go
+++ b/components/accelerator/nvidia/peermem/component.go
@@ -126,7 +126,16 @@ func (c *component) Events(ctx context.Context, since time.Time) ([]components.E
 		if logItem.Matched == nil {
 			continue
 		}
-		if logItem.Matched.Name != dmesg.EventNvidiaPeermemInvalidContext {
+
+		// skip this for now as the latest driver https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-560-35-03/index.html#abstract fixes this issue
+		// "4272659 – A design defect has been identified and mitigated in the GPU kernel-mode driver, related to the GPUDirect RDMA support
+		// in MLNX_OFED and some Ubuntu kernels, commonly referred to as the PeerDirect technology, i.e. the one using the peer-memory kernel
+		// patch. In specific scenarios, for example involving the cleanup after killing of a multi-process application, this issue may lead to
+		// use-after-free and potentially to kernel memory corruption."
+		//
+		// ref. https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-535-129-03/index.html
+		// ref. https://github.com/Mellanox/nv_peer_memory/issues/120
+		if logItem.Matched.Name == dmesg.EventNvidiaPeermemInvalidContext {
 			continue
 		}
 

--- a/components/accelerator/nvidia/peermem/component_test.go
+++ b/components/accelerator/nvidia/peermem/component_test.go
@@ -1,0 +1,92 @@
+package peermem
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/leptonai/gpud/components/dmesg"
+	query_log "github.com/leptonai/gpud/components/query/log"
+	query_log_common "github.com/leptonai/gpud/components/query/log/common"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetEvents(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    *dmesg.State
+		expected int
+	}{
+		{
+			name: "should skip non-peermem invalid context events",
+			input: &dmesg.State{
+				TailScanMatched: []query_log.Item{
+					{
+						Time: metav1.Time{Time: time.Now()},
+						Line: "some other event",
+						Matched: &query_log_common.Filter{
+							Name: "other_event",
+						},
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "should skip peermem invalid context events due to driver fix",
+			input: &dmesg.State{
+				TailScanMatched: []query_log.Item{
+					{
+						Time: metav1.Time{Time: time.Now()},
+						Line: "nvidia-peermem invalid context",
+						Matched: &query_log_common.Filter{
+							Name: dmesg.EventNvidiaPeermemInvalidContext,
+						},
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "should deduplicate events in same minute",
+			input: &dmesg.State{
+				TailScanMatched: []query_log.Item{
+					{
+						Time: metav1.Time{Time: time.Now()},
+						Line: "nvidia-peermem invalid context 1",
+						Matched: &query_log_common.Filter{
+							Name: dmesg.EventNvidiaPeermemInvalidContext,
+						},
+					},
+					{
+						Time: metav1.Time{Time: time.Now()},
+						Line: "nvidia-peermem invalid context 2",
+						Matched: &query_log_common.Filter{
+							Name: dmesg.EventNvidiaPeermemInvalidContext,
+						},
+					},
+				},
+			},
+			expected: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &component{}
+			events, err := c.getEvents(context.Background(), time.Now(), tc.input)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if len(events) != tc.expected {
+				t.Errorf("expected %d events, got %d", tc.expected, len(events))
+			}
+		})
+	}
+}

--- a/components/accelerator/nvidia/query/peermem/dmesg.go
+++ b/components/accelerator/nvidia/query/peermem/dmesg.go
@@ -1,22 +1,9 @@
 // Package peermem contains the implementation of the peermem query for NVIDIA GPUs.
 package peermem
 
-import "regexp"
-
 // repeated messages may indicate more persistent issue on the inter-GPU communication
 // e.g.,
 // [Thu Sep 19 02:29:46 2024] nvidia-peermem nv_get_p2p_free_callback:127 ERROR detected invalid context, skipping further processing
 // [Thu Sep 19 02:29:46 2024] nvidia-peermem nv_get_p2p_free_callback:127 ERROR detected invalid context, skipping further processing
 // [Thu Sep 19 02:29:46 2024] nvidia-peermem nv_get_p2p_free_callback:127 ERROR detected invalid context, skipping further processing
 const RegexInvalidContext = `.*ERROR detected invalid context, skipping further processing`
-
-var (
-	compiledInvalidContext = regexp.MustCompile(RegexInvalidContext)
-)
-
-func HasInvalidContext(line string) bool {
-	if match := compiledInvalidContext.FindStringSubmatch(line); match != nil {
-		return true
-	}
-	return false
-}

--- a/components/accelerator/nvidia/query/peermem/dmesg.go
+++ b/components/accelerator/nvidia/query/peermem/dmesg.go
@@ -1,9 +1,22 @@
 // Package peermem contains the implementation of the peermem query for NVIDIA GPUs.
 package peermem
 
+import "regexp"
+
 // repeated messages may indicate more persistent issue on the inter-GPU communication
 // e.g.,
 // [Thu Sep 19 02:29:46 2024] nvidia-peermem nv_get_p2p_free_callback:127 ERROR detected invalid context, skipping further processing
 // [Thu Sep 19 02:29:46 2024] nvidia-peermem nv_get_p2p_free_callback:127 ERROR detected invalid context, skipping further processing
 // [Thu Sep 19 02:29:46 2024] nvidia-peermem nv_get_p2p_free_callback:127 ERROR detected invalid context, skipping further processing
 const RegexInvalidContext = `.*ERROR detected invalid context, skipping further processing`
+
+var (
+	compiledInvalidContext = regexp.MustCompile(RegexInvalidContext)
+)
+
+func HasInvalidContext(line string) bool {
+	if match := compiledInvalidContext.FindStringSubmatch(line); match != nil {
+		return true
+	}
+	return false
+}

--- a/components/accelerator/nvidia/query/peermem/dmesg_test.go
+++ b/components/accelerator/nvidia/query/peermem/dmesg_test.go
@@ -1,7 +1,6 @@
 package peermem
 
 import (
-	"regexp"
 	"testing"
 )
 
@@ -17,12 +16,8 @@ func TestRegexInvalidContext(t *testing.T) {
 		{"[123213123123] ERROR detected invalid context, skipping further processing", true},
 	}
 
-	re, err := regexp.Compile(RegexInvalidContext)
-	if err != nil {
-		t.Fatalf("Error compiling regex: %v", err)
-	}
 	for _, test := range tests {
-		matched := re.MatchString(test.log)
+		matched := HasInvalidContext(test.log)
 		if matched != test.matches {
 			t.Errorf("Expected match: %v, got: %v for log: %s", test.matches, matched, test.log)
 		}

--- a/components/accelerator/nvidia/query/peermem/dmesg_test.go
+++ b/components/accelerator/nvidia/query/peermem/dmesg_test.go
@@ -1,6 +1,7 @@
 package peermem
 
 import (
+	"regexp"
 	"testing"
 )
 
@@ -17,9 +18,20 @@ func TestRegexInvalidContext(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		matched := HasInvalidContext(test.log)
+		matched := hasInvalidContext(test.log)
 		if matched != test.matches {
 			t.Errorf("Expected match: %v, got: %v for log: %s", test.matches, matched, test.log)
 		}
 	}
+}
+
+var (
+	compiledInvalidContext = regexp.MustCompile(RegexInvalidContext)
+)
+
+func hasInvalidContext(line string) bool {
+	if match := compiledInvalidContext.FindStringSubmatch(line); match != nil {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
as the latest driver fixes the issue

ref. https://github.com/Mellanox/nv_peer_memory/issues/120