### PR TITLE
fix(nvml): parse driver version to handle the one without patch version

### DIFF
--- a/components/accelerator/nvidia/query/nvml/nvml.go
+++ b/components/accelerator/nvidia/query/nvml/nvml.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -159,12 +161,30 @@ func GetDriverVersion() (string, error) {
 }
 
 func ParseDriverVersion(version string) (major, minor, patch int, err error) {
-	var parsed [3]int
-	if _, err = fmt.Sscanf(version, "%d.%d.%d", &parsed[0], &parsed[1], &parsed[2]); err != nil {
-		return 0, 0, 0, fmt.Errorf("failed to parse driver version: %v", err)
+	splits := strings.Split(version, ".")
+	if len(splits) < 2 {
+		return 0, 0, 0, fmt.Errorf("failed to parse driver version (expected at least 2 parts): %v", version)
+	}
+	if len(splits) > 3 {
+		return 0, 0, 0, fmt.Errorf("failed to parse driver version (expected at most 3 parts): %v", version)
 	}
 
-	major, minor, patch = parsed[0], parsed[1], parsed[2]
+	major, err = strconv.Atoi(splits[0])
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("failed to parse driver version (major): %v", err)
+	}
+	minor, err = strconv.Atoi(splits[1])
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("failed to parse driver version (minor): %v", err)
+	}
+	patch = 0
+	if len(splits) > 2 {
+		patch, err = strconv.Atoi(splits[2])
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf("failed to parse driver version (patch): %v", err)
+		}
+	}
+
 	return major, minor, patch, nil
 }
 

--- a/components/accelerator/nvidia/query/nvml/nvml_test.go
+++ b/components/accelerator/nvidia/query/nvml/nvml_test.go
@@ -32,7 +32,76 @@ func TestParseDriverVersion(t *testing.T) {
 			wantErrNil: true,
 		},
 		{
-			version:    "invalid.version",
+			version:    "550.120",
+			wantMajor:  550,
+			wantMinor:  120,
+			wantPatch:  0,
+			wantErrNil: true,
+		},
+		{
+			// Empty string
+			version:    "",
+			wantErrNil: false,
+		},
+		{
+			// Single number
+			version:    "525",
+			wantErrNil: false,
+		},
+		{
+			// Too many parts
+			version:    "525.85.12.1",
+			wantErrNil: false,
+		},
+		{
+			// Non-numeric major
+			version:    "abc.85.12",
+			wantErrNil: false,
+		},
+		{
+			// Non-numeric minor
+			version:    "525.abc.12",
+			wantErrNil: false,
+		},
+		{
+			// Non-numeric patch
+			version:    "525.85.abc",
+			wantErrNil: false,
+		},
+		{
+			// Invalid separators
+			version:    "525-85-12",
+			wantErrNil: false,
+		},
+		{
+			// Leading zeros in patch
+			version:    "525.85.08",
+			wantMajor:  525,
+			wantMinor:  85,
+			wantPatch:  8,
+			wantErrNil: true,
+		},
+		{
+			// Leading zeros in minor
+			version:    "525.085.12",
+			wantMajor:  525,
+			wantMinor:  85,
+			wantPatch:  12,
+			wantErrNil: true,
+		},
+		{
+			// Invalid version with spaces
+			version:    "525. 85.12",
+			wantErrNil: false,
+		},
+		{
+			// Invalid version with trailing dot
+			version:    "525.85.",
+			wantErrNil: false,
+		},
+		{
+			// Invalid version with leading dot
+			version:    ".525.85",
 			wantErrNil: false,
 		},
 	}


### PR DESCRIPTION
e.g.,
Driver Version: 550.120

Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
