### PR TITLE
feat(gpud update): trim space when fetching version from "_latest.txt"

### DIFF
--- a/cmd/gpud/command/update.go
+++ b/cmd/gpud/command/update.go
@@ -5,6 +5,7 @@
 package command
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"strings"
@@ -42,13 +43,18 @@ func detectLatestVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return detectLatestVersionByURL(defaultURLPrefix + track + "_latest.txt")
+}
 
-	fetchedVer, err := distsign.Fetch(defaultURLPrefix+track+"_latest.txt", 100)
+func detectLatestVersionByURL(url string) (string, error) {
+	fetchedVer, err := distsign.Fetch(url, 100)
 	if err != nil {
 		fmt.Printf("Failed to fetch latest version: %v\n", err)
 		return "", err
 	}
-	ver := string(fetchedVer)
+
+	// trim whitespaces in case the version _latest.txt file included trailing spaces
+	ver := string(bytes.TrimSpace(fetchedVer))
 	fmt.Printf("automatically fetched the latest version: %s\n", ver)
 
 	return ver, nil


### PR DESCRIPTION
Fix

> {"level":"info","ts":"2025-02-11T17:57:17-08:00","caller":"update/update.go:206","msg":"starting gpud update","version":"v0.4.2\n","url":"https://pkg.gpud.dev/","requireRoot":true,"useSystemd":true}
{"level":"info","ts":"2025-02-11T17:57:18-08:00","caller":"update/update.go:34","msg":"Downloading \"https://pkg.gpud.dev/gpud_v0.4.2%0A_linux_amd64_ubuntu24.04.tgz\""}