### PR TITLE
feat(eventstore): handle invalid sql conversion error better

### DIFF
--- a/pkg/eventstore/database.go
+++ b/pkg/eventstore/database.go
@@ -406,20 +406,37 @@ func scanRow(row *sql.Row) (components.Event, error) {
 	if msg.Valid {
 		event.Message = msg.String
 	}
-	if extraInfo.Valid && len(extraInfo.String) > 0 && extraInfo.String != "null" {
-		var extraInfoMap map[string]string
-		if err := json.Unmarshal([]byte(extraInfo.String), &extraInfoMap); err != nil {
-			return event, fmt.Errorf("failed to unmarshal extra info: %w", err)
+
+	// Handle extraInfo carefully
+	if extraInfo.Valid && len(extraInfo.String) > 0 {
+		// Make sure it's not "null" string and looks like valid JSON
+		if extraInfo.String != "null" && strings.HasPrefix(extraInfo.String, "{") {
+			var extraInfoMap map[string]string
+			if err := json.Unmarshal([]byte(extraInfo.String), &extraInfoMap); err != nil {
+				return event, fmt.Errorf("failed to unmarshal extra info: %w", err)
+			} else {
+				event.ExtraInfo = extraInfoMap
+			}
+		} else {
+			return event, fmt.Errorf("extra info is not valid: %q", extraInfo.String)
 		}
-		event.ExtraInfo = extraInfoMap
 	}
-	if suggestedActions.Valid && len(suggestedActions.String) > 0 && suggestedActions.String != "null" {
-		var suggestedActionsObj common.SuggestedActions
-		if err := json.Unmarshal([]byte(suggestedActions.String), &suggestedActionsObj); err != nil {
-			return event, fmt.Errorf("failed to unmarshal suggested actions: %w", err)
+
+	// Handle suggestedActions carefully
+	if suggestedActions.Valid && len(suggestedActions.String) > 0 {
+		// Make sure it's not "null" string and looks like valid JSON
+		if suggestedActions.String != "null" && strings.HasPrefix(suggestedActions.String, "{") {
+			var suggestedActionsObj common.SuggestedActions
+			if err := json.Unmarshal([]byte(suggestedActions.String), &suggestedActionsObj); err != nil {
+				return event, fmt.Errorf("failed to unmarshal suggested actions: %w", err)
+			} else {
+				event.SuggestedActions = &suggestedActionsObj
+			}
+		} else {
+			return event, fmt.Errorf("extra info is not valid: %q", extraInfo.String)
 		}
-		event.SuggestedActions = &suggestedActionsObj
 	}
+
 	return event, nil
 }
 
@@ -445,20 +462,35 @@ func scanRows(rows *sql.Rows) (components.Event, error) {
 	if msg.Valid {
 		event.Message = msg.String
 	}
-	if extraInfo.Valid {
-		var extraInfoMap map[string]string
-		if err := json.Unmarshal([]byte(extraInfo.String), &extraInfoMap); err != nil {
-			return event, fmt.Errorf("failed to unmarshal extra info: %w", err)
+
+	// Handle extraInfo carefully
+	if extraInfo.Valid && len(extraInfo.String) > 0 {
+		// Make sure it's not "null" string and looks like valid JSON
+		if extraInfo.String != "null" && strings.HasPrefix(extraInfo.String, "{") {
+			var extraInfoMap map[string]string
+			if err := json.Unmarshal([]byte(extraInfo.String), &extraInfoMap); err != nil {
+				return event, fmt.Errorf("failed to unmarshal extra info: %w", err)
+			}
+			event.ExtraInfo = extraInfoMap
+		} else {
+			return event, fmt.Errorf("extra info is not valid: %q", extraInfo.String)
 		}
-		event.ExtraInfo = extraInfoMap
 	}
-	if suggestedActions.Valid && suggestedActions.String != "" {
-		var suggestedActionsObj common.SuggestedActions
-		if err := json.Unmarshal([]byte(suggestedActions.String), &suggestedActionsObj); err != nil {
-			return event, fmt.Errorf("failed to unmarshal suggested actions: %w", err)
+
+	// Handle suggestedActions carefully
+	if suggestedActions.Valid && len(suggestedActions.String) > 0 {
+		// Make sure it's not "null" string and looks like valid JSON
+		if suggestedActions.String != "null" && strings.HasPrefix(suggestedActions.String, "{") {
+			var suggestedActionsObj common.SuggestedActions
+			if err := json.Unmarshal([]byte(suggestedActions.String), &suggestedActionsObj); err != nil {
+				return event, fmt.Errorf("failed to unmarshal suggested actions: %w", err)
+			}
+			event.SuggestedActions = &suggestedActionsObj
+		} else {
+			return event, fmt.Errorf("extra info is not valid: %q", extraInfo.String)
 		}
-		event.SuggestedActions = &suggestedActionsObj
 	}
+
 	return event, nil
 }
 


### PR DESCRIPTION
To help address:

```
unexpected fault address 0x630973f0815ea
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x1 addr=0x630973f0815ea pc=0x4247c1]

goroutine 394 gp=0xc001a70e00 m=49 mp=0xc001e34708 [running]:
runtime.throw({0x1b1a72d?, 0x796932e8a9d8?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/panic.go:1067 +0x48 fp=0xc001f43268 sp=0xc001f43238 pc=0x48bac8
runtime.sigpanic()
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/signal_unix.go:931 +0x26c fp=0xc001f432c8 sp=0xc001f43268 pc=0x48dd6c
runtime.buildTypeAssertCache.func1(...)
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/iface.go:532
runtime.buildTypeAssertCache(0x18e56e0?, 0x18e5860, 0x7968eacc4998)
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/iface.go:544 +0x141 fp=0xc001f43310 sp=0xc001f432c8 pc=0x4247c1
runtime.typeAssert(0x2ad77c0, 0x18e5860?)
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/iface.go:497 +0xfd fp=0xc001f43350 sp=0xc001f43310 pc=0x4245bd
database/sql.convertAssignRows({0x18e5860, 0xc001c5a480}, {0x0, 0x0}, 0xc000741680)
        /opt/hostedtoolcache/go/1.23.6/x64/src/database/sql/convert.go:395 +0x1f0e fp=0xc001f43608 sp=0xc001f43350 pc=0xaeabce
database/sql.(*Rows).Scan(0xc000741680, {0xc001f43728, 0x6, 0xc001f436f0?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/database/sql/sql.go:3392 +0x39a fp=0xc001f436e8 sp=0xc001f43608 pc=0xafb29a
github.com/leptonai/gpud/pkg/eventstore.scanRows(0xc000741680)
        /home/runner/work/gpud/gpud/pkg/eventstore/database.go:432 +0x17a fp=0xc001f437d0 sp=0xc001f436e8 pc=0xcbc45a
github.com/leptonai/gpud/pkg/eventstore.getEvents({0x1e1bdc0, 0xc001c14280}, 0xc0010f7380, {0xc0005812c0?, 0x1b2be85?}, {0xa?, 0x1?, 0x33fcec0?})
        /home/runner/work/gpud/gpud/pkg/eventstore/database.go:356 +0x525 fp=0xc001f43a68 sp=0xc001f437d0 pc=0xcbb665
github.com/leptonai/gpud/pkg/eventstore.(*table).Get(0x18?, {0x1e1bdc0?, 0xc001c14280?}, {0x0?, 0x1b17f86?, 0x33fcec0?})
        /home/runner/work/gpud/gpud/pkg/eventstore/database.go:171 +0x46 fp=0xc001f43ab8 sp=0xc001f43a68 pc=0xcb99a6
github.com/leptonai/gpud/components/os.(*component).Events(0x0?, {0x1e1bdc0?, 0xc001c14280?}, {0x4f9a93?, 0xc001f43b28?, 0x33fcec0?})
        /home/runner/work/gpud/gpud/components/os/component.go:99 +0x2b fp=0xc001f43af8 sp=0xc001f43ab8 pc=0x14ca38b
github.com/leptonai/gpud/pkg/gpud-metrics.(*WatchableComponentStruct).Events(0xc1ed62d0e324559e?, {0x1e1bdc0?, 0xc001c14280?}, {0xffff14424c130000?, 0xc001f43b80?, 0x33fcec0?})
        <autogenerated>:1 +0x33 fp=0xc001f43b38 sp=0xc001f43af8 pc=0xcb2f93
github.com/leptonai/gpud/components/accelerator/nvidia/sxid.getRebootEvents({0x1e1bdc0, 0xc001c14280})
        /home/runner/work/gpud/gpud/components/accelerator/nvidia/sxid/component.go:247 +0xba fp=0xc001f43b98 sp=0xc001f43b38 pc=0xd4597a
github.com/leptonai/gpud/components/accelerator/nvidia/sxid.(*SXIDComponent).updateCurrentState(0xc001c080b0)
        /home/runner/work/gpud/gpud/components/accelerator/nvidia/sxid/component.go:227 +0x34 fp=0xc001f43cb8 sp=0xc001f43b98 pc=0xd45674
github.com/leptonai/gpud/components/accelerator/nvidia/sxid.(*SXIDComponent).start(0xc001c080b0, {0x1e0d430, 0xc0006137c0}, 0x62327830203a0965?)
        /home/runner/work/gpud/gpud/components/accelerator/nvidia/sxid/component.go:154 +0x4a7 fp=0xc001f43fb0 sp=0xc001f43cb8 pc=0xd44c87
github.com/leptonai/gpud/components/accelerator/nvidia/sxid.(*SXIDComponent).Start.gowrap1()
        /home/runner/work/gpud/gpud/components/accelerator/nvidia/sxid/component.go:106 +0x32 fp=0xc001f43fe0 sp=0xc001f43fb0 pc=0xd44132
runtime.goexit({})
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/asm_amd64.s:1700 +0x1 fp=0xc001f43fe8 sp=0xc001f43fe0 pc=0x494361
created by github.com/leptonai/gpud/components/accelerator/nvidia/sxid.(*SXIDComponent).Start in goroutine 1
        /home/runner/work/gpud/gpud/components/accelerator/nvidia/sxid/component.go:106 +0x26f
```

Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
