### PR TITLE
fix(infiniband): simplify port check message, handle "Polling" state

### DIFF
--- a/components/accelerator/nvidia/infiniband/component_test.go
+++ b/components/accelerator/nvidia/infiniband/component_test.go
@@ -91,7 +91,7 @@ func TestEvaluate(t *testing.T) {
 				AtLeastPorts: 2,
 				AtLeastRate:  200,
 			},
-			wantReason:  "not enough LinkUp ports, only 1 LinkUp out of 1, expected at least 2 ports and 200 Gb/sec rate; some ports must be missing",
+			wantReason:  "only 1 LinkUp ports found (expected at least 2)",
 			wantHealthy: false,
 			wantErr:     false,
 		},
@@ -122,7 +122,7 @@ func TestEvaluate(t *testing.T) {
 				AtLeastPorts: 2,
 				AtLeastRate:  200,
 			},
-			wantReason:  "not enough LinkUp ports, only 0 LinkUp out of 2, expected at least 2 ports and 200 Gb/sec rate; some ports must be missing",
+			wantReason:  "only 0 LinkUp ports found (expected at least 2)",
 			wantHealthy: false,
 			wantErr:     false,
 		},
@@ -153,7 +153,7 @@ func TestEvaluate(t *testing.T) {
 				AtLeastPorts: 2,
 				AtLeastRate:  200,
 			},
-			wantReason:  "not enough LinkUp ports, only 0 LinkUp out of 2, expected at least 2 ports and 200 Gb/sec rate; some ports might be down, 2 Disabled devices with Rate > 200 found (mlx5_0, mlx5_1)",
+			wantReason:  "only 0 LinkUp ports found (expected at least 2); 2 device(s) found Disabled (mlx5_0, mlx5_1)",
 			wantHealthy: false,
 			wantErr:     false,
 		},
@@ -239,7 +239,7 @@ func TestEvaluateWithTestData(t *testing.T) {
 				AtLeastPorts: 12,  // Total number of ports
 				AtLeastRate:  400, // Only 8 ports have this rate
 			},
-			wantReason:  "not enough LinkUp ports, only 8 LinkUp out of 12, expected at least 12 ports and 400 Gb/sec rate; some ports must be missing",
+			wantReason:  "only 8 LinkUp ports found (expected at least 12)",
 			wantHealthy: false,
 			wantErr:     false,
 		},
@@ -313,7 +313,7 @@ func TestComponentStatesWithTestData(t *testing.T) {
 	assert.Equal(t, "ibstat", state.Name)
 	assert.False(t, state.Healthy)
 	assert.Equal(t, components.StateUnhealthy, state.Health)
-	assert.Contains(t, state.Reason, "not enough LinkUp ports")
+	assert.Contains(t, state.Reason, "only 8 LinkUp ports found (expected at least 12)")
 	assert.NotNil(t, state.SuggestedActions)
 	assert.Equal(t, []common.RepairActionType{common.RepairActionTypeHardwareInspection}, state.SuggestedActions.RepairActions)
 }

--- a/components/accelerator/nvidia/infiniband/component_test.go
+++ b/components/accelerator/nvidia/infiniband/component_test.go
@@ -91,7 +91,7 @@ func TestEvaluate(t *testing.T) {
 				AtLeastPorts: 2,
 				AtLeastRate:  200,
 			},
-			wantReason:  "only 1 LinkUp ports found (expected at least 2)",
+			wantReason:  "only 1 ports (>= 200 Gb/s) are active, expect at least 2",
 			wantHealthy: false,
 			wantErr:     false,
 		},
@@ -122,7 +122,7 @@ func TestEvaluate(t *testing.T) {
 				AtLeastPorts: 2,
 				AtLeastRate:  200,
 			},
-			wantReason:  "only 0 LinkUp ports found (expected at least 2)",
+			wantReason:  "only 0 ports (>= 200 Gb/s) are active, expect at least 2",
 			wantHealthy: false,
 			wantErr:     false,
 		},
@@ -153,7 +153,7 @@ func TestEvaluate(t *testing.T) {
 				AtLeastPorts: 2,
 				AtLeastRate:  200,
 			},
