### PR TITLE
feat(*): remove redundant utc call

### DIFF
--- a/components/accelerator/nvidia/hw-slowdown/state/options.go
+++ b/components/accelerator/nvidia/hw-slowdown/state/options.go
@@ -33,7 +33,7 @@ func (op *Op) applyOpts(opts []OpOption) error {
 // If not specified, it returns all events.
 func WithSince(t time.Time) OpOption {
 	return func(op *Op) {
-		op.sinceUnixSeconds = t.UTC().Unix()
+		op.sinceUnixSeconds = t.Unix()
 	}
 }
 
@@ -41,7 +41,7 @@ func WithSince(t time.Time) OpOption {
 // If not specified, it deletes all events.
 func WithBefore(t time.Time) OpOption {
 	return func(op *Op) {
-		op.beforeUnixSeconds = t.UTC().Unix()
+		op.beforeUnixSeconds = t.Unix()
 	}
 }
 

--- a/components/accelerator/nvidia/query/xid-sxid-state/options.go
+++ b/components/accelerator/nvidia/query/xid-sxid-state/options.go
@@ -39,7 +39,7 @@ func WithEventType(eventType string) OpOption {
 // If not specified, it returns all events.
 func WithSince(t time.Time) OpOption {
 	return func(op *Op) {
-		op.sinceUnixSeconds = t.UTC().Unix()
+		op.sinceUnixSeconds = t.Unix()
 	}
 }
 
@@ -47,7 +47,7 @@ func WithSince(t time.Time) OpOption {
 // If not specified, it deletes all events.
 func WithBefore(t time.Time) OpOption {
 	return func(op *Op) {
-		op.beforeUnixSeconds = t.UTC().Unix()
+		op.beforeUnixSeconds = t.Unix()
 	}
 }
 

--- a/components/fuse/state/options.go
+++ b/components/fuse/state/options.go
@@ -32,7 +32,7 @@ func (op *Op) applyOpts(opts []OpOption) error {
 // If not specified, it returns all events.
 func WithSince(t time.Time) OpOption {
 	return func(op *Op) {
-		op.sinceUnixSeconds = t.UTC().Unix()
+		op.sinceUnixSeconds = t.Unix()
 	}
 }
 
@@ -40,7 +40,7 @@ func WithSince(t time.Time) OpOption {
 // If not specified, it deletes all events.
 func WithBefore(t time.Time) OpOption {
 	return func(op *Op) {
-		op.beforeUnixSeconds = t.UTC().Unix()
+		op.beforeUnixSeconds = t.Unix()
 	}
 }
 

--- a/components/pci/state/options.go
+++ b/components/pci/state/options.go
@@ -32,7 +32,7 @@ func (op *Op) applyOpts(opts []OpOption) error {
 // If not specified, it returns all events.
 func WithSince(t time.Time) OpOption {
 	return func(op *Op) {
-		op.sinceUnixSeconds = t.UTC().Unix()
+		op.sinceUnixSeconds = t.Unix()
 	}
 }
 
@@ -40,7 +40,7 @@ func WithSince(t time.Time) OpOption {
 // If not specified, it deletes all events.
 func WithBefore(t time.Time) OpOption {
 	return func(op *Op) {
-		op.beforeUnixSeconds = t.UTC().Unix()
+		op.beforeUnixSeconds = t.Unix()
 	}
 }
 

--- a/components/state/boot_ids.go
+++ b/components/state/boot_ids.go
@@ -58,7 +58,7 @@ func InsertBootID(ctx context.Context, db *sql.DB, bootID string, ts time.Time) 
 		TableNameMachineBootIDs,
 		ColumnBootID,
 		ColumnBootUnixSeconds),
-		bootID, ts.UTC().Unix())
+		bootID, ts.Unix())
 	sqlite.RecordInsertUpdate(time.Since(start).Seconds())
 
 	return err
@@ -83,7 +83,7 @@ func GetRebootEvents(ctx context.Context, db *sql.DB, since time.Time) ([]Reboot
 	}
 
 	query := fmt.Sprintf("SELECT %s, %s FROM %s WHERE %s > ? AND %s != ?", ColumnBootID, ColumnBootUnixSeconds, TableNameMachineBootIDs, ColumnBootUnixSeconds, ColumnBootID)
-	params := []any{since.UTC().Unix(), firstBootID}
+	params := []any{since.Unix(), firstBootID}
 
 	start := time.Now()
 	rows, err := db.QueryContext(ctx, query, params...)

--- a/components/state/state.go
+++ b/components/state/state.go
@@ -104,7 +104,7 @@ INSERT OR REPLACE INTO %s (%s, %s) VALUES (?, ?);
 	)
 
 	start = time.Now()
-	_, err = dbRW.ExecContext(ctx, query, uid, time.Now().UTC().Unix())
+	_, err = dbRW.ExecContext(ctx, query, uid, time.Now().Unix())
 	sqlite.RecordInsertUpdate(time.Since(start).Seconds())
 
 	if err != nil {


### PR DESCRIPTION
```
// Unix returns t as a Unix time, the number of seconds elapsed
// since January 1, 1970 UTC. The result does not depend on the
// location associated with t.
```