### PR TITLE
feat(server): vacuum sqlite only once a week

### DIFF
--- a/cmd/gpud/command/run.go
+++ b/cmd/gpud/command/run.go
@@ -85,6 +85,9 @@ func cmdRun(cliContext *cli.Context) error {
 		cfg.RetentionPeriod = metav1.Duration{Duration: retentionPeriod}
 		cfg.Web.SincePeriod = metav1.Duration{Duration: retentionPeriod}
 	}
+	if cfg.CompactPeriod.Duration < time.Minute {
+		cfg.CompactPeriod = config.DefaultCompactPeriod
+	}
 
 	cfg.Web.Enable = webEnable
 	if webAdmin {

--- a/components/state/state.go
+++ b/components/state/state.go
@@ -194,6 +194,7 @@ func Register(reg *prometheus.Registry) error {
 	return nil
 }
 
+// Requires read-write db instance.
 func RecordMetrics(ctx context.Context, db *sql.DB) error {
 	var pageCount uint64
 	err := db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount)
@@ -219,11 +220,11 @@ func RecordMetrics(ctx context.Context, db *sql.DB) error {
 }
 
 func Compact(ctx context.Context, db *sql.DB) error {
-	log.Logger.Debugw("compacting state database")
+	log.Logger.Infow("compacting state database")
 	_, err := db.ExecContext(ctx, "VACUUM;")
 	if err != nil {
 		return err
 	}
-	log.Logger.Debugw("successfully compacted state database")
+	log.Logger.Infow("successfully compacted state database")
 	return nil
 }

--- a/components/state/state_test.go
+++ b/components/state/state_test.go
@@ -42,3 +42,20 @@ func TestOpenMemory(t *testing.T) {
 		t.Fatalf("machine id mismatch: %s != %s", id2, id)
 	}
 }
+
+func TestRecordMetrics(t *testing.T) {
+	t.Parallel()
+
+	dbRW, dbRO, close := sqlite.OpenTestDB(t)
+	defer close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := RecordMetrics(ctx, dbRO); err == nil {
+		t.Fatal("expected error but got nil")
+	}
+	if err := RecordMetrics(ctx, dbRW); err != nil {
+		t.Fatal("failed to record metrics:", err)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,9 @@ type Config struct {
 	// Once elapsed, old states/metrics are purged/compacted.
 	RetentionPeriod metav1.Duration `json:"retention_period"`
 
+	// Interval at which to compact the state database.
+	CompactPeriod metav1.Duration `json:"compact_period"`
+
 	// Interval at which to refresh selected components.
 	// Disables refresh if not set.
 	RefreshComponentsInterval metav1.Duration `json:"refresh_components_interval"`
@@ -75,6 +78,9 @@ func (config *Config) Validate() error {
 	}
 	if config.RetentionPeriod.Duration < time.Minute {
 		return fmt.Errorf("retention_period must be at least 1 minute, got %d", config.RetentionPeriod.Duration)
+	}
+	if config.CompactPeriod.Duration < time.Minute {
+		return fmt.Errorf("compact_period must be at least 1 minute, got %d", config.CompactPeriod.Duration)
 	}
 	if config.RefreshComponentsInterval.Duration < time.Minute {
 		return fmt.Errorf("refresh_components_interval must be at least 1 minute, got %d", config.RefreshComponentsInterval.Duration)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,6 +38,7 @@ func TestConfigValidate_AutoUpdateExitCode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &Config{
 				RetentionPeriod:           metav1.Duration{Duration: time.Hour},
+				CompactPeriod:             metav1.Duration{Duration: time.Hour},
 				RefreshComponentsInterval: metav1.Duration{Duration: time.Hour},
 				Address:                   "localhost:8080", // Add a valid address to pass other validations
 				EnableAutoUpdate:          tt.enableAutoUpdate,

--- a/config/default.go
+++ b/config/default.go
@@ -78,8 +78,16 @@ const (
 )
 
 var (
-	DefaultRefreshPeriod             = metav1.Duration{Duration: time.Minute}
-	DefaultRetentionPeriod           = metav1.Duration{Duration: 30 * time.Minute}
+	DefaultRefreshPeriod = metav1.Duration{Duration: time.Minute}
+
+	// keep the state only for the last 2 hours
+	DefaultRetentionPeriod = metav1.Duration{Duration: 2 * time.Hour}
+
+	// compact/vacuum is disruptive to existing queries (including reads)
+	// but necessary to keep the state database from growing indefinitely
+	// so we only compact/vacuum once a week
+	DefaultCompactPeriod = metav1.Duration{Duration: 7 * 24 * time.Hour}
+
 	DefaultRefreshComponentsInterval = metav1.Duration{Duration: time.Minute}
 )
 
@@ -136,7 +144,9 @@ func DefaultConfig(ctx context.Context, opts ...OpOption) (*Config, error) {
 			kernel_module_id.Name: nil,
 		},
 
-		RetentionPeriod:           DefaultRetentionPeriod,
+		RetentionPeriod: DefaultRetentionPeriod,
+		CompactPeriod:   DefaultCompactPeriod,
+
 		RefreshComponentsInterval: DefaultRefreshComponentsInterval,
 		Pprof:                     false,
 


### PR DESCRIPTION
To help with

```
goroutine 170 [select, 1350 minutes]:
database/sql.(*DB).connectionOpener(0xc001004340, {0x1cae590, 0xc0008fc5f0})
	/opt/hostedtoolcache/go/1.23.3/x64/src/database/sql/sql.go:1253 +0x87
created by database/sql.OpenDB in goroutine 1
	/opt/hostedtoolcache/go/1.23.3/x64/src/database/sql/sql.go:833 +0x130

goroutine 194 [select]:
github.com/leptonai/gpud/internal/server.New.func2()
	/home/runner/work/gpud/gpud/internal/server/server.go:204 +0xc5
created by github.com/leptonai/gpud/internal/server.New in goroutine 1
	/home/runner/work/gpud/gpud/internal/server/server.go:201 +0xa57

goroutine 196 [select, 90 minutes]:
github.com/leptonai/gpud/internal/server.New.func3()
	/home/runner/work/gpud/gpud/internal/server/server.go:227 +0xba
created by github.com/leptonai/gpud/internal/server.New in goroutine 1
	/home/runner/work/gpud/gpud/internal/server/server.go:224 +0xb69

goroutine 198 [select, 90 minutes]:
github.com/leptonai/gpud/internal/server.New.func4()
	/home/runner/work/gpud/gpud/internal/server/server.go:250 +0xba
created by github.com/leptonai/gpud/internal/server.New in goroutine 1
	/home/runner/work/gpud/gpud/internal/server/server.go:247 +0xc77

goroutine 200 [select, 1350 minutes]:
github.com/leptonai/gpud/internal/server.New.func5()
	/home/runner/work/gpud/gpud/internal/server/server.go:273 +0xba
created by github.com/leptonai/gpud/internal/server.New in goroutine 1
	/home/runner/work/gpud/gpud/internal/server/server.go:270 +0xd89
```