### PR TITLE
fix(nvidia/processes): handle nil output/data for /states response

### DIFF
--- a/components/accelerator/nvidia/processes/component_output.go
+++ b/components/accelerator/nvidia/processes/component_output.go
@@ -2,22 +2,21 @@ package processes
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/leptonai/gpud/components"
 	nvidia_query "github.com/leptonai/gpud/pkg/nvidia-query"
 	nvidia_query_nvml "github.com/leptonai/gpud/pkg/nvidia-query/nvml"
-
-	"sigs.k8s.io/yaml"
 )
 
 // ToOutput converts nvidia_query.Output to Output.
 // It returns an empty non-nil object, if the input or the required field is nil (e.g., i.SMI).
-func ToOutput(i *nvidia_query.Output) *Output {
+func ToOutput(i *nvidia_query.Output) *Data {
 	if i == nil {
-		return &Output{}
+		return &Data{}
 	}
 
-	o := &Output{}
+	o := &Data{}
 
 	if i.NVML != nil {
 		for _, device := range i.NVML.DeviceInfos {
@@ -28,37 +27,28 @@ func ToOutput(i *nvidia_query.Output) *Output {
 	return o
 }
 
-type Output struct {
+type Data struct {
 	Processes []nvidia_query_nvml.Processes `json:"processes"`
 }
 
-func (o *Output) JSON() ([]byte, error) {
-	return json.Marshal(o)
-}
+func (d *Data) States() ([]components.State, error) {
+	if d == nil {
+		return nil, nil
+	}
 
-func (o *Output) YAML() ([]byte, error) {
-	return yaml.Marshal(o)
-}
-
-const (
-	StateNameProcesses = "processes"
-
-	StateKeyProcessesData           = "data"
-	StateKeyProcessesEncoding       = "encoding"
-	StateValueProcessesEncodingJSON = "json"
-)
-
-func (o *Output) States() ([]components.State, error) {
-	yb, _ := o.YAML()
-	jb, _ := o.JSON()
+	data := ""
+	if d != nil {
+		b, _ := json.Marshal(d)
+		data = string(b)
+	}
 
 	state := components.State{
-		Name:    StateNameProcesses,
+		Name:    "processes",
 		Healthy: true,
-		Reason:  string(yb),
+		Reason:  fmt.Sprintf("total %d processes", len(d.Processes)),
 		ExtraInfo: map[string]string{
-			StateKeyProcessesData:     string(jb),
-			StateKeyProcessesEncoding: StateValueProcessesEncodingJSON,
+			"data":     data,
+			"encoding": "json",
 		},
 	}
 	return []components.State{state}, nil

--- a/components/accelerator/nvidia/processes/component_output_test.go
+++ b/components/accelerator/nvidia/processes/component_output_test.go
@@ -1,0 +1,83 @@
+package processes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	nvidia_query_nvml "github.com/leptonai/gpud/pkg/nvidia-query/nvml"
+)
+
+func TestData_States(t *testing.T) {
+	t.Run("with processes", func(t *testing.T) {
+		// Create test data with a single process
+		d := &Data{
+			Processes: []nvidia_query_nvml.Processes{
+				{
+					UUID: "GPU-12345678",
+					RunningProcesses: []nvidia_query_nvml.Process{
+						{
+							PID:                123,
+							CmdArgs:            []string{"/usr/bin/test", "-arg1"},
+							GPUUsedPercent:     50,
+							GPUUsedMemoryBytes: 1024 * 1024 * 100,
+						},
+					},
+				},
+			},
+		}
+
+		// Call States method
+		states, err := d.States()
+
+		// Verify results
+		assert.NoError(t, err)
+		assert.Len(t, states, 1)
+		assert.Equal(t, "processes", states[0].Name)
+		assert.True(t, states[0].Healthy)
+		assert.Equal(t, "total 1 processes", states[0].Reason)
+
+		// Validate that data field contains correct JSON
+		dataJSON := states[0].ExtraInfo["data"]
+		assert.NotEmpty(t, dataJSON)
+		assert.Equal(t, "json", states[0].ExtraInfo["encoding"])
+
+		// Unmarshal and verify the data matches our original struct
+		var parsedData Data
+		err = json.Unmarshal([]byte(dataJSON), &parsedData)
+		assert.NoError(t, err)
+		assert.Len(t, parsedData.Processes, 1)
+		assert.Equal(t, "GPU-12345678", parsedData.Processes[0].UUID)
+	})
+
+	t.Run("with empty processes", func(t *testing.T) {
+		// Create test data with no processes
+		d := &Data{
+			Processes: []nvidia_query_nvml.Processes{},
+		}
+
+		// Call States method
+		states, err := d.States()
+
+		// Verify results
+		assert.NoError(t, err)
+		assert.Len(t, states, 1)
+		assert.Equal(t, "processes", states[0].Name)
+		assert.True(t, states[0].Healthy)
+		assert.Equal(t, "total 0 processes", states[0].Reason)
+		assert.NotEmpty(t, states[0].ExtraInfo["data"])
+	})
+
+	t.Run("with nil data", func(t *testing.T) {
+		// Test with nil Data pointer
+		var d *Data = nil
+
+		// Call States method
+		states, err := d.States()
+
+		// Verify results
+		assert.NoError(t, err)
+		assert.Len(t, states, 0)
+	})
+}


### PR DESCRIPTION
To help address:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x6534f1]

goroutine 93521 [running]:
encoding/json.(*encodeState).marshal.func1()
        /opt/hostedtoolcache/go/1.23.6/x64/src/encoding/json/encode.go:294 +0x6d
panic({0x18caaa0?, 0x2ace010?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/panic.go:785 +0x132
encoding/json.addrMarshalerEncoder(0xc002b4a740, {0x1adb180?, 0xc001562e48?, 0xc001d30400?}, {0x76?, 0x0?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/encoding/json/encode.go:460 +0x151
encoding/json.condAddrEncoder.encode({0x1c3d598?, 0x1c3d5e0?}, 0x54e0a8?, {0x1adb180?, 0xc001562e48?, 0xc001562e28?}, {0xe?, 0x0?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/encoding/json/encode.go:902 +0x44
encoding/json.structEncoder.encode({{{0xc002998008, 0x9, 0x10}, 0xc001698a50, 0xc001698a80}}, 0xc002b4a740, {0x1a58100?, 0xc001562e00?, 0x40?}, {0x0, ...})
        /opt/hostedtoolcache/go/1.23.6/x64/src/encoding/json/encode.go:715 +0x21e
encoding/json.arrayEncoder.encode({0x80?}, 0xc002b4a740, {0x17f5480?, 0xc002305510?, 0xc001d30400?}, {0x0?, 0x0?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/encoding/json/encode.go:858 +0xcf
encoding/json.sliceEncoder.encode({0xc00172f270?}, 0xc002b4a740, {0x17f5480?, 0xc002305510?, 0xc002b4a740?}, {0x14?, 0x0?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/encoding/json/encode.go:831 +0x338
encoding/json.structEncoder.encode({{{0xc002606008, 0x4, 0x4}, 0xc001698b10, 0xc001698b40}}, 0xc002b4a740, {0x19e3d20?, 0xc002305500?, 0x0?}, {0x0, ...})
        /opt/hostedtoolcache/go/1.23.6/x64/src/encoding/json/encode.go:715 +0x21e
encoding/json.arrayEncoder.encode({0xc0038b6430?}, 0xc002b4a740, {0x17f5740?, 0xc0031270b0?, 0x0?}, {0xdd?, 0x4?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/encoding/json/encode.go:858 +0xcf
encoding/json.sliceEncoder.encode({0x10101853c08?}, 0xc002b4a740, {0x17f5740?, 0xc0031270b0?, 0xc002b4a740?}, {0xc?, 0x0?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/encoding/json/encode.go:831 +0x338
encoding/json.structEncoder.encode({{{0xc001517830, 0x1, 0x1}, 0xc001698bd0, 0xc001698c00}}, 0xc002b4a740, {0x19195e0?, 0xc0031270b0?, 0xc0031270b0?}, {0x0, ...})
        /opt/hostedtoolcache/go/1.23.6/x64/src/encoding/json/encode.go:715 +0x21e
encoding/json.ptrEncoder.encode({0xc0038b67d0?}, 0xc002b4a740, {0x1919660?, 0xc0031270b0?, 0x1919660?}, {0x30?, 0x0?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/encoding/json/encode.go:887 +0x223
encoding/json.(*encodeState).reflectValue(0xc002b4a740, {0x1919660?, 0xc0031270b0?, 0x426805?}, {0x38?, 0x0?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/encoding/json/encode.go:322 +0x73
encoding/json.(*encodeState).marshal(0xc0003eac00?, {0x1919660?, 0xc0031270b0?}, {0x10?, 0x0?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/encoding/json/encode.go:298 +0xbd
encoding/json.Marshal({0x1919660, 0xc0031270b0})
        /opt/hostedtoolcache/go/1.23.6/x64/src/encoding/json/encode.go:164 +0xbe
sigs.k8s.io/yaml.Marshal({0x1919660?, 0xc0031270b0?})
        /home/runner/go/pkg/mod/sigs.k8s.io/yaml@v1.4.0/yaml.go:32 +0x1d
github.com/leptonai/gpud/components/accelerator/nvidia/processes.(*Output).YAML(...)
        /home/runner/work/gpud/gpud/components/accelerator/nvidia/processes/component_output.go:40
github.com/leptonai/gpud/components/accelerator/nvidia/processes.(*Output).States(0xc0031270b0)
        /home/runner/work/gpud/gpud/components/accelerator/nvidia/processes/component_output.go:52 +0x32
github.com/leptonai/gpud/components/accelerator/nvidia/processes.(*component).States(0xc00069af40, {0x1e1bdc0?, 0xc002072960?})
        /home/runner/work/gpud/gpud/components/accelerator/nvidia/processes/component.go:81 +0x4f3
github.com/leptonai/gpud/pkg/gpud-metrics.(*WatchableComponentStruct).States(0xc0014a1230, {0x1e1bdc0?, 0xc002072960?})
        /home/runner/work/gpud/gpud/pkg/gpud-metrics/metrics.go:135 +0x42
github.com/leptonai/gpud/pkg/session.(*Session).getStatesFromComponent(0x1e1be30?, {0x1e1bdc0, 0xc002072960}, {0x1b514ca, 0x1c}, 0x0)
        /home/runner/work/gpud/gpud/pkg/session/serve.go:432 +0x18b
```

Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
