### PR TITLE
feat(dmesg): increase watch buffer size to 2,000 to avoid dropping events at the beginning

### DIFF
--- a/pkg/dmesg/watcher.go
+++ b/pkg/dmesg/watcher.go
@@ -84,7 +84,9 @@ func watch(
 	ctx context.Context,
 	cmds [][]string,
 ) (<-chan LogLine, error) {
-	ch := make(chan LogLine, 1000)
+	// initial dmesg output may contain more than 1000 lines
+	// use 2000 as buffer size to avoid dropping any lines
+	ch := make(chan LogLine, 2000)
 
 	opts := []process.OpOption{}
 	for _, cmd := range cmds {


### PR DESCRIPTION
Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