-			wantReason:  "only 0 LinkUp ports found (expected at least 2); 2 device(s) found Disabled (mlx5_0, mlx5_1)",
+			wantReason:  "only 0 ports (>= 200 Gb/s) are active, expect at least 2; 2 device(s) found Disabled (mlx5_0, mlx5_1)",
 			wantHealthy: false,
 			wantErr:     false,
 		},
@@ -239,7 +239,7 @@ func TestEvaluateWithTestData(t *testing.T) {
 				AtLeastPorts: 12,  // Total number of ports
 				AtLeastRate:  400, // Only 8 ports have this rate
 			},
-			wantReason:  "only 8 LinkUp ports found (expected at least 12)",
+			wantReason:  "only 8 ports (>= 400 Gb/s) are active, expect at least 12",
 			wantHealthy: false,
 			wantErr:     false,
 		},
@@ -313,7 +313,7 @@ func TestComponentStatesWithTestData(t *testing.T) {
 	assert.Equal(t, "ibstat", state.Name)
 	assert.False(t, state.Healthy)
 	assert.Equal(t, components.StateUnhealthy, state.Health)
-	assert.Contains(t, state.Reason, "only 8 LinkUp ports found (expected at least 12)")
+	assert.Contains(t, state.Reason, "only 8 ports (>= 400 Gb/s) are active, expect at least 12")
 	assert.NotNil(t, state.SuggestedActions)
 	assert.Equal(t, []common.RepairActionType{common.RepairActionTypeHardwareInspection}, state.SuggestedActions.RepairActions)
 }

--- a/pkg/nvidia-query/infiniband/ibstat.go
+++ b/pkg/nvidia-query/infiniband/ibstat.go
@@ -164,7 +164,7 @@ func (cards IBStatCards) CheckPortsAndRate(atLeastPorts int, atLeastRate int) er
 		return nil
 	}
 
-	errMsg := fmt.Sprintf("only %d LinkUp ports found (expected at least %d)", len(portNamesWithLinkUp), atLeastPorts)
+	errMsg := fmt.Sprintf("only %d ports (>= %d Gb/s) are active, expect at least %d", len(portNamesWithLinkUp), atLeastRate, atLeastPorts)
 	log.Logger.Warnw(errMsg, "totalPorts", len(cards), "atLeastPorts", atLeastPorts, "atLeastRateGbPerSec", atLeastRate)
 
 	pm, portNamesWithDisabledOrPolling := cards.match([]string{"Disabled", "Polling"}, "", 0) // atLeastRate is ignored

