### PR TITLE
feat(kmsg): initial commit (experiment to replace dmesg watcher)

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -37,7 +37,6 @@ var (
 	webAdmin         bool
 	webRefreshPeriod time.Duration
 
-	tailLines     int
 	createArchive bool
 
 	pollGPMEvents bool
@@ -520,12 +519,6 @@ cat summary.txt
 					Name:        "log-level,l",
 					Usage:       "set the logging level [debug, info, warn, error, fatal, panic, dpanic]",
 					Destination: &logLevel,
-				},
-				&cli.IntFlag{
-					Name:        "lines,n",
-					Usage:       "set the number of lines to tail log files (e.g., /var/log/dmesg)",
-					Destination: &tailLines,
-					Value:       5000,
 				},
 				&cli.BoolFlag{
 					Name:        "poll-gpm-events",

--- a/cmd/gpud/command/scan.go
+++ b/cmd/gpud/command/scan.go
@@ -19,7 +19,6 @@ func cmdScan(cliContext *cli.Context) error {
 	log.Logger = log.CreateLogger(zapLvl, logFile)
 
 	diagnoseOpts := []diagnose.OpOption{
-		diagnose.WithLines(tailLines),
 		diagnose.WithPollGPMEvents(pollGPMEvents),
 		diagnose.WithNetcheck(netcheck),
 		diagnose.WithDiskcheck(diskcheck),

--- a/components/memory/component.go
+++ b/components/memory/component.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
+	"runtime"
 	"time"
 
 	"github.com/leptonai/gpud/components"
@@ -12,6 +14,7 @@ import (
 	"github.com/leptonai/gpud/components/memory/metrics"
 	"github.com/leptonai/gpud/pkg/dmesg"
 	events_db "github.com/leptonai/gpud/pkg/events-db"
+	"github.com/leptonai/gpud/pkg/kmsg"
 	"github.com/leptonai/gpud/pkg/log"
 	"github.com/leptonai/gpud/pkg/query"
 
@@ -40,6 +43,31 @@ func New(ctx context.Context, cfg Config) (components.Component, error) {
 	setDefaultPoller(cfg)
 	getDefaultPoller().Start(cctx, cfg.Query, memory_id.Name)
 
+	// experimental
+	var kmsgWatcher kmsg.Watcher = nil
+	if runtime.GOOS == "linux" && os.Geteuid() == 0 {
+		kmsgWatcher, err = kmsg.NewWatcher()
+		if err != nil {
+			ccancel()
+			return nil, err
+		}
+		kmsgCh := make(chan kmsg.Message, 1024)
+		go func() {
+			werr := kmsgWatcher.Watch(kmsgCh)
+			if werr != nil {
+				log.Logger.Errorw("failed to watch kmsg", "err", werr)
+			}
+		}()
+		go func() {
+			for msg := range kmsgCh {
+				ev, n := Match(msg.Message)
+				if n != "" {
+					log.Logger.Infow("[EXPERIMENTAL] kmsg event", "event", ev, "message", n, "raw", msg.Message)
+				}
+			}
+		}()
+	}
+
 	return &component{
 		ctx:              cctx,
 		cancel:           ccancel,
@@ -47,6 +75,7 @@ func New(ctx context.Context, cfg Config) (components.Component, error) {
 		cfg:              cfg,
 		logLineProcessor: logLineProcessor,
 		eventsStore:      eventsStore,
+		kmsgWatcher:      kmsgWatcher,
 	}, nil
 }
 
@@ -60,6 +89,9 @@ type component struct {
 	logLineProcessor *dmesg.LogLineProcessor
 	eventsStore      events_db.Store
 	gatherer         prometheus.Gatherer
+
+	// experimental
+	kmsgWatcher kmsg.Watcher
 }
 
 func (c *component) Name() string { return memory_id.Name }
@@ -151,6 +183,10 @@ func (c *component) Close() error {
 
 	c.logLineProcessor.Close()
 	c.eventsStore.Close()
+
+	if c.kmsgWatcher != nil {
+		c.kmsgWatcher.Close()
+	}
 
 	return nil
 }

--- a/pkg/diagnose/options.go
+++ b/pkg/diagnose/options.go
@@ -5,7 +5,6 @@ type Op struct {
 	nvidiaSMIQueryCommand string
 	ibstatCommand         string
 
-	lines         int
 	debug         bool
 	createArchive bool
 
@@ -36,9 +35,6 @@ func (op *Op) applyOpts(opts []OpOption) error {
 		op.ibstatCommand = "ibstat"
 	}
 
-	if op.lines == 0 {
-		op.lines = 100
-	}
 	return nil
 }
 
@@ -59,12 +55,6 @@ func WithNvidiaSMIQueryCommand(p string) OpOption {
 func WithIbstatCommand(p string) OpOption {
 	return func(op *Op) {
 		op.ibstatCommand = p
-	}
-}
-
-func WithLines(lines int) OpOption {
-	return func(op *Op) {
-		op.lines = lines
 	}
 }
 

--- a/pkg/diagnose/scan.go
+++ b/pkg/diagnose/scan.go
@@ -363,33 +363,34 @@ func scanKmsg(ctx context.Context) {
 	}
 
 	fmt.Printf("%s scanned kmsg file -- found %d line(s)\n", checkMark, len(msgs))
+	if len(msgs) == 0 {
+		return
+	}
 
-	if len(msgs) > 0 {
-		ts := msgs[0].DescribeTimestamp(time.Now().UTC())
-		fmt.Printf("%s first kmsg line is %s old\n", checkMark, ts)
+	ts := msgs[0].DescribeTimestamp(time.Now().UTC())
+	fmt.Printf("%s first kmsg line is %s old\n", checkMark, ts)
 
-		for _, msg := range msgs {
-			if ev, m := cpu.Match(msg.Message); m != "" {
-				fmt.Printf("[cpu] (%s) %s %s %q\n", ts, ev, m, msg.Message)
-			}
-			if ev, m := memory.Match(msg.Message); m != "" {
-				fmt.Printf("[memory] (%s) %s %s %q\n", ts, ev, m, msg.Message)
-			}
-			if ev, m := fd.Match(msg.Message); m != "" {
-				fmt.Printf("[file descriptor] (%s) %s %s %q\n", ts, ev, m, msg.Message)
-			}
-			if found := nvidia_xid.Match(msg.Message); found != nil {
-				fmt.Printf("[nvidia xid] (%s) %q\n", ts, msg.Message)
-			}
-			if found := nvidia_sxid.Match(msg.Message); found != nil {
-				fmt.Printf("[nvidia sxid] (%s) %q\n", ts, msg.Message)
-			}
-			if ev, m := nvidia_nccl.Match(msg.Message); m != "" {
-				fmt.Printf("[nvidia nccl] (%s) %s %s %q\n", ts, ev, m, msg.Message)
-			}
-			if ev, m := nvidia_peermem.Match(msg.Message); m != "" {
-				fmt.Printf("[nvidia peermem] (%s) %s %s %q\n", ts, ev, m, msg.Message)
-			}
+	for _, msg := range msgs {
+		if ev, m := cpu.Match(msg.Message); m != "" {
+			fmt.Printf("[cpu] (%s) %s %s %q\n", ts, ev, m, msg.Message)
+		}
+		if ev, m := memory.Match(msg.Message); m != "" {
+			fmt.Printf("[memory] (%s) %s %s %q\n", ts, ev, m, msg.Message)
+		}
+		if ev, m := fd.Match(msg.Message); m != "" {
+			fmt.Printf("[file descriptor] (%s) %s %s %q\n", ts, ev, m, msg.Message)
+		}
+		if found := nvidia_xid.Match(msg.Message); found != nil {
+			fmt.Printf("[nvidia xid] (%s) %q\n", ts, msg.Message)
+		}
+		if found := nvidia_sxid.Match(msg.Message); found != nil {
+			fmt.Printf("[nvidia sxid] (%s) %q\n", ts, msg.Message)
+		}
+		if ev, m := nvidia_nccl.Match(msg.Message); m != "" {
+			fmt.Printf("[nvidia nccl] (%s) %s %s %q\n", ts, ev, m, msg.Message)
+		}
+		if ev, m := nvidia_peermem.Match(msg.Message); m != "" {
+			fmt.Printf("[nvidia peermem] (%s) %s %s %q\n", ts, ev, m, msg.Message)
 		}
 	}
 }

--- a/pkg/diagnose/scan.go
+++ b/pkg/diagnose/scan.go
@@ -12,12 +12,18 @@ import (
 	nvidia_xid "github.com/leptonai/gpud/components/accelerator/nvidia/error/xid"
 	nvidia_component_error_xid_id "github.com/leptonai/gpud/components/accelerator/nvidia/error/xid/id"
 	nvidia_hw_slowdown_id "github.com/leptonai/gpud/components/accelerator/nvidia/hw-slowdown/id"
+	nvidia_nccl "github.com/leptonai/gpud/components/accelerator/nvidia/nccl"
+	nvidia_peermem "github.com/leptonai/gpud/components/accelerator/nvidia/peermem"
+	"github.com/leptonai/gpud/components/cpu"
+	"github.com/leptonai/gpud/components/fd"
+	"github.com/leptonai/gpud/components/memory"
 	"github.com/leptonai/gpud/pkg/disk"
 	pkg_dmesg "github.com/leptonai/gpud/pkg/dmesg"
 	events_db "github.com/leptonai/gpud/pkg/events-db"
 	"github.com/leptonai/gpud/pkg/file"
 	"github.com/leptonai/gpud/pkg/fuse"
 	"github.com/leptonai/gpud/pkg/host"
+	"github.com/leptonai/gpud/pkg/kmsg"
 	"github.com/leptonai/gpud/pkg/log"
 	latency_edge "github.com/leptonai/gpud/pkg/netutil/latency/edge"
 	nvidia_query "github.com/leptonai/gpud/pkg/nvidia-query"
@@ -224,7 +230,7 @@ func Scan(ctx context.Context, opts ...OpOption) error {
 			return errors.New("requires sudo/root access in order to scan dmesg errors")
 		}
 
-		fmt.Printf("%s scanning dmesg for %d lines\n", inProgress, op.lines)
+		fmt.Printf("%s scanning dmesg\n", inProgress)
 		issueCnt, err := scanDmesg(ctx)
 		if err != nil {
 			return err
@@ -234,6 +240,8 @@ func Scan(ctx context.Context, opts ...OpOption) error {
 		} else {
 			fmt.Printf("%s scanned dmesg file -- found %d issue(s)\n", warningSign, issueCnt)
 		}
+
+		scanKmsg(ctx)
 	}
 
 	if op.netcheck {
@@ -339,4 +347,49 @@ func scanDmesg(ctx context.Context) (int, error) {
 	}
 
 	return issueCnt, nil
+}
+
+func scanKmsg(ctx context.Context) {
+	if os.Geteuid() != 0 {
+		fmt.Printf("%s skipping kmsg scan (requires sudo/root access)\n", checkMark)
+		return
+	}
+
+	fmt.Printf("%s scanning kmsg\n", inProgress)
+	msgs, err := kmsg.ReadAll(ctx)
+	if err != nil {
+		fmt.Printf("%s failed to read kmsg: %v\n", warningSign, err)
+		return
+	}
+
+	fmt.Printf("%s scanned kmsg file -- found %d line(s)\n", checkMark, len(msgs))
+
+	if len(msgs) > 0 {
+		ts := msgs[0].DescribeTimestamp(time.Now().UTC())
+		fmt.Printf("%s first kmsg line is %s old\n", checkMark, ts)
+
+		for _, msg := range msgs {
+			if ev, m := cpu.Match(msg.Message); m != "" {
+				fmt.Printf("[cpu] (%s) %s %s %q\n", ts, ev, m, msg.Message)
+			}
+			if ev, m := memory.Match(msg.Message); m != "" {
+				fmt.Printf("[memory] (%s) %s %s %q\n", ts, ev, m, msg.Message)
+			}
+			if ev, m := fd.Match(msg.Message); m != "" {
+				fmt.Printf("[file descriptor] (%s) %s %s %q\n", ts, ev, m, msg.Message)
+			}
+			if found := nvidia_xid.Match(msg.Message); found != nil {
+				fmt.Printf("[nvidia xid] (%s) %q\n", ts, msg.Message)
+			}
+			if found := nvidia_sxid.Match(msg.Message); found != nil {
+				fmt.Printf("[nvidia sxid] (%s) %q\n", ts, msg.Message)
+			}
+			if ev, m := nvidia_nccl.Match(msg.Message); m != "" {
+				fmt.Printf("[nvidia nccl] (%s) %s %s %q\n", ts, ev, m, msg.Message)
+			}
+			if ev, m := nvidia_peermem.Match(msg.Message); m != "" {
+				fmt.Printf("[nvidia peermem] (%s) %s %s %q\n", ts, ev, m, msg.Message)
+			}
+		}
+	}
 }

--- a/pkg/kmsg/kmsg.go
+++ b/pkg/kmsg/kmsg.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2016 Euan Kemp
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is a modified version of the following kmsg processing code:
+// - https://github.com/util-linux/util-linux/blob/9c45b256adfc22edbf3783731b7be2b924c8de85/sys-utils/dmesg.c#L1512
+// - https://github.com/euank/go-kmsg-parser
+
+package kmsg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/shirou/gopsutil/v4/host"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/leptonai/gpud/pkg/log"
+)
+
+// Message represents a given kmsg logline, including its timestamp (as
+// calculated based on offset from boot time), its possibly multi-line body,
+// and so on. More information about these mssages may be found here:
+// https://www.kernel.org/doc/Documentation/ABI/testing/dev-kmsg
+type Message struct {
+	Timestamp      metav1.Time `json:"timestamp"`
+	Priority       int         `json:"priority"`
+	SequenceNumber int         `json:"sequence_number"`
+	Message        string      `json:"message"`
+}
+
+func (m Message) DescribeTimestamp(since time.Time) string {
+	return humanize.RelTime(m.Timestamp.Time, since, "ago", "from now")
+}
+
+// ReadAll reads all messages from the kmsg file, with no follow mode.
+func ReadAll(ctx context.Context) ([]Message, error) {
+	kmsgFile, err := os.Open("/dev/kmsg")
+	if err != nil {
+		return nil, err
+	}
+	defer kmsgFile.Close()
+
+	// upstream "github.com/euank/go-kmsg-parser" uses "syscall.Sysinfo_t"
+	// which breaks darwin builds
+	// use multi-platform library "github.com/shirou/gopsutil/v4/host"
+	// to support darwin builds
+	cctx, ccancel := context.WithTimeout(ctx, 15*time.Second)
+	bt, err := host.BootTimeWithContext(cctx)
+	ccancel()
+	if err != nil {
+		return nil, err
+	}
+	bootTime := time.Unix(int64(bt), 0)
+
+	return readAll(kmsgFile, bootTime)
+}
+
+// any value >= PRINTK_MESSAGE_MAX (which is defined as 2048) is fine
+// "dmesg" uses 2048
+// ref. https://github.com/util-linux/util-linux/blob/9c45b256adfc22edbf3783731b7be2b924c8de85/sys-utils/dmesg.c#L212-L217
+const readBufferSize = 8192
+
+// readAll reads all messages from the kmsg file, with no follow mode.
+func readAll(kmsgFile *os.File, bootTime time.Time) ([]Message, error) {
+	rawReader, err := kmsgFile.SyscallConn()
+	if err != nil {
+		return nil, err
+	}
+
+	// we're forced to put the fd into non-blocking mode to be able to detect the
+	// end of the buffer, but to not use go's built-in epoll
+	if ctrlErr := rawReader.Control(func(fd uintptr) {
+		err = syscall.SetNonblock(int(fd), true)
+	}); ctrlErr != nil {
+		return nil, fmt.Errorf("error calling control on kmsg reader: %w", ctrlErr)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to set nonblocking on fd: %w", err)
+	}
+
+	msgs := make([]Message, 0)
+	buf := make([]byte, readBufferSize)
+	for {
+		// Each read call gives us one full message.
+		// https://www.kernel.org/doc/Documentation/ABI/testing/dev-kmsg
+		var err error
+		var n int
+		readErr := rawReader.Read(func(fd uintptr) bool {
+			n, err = syscall.Read(int(fd), buf)
+			return true
+		})
+		if readErr != nil && err == nil {
+			err = readErr
+		}
+
+		switch {
+		case err == nil:
+			// no-op
+
+		case errors.Is(err, syscall.EPIPE):
+			// error that indicates "continuation" of the ring buffer
+			continue
+
+		case errors.Is(err, syscall.EAGAIN):
+			// end of ring buffer in non-follow mode
+			return msgs, nil
+
+		default:
+			return nil, fmt.Errorf("unexpected kmsg reading error: %w", err)
+		}
+
+		line := string(buf[:n])
+		if len(line) == 0 {
+			continue
+		}
+
+		msg, err := parseLine(bootTime, line)
+		if err != nil {
+			return nil, fmt.Errorf("malformed kmsg message: %w (%q)", err, line)
+		}
+		msgs = append(msgs, *msg)
+	}
+}
+
+type Watcher interface {
+	// Watch reads from kmsg and provides a channel of messages.
+	// Watch will always close the provided channel before returning.
+	// Watch may be canceled by calling 'Close' on the parser.
+	//
+	// The caller should drain the channel after calling 'Close'.
+	Watch(chan<- Message) error
+	Close() error
+}
+
+type watcher struct {
+	kmsgFile *os.File
+	bootTime time.Time
+
+	// set to true when the watcher is started
+	// used to prevent redundant reads on kmsg file
+	watchStarted atomic.Bool
+}
+
+// Creates a new watcher that will read from /dev/kmsg.
+func NewWatcher() (Watcher, error) {
+	kmsgFile, err := os.Open("/dev/kmsg")
+	if err != nil {
+		return nil, err
+	}
+
+	// upstream "github.com/euank/go-kmsg-parser" uses "syscall.Sysinfo_t"
+	// which breaks darwin builds
+	// use multi-platform library "github.com/shirou/gopsutil/v4/host"
+	// to support darwin builds
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	bt, err := host.BootTimeWithContext(ctx)
+	cancel()
+	if err != nil {
+		return nil, err
+	}
+	bootTime := time.Unix(int64(bt), 0)
+
+	return &watcher{
+		kmsgFile: kmsgFile,
+		bootTime: bootTime,
+	}, nil
+}
+
+var ErrWatcherAlreadyStarted = errors.New("watcher already started")
+
+func (w *watcher) errIfStarted() error {
+	if w.watchStarted.CompareAndSwap(false, true) {
+		// has not started yet, thus set to started
+		return nil
+	}
+	return ErrWatcherAlreadyStarted
+}
+
+func (w *watcher) Watch(msgs chan<- Message) error {
+	if err := w.errIfStarted(); err != nil {
+		return err
+	}
+	return readFollow(w.kmsgFile, w.bootTime, msgs)
+}
+
+func (w *watcher) Close() error {
+	return w.kmsgFile.Close()
+}
+
+// readFollow reads messages from the kmsg file, with follow mode,
+// meaning it will continue to read the file as new messages are written to it.
+func readFollow(kmsgFile *os.File, bootTime time.Time, msgs chan<- Message) error {
+	defer close(msgs)
+
+	buf := make([]byte, readBufferSize)
+	for {
+		// Each read call gives us one full message.
+		// https://www.kernel.org/doc/Documentation/ABI/testing/dev-kmsg
+		n, err := kmsgFile.Read(buf)
+		switch {
+		case err == nil:
+			// no-op
+
+		case errors.Is(err, syscall.EPIPE):
+			log.Logger.Warnw("kmsg pipe error (short read)")
+			continue
+
+		case errors.Is(err, io.EOF),
+			errors.Is(err, os.ErrClosed):
+			// someone closed the kmsg file
+			return nil
+
+		default:
+			return fmt.Errorf("unexpected kmsg reading error: %w", err)
+		}
+
+		line := string(buf[:n])
+		if len(line) == 0 {
+			continue
+		}
+
+		msg, err := parseLine(bootTime, line)
+		if err != nil {
+			return fmt.Errorf("malformed kmsg message: %w (%q)", err, line)
+		}
+		msgs <- *msg
+	}
+}
+
+func parseLine(bootTime time.Time, line string) (*Message, error) {
+	// Format:
+	//   PRIORITY,SEQUENCE_NUM,TIMESTAMP,-;MESSAGE
+	parts := strings.SplitN(line, ";", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid kmsg; must contain a ';'")
+	}
+
+	metadata, message := parts[0], parts[1]
+
+	metadataParts := strings.Split(metadata, ",")
+	if len(metadataParts) < 3 {
+		return nil, fmt.Errorf("invalid kmsg: must contain at least 3 ',' separated pieces at the start")
+	}
+
+	priority, sequence, timestamp := metadataParts[0], metadataParts[1], metadataParts[2]
+
+	prioNum, err := strconv.Atoi(priority)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse %q as priority: %v", priority, err)
+	}
+
+	sequenceNum, err := strconv.Atoi(sequence)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse %q as sequence number: %v", priority, err)
+	}
+
+	timestampUsFromBoot, err := strconv.ParseInt(timestamp, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse %q as timestamp: %v", priority, err)
+	}
+	// timestamp is offset in microsecond from boottime.
+	msgTime := bootTime.Add(time.Duration(timestampUsFromBoot) * time.Microsecond)
+
+	return &Message{
+		Priority:       prioNum,
+		SequenceNumber: sequenceNum,
+		Timestamp:      metav1.NewTime(msgTime),
+		Message:        message,
+	}, nil
+}

--- a/pkg/kmsg/kmsg_test.go
+++ b/pkg/kmsg/kmsg_test.go
@@ -1,0 +1,461 @@
+package kmsg
+
+import (
+	"bufio"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_parseLineWithTestData(t *testing.T) {
+	bootTime := time.Unix(0xb100, 0x5ea1).Round(time.Microsecond)
+
+	f, err := os.Open("testdata/kmsg.1.log")
+	require.NoError(t, err)
+	defer f.Close()
+
+	buf := bufio.NewScanner(f)
+	for buf.Scan() {
+		line := buf.Text()
+		if len(line) == 0 {
+			continue
+		}
+		msg, err := parseLine(bootTime, line)
+		require.NotNil(t, msg)
+		require.NoError(t, err)
+	}
+}
+
+func Test_parseLine(t *testing.T) {
+	bootTime := time.Unix(0xb100, 0x5ea1).Round(time.Microsecond)
+
+	msg, err := parseLine(bootTime, "6,2565,102258085667,-;docker0: port 2(vethc1bb733) entered blocking state")
+	require.NoError(t, err)
+
+	assert.Equal(t, msg.Message, "docker0: port 2(vethc1bb733) entered blocking state")
+	assert.Equal(t, msg.Priority, 6)
+	assert.Equal(t, msg.SequenceNumber, 2565)
+	assert.Equal(t, msg.Timestamp, metav1.NewTime(bootTime.Add(102258085667*time.Microsecond)))
+}
+
+func Test_parseLineComprehensive(t *testing.T) {
+	bootTime := time.Unix(1000, 0).Round(time.Microsecond)
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    *Message
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:  "valid message with standard format",
+			input: "6,2565,102258085667,-;docker0: port 2(vethc1bb733) entered blocking state",
+			expected: &Message{
+				Priority:       6,
+				SequenceNumber: 2565,
+				Timestamp:      metav1.NewTime(bootTime.Add(102258085667 * time.Microsecond)),
+				Message:        "docker0: port 2(vethc1bb733) entered blocking state",
+			},
+			expectError: false,
+		},
+		{
+			name:  "valid message with high priority",
+			input: "0,1234,5000000,-;Critical kernel message",
+			expected: &Message{
+				Priority:       0,
+				SequenceNumber: 1234,
+				Timestamp:      metav1.NewTime(bootTime.Add(5000000 * time.Microsecond)),
+				Message:        "Critical kernel message",
+			},
+			expectError: false,
+		},
+		{
+			name:  "valid message with low priority",
+			input: "7,9999,10000,-;Debug kernel message",
+			expected: &Message{
+				Priority:       7,
+				SequenceNumber: 9999,
+				Timestamp:      metav1.NewTime(bootTime.Add(10000 * time.Microsecond)),
+				Message:        "Debug kernel message",
+			},
+			expectError: false,
+		},
+		{
+			name:  "valid message with large sequence number",
+			input: "3,2147483647,50000,-;Message with max int32 sequence",
+			expected: &Message{
+				Priority:       3,
+				SequenceNumber: 2147483647,
+				Timestamp:      metav1.NewTime(bootTime.Add(50000 * time.Microsecond)),
+				Message:        "Message with max int32 sequence",
+			},
+			expectError: false,
+		},
+		{
+			name:  "valid message with zero timestamp",
+			input: "4,100,0,-;Message at boot time",
+			expected: &Message{
+				Priority:       4,
+				SequenceNumber: 100,
+				Timestamp:      metav1.NewTime(bootTime),
+				Message:        "Message at boot time",
+			},
+			expectError: false,
+		},
+		{
+			name:  "valid message with semicolons in message part",
+			input: "3,123,5000,-;Message with; semicolons; in it",
+			expected: &Message{
+				Priority:       3,
+				SequenceNumber: 123,
+				Timestamp:      metav1.NewTime(bootTime.Add(5000 * time.Microsecond)),
+				Message:        "Message with; semicolons; in it",
+			},
+			expectError: false,
+		},
+		{
+			name:  "valid message with extra metadata fields",
+			input: "2,456,7890,extra,fields,-;Message with extra metadata",
+			expected: &Message{
+				Priority:       2,
+				SequenceNumber: 456,
+				Timestamp:      metav1.NewTime(bootTime.Add(7890 * time.Microsecond)),
+				Message:        "Message with extra metadata",
+			},
+			expectError: false,
+		},
+		{
+			name:        "error - missing semicolon",
+			input:       "6,2565,102258085667",
+			expectError: true,
+			errorMsg:    "invalid kmsg; must contain a ';'",
+		},
+		{
+			name:        "error - insufficient metadata parts",
+			input:       "6,2565;message",
+			expectError: true,
+			errorMsg:    "invalid kmsg: must contain at least 3 ',' separated pieces at the start",
+		},
+		{
+			name:        "error - invalid priority",
+			input:       "invalid,2565,102258085667,-;message",
+			expectError: true,
+			errorMsg:    "could not parse",
+		},
+		{
+			name:        "error - invalid sequence number",
+			input:       "6,invalid,102258085667,-;message",
+			expectError: true,
+			errorMsg:    "could not parse",
+		},
+		{
+			name:        "error - invalid timestamp",
+			input:       "6,2565,invalid,-;message",
+			expectError: true,
+			errorMsg:    "could not parse",
+		},
+		{
+			name:        "error - empty input",
+			input:       "",
+			expectError: true,
+			errorMsg:    "invalid kmsg; must contain a ';'",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg, err := parseLine(bootTime, tc.input)
+
+			if tc.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errorMsg)
+				assert.Nil(t, msg)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, msg)
+				assert.Equal(t, tc.expected.Priority, msg.Priority)
+				assert.Equal(t, tc.expected.SequenceNumber, msg.SequenceNumber)
+				assert.Equal(t, tc.expected.Timestamp, msg.Timestamp)
+				assert.Equal(t, tc.expected.Message, msg.Message)
+			}
+		})
+	}
+}
+
+func Test_parseLineWithDifferentBootTimes(t *testing.T) {
+	// Test that the timestamp calculation correctly uses the bootTime
+	input := "3,123,5000000,-;Test message"
+
+	bootTimes := []time.Time{
+		time.Unix(0, 0),
+		time.Unix(1000000000, 0),
+		time.Unix(1700000000, 0),
+		time.Now().Add(-24 * time.Hour),
+	}
+
+	for _, bootTime := range bootTimes {
+		t.Run(bootTime.String(), func(t *testing.T) {
+			msg, err := parseLine(bootTime, input)
+			require.NoError(t, err)
+
+			// The message timestamp should be bootTime + 5 seconds
+			expectedTime := metav1.NewTime(bootTime.Add(5000000 * time.Microsecond))
+			assert.Equal(t, expectedTime, msg.Timestamp)
+		})
+	}
+}
+
+func Test_parseLineEdgeCases(t *testing.T) {
+	bootTime := time.Unix(1000, 0)
+
+	// Test with very large timestamp value
+	t.Run("very large timestamp", func(t *testing.T) {
+		// Large but safe timestamp value that won't overflow
+		input := "1,100,9223372036854,-;Large timestamp message"
+		msg, err := parseLine(bootTime, input)
+		require.NoError(t, err)
+
+		// This should be bootTime + a large duration
+		expectedTime := metav1.NewTime(bootTime.Add(9223372036854 * time.Microsecond))
+		assert.Equal(t, expectedTime, msg.Timestamp)
+	})
+
+	// Test with negative priority (should still parse, even if unusual)
+	t.Run("negative priority", func(t *testing.T) {
+		input := "-1,100,5000,-;Negative priority message"
+		msg, err := parseLine(bootTime, input)
+		require.NoError(t, err)
+		assert.Equal(t, -1, msg.Priority)
+	})
+
+	// Test with negative sequence number (should still parse, even if unusual)
+	t.Run("negative sequence", func(t *testing.T) {
+		input := "1,-100,5000,-;Negative sequence message"
+		msg, err := parseLine(bootTime, input)
+		require.NoError(t, err)
+		assert.Equal(t, -100, msg.SequenceNumber)
+	})
+
+	// Test with empty message
+	t.Run("empty message", func(t *testing.T) {
+		input := "1,100,5000,-;"
+		msg, err := parseLine(bootTime, input)
+		require.NoError(t, err)
+		assert.Equal(t, "", msg.Message)
+	})
+}
+
+// Test_readFollow tests the readFollow function by reading the test data file
+func Test_readFollow(t *testing.T) {
+	// Open the test data file
+	testFile, err := os.Open("testdata/kmsg.1.log")
+	require.NoError(t, err)
+	defer testFile.Close()
+
+	// Use a fixed boot time for deterministic testing
+	bootTime := time.Unix(1000, 0)
+
+	// Create a channel to receive messages
+	msgChan := make(chan Message, 100)
+
+	// Start a goroutine to read messages
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- readFollow(testFile, bootTime, msgChan)
+	}()
+
+	// Collect messages for a short time
+	receivedMessages := []Message{}
+	timeout := time.After(500 * time.Millisecond)
+
+	messageCollection := func() {
+		for {
+			select {
+			case msg, ok := <-msgChan:
+				if !ok {
+					return
+				}
+				receivedMessages = append(receivedMessages, msg)
+			case <-timeout:
+				return
+			}
+		}
+	}
+
+	// Close the file after a short delay to trigger termination
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		testFile.Close()
+	}()
+
+	messageCollection()
+
+	// Wait for readFollow to return
+	err = <-errChan
+	require.NoError(t, err)
+
+	// Verify we received messages
+	require.NotEmpty(t, receivedMessages, "Should have received messages from the test file")
+
+	// Verify some message fields
+	for _, msg := range receivedMessages {
+		assert.NotZero(t, msg.Priority)
+		assert.NotZero(t, msg.SequenceNumber)
+		assert.NotEmpty(t, msg.Message)
+		assert.False(t, msg.Timestamp.IsZero())
+	}
+}
+
+// Test_readFollowMalformedData tests reading malformed data
+func Test_readFollowMalformedData(t *testing.T) {
+	// Create a temporary file with malformed data
+	tmpFile, err := os.CreateTemp("", "kmsg-test-malformed")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	// Write malformed data to the file
+	_, err = tmpFile.WriteString("malformed data without proper format\n")
+	require.NoError(t, err)
+
+	// Rewind the file
+	_, err = tmpFile.Seek(0, 0)
+	require.NoError(t, err)
+
+	// Try to read from the file
+	bootTime := time.Unix(1000, 0)
+	msgChan := make(chan Message, 10)
+
+	err = readFollow(tmpFile, bootTime, msgChan)
+
+	// Expect an error about malformed message
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "malformed kmsg message")
+}
+
+func Test_errIfStarted(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(*watcher)
+		wantErr bool
+	}{
+		{
+			name:    "not started",
+			setup:   func(w *watcher) {},
+			wantErr: false,
+		},
+		{
+			name: "already started",
+			setup: func(w *watcher) {
+				w.watchStarted.Store(true)
+			},
+			wantErr: true,
+		},
+		{
+			name: "call twice",
+			setup: func(w *watcher) {
+				_ = w.errIfStarted() // First call will set to true
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &watcher{}
+
+			tt.setup(w)
+
+			err := w.errIfStarted()
+
+			if tt.wantErr {
+				assert.Equal(t, ErrWatcherAlreadyStarted, err)
+			} else {
+				assert.NoError(t, err)
+				// Verify that watchStarted is now true
+				assert.True(t, w.watchStarted.Load())
+			}
+		})
+	}
+}
+
+func Test_DescribeTimestamp(t *testing.T) {
+	// Reference time for all tests
+	referenceTime := time.Date(2023, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name           string
+		messageTime    time.Time
+		referenceTime  time.Time
+		expectedOutput string
+	}{
+		{
+			name:           "exactly the same time",
+			messageTime:    referenceTime,
+			referenceTime:  referenceTime,
+			expectedOutput: "now",
+		},
+		{
+			name:           "1 minute ago",
+			messageTime:    referenceTime.Add(-1 * time.Minute),
+			referenceTime:  referenceTime,
+			expectedOutput: "1 minute ago",
+		},
+		{
+			name:           "5 minutes ago",
+			messageTime:    referenceTime.Add(-5 * time.Minute),
+			referenceTime:  referenceTime,
+			expectedOutput: "5 minutes ago",
+		},
+		{
+			name:           "1 hour ago",
+			messageTime:    referenceTime.Add(-1 * time.Hour),
+			referenceTime:  referenceTime,
+			expectedOutput: "1 hour ago",
+		},
+		{
+			name:           "1 day ago",
+			messageTime:    referenceTime.Add(-24 * time.Hour),
+			referenceTime:  referenceTime,
+			expectedOutput: "1 day ago",
+		},
+		{
+			name:           "1 minute in future",
+			messageTime:    referenceTime.Add(1 * time.Minute),
+			referenceTime:  referenceTime,
+			expectedOutput: "1 minute from now",
+		},
+		{
+			name:           "5 minutes in future",
+			messageTime:    referenceTime.Add(5 * time.Minute),
+			referenceTime:  referenceTime,
+			expectedOutput: "5 minutes from now",
+		},
+		{
+			name:           "1 hour in future",
+			messageTime:    referenceTime.Add(1 * time.Hour),
+			referenceTime:  referenceTime,
+			expectedOutput: "1 hour from now",
+		},
+		{
+			name:           "1 day in future",
+			messageTime:    referenceTime.Add(24 * time.Hour),
+			referenceTime:  referenceTime,
+			expectedOutput: "1 day from now",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := Message{
+				Timestamp: metav1.NewTime(tt.messageTime),
+			}
+			result := msg.DescribeTimestamp(tt.referenceTime)
+			assert.Equal(t, tt.expectedOutput, result)
+		})
+	}
+}

