### PR TITLE
fix(e2e): add missing shutdown, nvidia-smi input

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -63,7 +63,7 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred(), "failed to mock lspci")
 
 		By("mock nvidia-smi")
-		err = mocknvidiasmi.Mock(mocknvidiasmi.NormalSMIOutput, mocknvidiasmi.NormalSMIOutput)
+		err = mocknvidiasmi.Mock(mocknvidiasmi.NormalSMIOutput, mocknvidiasmi.NormalQueryOutput)
 		Expect(err).ToNot(HaveOccurred(), "failed to mock nvidia-smi")
 
 		By("start gpud scan")

--- a/e2e/mock/nvml/instance_mock.go
+++ b/e2e/mock/nvml/instance_mock.go
@@ -19,6 +19,10 @@ var MockInstance = &nvmlmock.Interface{
 		return 1, nvml.SUCCESS
 	},
 
+	ShutdownFunc: func() nvml.Return {
+		return nvml.SUCCESS
+	},
+
 	DeviceGetHandleByIndexFunc: func(n int) (nvml.Device, nvml.Return) {
 		return &nvmlmock.Device{
 			GetNameFunc: func() (string, nvml.Return) {


### PR DESCRIPTION
Found it in https://github.com/leptonai/gpud/pull/491.
