### PR TITLE
feat(nvidia): do not set infiniband expected ports default

### DIFF
--- a/components/accelerator/nvidia/infiniband/component_output.go
+++ b/components/accelerator/nvidia/infiniband/component_output.go
@@ -12,6 +12,7 @@ import (
 	nvidia_query "github.com/leptonai/gpud/components/accelerator/nvidia/query"
 	"github.com/leptonai/gpud/components/accelerator/nvidia/query/infiniband"
 	"github.com/leptonai/gpud/components/common"
+	"github.com/leptonai/gpud/log"
 )
 
 // ToOutput converts nvidia_query.Output to Output.
@@ -120,7 +121,7 @@ func (o *Output) Evaluate(cfg Config) (string, bool, error) {
 
 			// some H100 machines only have 1 ib port in ib class dir
 			if atLeastPorts == 0 {
-				atLeastPorts = infiniband.CountInfinibandClass()
+				log.Logger.Warnw("no at least ports set -- skipping ibstat check", "infinibandClassCount", infiniband.CountInfinibandClass())
 			}
 
 			// H100 machines with 12 ib ports should default to the GPU count 8


### PR DESCRIPTION
To fix

> not enough LinkUp ports, only 0 LinkUp out of 18, expected at least 8 ports and 400 Gb/sec rate; some ports must be missing

for now (need node group level configs as well)