--- a/pkg/nvidia-query/infiniband/ibstat.go
+++ b/pkg/nvidia-query/infiniband/ibstat.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -108,19 +109,26 @@ type IbstatOutput struct {
 
 type IBStatCards []IBStatCard
 
-// Match returns the IB port names whose physical state, state, and "Port 1"."Rate" match the expected values.
+// match returns the map from the physical state to each IB port names that matches the expected values.
 // The specified rate is the threshold for "Port 1"."Rate", where it evaluates with ">=" operator
 // (e.g., count all the cards whose rate is >= 400).
 //
 // If the `expectedPhysicalState` is empty, it matches all states.
+// If the `expectedPhysicalState` are multiple states, it matches all states with OR operator.
 // If the `expectedState` is empty, it matches all states.
-func (cards IBStatCards) Match(expectedPhysicalState string, expectedState string, atLeastRate int) []string {
-	names := make([]string, 0)
+func (cards IBStatCards) match(expectedPhysicalStates []string, expectedState string, atLeastRate int) (map[string][]string, []string) {
+	expStates := make(map[string]struct{})
+	for _, s := range expectedPhysicalStates {
+		expStates[s] = struct{}{}
+	}
+
+	all, names := make(map[string][]string), make([]string, 0)
 	for _, card := range cards {
 		// e.g.,
 		// expected "Physical state: LinkUp"
-		// but got "Physical state: Disabled"
-		if expectedPhysicalState != "" && card.Port1.PhysicalState != expectedPhysicalState {
+		// but got "Physical state: Disabled" or "Physical state: Polling"
+		_, found := expStates[card.Port1.PhysicalState]
+		if len(expStates) > 0 && !found {
 			continue
 		}
 
@@ -135,9 +143,13 @@ func (cards IBStatCards) Match(expectedPhysicalState string, expectedState strin
 			continue
 		}
 
+		if _, ok := all[card.Port1.PhysicalState]; !ok {
+			all[card.Port1.PhysicalState] = make([]string, 0)
+		}
+		all[card.Port1.PhysicalState] = append(all[card.Port1.PhysicalState], card.Name)
 		names = append(names, card.Name)
 	}
-	return names
+	return all, names
 }
 
 // CheckPortsAndRate checks if the number of active IB ports matches expectations
@@ -146,31 +158,26 @@ func (cards IBStatCards) CheckPortsAndRate(atLeastPorts int, atLeastRate int) er
 		return nil
 	}
 
-	totalPorts := len(cards)
-
 	// select all "up" devices, and count the ones that match the expected rate with ">="
-	portNamesWithLinkUp := cards.Match("LinkUp", "", atLeastRate)
-	unstatisfieldCount := atLeastPorts - len(portNamesWithLinkUp)
-	if unstatisfieldCount <= 0 {
+	_, portNamesWithLinkUp := cards.match([]string{"LinkUp"}, "", atLeastRate)
+	if len(portNamesWithLinkUp) >= atLeastPorts {
 		return nil
 	}
 
-	errMsg := fmt.Sprintf("not enough LinkUp ports, only %d LinkUp out of %d, expected at least %d ports and %d Gb/sec rate", len(portNamesWithLinkUp), totalPorts, atLeastPorts, atLeastRate)
+	errMsg := fmt.Sprintf("only %d LinkUp ports found (expected at least %d)", len(portNamesWithLinkUp), atLeastPorts)
+	log.Logger.Warnw(errMsg, "totalPorts", len(cards), "atLeastPorts", atLeastPorts, "atLeastRateGbPerSec", atLeastRate)
 
-	portNamesWithDisabled := cards.Match("Disabled", "", atLeastRate)
-	if len(portNamesWithDisabled) > 0 {
+	pm, portNamesWithDisabledOrPolling := cards.match([]string{"Disabled", "Polling"}, "", 0) // atLeastRate is ignored
+	if len(portNamesWithDisabledOrPolling) > 0 {
 		// some ports must be missing -- construct error message accordingly
-		errMsg += fmt.Sprintf("; some ports might be down, %v Disabled devices with Rate > %v found (%v)",
-			len(portNamesWithDisabled),
-			atLeastRate,
-			strings.Join(portNamesWithDisabled, ", "),
-		)
+		msgs := make([]string, 0)
+		for state, names := range pm {
+			msgs = append(msgs, fmt.Sprintf("%d device(s) found %s (%s)", len(names), state, strings.Join(names, ", ")))
+		}
+		sort.Strings(msgs)
+		errMsg += fmt.Sprintf("; %s", strings.Join(msgs, "; "))
 	}
 
-	unstatisfieldCount -= len(portNamesWithDisabled)
-	if unstatisfieldCount > 0 {
-		errMsg += "; some ports must be missing"
-	}
 	return errors.New(errMsg)
 }
 

--- a/pkg/nvidia-query/infiniband/ibstat_test.go
+++ b/pkg/nvidia-query/infiniband/ibstat_test.go
@@ -182,60 +182,68 @@ func TestParseIBStatFiles(t *testing.T) {
 
 func TestParseIBStatCountByRates(t *testing.T) {
 	tt := []struct {
-		fileName              string
-		expectedPhysicalState string
-		expectedState         string
-		expectedAtLeastRate   int
-		expectedCount         int
-		expectedPortNames     []string
+		fileName               string
+		expectedPhysicalStates []string
+		expectedState          string
+		expectedAtLeastRate    int
+		expectedCount          int
+		expectedPortNames      []string
 	}{
 		{
-			fileName:              "testdata/ibstat.47.0.a100.all.active.0",
-			expectedPhysicalState: "LinkUp",
-			expectedState:         "Active",
-			expectedAtLeastRate:   200,
-			expectedCount:         9,
-			expectedPortNames:     []string{"mlx5_0", "mlx5_1", "mlx5_2", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_7", "mlx5_8"},
+			fileName:               "testdata/ibstat.47.0.a100.all.active.0",
+			expectedPhysicalStates: []string{"LinkUp"},
+			expectedState:          "Active",
+			expectedAtLeastRate:    200,
+			expectedCount:          9,
+			expectedPortNames:      []string{"mlx5_0", "mlx5_1", "mlx5_2", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_7", "mlx5_8"},
 		},
 		{
-			fileName:              "testdata/ibstat.47.0.a100.all.active.0",
-			expectedPhysicalState: "LinkUp",
-			expectedState:         "Active",
-			expectedAtLeastRate:   100,
-			expectedCount:         9,
-			expectedPortNames:     []string{"mlx5_0", "mlx5_1", "mlx5_2", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_7", "mlx5_8"},
+			fileName:               "testdata/ibstat.47.0.a100.all.active.0",
+			expectedPhysicalStates: []string{"LinkUp"},
+			expectedState:          "Active",
+			expectedAtLeastRate:    100,
+			expectedCount:          9,
+			expectedPortNames:      []string{"mlx5_0", "mlx5_1", "mlx5_2", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_7", "mlx5_8"},
 		},
 		{
-			fileName:              "testdata/ibstat.47.0.h100.all.active.0",
-			expectedPhysicalState: "LinkUp",
-			expectedState:         "Active",
-			expectedAtLeastRate:   400,
-			expectedCount:         8,
-			expectedPortNames:     []string{"mlx5_0", "mlx5_10", "mlx5_11", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_9"},
+			fileName:               "testdata/ibstat.47.0.h100.all.active.0",
+			expectedPhysicalStates: []string{"LinkUp"},
+			expectedState:          "Active",
+			expectedAtLeastRate:    400,
+			expectedCount:          8,
+			expectedPortNames:      []string{"mlx5_0", "mlx5_10", "mlx5_11", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_9"},
 		},
 		{
-			fileName:              "testdata/ibstat.47.0.h100.all.active.1",
-			expectedPhysicalState: "LinkUp",
-			expectedState:         "Active",
-			expectedAtLeastRate:   400,
-			expectedCount:         8,
-			expectedPortNames:     []string{"mlx5_0", "mlx5_10", "mlx5_11", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_9"},
+			fileName:               "testdata/ibstat.47.0.h100.all.active.1",
+			expectedPhysicalStates: []string{"LinkUp"},
+			expectedState:          "Active",
+			expectedAtLeastRate:    400,
+			expectedCount:          8,
+			expectedPortNames:      []string{"mlx5_0", "mlx5_10", "mlx5_11", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_9"},
 		},
 		{
-			fileName:              "testdata/ibstat.47.0.h100.some.down.0",
-			expectedPhysicalState: "LinkUp",
-			expectedState:         "Active",
-			expectedAtLeastRate:   400,
-			expectedCount:         8,
-			expectedPortNames:     []string{"mlx5_0", "mlx5_10", "mlx5_11", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_9"},
+			fileName:               "testdata/ibstat.47.0.h100.some.down.0",
+			expectedPhysicalStates: []string{"LinkUp"},
+			expectedState:          "Active",
+			expectedAtLeastRate:    400,
+			expectedCount:          8,
+			expectedPortNames:      []string{"mlx5_0", "mlx5_10", "mlx5_11", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_9"},
 		},
 		{
-			fileName:              "testdata/ibstat.47.0.h100.some.down.1",
-			expectedAtLeastRate:   400,
-			expectedPhysicalState: "LinkUp",
-			expectedState:         "Active",
-			expectedCount:         6,
-			expectedPortNames:     []string{"mlx5_0", "mlx5_10", "mlx5_3", "mlx5_4", "mlx5_6", "mlx5_9"},
+			fileName:               "testdata/ibstat.47.0.h100.some.down.1",
+			expectedAtLeastRate:    400,
+			expectedPhysicalStates: []string{"LinkUp"},
+			expectedState:          "Active",
+			expectedCount:          6,
+			expectedPortNames:      []string{"mlx5_0", "mlx5_10", "mlx5_3", "mlx5_4", "mlx5_6", "mlx5_9"},
+		},
+		{
+			fileName:               "testdata/ibstat.47.0.h100.some.down.with.polling.1",
+			expectedPhysicalStates: []string{"Disabled", "Polling"},
+			expectedState:          "",
+			expectedAtLeastRate:    0,
+			expectedCount:          2,
+			expectedPortNames:      []string{"mlx5_11", "mlx5_5"},
 		},
 	}
 	for _, tc := range tt {
@@ -248,8 +256,8 @@ func TestParseIBStatCountByRates(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to parse ibstat file %s: %v", tc.fileName, err)
 			}
-			matched := parsed.Match(
-				tc.expectedPhysicalState,
+			_, matched := parsed.match(
+				tc.expectedPhysicalStates,
 				tc.expectedState,
 				tc.expectedAtLeastRate,
 			)
@@ -430,7 +438,7 @@ func TestValidateIBPorts(t *testing.T) {
 			},
 			atLeastPorts: 2,
 			atLeastRate:  200,
-			wantErr:      errors.New("not enough LinkUp ports, only 0 LinkUp out of 2, expected at least 2 ports and 200 Gb/sec rate; some ports might be down, 2 Disabled devices with Rate > 200 found (mlx5_0, mlx5_1)"),
+			wantErr:      errors.New("only 0 LinkUp ports found (expected at least 2); 2 device(s) found Disabled (mlx5_0, mlx5_1)"),
 		},
 		{
 			name: "some ports down",
@@ -454,7 +462,7 @@ func TestValidateIBPorts(t *testing.T) {
 			},
 			atLeastPorts: 4,
 			atLeastRate:  200,
-			wantErr:      errors.New("not enough LinkUp ports, only 2 LinkUp out of 4, expected at least 4 ports and 200 Gb/sec rate; some ports might be down, 2 Disabled devices with Rate > 200 found (mlx5_1, mlx5_3)"),
+			wantErr:      errors.New("only 2 LinkUp ports found (expected at least 4); 2 device(s) found Disabled (mlx5_1, mlx5_3)"),
 		},
 		{
 			name: "wrong rate",
@@ -470,7 +478,7 @@ func TestValidateIBPorts(t *testing.T) {
 			},
 			atLeastPorts: 2,
 			atLeastRate:  200,
-			wantErr:      errors.New("not enough LinkUp ports, only 0 LinkUp out of 2, expected at least 2 ports and 200 Gb/sec rate; some ports must be missing"),
+			wantErr:      errors.New("only 0 LinkUp ports found (expected at least 2)"),
 		},
 		{
 			name: "mixed rates with lower threshold",
@@ -510,7 +518,31 @@ func TestValidateIBPorts(t *testing.T) {
 			},
 			atLeastPorts: 3,
 			atLeastRate:  200,
-			wantErr:      errors.New("not enough LinkUp ports, only 2 LinkUp out of 3, expected at least 3 ports and 200 Gb/sec rate; some ports might be down, 1 Disabled devices with Rate > 200 found (mlx5_1)"),
+			wantErr:      errors.New("only 2 LinkUp ports found (expected at least 3); 1 device(s) found Disabled (mlx5_1)"),
+		},
+		{
+			name: "mixed states with empty expected state matches all and with polling state",
+			cards: IBStatCards{
+				{
+					Name:  "mlx5_0",
+					Port1: IBStatPort{State: "Active", PhysicalState: "LinkUp", Rate: 200},
+				},
+				{
+					Name:  "mlx5_1",
+					Port1: IBStatPort{State: "Down", PhysicalState: "Disabled", Rate: 200},
+				},
+				{
+					Name:  "mlx5_2",
+					Port1: IBStatPort{State: "Init", PhysicalState: "LinkUp", Rate: 200},
+				},
+				{
+					Name:  "mlx5_3",
+					Port1: IBStatPort{State: "Init", PhysicalState: "Polling", Rate: 200},
+				},
+			},
+			atLeastPorts: 3,
+			atLeastRate:  200,
+			wantErr:      errors.New("only 2 LinkUp ports found (expected at least 3); 1 device(s) found Disabled (mlx5_1); 1 device(s) found Polling (mlx5_3)"),
 		},
 		{
 			name: "mixed states with wrong rate",
@@ -530,14 +562,14 @@ func TestValidateIBPorts(t *testing.T) {
 			},
 			atLeastPorts: 3,
 			atLeastRate:  200,
-			wantErr:      errors.New("not enough LinkUp ports, only 0 LinkUp out of 3, expected at least 3 ports and 200 Gb/sec rate; some ports must be missing"),
+			wantErr:      errors.New("only 0 LinkUp ports found (expected at least 3)"),
 		},
 		{
 			name:         "empty cards",
 			cards:        IBStatCards{},
 			atLeastPorts: 2,
 			atLeastRate:  200,
-			wantErr:      errors.New("not enough LinkUp ports, only 0 LinkUp out of 0, expected at least 2 ports and 200 Gb/sec rate; some ports must be missing"),
+			wantErr:      errors.New("only 0 LinkUp ports found (expected at least 2)"),
 		},
 		{
 			name: "some ports disabled but with high enough rate",
@@ -561,7 +593,7 @@ func TestValidateIBPorts(t *testing.T) {
 			},
 			atLeastPorts: 4,
 			atLeastRate:  200,
-			wantErr:      errors.New("not enough LinkUp ports, only 2 LinkUp out of 4, expected at least 4 ports and 200 Gb/sec rate; some ports might be down, 2 Disabled devices with Rate > 200 found (mlx5_1, mlx5_3)"),
+			wantErr:      errors.New("only 2 LinkUp ports found (expected at least 4); 2 device(s) found Disabled (mlx5_1, mlx5_3)"),
 		},
 		{
 			name: "some ports disabled but with high enough rate but missing ports/rates",

--- a/pkg/nvidia-query/infiniband/ibstat_test.go
+++ b/pkg/nvidia-query/infiniband/ibstat_test.go
@@ -438,7 +438,7 @@ func TestValidateIBPorts(t *testing.T) {
 			},
 			atLeastPorts: 2,
 			atLeastRate:  200,
-			wantErr:      errors.New("only 0 LinkUp ports found (expected at least 2); 2 device(s) found Disabled (mlx5_0, mlx5_1)"),
+			wantErr:      errors.New("only 0 ports (>= 200 Gb/s) are active, expect at least 2; 2 device(s) found Disabled (mlx5_0, mlx5_1)"),
 		},
 		{
 			name: "some ports down",
@@ -462,7 +462,7 @@ func TestValidateIBPorts(t *testing.T) {
 			},
 			atLeastPorts: 4,
 			atLeastRate:  200,
-			wantErr:      errors.New("only 2 LinkUp ports found (expected at least 4); 2 device(s) found Disabled (mlx5_1, mlx5_3)"),
+			wantErr:      errors.New("only 2 ports (>= 200 Gb/s) are active, expect at least 4; 2 device(s) found Disabled (mlx5_1, mlx5_3)"),
 		},
 		{
 			name: "wrong rate",
@@ -478,7 +478,7 @@ func TestValidateIBPorts(t *testing.T) {
 			},
 			atLeastPorts: 2,
 			atLeastRate:  200,
-			wantErr:      errors.New("only 0 LinkUp ports found (expected at least 2)"),
+			wantErr:      errors.New("only 0 ports (>= 200 Gb/s) are active, expect at least 2"),
 		},
 		{
 			name: "mixed rates with lower threshold",
@@ -518,7 +518,7 @@ func TestValidateIBPorts(t *testing.T) {
 			},
 			atLeastPorts: 3,
 			atLeastRate:  200,
-			wantErr:      errors.New("only 2 LinkUp ports found (expected at least 3); 1 device(s) found Disabled (mlx5_1)"),
+			wantErr:      errors.New("only 2 ports (>= 200 Gb/s) are active, expect at least 3; 1 device(s) found Disabled (mlx5_1)"),
 		},
 		{
 			name: "mixed states with empty expected state matches all and with polling state",
@@ -542,7 +542,7 @@ func TestValidateIBPorts(t *testing.T) {
 			},
 			atLeastPorts: 3,
 			atLeastRate:  200,
-			wantErr:      errors.New("only 2 LinkUp ports found (expected at least 3); 1 device(s) found Disabled (mlx5_1); 1 device(s) found Polling (mlx5_3)"),
+			wantErr:      errors.New("only 2 ports (>= 200 Gb/s) are active, expect at least 3; 1 device(s) found Disabled (mlx5_1); 1 device(s) found Polling (mlx5_3)"),
 		},
 		{
 			name: "mixed states with wrong rate",
@@ -562,14 +562,14 @@ func TestValidateIBPorts(t *testing.T) {
 			},
 			atLeastPorts: 3,
 			atLeastRate:  200,
-			wantErr:      errors.New("only 0 LinkUp ports found (expected at least 3)"),
+			wantErr:      errors.New("only 0 ports (>= 200 Gb/s) are active, expect at least 3"),
 		},
 		{
 			name:         "empty cards",
 			cards:        IBStatCards{},
 			atLeastPorts: 2,
 			atLeastRate:  200,
-			wantErr:      errors.New("only 0 LinkUp ports found (expected at least 2)"),
+			wantErr:      errors.New("only 0 ports (>= 200 Gb/s) are active, expect at least 2"),
 		},
 		{
 			name: "some ports disabled but with high enough rate",
@@ -593,7 +593,7 @@ func TestValidateIBPorts(t *testing.T) {
 			},
 			atLeastPorts: 4,
 			atLeastRate:  200,
-			wantErr:      errors.New("only 2 LinkUp ports found (expected at least 4); 2 device(s) found Disabled (mlx5_1, mlx5_3)"),
+			wantErr:      errors.New("only 2 ports (>= 200 Gb/s) are active, expect at least 4; 2 device(s) found Disabled (mlx5_1, mlx5_3)"),
 		},
 		{
 			name: "some ports disabled but with high enough rate but missing ports/rates",

--- a/pkg/nvidia-query/infiniband/testdata/ibstat.47.0.h100.some.down.with.polling.1
+++ b/pkg/nvidia-query/infiniband/testdata/ibstat.47.0.h100.some.down.with.polling.1
@@ -1,0 +1,204 @@
+CA 'mlx5_0'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300adeab8
+	System image GUID: 0xa088c20300adeab8
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffeadeab8
+		Link layer: Ethernet
+CA 'mlx5_1'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xb83fd203002a1a1c
+	System image GUID: 0xb83fd203002a1a1c
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_10'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300bb98b4
+	System image GUID: 0xa088c20300bb98b4
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffebb98b4
+		Link layer: Ethernet
+CA 'mlx5_11'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300bb3514
+	System image GUID: 0xa088c20300bb3514
+	Port 1:
+		State: Down
+		Physical state: Polling
+		Rate: 40
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_2'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xb83fd203002a1a1d
+	System image GUID: 0xb83fd203002a1a1c
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_3'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300adeaa8
+	System image GUID: 0xa088c20300adeaa8
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffeadeaa8
+		Link layer: Ethernet
+CA 'mlx5_4'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300adeb88
+	System image GUID: 0xa088c20300adeb88
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffeadeb88
+		Link layer: Ethernet
+CA 'mlx5_5'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300adeb20
+	System image GUID: 0xa088c20300adeb20
+	Port 1:
+		State: Down
+		Physical state: Disabled
+		Rate: 40
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_6'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300bb9804
+	System image GUID: 0xa088c20300bb9804
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffebb9804
+		Link layer: Ethernet
+CA 'mlx5_7'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xe8ebd303003307a2
+	System image GUID: 0xe8ebd303003307a2
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_8'
+	CA type: MT4125
+	Number of ports: 1
+	Firmware version: 22.39.1002
+	Hardware version: 0
+	Node GUID: 0xe8ebd303003307a3
+	System image GUID: 0xe8ebd303003307a2
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 100
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0x0000000000000000
+		Link layer: Ethernet
+CA 'mlx5_9'
+	CA type: MT4129
+	Number of ports: 1
+	Firmware version: 28.39.1002
+	Hardware version: 0
+	Node GUID: 0xa088c20300adeb60
+	System image GUID: 0xa088c20300adeb60
+	Port 1:
+		State: Active
+		Physical state: LinkUp
+		Rate: 400
+		Base lid: 0
+		LMC: 0
+		SM lid: 0
+		Capability mask: 0x00010000
+		Port GUID: 0xa288c2fffeadeb60
+		Link layer: Ethernet


### PR DESCRIPTION
To handle

```
CA 'mlx5_10'
    CA type: MT4129
    Number of ports: 1
    Firmware version: 28.39.1002
    Hardware version: 0
    Node GUID: ...
    System image GUID: ...
    Port 1:
        State: Down
        Physical state: Polling
        Rate: 10
        Base lid: 868
        LMC: 0
        SM lid: 334
        Capability mask: 0xa751e848
        Port GUID: ...
        Link layer: InfiniBand
```

