### PR TITLE
fix(nvidia/remapped-rows): do not check row remapping for 4090 and other unsupported GPUs

### DIFF
--- a/components/accelerator/nvidia/query/gpu_memory.go
+++ b/components/accelerator/nvidia/query/gpu_memory.go
@@ -2,30 +2,42 @@ package query
 
 import "strings"
 
-// GetMemoryErrorManagementCapabilities returns the GPU memory error management capabilities
+var (
+	// ref. https://docs.nvidia.com/deploy/a100-gpu-mem-error-mgmt/index.html#supported-gpus
+	memMgmtCapAllSupported = MemoryErrorManagementCapabilities{
+		ErrorContainment:     true,
+		DynamicPageOfflining: true,
+		RowRemapping:         true,
+	}
+	memMgmtCapOnlyRowRemappingSupported = MemoryErrorManagementCapabilities{
+		RowRemapping: true,
+	}
+	gpuProductToMemMgmtCaps = map[string]MemoryErrorManagementCapabilities{
+		"a100": memMgmtCapAllSupported,
+		"b100": memMgmtCapAllSupported,
+		"b200": memMgmtCapAllSupported,
+		"h100": memMgmtCapAllSupported,
+		"h200": memMgmtCapAllSupported,
+		"a10":  memMgmtCapOnlyRowRemappingSupported,
+	}
+)
+
+// SupportedMemoryMgmtCapsByGPUProduct returns the GPU memory error management capabilities
 // based on the GPU product name.
 // ref. https://docs.nvidia.com/deploy/a100-gpu-mem-error-mgmt/index.html#supported-gpus
