### PR TITLE
feat(os, peermem): ignore lsmod, system virt cmd timeouts (as non-actionable)

### DIFF
--- a/components/os/component_output_test.go
+++ b/components/os/component_output_test.go
@@ -20,11 +20,7 @@ func TestGet(t *testing.T) {
 
 	getFunc := createGet(nil)
 	_, err := getFunc(ctx)
-	if err == nil {
-		t.Fatalf("expected error, got nil")
-	}
-	expectedError := "failed to get virtualization environment using 'systemd-detect-virt': context deadline exceeded"
-	if err.Error() != expectedError {
-		t.Fatalf("expected error: %s, got: %s", expectedError, err.Error())
+	if err != nil {
+		t.Fatalf("expected nil")
 	}
 }

--- a/components/os/component_output_test.go
+++ b/components/os/component_output_test.go
@@ -18,7 +18,7 @@ func TestGet(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 0)
 	defer cancel()
 
-	getFunc := createGet(Config{}, nil)
+	getFunc := createGet(nil)
 	_, err := getFunc(ctx)
 	if err == nil {
 		t.Fatalf("expected error, got nil")

--- a/pkg/nvidia-query/query.go
+++ b/pkg/nvidia-query/query.go
@@ -134,7 +134,12 @@ func Get(ctx context.Context, opts ...OpOption) (output any, err error) {
 	o.LsmodPeermem, err = peermem.CheckLsmodPeermemModule(cctx)
 	ccancel()
 	if err != nil {
-		o.LsmodPeermemErrors = append(o.LsmodPeermemErrors, err.Error())
+		// ignore "context.DeadlineExceeded" since it's not a critical error and it's non-actionable
+		if !errors.Is(err, context.DeadlineExceeded) {
+			o.LsmodPeermemErrors = append(o.LsmodPeermemErrors, err.Error())
+		} else {
+			log.Logger.Warnw("lsmod peermem check timed out", "error", err)
+		}
 	}
 
 	log.Logger.Infow("waiting for default nvml instance")


### PR DESCRIPTION
Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
