### PR TITLE
test(db/events): make retention purge unit tests less flaky

### DIFF
--- a/components/db/events.go
+++ b/components/db/events.go
@@ -64,10 +64,12 @@ type storeImpl struct {
 	rootCtx    context.Context
 	rootCancel context.CancelFunc
 
-	table     string
-	dbRW      *sql.DB
-	dbRO      *sql.DB
-	retention time.Duration
+	table string
+	dbRW  *sql.DB
+	dbRO  *sql.DB
+
+	retention        time.Duration
+	getPurgeInterval func() time.Duration
 }
 
 var (
@@ -98,6 +100,18 @@ var _ Store = (*storeImpl)(nil)
 // Requires write-only and read-only instances for minimize conflicting writes/reads.
 // ref. https://github.com/mattn/go-sqlite3/issues/1179#issuecomment-1638083995
 func NewStore(dbRW *sql.DB, dbRO *sql.DB, tableName string, retention time.Duration) (Store, error) {
+	return newStore(dbRW, dbRO, tableName, retention, func() time.Duration {
+		// actual check interval should be lower than the retention period
+		// in case of GPUd restarts
+		checkInterval := retention / 5
+		if checkInterval < time.Second {
+			checkInterval = time.Second
+		}
+		return checkInterval
+	})
+}
+
+func newStore(dbRW *sql.DB, dbRO *sql.DB, tableName string, retention time.Duration, getPurgeInterval func() time.Duration) (Store, error) {
 	if dbRW == nil {
 		return nil, ErrNoDBRWSet
 	}
@@ -114,12 +128,13 @@ func NewStore(dbRW *sql.DB, dbRO *sql.DB, tableName string, retention time.Durat
 
 	rootCtx, rootCancel := context.WithCancel(context.Background())
 	s := &storeImpl{
-		rootCtx:    rootCtx,
-		rootCancel: rootCancel,
-		table:      tableName,
-		dbRW:       dbRW,
-		dbRO:       dbRO,
-		retention:  retention,
+		rootCtx:          rootCtx,
+		rootCancel:       rootCancel,
+		table:            tableName,
+		dbRW:             dbRW,
+		dbRO:             dbRO,
+		retention:        retention,
+		getPurgeInterval: getPurgeInterval,
 	}
 	go s.runPurge()
 
@@ -131,19 +146,14 @@ func (s *storeImpl) runPurge() {
 		return
 	}
 
-	// actual check interval should be lower than the retention period
-	// in case of GPUd restarts
-	checkInterval := s.retention / 5
-	if checkInterval < time.Second {
-		checkInterval = time.Second
-	}
+	purgeInterval := s.getPurgeInterval()
 
 	log.Logger.Infow("start purging", "table", s.table, "retention", s.retention)
 	for {
 		select {
 		case <-s.rootCtx.Done():
 			return
-		case <-time.After(checkInterval):
+		case <-time.After(purgeInterval):
 		}
 
 		now := time.Now().UTC()

--- a/components/db/events_test.go
+++ b/components/db/events_test.go
@@ -1341,11 +1341,9 @@ func TestRetentionPurge(t *testing.T) {
 		dbRO,
 		testTableName,
 		10*time.Second,
-		func() time.Duration {
-			// much shorter than the retention period
-			// to make tests less flaky
-			return 50 * time.Millisecond
-		},
+		// much shorter than the retention period
+		// to make tests less flaky
+		50*time.Millisecond,
 	)
 	assert.NoError(t, err)
 	defer store.Close()

--- a/components/db/events_test.go
+++ b/components/db/events_test.go
@@ -1336,8 +1336,17 @@ func TestRetentionPurge(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	// Create store with 10 second retention
-	store, err := NewStore(dbRW, dbRO, testTableName, 10*time.Second)
+	store, err := newStore(
+		dbRW,
+		dbRO,
+		testTableName,
+		10*time.Second,
+		func() time.Duration {
+			// much shorter than the retention period
+			// to make tests less flaky
+			return 50 * time.Millisecond
+		},
+	)
 	assert.NoError(t, err)
 	defer store.Close()
 
@@ -1363,16 +1372,13 @@ func TestRetentionPurge(t *testing.T) {
 		},
 	}
 
-	// Insert events
 	for _, event := range events {
 		err = store.Insert(ctx, event)
 		assert.NoError(t, err)
 	}
 
-	// Wait for purge to run (retention/10 = 1 second)
-	time.Sleep(2 * time.Second)
+	time.Sleep(time.Second)
 
-	// Verify only new event remains
 	remaining, err := store.Get(ctx, baseTime.Add(-20*time.Second))
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(remaining))


### PR DESCRIPTION
Address:

```
=== NAME  TestRetentionPurge
    events_test.go:1378: 
        	Error Trace:	/home/runner/work/gpud/gpud/components/db/events_test.go:1378
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	TestRetentionPurge
{"level":"info","ts":"2025-02-10T10:17:41Z","caller":"db/events.go:160","msg":"closing the store","table":"test_table"}
{"level":"info","ts":"2025-02-10T10:17:41Z","caller":"db/events.go:154","msg":"purged data","table":"test_table","retention":10,"purged":1}
--- FAIL: TestRetentionPurge (2.01s)
```