### PR TITLE
nit(session): do not shadow component name var in metrics get within for-loops

### DIFF
--- a/pkg/session/serve.go
+++ b/pkg/session/serve.go
@@ -331,9 +331,9 @@ func (s *Session) getStates(ctx context.Context, payload Request) (v1.LeptonStat
 	localCtx, done := context.WithTimeout(ctx, time.Minute)
 	defer done()
 	for _, componentName := range allComponents {
-		go func() {
-			statesBuf <- s.getStatesFromComponent(localCtx, componentName, lastRebootTime)
-		}()
+		go func(name string) {
+			statesBuf <- s.getStatesFromComponent(localCtx, name, lastRebootTime)
+		}(componentName)
 	}
 	var states v1.LeptonStates
 	for currState := range statesBuf {

--- a/pkg/session/serve.go
+++ b/pkg/session/serve.go
@@ -303,9 +303,9 @@ func (s *Session) getMetrics(ctx context.Context, payload Request) (v1.LeptonMet
 	localCtx, done := context.WithTimeout(ctx, time.Minute)
 	defer done()
 	for _, componentName := range allComponents {
-		go func() {
-			metricBuf <- s.getMetricsFromComponent(localCtx, componentName, metricsSince)
-		}()
+		go func(name string) {
+			metricBuf <- s.getMetricsFromComponent(localCtx, name, metricsSince)
+		}(componentName)
 	}
 	var retMetrics v1.LeptonMetrics
 	for currMetric := range metricBuf {


### PR DESCRIPTION
in case someone uses Go 1.22<

Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
