### PR TITLE
feat(nvidia): remove nvidia-smi dependency in all places (use NVML instead)

### DIFF
--- a/pkg/diagnose/diagnose.go
+++ b/pkg/diagnose/diagnose.go
@@ -263,7 +263,7 @@ func run(ctx context.Context, dir string, opts ...OpOption) error {
 		})
 	}
 
-	if !nvidia_query.SMIExists() {
+	if exists, err := nvidia_query.GPUsInstalled(ctx); !exists || err != nil {
 		o.Results = append(o.Results, CommandResult{
 			Command: "nvidia-smi",
 			Error:   "nvidia-smi is not installed",

--- a/pkg/nvidia-query/detect.go
+++ b/pkg/nvidia-query/detect.go
@@ -14,21 +14,8 @@ import (
 	"github.com/leptonai/gpud/pkg/process"
 )
 
-// Returns true if the local machine runs on Nvidia GPU
-// by running "nvidia-smi".
-func SMIExists() bool {
-	_, err := file.LocateExecutable("nvidia-smi")
-	return err == nil
-}
-
 // Returns true if the local machine has NVIDIA GPUs installed.
 func GPUsInstalled(ctx context.Context) (bool, error) {
-	smiInstalled := SMIExists()
-	if !smiInstalled {
-		return false, nil
-	}
-	log.Logger.Debugw("nvidia-smi installed")
-
 	// now that nvidia-smi installed,
 	// check the NVIDIA GPU presence via PCI bus
 	pciDevices, err := ListNVIDIAPCIs(ctx)

--- a/pkg/nvidia-query/query.go
+++ b/pkg/nvidia-query/query.go
@@ -104,8 +104,7 @@ func Get(ctx context.Context, opts ...OpOption) (output any, err error) {
 	}
 
 	o := &Output{
-		Time:      time.Now().UTC(),
-		SMIExists: SMIExists(),
+		Time: time.Now().UTC(),
 	}
 
 	log.Logger.Debugw("counting gpu devices")
@@ -189,7 +188,6 @@ func Get(ctx context.Context, opts ...OpOption) (output any, err error) {
 
 const (
 	StateKeyGPUProductName      = "gpu_product_name"
-	StateKeySMIExists           = "smi_exists"
 	StateKeyFabricManagerExists = "fabric_manager_exists"
 	StateKeyIbstatExists        = "ibstat_exists"
 )
@@ -213,10 +211,6 @@ type Output struct {
 	NVMLErrors []string     `json:"nvml_errors,omitempty"`
 
 	MemoryErrorManagementCapabilities MemoryErrorManagementCapabilities `json:"memory_error_management_capabilities,omitempty"`
-
-	// at some point, we will deprecate "nvidia-smi" parsing
-	// as the NVML API provides all the data we need
-	SMIExists bool `json:"smi_exists"`
 }
 
 func (o *Output) YAML() ([]byte, error) {


### PR DESCRIPTION
```
⌛ scanning nvidia accelerators
✔ found library libnvidia-ml.so at /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.535.216.03
✔ found library libcuda.so at /usr/lib/x86_64-linux-gnu/libcuda.so.535.216.03
```