### PR TITLE
fix(kmsg): fix uptime-based kmsg timestamp parsing

### DIFF
--- a/pkg/diagnose/scan.go
+++ b/pkg/diagnose/scan.go
@@ -371,6 +371,8 @@ func scanKmsg(ctx context.Context) {
 	fmt.Printf("%s first kmsg line is %s old\n", checkMark, ts)
 
 	for _, msg := range msgs {
+		ts = msg.DescribeTimestamp(time.Now().UTC())
+
 		if ev, m := cpu.Match(msg.Message); m != "" {
 			fmt.Printf("[cpu] (%s) %s %s %q\n", ts, ev, m, msg.Message)
 		}

--- a/pkg/kmsg/kmsg.go
+++ b/pkg/kmsg/kmsg.go
@@ -175,12 +175,12 @@ func NewWatcher() (Watcher, error) {
 	// use multi-platform library "github.com/shirou/gopsutil/v4/host"
 	// to support darwin builds
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	bt, err := host.BootTimeWithContext(ctx)
+	ut, err := host.UptimeWithContext(ctx)
 	cancel()
 	if err != nil {
 		return nil, err
 	}
-	bootTime := time.Unix(int64(bt), 0)
+	bootTime := time.Unix(int64(ut), 0)
 
 	return &watcher{
 		kmsgFile: kmsgFile,


### PR DESCRIPTION
```
⌛ scanning dmesg
[XID found] (54 minutes ago) "NVRM: Xid (PCI:0000:9b:00): 119, pid=4071838, name=python, Timeout after 45s of waiting for RPC response from GPU4 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20801702 0x4)."
[XID found] (53 minutes ago) "NVRM: Xid (PCI:0000:9b:00): 119, pid=28232, name=cache_mgr_main, Timeout after 45s of waiting for RPC response from GPU4 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20810108 0x3e0)."
[XID found] (52 minutes ago) "NVRM: Xid (PCI:0000:9b:00): 119, pid=28232, name=cache_mgr_main, Timeout after 45s of waiting for RPC response from GPU4 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20803039 0x20)."
[XID found] (32 minutes ago) "NVRM: Xid (PCI:0000:9b:00): 119, pid=28098, name=gpu-feature-dis, Timeout after 45s of waiting for RPC response from GPU4 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20803039 0x20)."
[XID found] (10 minutes ago) "NVRM: Xid (PCI:0000:9b:00): 119, pid=4071838, name=python, Timeout after 45s of waiting for RPC response from GPU4 GSP! Expected function 76 (GSP_RM_CONTROL) (0x2080012c 0x14)."
✘ scanned dmesg file -- found 5 issue(s)
⌛ scanning kmsg
✔ scanned kmsg file -- found 4614 line(s)
✔ first kmsg line is 3 days ago old
[nvidia xid] (54 minutes ago) "NVRM: Xid (PCI:0000:9b:00): 119, pid=4071838, name=python, Timeout after 45s of waiting for RPC response from GPU4 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20801702 0x4).\n"
[nvidia xid] (53 minutes ago) "NVRM: Xid (PCI:0000:9b:00): 119, pid=28232, name=cache_mgr_main, Timeout after 45s of waiting for RPC response from GPU4 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20810108 0x3e0).\n"
[nvidia xid] (52 minutes ago) "NVRM: Xid (PCI:0000:9b:00): 119, pid=28232, name=cache_mgr_main, Timeout after 45s of waiting for RPC response from GPU4 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20803039 0x20).\n"
[cpu] (38 minutes ago) cpu_blocked_too_long CPU task blocked for more than 120 seconds "INFO: task gpud:3654 blocked for more than 120 seconds.\n"
[cpu] (38 minutes ago) cpu_blocked_too_long CPU task blocked for more than 120 seconds "INFO: task cache_mgr_main:28431 blocked for more than 120 seconds.\n"
[cpu] (38 minutes ago) cpu_blocked_too_long CPU task blocked for more than 120 seconds "INFO: task python:4072565 blocked for more than 120 seconds.\n"
[cpu] (38 minutes ago) cpu_blocked_too_long CPU task blocked for more than 120 seconds "INFO: task nvidia-smi:3228970 blocked for more than 120 seconds.\n"
[cpu] (36 minutes ago) cpu_blocked_too_long CPU task blocked for more than 120 seconds "INFO: task gpu-feature-dis:67427 blocked for more than 120 seconds.\n"
[cpu] (36 minutes ago) cpu_blocked_too_long CPU task blocked for more than 120 seconds "INFO: task cache_mgr_main:28431 blocked for more than 241 seconds.\n"
[cpu] (36 minutes ago) cpu_blocked_too_long CPU task blocked for more than 120 seconds "INFO: task nvidia-smi:3228970 blocked for more than 241 seconds.\n"
[cpu] (34 minutes ago) cpu_blocked_too_long CPU task blocked for more than 120 seconds "INFO: task gpud:3654 blocked for more than 120 seconds.\n"
[cpu] (34 minutes ago) cpu_blocked_too_long CPU task blocked for more than 120 seconds "INFO: task gpu-feature-dis:67427 blocked for more than 241 seconds.\n"
[cpu] (34 minutes ago) cpu_blocked_too_long CPU task blocked for more than 120 seconds "INFO: task nvidia-smi:3167926 blocked for more than 120 seconds.\n"
[nvidia xid] (32 minutes ago) "NVRM: Xid (PCI:0000:9b:00): 119, pid=28098, name=gpu-feature-dis, Timeout after 45s of waiting for RPC response from GPU4 GSP! Expected function 76 (GSP_RM_CONTROL) (0x20803039 0x20).\n"
[nvidia xid] (10 minutes ago) "NVRM: Xid (PCI:0000:9b:00): 119, pid=4071838, name=python, Timeout after 45s of waiting for RPC response from GPU4 GSP! Expected function 76 (GSP_RM_CONTROL) (0x2080012c 0x14).\n"
```