### PR TITLE
fix(metrics/state): fix select query on empty secondaryName

### DIFF
--- a/pkg/gpud-metrics/state/state.go
+++ b/pkg/gpud-metrics/state/state.go
@@ -5,10 +5,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os/exec"
 	"time"
 
-	"github.com/leptonai/gpud/pkg/sqlite"
 	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/leptonai/gpud/pkg/log"
+	"github.com/leptonai/gpud/pkg/sqlite"
 )
 
 type Metric struct {
@@ -262,9 +265,17 @@ WHERE %s = ? AND %s >= ?`,
 	defer func() {
 		rerr := recover()
 		if rerr != nil {
-			fmt.Println("panic", rerr)
-			fmt.Println("query", query)
-			fmt.Println("args", args)
+			log.Logger.Infow("panic recovered", "error", rerr)
+			log.Logger.Infow("query", "query", query)
+			log.Logger.Infow("args", "args", args)
+
+			// print "go env" output
+			out, err := exec.Command("go", "env").Output()
+			if err != nil {
+				log.Logger.Infow("error", "error", err)
+			} else {
+				log.Logger.Infow("go env", "output", string(out))
+			}
 		}
 	}()
 

--- a/pkg/gpud-metrics/state/state.go
+++ b/pkg/gpud-metrics/state/state.go
@@ -5,12 +5,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"os/exec"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 
-	"github.com/leptonai/gpud/pkg/log"
 	"github.com/leptonai/gpud/pkg/sqlite"
 )
 
@@ -261,23 +259,6 @@ WHERE %s = ? AND %s >= ?`,
 		query += fmt.Sprintf(` AND %s = ?`, ColumnMetricSecondaryName)
 		args = append(args, secondaryName)
 	}
-
-	defer func() {
-		rerr := recover()
-		if rerr != nil {
-			log.Logger.Infow("panic recovered", "error", rerr)
-			log.Logger.Infow("query", "query", query)
-			log.Logger.Infow("args", "args", args)
-
-			// print "go env" output
-			out, err := exec.Command("go", "env").Output()
-			if err != nil {
-				log.Logger.Infow("error", "error", err)
-			} else {
-				log.Logger.Infow("go env", "output", string(out))
-			}
-		}
-	}()
 
 	start := time.Now()
 	var avg sql.NullFloat64


### PR DESCRIPTION
To help debug:

