### PR TITLE
feat(metrics): remove unused EMA sql track/query

### DIFF
--- a/components/cpu/metrics/metrics.go
+++ b/components/cpu/metrics/metrics.go
@@ -14,7 +14,7 @@ import (
 
 const SubSystem = "cpu"
 
-// Used for tracking the past x-minute averages + EMAs.
+// Used for tracking the past x-minute averages.
 var defaultPeriods = []time.Duration{5 * time.Minute}
 
 var (

--- a/components/disk/metrics/metrics.go
+++ b/components/disk/metrics/metrics.go
@@ -14,7 +14,7 @@ import (
 
 const SubSystem = "disk"
 
-// Used for tracking the past x-minute averages + EMAs.
+// Used for tracking the past x-minute averages.
 var defaultPeriods = []time.Duration{5 * time.Minute}
 
 var (

--- a/pkg/gpud-metrics/state/state_test.go
+++ b/pkg/gpud-metrics/state/state_test.go
@@ -45,16 +45,6 @@ func TestState(t *testing.T) {
 		t.Errorf("expected average 0 with no rows, got %f", avg)
 	}
 
-	// test EMASince with no rows
-	period := 1 * time.Minute
-	ema, err := EMASince(ctx, db, tableName, "test_metric", "", period, since)
-	if err != nil {
-		t.Errorf("EMASince failed with no rows: %v", err)
-	}
-	if ema != 0 {
-		t.Errorf("expected EMA 0 with no rows, got %f", ema)
-	}
-
 	now := time.Now()
 	metrics := []Metric{
 		{UnixSeconds: now.Unix(), MetricName: "test_metric", Value: 10.0},
@@ -93,20 +83,6 @@ func TestState(t *testing.T) {
 		t.Errorf("expected average %f, got %f", expectedAvg, avg)
 	}
 	t.Logf("expected avg: %f, avg: %f", expectedAvg, avg)
-
-	// test EMASince with a period parameter
-	period = 1 * time.Minute
-	ema, err = EMASince(ctx, db, tableName, "test_metric", "", period, since)
-	if err != nil {
-		t.Errorf("failed to get EMA: %v", err)
-	}
-	t.Logf("ema: %f", ema)
-
-	// test if EMA value is approximately 10.000
-	expectedEMA := 10.000
-	if math.Abs(ema-expectedEMA) > 0.001 {
-		t.Errorf("expected EMA %f, got %f", expectedEMA, ema)
-	}
 }
 
 func TestStateMoreDataPoints(t *testing.T) {
@@ -139,16 +115,6 @@ func TestStateMoreDataPoints(t *testing.T) {
 	}
 	if avg != 0 {
 		t.Errorf("expected average 0 with no rows, got %f", avg)
-	}
-
-	// test EMASince with no rows
-	period := 1 * time.Minute
-	ema, err := EMASince(ctx, db, tableName, "test_metric", "", period, since)
-	if err != nil {
-		t.Errorf("EMASince failed with no rows: %v", err)
-	}
-	if ema != 0 {
-		t.Errorf("expected EMA 0 with no rows, got %f", ema)
 	}
 
 	now := time.Now()
@@ -208,20 +174,6 @@ func TestStateMoreDataPoints(t *testing.T) {
 				t.Errorf("Average for %s doesn't match: expected %.3f, got %.3f", metricName, expectedAvg, avg)
 			} else {
 				t.Logf("Average for %s: %.3f", metricName, avg)
-			}
-		}
-
-		ema, err := EMASince(ctx, db, tableName, metricName, "", time.Minute, since)
-		if err != nil {
-			t.Errorf("failed to get EMA for %s since %v: %v", metricName, since, err)
-		} else {
-			t.Logf("1-minute EMA for %s: %.3f", metricName, ema)
-
-			// Compare EMA to simple average
-			if math.Abs(ema-avg) < 0.001 {
-				t.Errorf("EMA and simple average for %s are too close: EMA %.3f, Avg %.3f", metricName, ema, avg)
-			} else {
-				t.Logf("EMA differs from simple average for %s: EMA %.3f, Avg %.3f", metricName, ema, avg)
 			}
 		}
 	}
@@ -289,19 +241,6 @@ func TestStateMoreDataPoints(t *testing.T) {
 			t.Errorf("Average with secondary ID doesn't match: expected %.3f, got %.3f", expectedAvg, secondaryAvg)
 		} else {
 			t.Logf("Average with secondary ID: %.3f", secondaryAvg)
-		}
-	}
-
-	// Test EMASince with secondary ID
-	secondaryEMA, err := EMASince(ctx, db, tableName, "test_metric", secondaryID, time.Minute, secondarySince)
-	if err != nil {
-		t.Errorf("EMASince failed with secondary ID: %v", err)
-	} else {
-		t.Logf("1-minute EMA with secondary ID: %.3f", secondaryEMA)
-		if math.Abs(secondaryEMA-secondaryAvg) < 0.001 {
-			t.Errorf("EMA and simple average with secondary ID are too close: EMA %.3f, Avg %.3f", secondaryEMA, secondaryAvg)
-		} else {
-			t.Logf("EMA differs from simple average with secondary ID: EMA %.3f, Avg %.3f", secondaryEMA, secondaryAvg)
 		}
 	}
 }


### PR DESCRIPTION
Fault-prone...

```
unexpected fault address 0x6304e55848a6b
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x1 addr=0x6304e55848a6b pc=0x4247c1]

goroutine 307 gp=0xc0004fb6c0 m=42 mp=0xc001b1b108 [running]:
runtime.throw({0x1b12994?, 0x7c47e5b223c8?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/panic.go:1067 +0x48 fp=0xc001540e30 sp=0xc001540e00 pc=0x48bac8
runtime.sigpanic()
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/signal_unix.go:931 +0x26c fp=0xc001540e90 sp=0xc001540e30 pc=0x48dd6c
runtime.buildTypeAssertCache.func1(...)
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/iface.go:532
runtime.buildTypeAssertCache(0x18d96c0?, 0x18d9940, 0x7c479d9bae28)
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/iface.go:544 +0x141 fp=0xc001540ed8 sp=0xc001540e90 pc=0x4247c1
runtime.typeAssert(0x2ab06a0, 0x18d9940?)
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/iface.go:497 +0xfd fp=0xc001540f18 sp=0xc001540ed8 pc=0x4245bd
database/sql.convertAssignRows({0x18d9940, 0xc002aba6e0}, {0x180ae80, 0xc002aba710}, 0xc002c6d720)
        /opt/hostedtoolcache/go/1.23.6/x64/src/database/sql/convert.go:395 +0x1f0e fp=0xc0015411d0 sp=0xc001540f18 pc=0xacebae
database/sql.(*Rows).Scan(0xc002c6d720, {0xc001541478, 0x1, 0xc0015412a8?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/database/sql/sql.go:3392 +0x39a fp=0xc0015412b0 sp=0xc0015411d0 pc=0xadf27a
database/sql.(*Row).Scan(0xc001541410, {0xc001541478?, 0xc00038bc70?, 0x1})
        /opt/hostedtoolcache/go/1.23.6/x64/src/database/sql/sql.go:3509 +0x132 fp=0xc001541320 sp=0xc0015412b0 pc=0xadf952
github.com/leptonai/gpud/pkg/gpud-metrics/state.EMASince({0x1e187f0, 0xc00038bc70}, 0xc00042cdd0, {0x1b3366e, 0x12}, {0x1b7db54, 0x32}, {0xc000922510, 0x28}, 0x45d964b800, ...)
        /home/runner/work/gpud/gpud/pkg/gpud-metrics/state/state.go:335 +0x579 fp=0xc0015414b0 sp=0xc001541320 pc=0xbfe279
github.com/leptonai/gpud/pkg/gpud-metrics.(*continuousAverager).EMA(0xc001d2a000, {0x1e187f0, 0xc00038bc70}, {0xc001d67bf0, 0x2, 0x2})
```