### PR TITLE
feat(sqlite): disable vacuum for now, bump up retention period, track latency, qps, expose via /info component

### DIFF
--- a/cmd/gpud/command/run.go
+++ b/cmd/gpud/command/run.go
@@ -85,9 +85,8 @@ func cmdRun(cliContext *cli.Context) error {
 		cfg.RetentionPeriod = metav1.Duration{Duration: retentionPeriod}
 		cfg.Web.SincePeriod = metav1.Duration{Duration: retentionPeriod}
 	}
-	if cfg.CompactPeriod.Duration < time.Minute {
-		cfg.CompactPeriod = config.DefaultCompactPeriod
-	}
+
+	cfg.CompactPeriod = config.DefaultCompactPeriod
 
 	cfg.Web.Enable = webEnable
 	if webAdmin {

--- a/components/accelerator/nvidia/query/clock-events-state/state.go
+++ b/components/accelerator/nvidia/query/clock-events-state/state.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/leptonai/gpud/log"
+	"github.com/leptonai/gpud/pkg/sqlite"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -35,7 +36,8 @@ const (
 	ColumnReasons = "reasons"
 )
 
-const DefaultRetentionPeriod = 3 * time.Hour
+// retain up to 3 days of events
+const DefaultRetentionPeriod = 3 * 24 * time.Hour
 
 type Event struct {
 	UnixSeconds int64
@@ -81,6 +83,8 @@ INSERT OR REPLACE INTO %s (%s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, NULLIF(?, '')
 	if err != nil {
 		return err
 	}
+
+	start := time.Now()
 	_, err = db.ExecContext(
 		ctx,
 		insertStatement,
@@ -90,6 +94,8 @@ INSERT OR REPLACE INTO %s (%s, %s, %s, %s, %s) VALUES (?, ?, ?, ?, NULLIF(?, '')
 		event.GPUUUID,
 		string(reasonsBytes),
 	)
+	sqlite.RecordInsertUpdate(time.Since(start).Seconds())
+
 	return err
 }
 
@@ -109,9 +115,10 @@ SELECT %s, %s, %s, %s, %s FROM %s WHERE %s = ? AND %s = ? AND %s = ? AND %s = ?;
 		ColumnGPUUUID,
 	)
 
+	start := time.Now()
 	var foundEvent Event
 	var reasonsRaw string
-	if err := db.QueryRowContext(
+	err := db.QueryRowContext(
 		ctx,
 		selectStatement,
 		event.UnixSeconds,
@@ -124,7 +131,10 @@ SELECT %s, %s, %s, %s, %s FROM %s WHERE %s = ? AND %s = ? AND %s = ? AND %s = ?;
 		&foundEvent.EventType,
 		&foundEvent.GPUUUID,
 		&reasonsRaw,
-	); err != nil {
+	)
+	sqlite.RecordSelect(time.Since(start).Seconds())
+
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, nil
 		}
@@ -282,10 +292,15 @@ func Purge(ctx context.Context, db *sql.DB, opts ...OpOption) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+
+	start := time.Now()
 	rs, err := db.ExecContext(ctx, deleteStatement, args...)
+	sqlite.RecordDelete(time.Since(start).Seconds())
+
 	if err != nil {
 		return 0, err
 	}
+
 	affected, err := rs.RowsAffected()
 	if err != nil {
 		return 0, err

--- a/components/info/component_test.go
+++ b/components/info/component_test.go
@@ -3,12 +3,14 @@ package info
 import (
 	"context"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestComponent(t *testing.T) {
 	t.Parallel()
 
-	component := New(map[string]string{"a": "b"}, nil)
+	component := New(map[string]string{"a": "b"}, nil, prometheus.DefaultGatherer)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/components/query/log/state/state.go
+++ b/components/query/log/state/state.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
+
+	"github.com/leptonai/gpud/pkg/sqlite"
 )
 
 const TableNameLogFileSeekInfo = "components_query_log_seek_info"
@@ -37,14 +40,22 @@ INSERT OR REPLACE INTO %s (%s, %s, %s) VALUES (?, ?, ?);
 		ColumnOffset,
 		ColumnWhence,
 	)
+
+	start := time.Now()
 	_, err := db.ExecContext(ctx, query, file, offset, whence)
+	sqlite.RecordInsertUpdate(time.Since(start).Seconds())
+
 	return err
 }
 
 // Returns "database/sql.ErrNoRows" if no record is found.
 func GetLogFileSeekInfo(ctx context.Context, db *sql.DB, file string) (int64, int64, error) {
 	query := fmt.Sprintf(`SELECT %s, %s FROM %s WHERE %s = ?;`, ColumnOffset, ColumnWhence, TableNameLogFileSeekInfo, ColumnFile)
+
+	start := time.Now()
 	row := db.QueryRowContext(ctx, query, file)
+	sqlite.RecordSelect(time.Since(start).Seconds())
+
 	var offset, whence int64
 	err := row.Scan(&offset, &whence)
 	return offset, whence, err

--- a/components/state/api_version.go
+++ b/components/state/api_version.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
+
+	"github.com/leptonai/gpud/pkg/sqlite"
 )
 
 const (
@@ -36,7 +39,11 @@ func UpdateAPIVersion(ctx context.Context, db *sql.DB, apiVersion string) error 
 	query := fmt.Sprintf(`
 INSERT OR REPLACE INTO %s (%s) VALUES (?)
 `, TableNameAPIVersion, ColumnAPIVersion)
+
+	start := time.Now()
 	_, err := db.ExecContext(ctx, query, apiVersion)
+	sqlite.RecordInsertUpdate(time.Since(start).Seconds())
+
 	return err
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -79,9 +79,6 @@ func (config *Config) Validate() error {
 	if config.RetentionPeriod.Duration < time.Minute {
 		return fmt.Errorf("retention_period must be at least 1 minute, got %d", config.RetentionPeriod.Duration)
 	}
-	if config.CompactPeriod.Duration < time.Minute {
-		return fmt.Errorf("compact_period must be at least 1 minute, got %d", config.CompactPeriod.Duration)
-	}
 	if config.RefreshComponentsInterval.Duration < time.Minute {
 		return fmt.Errorf("refresh_components_interval must be at least 1 minute, got %d", config.RefreshComponentsInterval.Duration)
 	}

--- a/config/default.go
+++ b/config/default.go
@@ -80,13 +80,13 @@ const (
 var (
 	DefaultRefreshPeriod = metav1.Duration{Duration: time.Minute}
 
-	// keep the state only for the last 2 hours
-	DefaultRetentionPeriod = metav1.Duration{Duration: 2 * time.Hour}
+	// keep the metrics only for the last 3 hours
+	DefaultRetentionPeriod = metav1.Duration{Duration: 3 * time.Hour}
 
 	// compact/vacuum is disruptive to existing queries (including reads)
 	// but necessary to keep the state database from growing indefinitely
-	// so we only compact/vacuum once a week
-	DefaultCompactPeriod = metav1.Duration{Duration: 7 * 24 * time.Hour}
+	// TODO: disabled for now, until we have a better way to detect the performance issue
+	DefaultCompactPeriod = metav1.Duration{Duration: 0}
 
 	DefaultRefreshComponentsInterval = metav1.Duration{Duration: time.Minute}
 )

--- a/pkg/sqlite/metrics.go
+++ b/pkg/sqlite/metrics.go
@@ -1,0 +1,187 @@
+package sqlite
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	insertUpdateTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "sqlite",
+			Subsystem: "insert_update",
+			Name:      "total",
+			Help:      "total number of inserts and updates",
+		},
+	)
+	insertUpdateSecondsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "sqlite",
+			Subsystem: "insert_update",
+			Name:      "seconds_total",
+			Help:      "total number of seconds spent on inserts and updates",
+		},
+	)
+
+	deleteTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "sqlite",
+			Subsystem: "delete",
+			Name:      "total",
+			Help:      "total number of deletes",
+		},
+	)
+	deleteSecondsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "sqlite",
+			Subsystem: "delete",
+			Name:      "seconds_total",
+			Help:      "total number of seconds spent on deletes",
+		},
+	)
+
+	selectTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "sqlite",
+			Subsystem: "select",
+			Name:      "total",
+			Help:      "total number of selects",
+		},
+	)
+	selectSecondsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "sqlite",
+			Subsystem: "select",
+			Name:      "seconds_total",
+			Help:      "total number of seconds spent on selects",
+		},
+	)
+)
+
+func Register(reg *prometheus.Registry) error {
+	if err := reg.Register(insertUpdateTotal); err != nil {
+		return err
+	}
+	if err := reg.Register(insertUpdateSecondsTotal); err != nil {
+		return err
+	}
+
+	if err := reg.Register(deleteTotal); err != nil {
+		return err
+	}
+	if err := reg.Register(deleteSecondsTotal); err != nil {
+		return err
+	}
+
+	if err := reg.Register(selectTotal); err != nil {
+		return err
+	}
+	if err := reg.Register(selectSecondsTotal); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func RecordInsertUpdate(tookSeconds float64) {
+	insertUpdateTotal.Inc()
+	insertUpdateSecondsTotal.Add(tookSeconds)
+}
+
+func RecordDelete(tookSeconds float64) {
+	deleteTotal.Inc()
+	deleteSecondsTotal.Add(tookSeconds)
+}
+
+func RecordSelect(tookSeconds float64) {
+	selectTotal.Inc()
+	selectSecondsTotal.Add(tookSeconds)
+}
+
+type Metrics struct {
+	Time time.Time
+
+	InsertUpdateTotal        int64
+	InsertUpdateSecondsTotal float64
+	InsertUpdateSecondsAvg   float64
+
+	DeleteTotal        int64
+	DeleteSecondsTotal float64
+	DeleteSecondsAvg   float64
+
+	SelectTotal        int64
+	SelectSecondsTotal float64
+	SelectSecondsAvg   float64
+}
+
+func (m Metrics) IsZero() bool {
+	return m.InsertUpdateTotal == 0 &&
+		m.InsertUpdateSecondsTotal == 0 &&
+		m.InsertUpdateSecondsAvg == 0 &&
+		m.DeleteTotal == 0 &&
+		m.DeleteSecondsTotal == 0 &&
+		m.DeleteSecondsAvg == 0 &&
+		m.SelectTotal == 0 &&
+		m.SelectSecondsTotal == 0 &&
+		m.SelectSecondsAvg == 0
+}
+
+func ReadMetrics(gatherer prometheus.Gatherer) (Metrics, error) {
+	metricFamilies, err := gatherer.Gather()
+	if err != nil {
+		return Metrics{}, err
+	}
+
+	mtr := Metrics{
+		Time: time.Now().UTC(),
+	}
+	for _, mf := range metricFamilies {
+		metricName := mf.GetName()
+
+		if metricName == "sqlite_insert_update_total" {
+			for _, m := range mf.GetMetric() {
+				mtr.InsertUpdateTotal = int64(m.GetCounter().GetValue())
+			}
+		}
+		if metricName == "sqlite_insert_update_seconds_total" {
+			for _, m := range mf.GetMetric() {
+				mtr.InsertUpdateSecondsTotal = m.GetCounter().GetValue()
+			}
+		}
+
+		if metricName == "sqlite_delete_total" {
+			for _, m := range mf.GetMetric() {
+				mtr.DeleteTotal = int64(m.GetCounter().GetValue())
+			}
+		}
+		if metricName == "sqlite_delete_seconds_total" {
+			for _, m := range mf.GetMetric() {
+				mtr.DeleteSecondsTotal = m.GetCounter().GetValue()
+			}
+		}
+
+		if metricName == "sqlite_select_total" {
+			for _, m := range mf.GetMetric() {
+				mtr.SelectTotal = int64(m.GetCounter().GetValue())
+			}
+		}
+		if metricName == "sqlite_select_seconds_total" {
+			for _, m := range mf.GetMetric() {
+				mtr.SelectSecondsTotal = m.GetCounter().GetValue()
+			}
+		}
+	}
+
+	if mtr.InsertUpdateTotal > 0 {
+		mtr.InsertUpdateSecondsAvg = mtr.InsertUpdateSecondsTotal / float64(mtr.InsertUpdateTotal)
+	}
+	if mtr.DeleteTotal > 0 {
+		mtr.DeleteSecondsAvg = mtr.DeleteSecondsTotal / float64(mtr.DeleteTotal)
+	}
+	if mtr.SelectTotal > 0 {
+		mtr.SelectSecondsAvg = mtr.SelectSecondsTotal / float64(mtr.SelectTotal)
+	}
+
+	return mtr, nil
+}

--- a/pkg/sqlite/metrics_test.go
+++ b/pkg/sqlite/metrics_test.go
@@ -1,0 +1,125 @@
+package sqlite
+
+import (
+	"math"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	if err := Register(reg); err != nil {
+		t.Fatalf("failed to register metrics: %v", err)
+	}
+
+	mtr, err := ReadMetrics(reg)
+	if err != nil {
+		t.Fatalf("failed to read select metrics: %v", err)
+	}
+	if mtr.InsertUpdateTotal != 0 {
+		t.Fatalf("initial insert/update total should be 0, got %d", mtr.InsertUpdateTotal)
+	}
+	if mtr.InsertUpdateSecondsTotal != 0 {
+		t.Fatalf("initial insert/update seconds total should be 0, got %f", mtr.InsertUpdateSecondsTotal)
+	}
+	if mtr.DeleteTotal != 0 {
+		t.Fatalf("initial delete total should be 0, got %d", mtr.DeleteTotal)
+	}
+	if mtr.DeleteSecondsTotal != 0 {
+		t.Fatalf("initial delete seconds total should be 0, got %f", mtr.DeleteSecondsTotal)
+	}
+	if mtr.SelectTotal != 0 {
+		t.Fatalf("initial select total should be 0, got %d", mtr.SelectTotal)
+	}
+	if mtr.SelectSecondsTotal != 0 {
+		t.Fatalf("initial select seconds total should be 0, got %f", mtr.SelectSecondsTotal)
+	}
+	if mtr.SelectSecondsAvg != 0 {
+		t.Fatalf("initial select seconds avg should be 0, got %f", mtr.SelectSecondsAvg)
+	}
+
+	const (
+		inserts          = 10
+		secondsPerInsert = float64(0.7)
+	)
+	expectedSecondsWrites := float64(inserts) * secondsPerInsert
+
+	for i := 0; i < inserts; i++ {
+		RecordInsertUpdate(secondsPerInsert)
+	}
+
+	mtr, err = ReadMetrics(reg)
+	if err != nil {
+		t.Fatalf("failed to read insert/update metrics: %v", err)
+	}
+	if mtr.InsertUpdateTotal != int64(inserts) {
+		t.Fatalf("expected %d inserts, got %d", inserts, mtr.InsertUpdateTotal)
+	}
+	if !floatEquals(mtr.InsertUpdateSecondsTotal, expectedSecondsWrites) {
+		t.Fatalf("expected %.3f seconds total for inserts, got %.3f", expectedSecondsWrites, mtr.InsertUpdateSecondsTotal)
+	}
+	if !floatEquals(mtr.InsertUpdateSecondsAvg, secondsPerInsert) {
+		t.Fatalf("expected %.3f seconds avg for inserts, got %.3f", secondsPerInsert, mtr.InsertUpdateSecondsAvg)
+	}
+
+	const (
+		deletes          = 5
+		secondsPerDelete = float64(0.9)
+	)
+	expectedSecondsDeletes := float64(deletes) * secondsPerDelete
+	for i := 0; i < deletes; i++ {
+		RecordDelete(secondsPerDelete)
+	}
+
+	mtr, err = ReadMetrics(reg)
+	if err != nil {
+		t.Fatalf("failed to read delete metrics: %v", err)
+	}
+	if mtr.DeleteTotal != int64(deletes) {
+		t.Fatalf("expected %d deletes, got %d", deletes, mtr.DeleteTotal)
+	}
+	if !floatEquals(mtr.DeleteSecondsTotal, expectedSecondsDeletes) {
+		t.Fatalf("expected %.3f seconds total for deletes, got %.3f", expectedSecondsDeletes, mtr.DeleteSecondsTotal)
+	}
+	if !floatEquals(mtr.DeleteSecondsAvg, secondsPerDelete) {
+		t.Fatalf("expected %.3f seconds avg for deletes, got %.3f", secondsPerDelete, mtr.DeleteSecondsAvg)
+	}
+
+	const (
+		selects       = 20
+		secsPerSelect = 0.50
+	)
+	expectedSecondsSelect := float64(selects) * secsPerSelect
+
+	for i := 0; i < selects; i++ {
+		RecordSelect(secsPerSelect)
+	}
+
+	mtr, err = ReadMetrics(reg)
+	if err != nil {
+		t.Fatalf("failed to read select metrics: %v", err)
+	}
+	if mtr.SelectTotal != int64(selects) {
+		t.Fatalf("expected %d selects, got %d", selects, mtr.SelectTotal)
+	}
+	if !floatEquals(mtr.SelectSecondsTotal, expectedSecondsSelect) {
+		t.Fatalf("expected %.3f seconds total for selects, got %.3f", expectedSecondsSelect, mtr.SelectSecondsTotal)
+	}
+	if mtr.InsertUpdateTotal != int64(inserts) {
+		t.Fatalf("insert count changed unexpectedly: expected %d, got %d", inserts, mtr.InsertUpdateTotal)
+	}
+	if !floatEquals(mtr.InsertUpdateSecondsTotal, expectedSecondsWrites) {
+		t.Fatalf("insert seconds changed unexpectedly: expected %.3f, got %.3f", expectedSecondsWrites, mtr.InsertUpdateSecondsTotal)
+	}
+	if !floatEquals(mtr.DeleteSecondsAvg, secondsPerDelete) {
+		t.Fatalf("delete seconds avg changed unexpectedly: expected %.3f, got %.3f", secondsPerDelete, mtr.DeleteSecondsAvg)
+	}
+	if !floatEquals(mtr.SelectSecondsAvg, secsPerSelect) {
+		t.Fatalf("select seconds avg changed unexpectedly: expected %.3f, got %.3f", secsPerSelect, mtr.SelectSecondsAvg)
+	}
+}
+
+func floatEquals(a, b float64) bool {
+	return math.Abs(a-b) < 0.0005
+}


### PR DESCRIPTION
```json
          "daemon_version": "v0.3.7",
          "gpud_pid": "2301600",
          "gpud_start_time_humanized": "1 minute ago",
          "gpud_start_time_in_unix_time": "1737385595",
          "gpud_usage_db_humanized": "10 MB",
          "gpud_usage_db_in_bytes": "10244096",
          "gpud_usage_delete_avg_latency_in_seconds": "0.000",
          "gpud_usage_delete_avg_qps": "0.000",
          "gpud_usage_delete_total": "0",
          "gpud_usage_file_descriptors": "1056",
          "gpud_usage_insert_update_avg_latency_in_seconds": "0.000",
          "gpud_usage_insert_update_avg_qps": "64.639",
          "gpud_usage_insert_update_total": "799",
          "gpud_usage_memory_humanized": "224 MB",
          "gpud_usage_memory_in_bytes": "224346112",
          "gpud_usage_select_avg_latency_in_seconds": "0.009",
          "gpud_usage_select_avg_qps": "31.713",
          "gpud_usage_select_total": "392",
          "mac_address": "74:50:4e:d3:48:98",
          "packages": "null"
```