```
unexpected fault address 0x630ccf4982166
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x1 addr=0x630ccf4982166 pc=0x4247c1]

goroutine 318 gp=0xc0006848c0 m=8 mp=0xc000600008 [running]:
runtime.throw({0x1b1dbc5?, 0x79ff8aa98a68?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/panic.go:1067 +0x48 fp=0xc002e4b0a0 sp=0xc002e4b070 pc=0x48bac8
runtime.sigpanic()
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/signal_unix.go:931 +0x26c fp=0xc002e4b100 sp=0xc002e4b0a0 pc=0x48dd6c
runtime.buildTypeAssertCache.func1(...)
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/iface.go:532
runtime.buildTypeAssertCache(0x18e8180?, 0x18e8400, 0x79ff4334d228)
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/iface.go:544 +0x141 fp=0xc002e4b148 sp=0xc002e4b100 pc=0x4247c1
runtime.typeAssert(0x2add7e0, 0x18e8400?)
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/iface.go:497 +0xfd fp=0xc002e4b188 sp=0xc002e4b148 pc=0x4245bd
database/sql.convertAssignRows({0x18e8400, 0xc001b17880}, {0x1815ae0, 0xc001b178a0}, 0xc000898d20)
        /opt/hostedtoolcache/go/1.23.6/x64/src/database/sql/convert.go:395 +0x1f0e fp=0xc002e4b440 sp=0xc002e4b188 pc=0xaeabce
database/sql.(*Rows).Scan(0xc000898d20, {0xc002e4b658, 0x1, 0xc002e4b518?})
        /opt/hostedtoolcache/go/1.23.6/x64/src/database/sql/sql.go:3392 +0x39a fp=0xc002e4b520 sp=0xc002e4b440 pc=0xafb29a
database/sql.(*Row).Scan(0xc002e4b610, {0xc002e4b658?, 0xc001d8d030?, 0x1})
        /opt/hostedtoolcache/go/1.23.6/x64/src/database/sql/sql.go:3509 +0x132 fp=0xc002e4b590 sp=0xc002e4b520 pc=0xafb972
github.com/leptonai/gpud/pkg/gpud-metrics/state.AvgSince({0x1e1fbf0, 0xc001d8d030}, 0xc000994b60, {0x1b3e7a4?, 0xc0015503d0?}, {0x1b68c5d, 0x24}, {0xc000639230, 0x28}, {0x1f294da0, ...})
        /home/runner/work/gpud/gpud/pkg/gpud-metrics/state/state.go:260 +0x30d fp=0xc002e4b6d0 sp=0xc002e4b590 pc=0xc2f94d
github.com/leptonai/gpud/pkg/gpud-metrics.(*continuousAverager).Avg(0xc001db2320, {0x1e1fbf0, 0xc001d8d030}, {0xc0015503d0, 0x2, 0x2})
        /home/runner/work/gpud/gpud/pkg/gpud-metrics/averager.go:144 +0xd0 fp=0xc002e4b748 sp=0xc002e4b6d0 pc=0xcb1fb0
github.com/leptonai/gpud/pkg/nvidia-query/metrics/memory.SetUsedBytes({0x1e1fbf0, 0xc001d8d030}, {0xc000639230, 0x28}, 0x4233222a00000000, {0xc001d8d030?, 0x0?, 0x0?})
        /home/runner/work/gpud/gpud/pkg/nvidia-query/metrics/memory/metrics.go:156 +0x3aa fp=0xc002e4b848 sp=0xc002e4b748 pc=0xced78a
github.com/leptonai/gpud/pkg/nvidia-query.setMemoryMetrics({0x1e1fbf0, 0xc001d8d030}, 0xc0029f9c08, {0xc0005208a0?, 0xff?, 0x0?}, 0xc002106f00)
        /home/runner/work/gpud/gpud/pkg/nvidia-query/query.go:489 +0x168 fp=0xc002e4b948 sp=0xc002e4b848 pc=0xcfcf68
github.com/leptonai/gpud/pkg/nvidia-query.setMetricsForDevice({0x1e1fbf0, 0xc001d8d030}, 0xc0029f9c08, {0xc0005208a0?, 0xff?, 0x0?}, 0xc002106f00)
        /home/runner/work/gpud/gpud/pkg/nvidia-query/query.go:418 +0x2a7 fp=0xc002e4ba48 sp=0xc002e4b948 pc=0xcfc767
github.com/leptonai/gpud/pkg/nvidia-query.Get({0x1e1fbf0, 0xc001d8d030}, {0xc000012e88, 0x3, 0x0?})
        /home/runner/work/gpud/gpud/pkg/nvidia-query/query.go:175 +0xd98 fp=0xc002e4bd28 sp=0xc002e4ba48 pc=0xcfa898
github.com/leptonai/gpud/pkg/nvidia-query.SetDefaultPoller.func1.CreateGet.1({0x1e1fbf0?, 0xc001d8d030?})
        /home/runner/work/gpud/gpud/pkg/nvidia-query/query.go:76 +0x29 fp=0xc002e4bd60 sp=0xc002e4bd28 pc=0xcf9ac9
github.com/leptonai/gpud/pkg/query.pollLoops({0x1e1fb80, 0xc00052c910}, {0x1b42cff, 0x14}, 0xc0006f8000, 0xdf8475800, 0x61c9f36800, 0xc0005231c0, 0x1c40d30)
        /home/runner/work/gpud/gpud/pkg/query/poller.go:154 +0x242 fp=0xc002e4bf88 sp=0xc002e4bd60 pc=0xcde182
github.com/leptonai/gpud/pkg/query.startPoll.gowrap1()
        /home/runner/work/gpud/gpud/pkg/query/poller.go:118 +0x45 fp=0xc002e4bfe0 sp=0xc002e4bf88 pc=0xcddf05
runtime.goexit({})
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/asm_amd64.s:1700 +0x1 fp=0xc002e4bfe8 sp=0xc002e4bfe0 pc=0x494361
created by github.com/leptonai/gpud/pkg/query.startPoll in goroutine 1
        /home/runner/work/gpud/gpud/pkg/query/poller.go:118 +0xf8

goroutine 1 gp=0xc0000061c0 m=nil [chan receive, 27 minutes]:
runtime.gopark(0x13?, 0x1?, 0xa8?, 0x36?, 0x2217a90?)
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/proc.go:424 +0xce fp=0xc003167590 sp=0xc003167570 pc=0x48bbee
runtime.chanrecv(0xc0005687e0, 0x0, 0x1)
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/chan.go:639 +0x41c fp=0xc003167608 sp=0xc003167590 pc=0x41fbbc
runtime.chanrecv1(0xc0035a3748?, 0x2?)
        /opt/hostedtoolcache/go/1.23.6/x64/src/runtime/chan.go:489 +0x12 fp=0xc003167630 sp=0xc003167608 pc=0x41f772
github.com/leptonai/gpud/cmd/gpud/command.cmdRun(0xc0002fa6e0)
        /home/runner/work/gpud/gpud/cmd/gpud/command/run.go:126 +0x7fa fp=0xc0031677f0 sp=0xc003167630 pc=0x16337ba
github.com/urfave/cli.HandleAction({0x18446e0?, 0x1c405d0?}, 0x3?)
        /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.15/app.go:524 +0x50 fp=0xc003167808 sp=0xc0031677f0 pc=0x5c0ef0
github.com/urfave/cli.Command.Run({{0x1b1b9ab, 0x3}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0x1bad941, 0x4a}, {0x0, ...}, ...}, ...)
        /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.15/command.go:175 +0x67c fp=0xc003167a40 sp=0xc003167808 pc=0x5c1cdc
github.com/urfave/cli.(*App).Run(0xc000704a80, {0xc000040050, 0x5, 0x5})
        /home/runner/go/pkg/mod/github.com/urfave/cli@v1.22.15/app.go:277 +0xb3b fp=0xc003167ef8 sp=0xc003167a40 pc=0x5beb9b
main.main()

```

Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