-func GetMemoryErrorManagementCapabilities(gpuProductName string) MemoryErrorManagementCapabilities {
+func SupportedMemoryMgmtCapsByGPUProduct(gpuProductName string) MemoryErrorManagementCapabilities {
 	p := strings.ToLower(gpuProductName)
-	switch {
-	case strings.Contains(p, "a100"),
-		strings.Contains(p, "h100"),
-		strings.Contains(p, "b100"),
-		strings.Contains(p, "b200"):
-		return MemoryErrorManagementCapabilities{
-			ErrorContainment:     true,
-			DynamicPageOfflining: true,
-			RowRemapping:         true,
+	longestName, memCaps := "", MemoryErrorManagementCapabilities{}
+	for k, v := range gpuProductToMemMgmtCaps {
+		if !strings.Contains(p, k) {
+			continue
 		}
-
-	case strings.Contains(p, "a10"):
-		return MemoryErrorManagementCapabilities{
-			RowRemapping: true,
+		if len(longestName) < len(k) {
+			longestName = k
+			memCaps = v
 		}
-
-	default:
-		return MemoryErrorManagementCapabilities{}
 	}
+	return memCaps
 }
 
 // Contains information about the GPU's memory error management capabilities.

--- a/components/accelerator/nvidia/query/gpu_memory.go
+++ b/components/accelerator/nvidia/query/gpu_memory.go
@@ -8,14 +8,10 @@ import "strings"
 func GetMemoryErrorManagementCapabilities(gpuProductName string) MemoryErrorManagementCapabilities {
 	p := strings.ToLower(gpuProductName)
 	switch {
-	case strings.Contains(p, "h100"):
-		return MemoryErrorManagementCapabilities{
-			ErrorContainment:     true,
-			DynamicPageOfflining: true,
-			RowRemapping:         true,
-		}
-
-	case strings.Contains(p, "a100"):
+	case strings.Contains(p, "a100"),
+		strings.Contains(p, "h100"),
+		strings.Contains(p, "b100"),
+		strings.Contains(p, "b200"):
 		return MemoryErrorManagementCapabilities{
 			ErrorContainment:     true,
 			DynamicPageOfflining: true,

--- a/components/accelerator/nvidia/query/gpu_memory_test.go
+++ b/components/accelerator/nvidia/query/gpu_memory_test.go
@@ -50,6 +50,55 @@ func TestGetMemoryErrorManagementCapabilities(t *testing.T) {
 				RowRemapping:         true,
 			},
 		},
+		{
+			name:           "NVIDIA B100",
+			gpuProductName: "NVIDIA B100",
+			expected: MemoryErrorManagementCapabilities{
+				ErrorContainment:     true,
+				DynamicPageOfflining: true,
+				RowRemapping:         true,
+			},
+		},
+		{
+			name:           "NVIDIA B200",
+			gpuProductName: "NVIDIA B200",
+			expected: MemoryErrorManagementCapabilities{
+				ErrorContainment:     true,
+				DynamicPageOfflining: true,
+				RowRemapping:         true,
+			},
+		},
+		{
+			name:           "Mixed case input",
+			gpuProductName: "NvIdIa A100 PCIe",
+			expected: MemoryErrorManagementCapabilities{
+				ErrorContainment:     true,
+				DynamicPageOfflining: true,
+				RowRemapping:         true,
+			},
+		},
+		{
+			name:           "Empty string",
+			gpuProductName: "",
+			expected:       MemoryErrorManagementCapabilities{},
+		},
+		{
+			name:           "NVIDIA T4",
+			gpuProductName: "NVIDIA T4",
+			expected:       MemoryErrorManagementCapabilities{},
+		},
+		{
+			name:           "NVIDIA V100",
+			gpuProductName: "NVIDIA V100",
+			expected:       MemoryErrorManagementCapabilities{},
+		},
+		{
+			name:           "NVIDIA A10G",
+			gpuProductName: "NVIDIA A10G",
+			expected: MemoryErrorManagementCapabilities{
+				RowRemapping: true,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/components/accelerator/nvidia/query/gpu_memory_test.go
+++ b/components/accelerator/nvidia/query/gpu_memory_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestGetMemoryErrorManagementCapabilities(t *testing.T) {
+func TestSupportedMemoryMgmtCapsByGPUProduct(t *testing.T) {
 	tests := []struct {
 		name           string
 		gpuProductName string
@@ -99,11 +99,56 @@ func TestGetMemoryErrorManagementCapabilities(t *testing.T) {
 				RowRemapping: true,
 			},
 		},
+		{
+			name:           "GPU with SXM suffix",
+			gpuProductName: "NVIDIA A100-SXM",
+			expected: MemoryErrorManagementCapabilities{
+				ErrorContainment:     true,
+				DynamicPageOfflining: true,
+				RowRemapping:         true,
+			},
+		},
+		{
+			name:           "GPU with PCIe suffix",
+			gpuProductName: "NVIDIA A100 PCIe",
+			expected: MemoryErrorManagementCapabilities{
+				ErrorContainment:     true,
+				DynamicPageOfflining: true,
+				RowRemapping:         true,
+			},
+		},
+		{
+			name:           "GPU with memory size suffix",
+			gpuProductName: "NVIDIA A100 80GB",
+			expected: MemoryErrorManagementCapabilities{
+				ErrorContainment:     true,
+				DynamicPageOfflining: true,
+				RowRemapping:         true,
+			},
+		},
+		{
+			name:           "Special characters in name",
+			gpuProductName: "NVIDIA-A100_80GB",
+			expected: MemoryErrorManagementCapabilities{
+				ErrorContainment:     true,
+				DynamicPageOfflining: true,
+				RowRemapping:         true,
+			},
+		},
+		{
+			name:           "Non-NVIDIA prefix",
+			gpuProductName: "Some A100 GPU",
+			expected: MemoryErrorManagementCapabilities{
+				ErrorContainment:     true,
+				DynamicPageOfflining: true,
+				RowRemapping:         true,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := GetMemoryErrorManagementCapabilities(tt.gpuProductName)
+			result := SupportedMemoryMgmtCapsByGPUProduct(tt.gpuProductName)
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("GetGPUMemoryErrorManagement(%q) = %v, want %v", tt.gpuProductName, result, tt.expected)
 			}

--- a/components/accelerator/nvidia/query/nvml/remapped_rows.go
+++ b/components/accelerator/nvidia/query/nvml/remapped_rows.go
@@ -36,6 +36,8 @@ type RemappedRows struct {
 	RemappingFailed bool `json:"remapping_failed"`
 
 	// Supported is true if the remapped rows are supported by the device.
+	// Even for "NVIDIA GeForce RTX 4090", this "GetRemappedRows" returns no error,
+	// thus "Supported" is not a reliable way to check if row remapping is supported.
 	Supported bool `json:"supported"`
 }
 
@@ -48,6 +50,8 @@ func GetRemappedRows(uuid string, dev device.Device) (RemappedRows, error) {
 	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g055e7c34f7f15b6ae9aac1dabd60870d
 	corrRows, uncRows, isPending, failureOccurred, ret := dev.GetRemappedRows()
 	if IsNotSupportError(ret) {
+		// even for "NVIDIA GeForce RTX 4090", this returns no error
+		// thus "Supported" is not a reliable way to check if row remapping is supported
 		remRws.Supported = false
 		return remRws, nil
 	}

--- a/components/accelerator/nvidia/query/query.go
+++ b/components/accelerator/nvidia/query/query.go
@@ -537,6 +537,18 @@ func (o *Output) PrintInfo(opts ...OpOption) {
 				}
 			}
 
+			if dev.RemappedRows.Supported {
+				fmt.Printf("%s NVML remapped rows supported\n", checkMark)
+				if dev.RemappedRows.RequiresReset() {
+					fmt.Printf("%s NVML found that the GPU needs a reset\n", warningSign)
+				}
+				if dev.RemappedRows.QualifiesForRMA() {
+					fmt.Printf("%s NVML found that the GPU qualifies for RMA\n", warningSign)
+				}
+			} else {
+				fmt.Printf("%s NVML remapped rows are not supported\n", warningSign)
+			}
+
 			uncorrectedErrs := dev.ECCErrors.Volatile.FindUncorrectedErrs()
 			if len(uncorrectedErrs) > 0 {
 				fmt.Printf("%s NVML found %d ecc volatile uncorrected error(s)\n", warningSign, len(uncorrectedErrs))

--- a/components/accelerator/nvidia/query/query.go
+++ b/components/accelerator/nvidia/query/query.go
@@ -252,7 +252,7 @@ func Get(ctx context.Context, opts ...OpOption) (output any, err error) {
 
 	productName := o.GPUProductName()
 	if productName != "" {
-		o.MemoryErrorManagementCapabilities = GetMemoryErrorManagementCapabilities(o.GPUProductName())
+		o.MemoryErrorManagementCapabilities = SupportedMemoryMgmtCapsByGPUProduct(o.GPUProductName())
 	} else {
 		log.Logger.Warnw("no gpu product name found -- skipping evaluating memory error management capabilities")
 	}

--- a/components/accelerator/nvidia/remapped-rows/component_output.go
+++ b/components/accelerator/nvidia/remapped-rows/component_output.go
@@ -151,6 +151,15 @@ func ParseStatesToOutput(states ...components.State) (*Output, error) {
 	return nil, errors.New("no state found")
 }
 
+func (o *Output) isRowRemappingSupported() bool {
+	for _, r := range o.RemappedRowsNVML {
+		if !r.Supported {
+			return false
+		}
+	}
+	return true
+}
+
 // Returns the output evaluation reason and its healthy-ness.
 func (o *Output) Evaluate() (string, bool, error) {
 	if o == nil {
@@ -160,7 +169,7 @@ func (o *Output) Evaluate() (string, bool, error) {
 	healthy := true
 	reasons := []string{}
 
-	if !o.MemoryErrorManagementCapabilities.RowRemapping {
+	if !o.isRowRemappingSupported() {
 		reasons = append(reasons, fmt.Sprintf("GPU product name %q does not support row remapping (message: %q)", o.GPUProductName, o.MemoryErrorManagementCapabilities.Message))
 	} else {
 		for _, r := range o.RemappedRowsSMI {

--- a/components/accelerator/nvidia/remapped-rows/component_output.go
+++ b/components/accelerator/nvidia/remapped-rows/component_output.go
@@ -152,12 +152,9 @@ func ParseStatesToOutput(states ...components.State) (*Output, error) {
 }
 
 func (o *Output) isRowRemappingSupported() bool {
-	for _, r := range o.RemappedRowsNVML {
-		if !r.Supported {
-			return false
-		}
-	}
-	return true
+	// even for "NVIDIA GeForce RTX 4090", this returns no error
+	// thus "RemappedRowsNVML.Supported" is not a reliable way to check if row remapping is supported
+	return o.MemoryErrorManagementCapabilities.RowRemapping
 }
 
 // Returns the output evaluation reason and its healthy-ness.
@@ -186,7 +183,6 @@ func (o *Output) Evaluate() (string, bool, error) {
 
 			needsReset, err := r.RequiresReset()
 			if err != nil {
-				healthy = false
 				reasons = append(reasons, fmt.Sprintf("nvidia-smi GPU %s failed to determine if it needs reset: %s", r.ID, err.Error()))
 				continue
 			}

--- a/components/accelerator/nvidia/remapped-rows/component_output_test.go
+++ b/components/accelerator/nvidia/remapped-rows/component_output_test.go
@@ -18,31 +18,29 @@ func TestOutput_isRowRemappingSupported(t *testing.T) {
 		expected bool
 	}{
 		{
-			name: "all GPUs support remapping",
+			name: "row remapping supported",
 			output: &Output{
-				RemappedRowsNVML: []nvml.RemappedRows{
-					{Supported: true},
-					{Supported: true},
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: true,
 				},
 			},
 			expected: true,
 		},
 		{
-			name: "one GPU doesn't support remapping",
+			name: "row remapping not supported",
 			output: &Output{
-				RemappedRowsNVML: []nvml.RemappedRows{
-					{Supported: true},
-					{Supported: false},
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: false,
 				},
 			},
 			expected: false,
 		},
 		{
-			name: "no GPUs",
+			name: "empty output",
 			output: &Output{
-				RemappedRowsNVML: []nvml.RemappedRows{},
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{},
 			},
-			expected: true,
+			expected: false,
 		},
 	}
 
@@ -259,10 +257,8 @@ func TestOutput_Evaluate(t *testing.T) {
 			output: &Output{
 				GPUProductName: "Test GPU",
 				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
-					Message: "not supported",
-				},
-				RemappedRowsNVML: []nvml.RemappedRows{
-					{Supported: false},
+					RowRemapping: false,
+					Message:      "not supported",
 				},
 			},
 			wantReason:  `GPU product name "Test GPU" does not support row remapping (message: "not supported")`,
@@ -273,8 +269,8 @@ func TestOutput_Evaluate(t *testing.T) {
 			name: "healthy state with supported remapping",
 			output: &Output{
 				GPUProductName: "Test GPU",
-				RemappedRowsNVML: []nvml.RemappedRows{
-					{Supported: true},
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: true,
 				},
 			},
 			wantReason:  "no issue detected",
@@ -285,8 +281,8 @@ func TestOutput_Evaluate(t *testing.T) {
 			name: "SMI GPU needs RMA",
 			output: &Output{
 				GPUProductName: "Test GPU",
-				RemappedRowsNVML: []nvml.RemappedRows{
-					{Supported: true},
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: true,
 				},
 				RemappedRowsSMI: []query.ParsedSMIRemappedRows{
 					{
@@ -305,8 +301,8 @@ func TestOutput_Evaluate(t *testing.T) {
 			name: "SMI GPU needs reset",
 			output: &Output{
 				GPUProductName: "Test GPU",
-				RemappedRowsNVML: []nvml.RemappedRows{
-					{Supported: true},
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: true,
 				},
 				RemappedRowsSMI: []query.ParsedSMIRemappedRows{
 					{
@@ -325,9 +321,11 @@ func TestOutput_Evaluate(t *testing.T) {
 			name: "NVML GPU needs RMA",
 			output: &Output{
 				GPUProductName: "Test GPU",
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: true,
+				},
 				RemappedRowsNVML: []nvml.RemappedRows{
 					{
-						Supported:                        true,
 						UUID:                             "GPU-456",
 						RemappingFailed:                  true,
 						RemappedDueToUncorrectableErrors: 1,
@@ -342,9 +340,11 @@ func TestOutput_Evaluate(t *testing.T) {
 			name: "NVML GPU needs reset",
 			output: &Output{
 				GPUProductName: "Test GPU",
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: true,
+				},
 				RemappedRowsNVML: []nvml.RemappedRows{
 					{
-						Supported:        true,
 						UUID:             "GPU-456",
 						RemappingPending: true,
 					},
@@ -358,9 +358,11 @@ func TestOutput_Evaluate(t *testing.T) {
 			name: "multiple issues",
 			output: &Output{
 				GPUProductName: "Test GPU",
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: true,
+				},
 				RemappedRowsNVML: []nvml.RemappedRows{
 					{
-						Supported:        true,
 						UUID:             "GPU-456",
 						RemappingPending: true,
 					},

--- a/components/accelerator/nvidia/remapped-rows/component_output_test.go
+++ b/components/accelerator/nvidia/remapped-rows/component_output_test.go
@@ -5,9 +5,239 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/leptonai/gpud/components"
 	"github.com/leptonai/gpud/components/accelerator/nvidia/query"
 	"github.com/leptonai/gpud/components/accelerator/nvidia/query/nvml"
+	"github.com/leptonai/gpud/components/common"
 )
+
+func TestOutput_isRowRemappingSupported(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   *Output
+		expected bool
+	}{
+		{
+			name: "all GPUs support remapping",
+			output: &Output{
+				RemappedRowsNVML: []nvml.RemappedRows{
+					{Supported: true},
+					{Supported: true},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "one GPU doesn't support remapping",
+			output: &Output{
+				RemappedRowsNVML: []nvml.RemappedRows{
+					{Supported: true},
+					{Supported: false},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "no GPUs",
+			output: &Output{
+				RemappedRowsNVML: []nvml.RemappedRows{},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.output.isRowRemappingSupported()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseOutputJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name: "valid JSON",
+			input: `{
+				"gpu_product_name": "NVIDIA A100",
+				"memory_error_management_capabilities": {
+					"row_remapping": true
+				},
+				"remapped_rows_smi": [],
+				"remapped_rows_nvml": []
+			}`,
+			wantErr: false,
+		},
+		{
+			name:    "invalid JSON",
+			input:   `{invalid json}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := ParseOutputJSON([]byte(tt.input))
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, output)
+		})
+	}
+}
+
+func TestParseStateRemappedRows(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   map[string]string
+		wantErr bool
+	}{
+		{
+			name: "valid state",
+			input: map[string]string{
+				StateKeyRemappedRowsData: `{
+					"gpu_product_name": "NVIDIA A100",
+					"memory_error_management_capabilities": {
+						"row_remapping": true
+					},
+					"remapped_rows_smi": [],
+					"remapped_rows_nvml": []
+				}`,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid JSON in state",
+			input: map[string]string{
+				StateKeyRemappedRowsData: `{invalid json}`,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := ParseStateRemappedRows(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, output)
+		})
+	}
+}
+
+func TestParseStatesToOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		states  []components.State
+		wantErr bool
+	}{
+		{
+			name: "valid remapped rows state",
+			states: []components.State{
+				{
+					Name: StateNameRemappedRows,
+					ExtraInfo: map[string]string{
+						StateKeyRemappedRowsData: `{
+							"gpu_product_name": "NVIDIA A100",
+							"memory_error_management_capabilities": {
+								"row_remapping": true
+							},
+							"remapped_rows_smi": [],
+							"remapped_rows_nvml": []
+						}`,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "unknown state name",
+			states: []components.State{
+				{
+					Name: "unknown_state",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "no states",
+			states:  []components.State{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := ParseStatesToOutput(tt.states...)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, output)
+		})
+	}
+}
+
+func TestOutput_States(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  *Output
+		wantErr bool
+	}{
+		{
+			name: "healthy state",
+			output: &Output{
+				GPUProductName: "NVIDIA A100",
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: true,
+				},
+				RemappedRowsSMI:  []query.ParsedSMIRemappedRows{},
+				RemappedRowsNVML: []nvml.RemappedRows{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "state with suggested actions",
+			output: &Output{
+				GPUProductName: "NVIDIA A100",
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: true,
+				},
+				SuggestedActions: &common.SuggestedActions{
+					Descriptions:  []string{"Test action"},
+					RepairActions: []common.RepairActionType{common.RepairActionTypeRebootSystem},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			states, err := tt.output.States()
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotEmpty(t, states)
+			assert.Equal(t, StateNameRemappedRows, states[0].Name)
+			assert.Contains(t, states[0].ExtraInfo, StateKeyRemappedRowsData)
+			assert.Contains(t, states[0].ExtraInfo, StateKeyRemappedRowsEncoding)
+			assert.Equal(t, StateValueRemappedRowsEncodingJSON, states[0].ExtraInfo[StateKeyRemappedRowsEncoding])
+		})
+	}
+}
 
 func TestOutput_Evaluate(t *testing.T) {
 	tests := []struct {
@@ -25,44 +255,58 @@ func TestOutput_Evaluate(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name: "GPU without row remapping support",
+			name: "row remapping not supported",
 			output: &Output{
-				GPUProductName: "NVIDIA T4",
+				GPUProductName: "Test GPU",
 				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
-					RowRemapping: false,
-					Message:      "Row remapping not supported",
+					Message: "not supported",
+				},
+				RemappedRowsNVML: []nvml.RemappedRows{
+					{Supported: false},
 				},
 			},
-			wantReason:  `GPU product name "NVIDIA T4" does not support row remapping (message: "Row remapping not supported")`,
+			wantReason:  `GPU product name "Test GPU" does not support row remapping (message: "not supported")`,
 			wantHealthy: true,
 			wantErr:     false,
 		},
 		{
-			name: "SMI GPU qualifies for RMA",
+			name: "healthy state with supported remapping",
 			output: &Output{
-				GPUProductName: "NVIDIA A100",
-				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
-					RowRemapping: true,
+				GPUProductName: "Test GPU",
+				RemappedRowsNVML: []nvml.RemappedRows{
+					{Supported: true},
+				},
+			},
+			wantReason:  "no issue detected",
+			wantHealthy: true,
+			wantErr:     false,
+		},
+		{
+			name: "SMI GPU needs RMA",
+			output: &Output{
+				GPUProductName: "Test GPU",
+				RemappedRowsNVML: []nvml.RemappedRows{
+					{Supported: true},
 				},
 				RemappedRowsSMI: []query.ParsedSMIRemappedRows{
 					{
 						ID:                               "GPU-123",
 						RemappingFailed:                  "Yes",
-						RemappedDueToUncorrectableErrors: "1",
 						RemappingPending:                 "No",
+						RemappedDueToUncorrectableErrors: "5",
 					},
 				},
 			},
-			wantReason:  "nvidia-smi GPU GPU-123 qualifies for RMA (remapping failure occurred Yes, remapped due to uncorrectable errors 1)",
+			wantReason:  `nvidia-smi GPU GPU-123 qualifies for RMA (remapping failure occurred Yes, remapped due to uncorrectable errors 5)`,
 			wantHealthy: false,
 			wantErr:     false,
 		},
 		{
 			name: "SMI GPU needs reset",
 			output: &Output{
-				GPUProductName: "NVIDIA A100",
-				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
-					RowRemapping: true,
+				GPUProductName: "Test GPU",
+				RemappedRowsNVML: []nvml.RemappedRows{
+					{Supported: true},
 				},
 				RemappedRowsSMI: []query.ParsedSMIRemappedRows{
 					{
@@ -73,85 +317,65 @@ func TestOutput_Evaluate(t *testing.T) {
 					},
 				},
 			},
-			wantReason:  "nvidia-smi GPU GPU-123 needs reset (pending remapping true)",
+			wantReason:  `nvidia-smi GPU GPU-123 needs reset (pending remapping true)`,
 			wantHealthy: false,
 			wantErr:     false,
 		},
 		{
-			name: "NVML GPU qualifies for RMA",
+			name: "NVML GPU needs RMA",
 			output: &Output{
-				GPUProductName: "NVIDIA A100",
-				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
-					RowRemapping: true,
-				},
+				GPUProductName: "Test GPU",
 				RemappedRowsNVML: []nvml.RemappedRows{
 					{
+						Supported:                        true,
 						UUID:                             "GPU-456",
 						RemappingFailed:                  true,
 						RemappedDueToUncorrectableErrors: 1,
 					},
 				},
 			},
-			wantReason:  "nvml GPU GPU-456 qualifies for RMA (remapping failure occurred true, remapped due to uncorrectable errors 1)",
+			wantReason:  `nvml GPU GPU-456 qualifies for RMA (remapping failure occurred true, remapped due to uncorrectable errors 1)`,
 			wantHealthy: false,
 			wantErr:     false,
 		},
 		{
 			name: "NVML GPU needs reset",
 			output: &Output{
-				GPUProductName: "NVIDIA A100",
-				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
-					RowRemapping: true,
-				},
+				GPUProductName: "Test GPU",
 				RemappedRowsNVML: []nvml.RemappedRows{
 					{
+						Supported:        true,
 						UUID:             "GPU-456",
 						RemappingPending: true,
 					},
 				},
 			},
-			wantReason:  "nvml GPU GPU-456 needs reset (pending remapping true)",
+			wantReason:  `nvml GPU GPU-456 needs reset (pending remapping true)`,
 			wantHealthy: false,
 			wantErr:     false,
 		},
 		{
-			name: "Multiple issues",
+			name: "multiple issues",
 			output: &Output{
-				GPUProductName: "NVIDIA A100",
-				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
-					RowRemapping: true,
+				GPUProductName: "Test GPU",
+				RemappedRowsNVML: []nvml.RemappedRows{
+					{
+						Supported:        true,
+						UUID:             "GPU-456",
+						RemappingPending: true,
+					},
 				},
 				RemappedRowsSMI: []query.ParsedSMIRemappedRows{
 					{
 						ID:                               "GPU-123",
 						RemappingFailed:                  "Yes",
-						RemappedDueToUncorrectableErrors: "1",
 						RemappingPending:                 "No",
-					},
-				},
-				RemappedRowsNVML: []nvml.RemappedRows{
-					{
-						UUID:             "GPU-456",
-						RemappingPending: true,
+						RemappedDueToUncorrectableErrors: "5",
 					},
 				},
 			},
-			wantReason:  "nvidia-smi GPU GPU-123 qualifies for RMA (remapping failure occurred Yes, remapped due to uncorrectable errors 1), nvml GPU GPU-456 needs reset (pending remapping true)",
+			wantReason:  `nvidia-smi GPU GPU-123 qualifies for RMA (remapping failure occurred Yes, remapped due to uncorrectable errors 5), nvml GPU GPU-456 needs reset (pending remapping true)`,
 			wantHealthy: false,
-			wantErr:     false,
-		},
-		{
-			name: "No issues detected",
-			output: &Output{
-				GPUProductName: "NVIDIA A100",
-				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
-					RowRemapping: true,
-				},
-				RemappedRowsSMI:  []query.ParsedSMIRemappedRows{},
-				RemappedRowsNVML: []nvml.RemappedRows{},
-			},
-			wantReason:  "no issue detected",
-			wantHealthy: true,
 			wantErr:     false,
 		},
 	}
@@ -159,15 +383,13 @@ func TestOutput_Evaluate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reason, healthy, err := tt.output.Evaluate()
-
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
 			}
-
 			assert.NoError(t, err)
-			assert.Equal(t, tt.wantHealthy, healthy)
 			assert.Equal(t, tt.wantReason, reason)
+			assert.Equal(t, tt.wantHealthy, healthy)
 		})
 	}
 }

--- a/components/accelerator/nvidia/remapped-rows/component_output_test.go
+++ b/components/accelerator/nvidia/remapped-rows/component_output_test.go
@@ -1,0 +1,173 @@
+package remappedrows
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/leptonai/gpud/components/accelerator/nvidia/query"
+	"github.com/leptonai/gpud/components/accelerator/nvidia/query/nvml"
+)
+
+func TestOutput_Evaluate(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      *Output
+		wantReason  string
+		wantHealthy bool
+		wantErr     bool
+	}{
+		{
+			name:        "nil output",
+			output:      nil,
+			wantReason:  "no data",
+			wantHealthy: true,
+			wantErr:     false,
+		},
+		{
+			name: "GPU without row remapping support",
+			output: &Output{
+				GPUProductName: "NVIDIA T4",
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: false,
+					Message:      "Row remapping not supported",
+				},
+			},
+			wantReason:  `GPU product name "NVIDIA T4" does not support row remapping (message: "Row remapping not supported")`,
+			wantHealthy: true,
+			wantErr:     false,
+		},
+		{
+			name: "SMI GPU qualifies for RMA",
+			output: &Output{
+				GPUProductName: "NVIDIA A100",
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: true,
+				},
+				RemappedRowsSMI: []query.ParsedSMIRemappedRows{
+					{
+						ID:                               "GPU-123",
+						RemappingFailed:                  "Yes",
+						RemappedDueToUncorrectableErrors: "1",
+						RemappingPending:                 "No",
+					},
+				},
+			},
+			wantReason:  "nvidia-smi GPU GPU-123 qualifies for RMA (remapping failure occurred Yes, remapped due to uncorrectable errors 1)",
+			wantHealthy: false,
+			wantErr:     false,
+		},
+		{
+			name: "SMI GPU needs reset",
+			output: &Output{
+				GPUProductName: "NVIDIA A100",
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: true,
+				},
+				RemappedRowsSMI: []query.ParsedSMIRemappedRows{
+					{
+						ID:                               "GPU-123",
+						RemappingPending:                 "Yes",
+						RemappingFailed:                  "No",
+						RemappedDueToUncorrectableErrors: "0",
+					},
+				},
+			},
+			wantReason:  "nvidia-smi GPU GPU-123 needs reset (pending remapping true)",
+			wantHealthy: false,
+			wantErr:     false,
+		},
+		{
+			name: "NVML GPU qualifies for RMA",
+			output: &Output{
+				GPUProductName: "NVIDIA A100",
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: true,
+				},
+				RemappedRowsNVML: []nvml.RemappedRows{
+					{
+						UUID:                             "GPU-456",
+						RemappingFailed:                  true,
+						RemappedDueToUncorrectableErrors: 1,
+					},
+				},
+			},
+			wantReason:  "nvml GPU GPU-456 qualifies for RMA (remapping failure occurred true, remapped due to uncorrectable errors 1)",
+			wantHealthy: false,
+			wantErr:     false,
+		},
+		{
+			name: "NVML GPU needs reset",
+			output: &Output{
+				GPUProductName: "NVIDIA A100",
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: true,
+				},
+				RemappedRowsNVML: []nvml.RemappedRows{
+					{
+						UUID:             "GPU-456",
+						RemappingPending: true,
+					},
+				},
+			},
+			wantReason:  "nvml GPU GPU-456 needs reset (pending remapping true)",
+			wantHealthy: false,
+			wantErr:     false,
+		},
+		{
+			name: "Multiple issues",
+			output: &Output{
+				GPUProductName: "NVIDIA A100",
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: true,
+				},
+				RemappedRowsSMI: []query.ParsedSMIRemappedRows{
+					{
+						ID:                               "GPU-123",
+						RemappingFailed:                  "Yes",
+						RemappedDueToUncorrectableErrors: "1",
+						RemappingPending:                 "No",
+					},
+				},
+				RemappedRowsNVML: []nvml.RemappedRows{
+					{
+						UUID:             "GPU-456",
+						RemappingPending: true,
+					},
+				},
+			},
+			wantReason:  "nvidia-smi GPU GPU-123 qualifies for RMA (remapping failure occurred Yes, remapped due to uncorrectable errors 1), nvml GPU GPU-456 needs reset (pending remapping true)",
+			wantHealthy: false,
+			wantErr:     false,
+		},
+		{
+			name: "No issues detected",
+			output: &Output{
+				GPUProductName: "NVIDIA A100",
+				MemoryErrorManagementCapabilities: query.MemoryErrorManagementCapabilities{
+					RowRemapping: true,
+				},
+				RemappedRowsSMI:  []query.ParsedSMIRemappedRows{},
+				RemappedRowsNVML: []nvml.RemappedRows{},
+			},
+			wantReason:  "no issue detected",
+			wantHealthy: true,
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, healthy, err := tt.output.Evaluate()
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantHealthy, healthy)
+			assert.Equal(t, tt.wantReason, reason)
+		})
+	}
+}


### PR DESCRIPTION
Fix

> nvidia-smi GPU GPU 00000000:E1:00.0 failed to determine if it qualifies for RMA: invalid remapping failure occurred value: "", GPU product name "NVIDIA GeForce RTX 4090" does not support row remapping (message: "GPU product name: \"NVIDIA GeForce RTX 4090\"