--- a/pkg/kmsg/testdata/kmsg.1.log
+++ b/pkg/kmsg/testdata/kmsg.1.log
@@ -1,0 +1,47 @@
+6,3964,206764307,-;nvidia-nvswitch2: open (major=510)
+6,3965,206764310,-;nvidia-nvswitch2: open (major=510)
+6,3966,206764312,-;nvidia-nvswitch2: open (major=510)
+6,3967,206764314,-;nvidia-nvswitch2: open (major=510)
+6,3968,206764317,-;nvidia-nvswitch3: open (major=510)
+6,3969,206764319,-;nvidia-nvswitch3: open (major=510)
+6,3970,206764321,-;nvidia-nvswitch3: open (major=510)
+6,3971,206764324,-;nvidia-nvswitch3: open (major=510)
+6,3972,206764326,-;nvidia-nvswitch3: open (major=510)
+6,3973,227986636,-;IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+6,3974,227986678,-;IPv6: ADDRCONF(NETDEV_CHANGE): calib317e2eeb40: link becomes ready
+6,3975,231320398,-;IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+6,3976,231320445,-;IPv6: ADDRCONF(NETDEV_CHANGE): cali817bc444564: link becomes ready
+6,3977,232192800,-;IPv6: ADDRCONF(NETDEV_CHANGE): cali16b7bb8d9d5: link becomes ready
+6,3978,233839047,-;IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+6,3979,233839101,-;IPv6: ADDRCONF(NETDEV_CHANGE): cali7d4279dcdef: link becomes ready
+6,3980,234700472,-;IPv6: ADDRCONF(NETDEV_CHANGE): cali192c173bf63: link becomes ready
+6,3981,238298440,-;IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+6,3982,238298483,-;IPv6: ADDRCONF(NETDEV_CHANGE): cali77b6400b38f: link becomes ready
+6,3983,240602554,-;IPv6: ADDRCONF(NETDEV_CHANGE): cali201b519bdba: link becomes ready
+6,3984,241965918,-;IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+6,3985,241965979,-;IPv6: ADDRCONF(NETDEV_CHANGE): cali44287ff2a69: link becomes ready
+6,3986,242226782,-;wireguard: WireGuard 1.0.0 loaded. See www.wireguard.com for information.
+6,3987,242226785,-;wireguard: Copyright (C) 2015-2019 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
+6,3988,251568620,-;IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+6,3989,251568671,-;IPv6: ADDRCONF(NETDEV_CHANGE): calic1ed24fe77c: link becomes ready
+6,3990,251895583,-;Initializing XFRM netlink socket
+6,3991,255473436,-;IPv6: ADDRCONF(NETDEV_CHANGE): califb6c0b21ee7: link becomes ready
+6,3992,256593815,-;IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+6,3993,256593857,-;IPv6: ADDRCONF(NETDEV_CHANGE): caliad6cf817e1b: link becomes ready
+6,3994,258429679,-;IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+6,3995,258429745,-;IPv6: ADDRCONF(NETDEV_CHANGE): cali160c958f6d3: link becomes ready
+6,3996,259919742,-;IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+6,3997,259919785,-;IPv6: ADDRCONF(NETDEV_CHANGE): cali990e6b401ee: link becomes ready
+6,3998,261229012,-;nvidia-nvswitch3: open (major=510)
+6,3999,261323780,-;nvidia-nvswitch2: open (major=510)
+6,4000,261448167,-;nvidia-nvswitch1: open (major=510)
+6,4001,261573217,-;nvidia-nvswitch0: open (major=510)
+6,4002,3757433091,-;IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+6,4003,3757433151,-;IPv6: ADDRCONF(NETDEV_CHANGE): calia3f11b97c70: link becomes ready
+6,4004,9184121699,-;perf: interrupt took too long (2509 > 2500), lowering kernel.perf_event_max_sample_rate to 79500
+6,4005,11424928251,-;perf: interrupt took too long (3141 > 3136), lowering kernel.perf_event_max_sample_rate to 63500
+6,4006,15519938051,-;perf: interrupt took too long (7156 > 3926), lowering kernel.perf_event_max_sample_rate to 27750
+6,4007,41700858271,-;perf: interrupt took too long (9494 > 8945), lowering kernel.perf_event_max_sample_rate to 21000
+6,4008,56238116492,-;IPv6: ADDRCONF(NETDEV_CHANGE): cali21960952cd0: link becomes ready
+6,4009,57631398407,-;IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
+6,4010,57631398464,-;IPv6: ADDRCONF(NETDEV_CHANGE): calic24dd7712a6: link becomes ready


### PR DESCRIPTION
```
⌛ scanning kmsg
✔ scanned kmsg file -- found 4040 line(s)
✔ first kmsg line is 1 week ago old
```

to replace https://github.com/leptonai/gpud/pull/488 and address https://github.com/leptonai/gpud/issues/442.

Also close https://github.com/leptonai/gpud/issues/478.

c.f., https://github.com/euank/go-kmsg-parser