### PR TITLE
fix(nvidia): handle nvml.ERROR_NOT_FOUND in utilization query

### DIFF
--- a/pkg/nvidia-query/nvml/error.go
+++ b/pkg/nvidia-query/nvml/error.go
@@ -12,21 +12,21 @@ func IsVersionMismatchError(ret nvml.Return) bool {
 		return true
 	}
 
-	e := normalizeErrorString(nvml.ErrorString(ret))
+	e := normalizeNVMLReturnString(ret)
 	return strings.Contains(e, "version mismatch")
 }
 
-// Returns true if the error indicates that the operation is not supported.
+// IsNotSupportError returns true if the error indicates that the operation is not supported.
 func IsNotSupportError(ret nvml.Return) bool {
 	if ret == nvml.ERROR_NOT_SUPPORTED {
 		return true
 	}
 
-	e := normalizeErrorString(nvml.ErrorString(ret))
+	e := normalizeNVMLReturnString(ret)
 	return strings.Contains(e, "not supported")
 }
 
-// Returns true if the error indicates that the system is not ready,
+// IsNotReadyError returns true if the error indicates that the system is not ready,
 // meaning that the GPU is not yet initialized.
 // e.g.,
 // "nvml.CLOCK_GRAPHICS: System is not in ready state"
@@ -35,11 +35,23 @@ func IsNotReadyError(ret nvml.Return) bool {
 		return true
 	}
 
-	e := normalizeErrorString(nvml.ErrorString(ret))
+	e := normalizeNVMLReturnString(ret)
 	return strings.Contains(e, "not in ready")
 }
 
-// normalizeErrorString normalizes an NVML error string by converting it to lowercase and trimming whitespace.
-func normalizeErrorString(e string) string {
-	return strings.ToLower(strings.TrimSpace(e))
+// IsNotFoundError returns true if the error indicates that the object/instance is not found.
+// e.g., process not found from nvml
+func IsNotFoundError(ret nvml.Return) bool {
+	if ret == nvml.ERROR_NOT_FOUND {
+		return true
+	}
+
+	e := normalizeNVMLReturnString(ret)
+	return strings.Contains(e, "not found") || strings.Contains(e, "not_found")
+}
+
+// normalizeNVMLReturnString normalizes an NVML return to a string.
+func normalizeNVMLReturnString(ret nvml.Return) string {
+	s := nvml.ErrorString(ret)
+	return strings.ToLower(strings.TrimSpace(s))
 }

--- a/pkg/nvidia-query/nvml/processes.go
+++ b/pkg/nvidia-query/nvml/processes.go
@@ -110,16 +110,13 @@ func GetProcesses(uuid string, dev device.Device) (Processes, error) {
 			procs.GetProcessUtilizationSupported = false
 			return procs, nil
 		}
-
-		if ret != nvml.SUCCESS { // not a "not supported" error, not a success return, thus return an error here
-			es := nvml.ErrorString(ret)
-
-			// e.g., Not Found
-			if strings.Contains(strings.ToLower(es), "not found") {
-				continue
-			}
-			return procs, fmt.Errorf("failed to get process %d utilization: %v", proc.Pid, es)
+		if IsNotFoundError(ret) {
+			continue
 		}
+		if ret != nvml.SUCCESS { // not a "not supported" error, not a success return, thus return an error here
+			return procs, fmt.Errorf("failed to get process %d utilization (%v)", proc.Pid, nvml.ErrorString(ret))
+		}
+
 		if len(utils) > 0 {
 			// sort by last seen timestamp, so that first is the latest
 			sort.Slice(utils, func(i, j int) bool {


### PR DESCRIPTION
To address:

>,"caller":"nvidia-query/query.go:159","msg":"nvml get failed","error":"failed to get process 130925 utilization: ERROR_NOT_FOUND (GPU uuid GPU-871a1068-5809-c0c4-5286-7b06ef9fc3e3)\nfailed to get process 130925 utilization: ERROR_NOT_FOUND (GPU uuid GPU-305d4b1a-067c-7fe2-efc5-e8d0df2036ba)"}

Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
