### PR TITLE
fix(e2e): add missing get cuda version nvml call mock

### DIFF
--- a/e2e/mock/nvml/instance_mock.go
+++ b/e2e/mock/nvml/instance_mock.go
@@ -15,6 +15,10 @@ var MockInstance = &nvmlmock.Interface{
 		return "535.161.08", nvml.SUCCESS
 	},
 
+	SystemGetCudaDriverVersion_v2Func: func() (int, nvml.Return) {
+		return 12000, nvml.SUCCESS // CUDA 12.0 version
+	},
+
 	DeviceGetCountFunc: func() (int, nvml.Return) {
 		return 1, nvml.SUCCESS
 	},


### PR DESCRIPTION
To fix

```
{"level":"info","ts":"2025-03-11T06:09:41Z","caller":"nvml/nvml.go:243","msg":"getting driver version from nvml library"}
  panic: Interface.SystemGetCudaDriverVersion_v2Func: method is nil but Interface.SystemGetCudaDriverVersion_v2 was just called

  goroutine 1 [running]:
  github.com/NVIDIA/go-nvml/pkg/nvml/mock.(*Interface).SystemGetCudaDriverVersion_v2(0x2aa0ac0?)
  	/home/runner/go/pkg/mod/github.com/!n!v!i!d!i!a/go-nvml@v0.12.4-1/pkg/nvml/mock/interface.go:13299 +0xe5
  github.com/leptonai/gpud/pkg/nvidia-query/nvml.GetCUDAVersion()
  	/home/runner/work/gpud/gpud/pkg/nvidia-query/nvml/nvml.go:203 +0x48
  github.com/leptonai/gpud/pkg/nvidia-query/nvml.NewInstance({0x1deb870, 0xc00057dd50}, {0xc00005aac8, 0x2, 0x2})
  	/home/runner/work/gpud/gpud/pkg/nvidia-query/nvml/nvml.go:252 +0x29f
  github.com/leptonai/gpud/pkg/nvidia-query/nvml.StartDefaultInstance({0x1deb870, 0xc00057dd50}, {0xc00005aac8, 0x2, 0x2})
  	/home/runner/work/gpud/gpud/pkg/nvidia-query/nvml/nvml.go:633 +0xf7
  github.com/leptonai/gpud/pkg/nvidia-query.Get({0x1deb870, 0xc00057dd50}, {0xc00005b628, 0x3, 0x184c[201](https://github.com/leptonai/gpud/actions/runs/13781501182/job/38540433871?pr=515#step:4:202)?})
  	/home/runner/work/gpud/gpud/pkg/nvidia-query/query.go:88 +0x1cf
  github.com/leptonai/gpud/pkg/diagnose.Scan({0x1deb870, 0xc00057dd50}, {0xc00005b7a8, 0x6, 0x6})
  	/home/runner/work/gpud/gpud/pkg/diagnose/scan.go:134 +0x1d49
  github.com/leptonai/gpud/cmd/gpud/command.cmdScan(0xc0001d0150?)
  	/home/runner/work/gpud/gpud/cmd/gpud/command/scan.go:35 +0x326
  github.com/urfave/cli.HandleAction({0x1816e20?, 0x1c0d648?}, 0x4?)
  	/home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.15/app.go:524 +0x50
  github.com/urfave/cli.Command.Run({{0x1ae9464, 0x4}, {0x0, 0x0}, {0xc00028aac0, 0x2, 0x2}, {0x1b3f3e2, 0x29}, {0x0, ...}, ...}, ...)
  	/home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.15/command.go:175 +0x67c
  github.com/urfave/cli.(*App).Run(0xc0001f16c0, {0xc0000402d0, 0x3, 0x3})
  	/home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.15/app.go:277 +0xb3b
  main.main()
  	/home/runner/work/gpud/gpud/cmd/gpud/main.go:12 +0x2d
```