### PR TITLE
feat(network/edge/derpmap): add Ashburn (Virginia), Nuremberg (Germany)

### DIFF
--- a/pkg/latency/edge/derpmap/derp_regions.go
+++ b/pkg/latency/edge/derpmap/derp_regions.go
@@ -4,6 +4,7 @@ package derpmap
 // ref. https://aws.amazon.com/about-aws/global-infrastructure/regions_az/
 var derpRegionNameToAWSRegion = map[string]string{
 	"Amsterdam":     "eu-west-1",
+	"Ashburn":       "us-east-1",
 	"Bangalore":     "ap-south-1",
 	"Chicago":       "us-east-2",
 	"Dallas":        "us-east-1",
@@ -19,6 +20,7 @@ var derpRegionNameToAWSRegion = map[string]string{
 	"Miami":         "us-east-1",
 	"Nairobi":       "af-south-1",
 	"New York City": "us-east-1",
+	"Nuremberg":     "eu-central-1",
 	"Paris":         "eu-west-3",
 	"San Francisco": "us-west-1",
 	"Seattle":       "us-west-2",

--- a/pkg/latency/edge/derpmap/derpmap.json
+++ b/pkg/latency/edge/derpmap/derpmap.json
@@ -37,7 +37,6 @@
           "HostName": "derp1i.tailscale.com",
           "IPv4": "199.38.181.103",
           "IPv6": "2607:f740:f::e19",
-          "STUNOnly": true,
           "CanPort80": true
         }
       ]
@@ -599,6 +598,80 @@
           "HostName": "derp25d.tailscale.com",
           "IPv4": "102.67.167.188",
           "IPv6": "2c0f:edb0:2000:1::188",
+          "CanPort80": true
+        }
+      ]
+    },
+    "26": {
+      "RegionID": 26,
+      "RegionCode": "nue",
+      "RegionName": "Nuremberg",
+      "Latitude": 49.453889,
+      "Longitude": 11.0775,
+      "Nodes": [
+        {
+          "Name": "26b",
+          "RegionID": 26,
+          "HostName": "derp26b.tailscale.com",
+          "IPv4": "167.235.72.200",
+          "IPv6": "2a01:4f8:1c1c:47b6::1",
+          "CanPort80": true
+        },
+        {
+          "Name": "26c",
+          "RegionID": 26,
+          "HostName": "derp26c.tailscale.com",
+          "IPv4": "49.12.193.137",
+          "IPv6": "2a01:4f8:1c1c:5c70::1",
+          "CanPort80": true
+        },
+        {
+          "Name": "26d",
+          "RegionID": 26,
+          "HostName": "derp26d.tailscale.com",
+          "IPv4": "49.13.204.141",
+          "IPv6": "2a01:4f8:1c0c:7d06::1",
+          "CanPort80": true
+        }
+      ]
+    },
+    "27": {
+      "RegionID": 27,
+      "RegionCode": "iad",
+      "RegionName": "Ashburn",
+      "Latitude": 39.03,
+      "Longitude": -77.471111,
+      "Nodes": [
+        {
+          "Name": "27b",
+          "RegionID": 27,
+          "HostName": "derp27b.tailscale.com",
+          "IPv4": "5.161.218.233",
+          "IPv6": "2a01:4ff:f0:3db9::1",
+          "CanPort80": true
+        },
+        {
+          "Name": "27c",
+          "RegionID": 27,
+          "HostName": "derp27c.tailscale.com",
+          "IPv4": "178.156.152.91",
+          "IPv6": "2a01:4ff:f0:3913::1",
+          "CanPort80": true
+        },
+        {
+          "Name": "27d",
+          "RegionID": 27,
+          "HostName": "derp27d.tailscale.com",
+          "IPv4": "178.156.152.106",
+          "IPv6": "2a01:4ff:f0:3c8e::1",
+          "CanPort80": true
+        },
+        {
+          "Name": "27e",
+          "RegionID": 27,
+          "HostName": "derp27e.tailscale.com",
+          "IPv4": "178.156.134.232",
+          "IPv6": "2a01:4ff:f0:28d4::1",
           "CanPort80": true
         }
       ]


### PR DESCRIPTION
```
+----------------+---------------+----------------+--------------+
|    PROVIDER    |  REGION NAME  |  REGION CODE   |   LATENCY    |
+----------------+---------------+----------------+--------------+
| tailscale-derp | Tokyo         | ap-northeast-1 | 42.579875ms  |
| tailscale-derp | Hong Kong     | ap-east-1      | 90.562042ms  |
| tailscale-derp | Singapore     | ap-southeast-1 | 90.938833ms  |
| tailscale-derp | San Francisco | us-west-1      | 136.052667ms |
| tailscale-derp | Los Angeles   | us-west-1      | 142.900166ms |
| tailscale-derp | Seattle       | us-west-2      | 151.225084ms |
| tailscale-derp | Dallas        | us-east-1      | 169.166667ms |
| tailscale-derp | Sydney        | ap-southeast-2 | 172.688417ms |
| tailscale-derp | Denver        | us-west-1      | 173.116417ms |
| tailscale-derp | Chicago       | us-east-2      | 182.289333ms |
| tailscale-derp | Honolulu      | us-west-3      | 190.702083ms |
| tailscale-derp | Miami         | us-east-1      | 195.055375ms |
| tailscale-derp | New York City | us-east-1      | 196.265042ms |
| tailscale-derp | Ashburn       | us-east-1      | 202.490666ms |
| tailscale-derp | Toronto       | ca-central-1   | 206.010833ms |
| tailscale-derp | Amsterdam     | eu-west-1      | 223.2075ms   |
| tailscale-derp | Nuremberg     | eu-central-1   | 228.580916ms |
| tailscale-derp | Bangalore     | ap-south-1     | 252.46775ms  |
| tailscale-derp | Frankfurt     | eu-central-1   | 260.678209ms |
| tailscale-derp | London        | eu-west-2      | 273.572917ms |
| tailscale-derp | Paris         | eu-west-3      | 279.616917ms |
| tailscale-derp | Madrid        | eu-south-2     | 286.98125ms  |
| tailscale-derp | Warsaw        | eu-central-1   | 302.204041ms |
| tailscale-derp | São Paulo     | sa-east-1      | 315.67225ms  |
| tailscale-derp | Dubai         | me-central-1   | 386.388666ms |
| tailscale-derp | Johannesburg  | af-south-1     | 419.718708ms |
| tailscale-derp | Nairobi       | af-south-1     | 438.258167ms |
+----------------+---------------+----------------+--------------+
```