### PR TITLE
fix(xid/sxid): add rand millisecond to event timestamp to avoid conflict

### DIFF
--- a/components/accelerator/nvidia/sxid/component.go
+++ b/components/accelerator/nvidia/sxid/component.go
@@ -5,6 +5,7 @@ package sxid
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sort"
 	"strconv"
 	"strings"
@@ -178,7 +179,7 @@ func (c *SXIDComponent) start(watcher pkg_dmesg.Watcher, updatePeriod time.Durat
 				continue
 			}
 			event := components.Event{
-				Time: metav1.Time{Time: dmesgLine.Timestamp},
+				Time: metav1.Time{Time: dmesgLine.Timestamp.Add(time.Duration(rand.Intn(1000)) * time.Millisecond)},
 				Name: EventNameErroSXid,
 				ExtraInfo: map[string]string{
 					EventKeyErroSXidData: strconv.FormatInt(int64(sxidErr.SXid), 10),

--- a/components/accelerator/nvidia/xid/component.go
+++ b/components/accelerator/nvidia/xid/component.go
@@ -6,6 +6,7 @@ package xid
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sort"
 	"strconv"
 	"strings"
@@ -183,7 +184,7 @@ func (c *XIDComponent) start(watcher pkg_dmesg.Watcher, updatePeriod time.Durati
 				continue
 			}
 			event := components.Event{
-				Time: metav1.Time{Time: dmesgLine.Timestamp},
+				Time: metav1.Time{Time: dmesgLine.Timestamp.Add(time.Duration(rand.Intn(1000)) * time.Millisecond)},
 				Name: EventNameErrorXid,
 				ExtraInfo: map[string]string{
 					EventKeyErrorXidData: strconv.FormatInt(int64(xidErr.Xid), 10),


### PR DESCRIPTION
multiple xid might happen at same timestamp, add a rand millisecond to event timestamp to avoid conflict