### PR TITLE
feat(nvidia): remove "github.com/NVIDIA/go-nvlib/pkg/nvlib/device" usage

### DIFF
--- a/components/accelerator/nvidia/remapped-rows/component.go
+++ b/components/accelerator/nvidia/remapped-rows/component.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	go_nvml "github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/prometheus/client_golang/prometheus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -35,7 +35,7 @@ type component struct {
 	eventBucket  eventstore.Bucket
 	gatherer     prometheus.Gatherer
 
-	getRemappedRowsFunc func(uuid string, dev device.Device) (nvml.RemappedRows, error)
+	getRemappedRowsFunc func(uuid string, dev go_nvml.Device) (nvml.RemappedRows, error)
 
 	lastMu   sync.RWMutex
 	lastData *Data

--- a/components/accelerator/nvidia/remapped-rows/component_test.go
+++ b/components/accelerator/nvidia/remapped-rows/component_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	go_nvml "github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,7 +25,7 @@ import (
 type mockNVMLInstance struct {
 	productName                       string
 	memoryErrorManagementCapabilities nvml.MemoryErrorManagementCapabilities
-	devices                           map[string]device.Device
+	devices                           map[string]go_nvml.Device
 }
 
 func (m *mockNVMLInstance) Library() lib.Library {
@@ -44,7 +44,7 @@ func (m *mockNVMLInstance) GetMemoryErrorManagementCapabilities() nvml.MemoryErr
 	return m.memoryErrorManagementCapabilities
 }
 
-func (m *mockNVMLInstance) Devices() map[string]device.Device {
+func (m *mockNVMLInstance) Devices() map[string]go_nvml.Device {
 	return m.devices
 }
 
@@ -113,7 +113,7 @@ func createMockNVMLInstance() *mockNVMLInstance {
 		memoryErrorManagementCapabilities: nvml.MemoryErrorManagementCapabilities{
 			RowRemapping: true,
 		},
-		devices: make(map[string]device.Device),
+		devices: make(map[string]go_nvml.Device),
 	}
 }
 
@@ -397,7 +397,7 @@ func TestCheckOnceEventsGeneratedAndPersisted(t *testing.T) {
 		memoryErrorManagementCapabilities: nvml.MemoryErrorManagementCapabilities{
 			RowRemapping: true,
 		},
-		devices: map[string]device.Device{
+		devices: map[string]go_nvml.Device{
 			"GPU1": nil, // We don't use the actual device in our test
 			"GPU2": nil,
 			"GPU3": nil,
@@ -416,7 +416,7 @@ func TestCheckOnceEventsGeneratedAndPersisted(t *testing.T) {
 
 	// Get the underlying component to modify getRemappedRowsFunc
 	c := comp.(*component)
-	c.getRemappedRowsFunc = func(uuid string, dev device.Device) (nvml.RemappedRows, error) {
+	c.getRemappedRowsFunc = func(uuid string, dev go_nvml.Device) (nvml.RemappedRows, error) {
 		switch uuid {
 		case "GPU1":
 			// Healthy GPU - no events expected
@@ -513,7 +513,7 @@ func TestCheckOnceWithNVMLError(t *testing.T) {
 		memoryErrorManagementCapabilities: nvml.MemoryErrorManagementCapabilities{
 			RowRemapping: true,
 		},
-		devices: map[string]device.Device{
+		devices: map[string]go_nvml.Device{
 			"GPU1": nil,
 		},
 	}
@@ -531,7 +531,7 @@ func TestCheckOnceWithNVMLError(t *testing.T) {
 	// Override getRemappedRowsFunc to return an error
 	c := comp.(*component)
 	expectedErr := errors.New("nvml error")
-	c.getRemappedRowsFunc = func(uuid string, dev device.Device) (nvml.RemappedRows, error) {
+	c.getRemappedRowsFunc = func(uuid string, dev go_nvml.Device) (nvml.RemappedRows, error) {
 		return nvml.RemappedRows{}, expectedErr
 	}
 

--- a/pkg/nvidia-query/nvml/clock_events.go
+++ b/pkg/nvidia-query/nvml/clock_events.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -30,7 +29,7 @@ func ClockEventsSupported() (bool, error) {
 
 	// "NVIDIA Xid 79: GPU has fallen off the bus" may fail this syscall with:
 	// "error getting device handle for index '6': Unknown Error"
-	devices, err := nvmlLib.Device().GetDevices()
+	devices, err := nvmlLib.GetDevices()
 	if err != nil {
 		return false, err
 	}
@@ -55,7 +54,7 @@ func ClockEventsSupported() (bool, error) {
 }
 
 // Returns true if clock events is supported by this device.
-func ClockEventsSupportedByDevice(dev device.Device) (bool, error) {
+func ClockEventsSupportedByDevice(dev nvml.Device) (bool, error) {
 	// clock events are supported in versions 535 and above
 	// otherwise, CGO call just exits with
 	// undefined symbol: nvmlDeviceGetCurrentClocksEventReasons
@@ -123,7 +122,7 @@ func (evs *ClockEvents) YAML() ([]byte, error) {
 	return yaml.Marshal(evs)
 }
 
-func GetClockEvents(uuid string, dev device.Device) (ClockEvents, error) {
+func GetClockEvents(uuid string, dev nvml.Device) (ClockEvents, error) {
 	clockEvents := ClockEvents{
 		Time:      metav1.Time{Time: time.Now().UTC()},
 		UUID:      uuid,

--- a/pkg/nvidia-query/nvml/clock_events_test.go
+++ b/pkg/nvidia-query/nvml/clock_events_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	"github.com/stretchr/testify/assert"
@@ -379,7 +378,7 @@ func TestClockEventsSupported(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create mock devices
-			mockDevices := make([]device.Device, len(tt.mockDevices))
+			mockDevices := make([]nvml.Device, len(tt.mockDevices))
 			for i, d := range tt.mockDevices {
 				mockDevices[i] = d
 			}

--- a/pkg/nvidia-query/nvml/clock_speed.go
+++ b/pkg/nvidia-query/nvml/clock_speed.go
@@ -3,7 +3,6 @@ package nvml
 import (
 	"fmt"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
 
@@ -24,7 +23,7 @@ type ClockSpeed struct {
 	ClockMemorySupported bool `json:"clock_memory_supported"`
 }
 
-func GetClockSpeed(uuid string, dev device.Device) (ClockSpeed, error) {
+func GetClockSpeed(uuid string, dev nvml.Device) (ClockSpeed, error) {
 	clockSpeed := ClockSpeed{
 		UUID: uuid,
 	}

--- a/pkg/nvidia-query/nvml/ecc_errors.go
+++ b/pkg/nvidia-query/nvml/ecc_errors.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/leptonai/gpud/pkg/log"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"sigs.k8s.io/yaml"
 )
@@ -128,7 +127,7 @@ func (allCounts AllECCErrorCounts) FindUncorrectedErrs() []string {
 	return errs
 }
 
-func GetECCErrors(uuid string, dev device.Device, eccModeEnabledCurrent bool) (ECCErrors, error) {
+func GetECCErrors(uuid string, dev nvml.Device, eccModeEnabledCurrent bool) (ECCErrors, error) {
 	result := ECCErrors{
 		UUID:      uuid,
 		Aggregate: AllECCErrorCounts{},

--- a/pkg/nvidia-query/nvml/ecc_errors_test.go
+++ b/pkg/nvidia-query/nvml/ecc_errors_test.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	"github.com/stretchr/testify/assert"
@@ -20,7 +19,7 @@ func createECCErrorsDevice(
 	totalECCUncorrected uint64,
 	totalECCRet nvml.Return,
 	memoryErrorRet nvml.Return,
-) device.Device {
+) nvml.Device {
 	mockDevice := &mock.Device{
 		GetTotalEccErrorsFunc: func(errorType nvml.MemoryErrorType, counterType nvml.EccCounterType) (uint64, nvml.Return) {
 			if totalECCRet != nvml.SUCCESS {

--- a/pkg/nvidia-query/nvml/ecc_mode.go
+++ b/pkg/nvidia-query/nvml/ecc_mode.go
@@ -3,7 +3,6 @@ package nvml
 import (
 	"fmt"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
 
@@ -22,7 +21,7 @@ type ECCMode struct {
 
 // Returns the current and pending ECC modes.
 // "pending" ECC mode refers to the target mode following the next reboot.
-func GetECCModeEnabled(uuid string, dev device.Device) (ECCMode, error) {
+func GetECCModeEnabled(uuid string, dev nvml.Device) (ECCMode, error) {
 	result := ECCMode{
 		UUID:      uuid,
 		Supported: true,

--- a/pkg/nvidia-query/nvml/gpm.go
+++ b/pkg/nvidia-query/nvml/gpm.go
@@ -10,7 +10,6 @@ import (
 	metrics_gpm "github.com/leptonai/gpud/pkg/nvidia-query/metrics/gpm"
 	nvml_lib "github.com/leptonai/gpud/pkg/nvidia-query/nvml/lib"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -27,7 +26,7 @@ func GPMSupported() (bool, error) {
 
 	// "NVIDIA Xid 79: GPU has fallen off the bus" may fail this syscall with:
 	// "error getting device handle for index '6': Unknown Error"
-	devices, err := nvmlLib.Device().GetDevices()
+	devices, err := nvmlLib.GetDevices()
 	if err != nil {
 		return false, err
 	}
@@ -54,7 +53,7 @@ func (ev *GPMEvent) YAML() ([]byte, error) {
 	return yaml.Marshal(ev)
 }
 
-func GPMSupportedByDevice(dev device.Device) (bool, error) {
+func GPMSupportedByDevice(dev nvml.Device) (bool, error) {
 	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlGpmFunctions.html#group__nvmlGpmFunctions_1gdfd08d875be65f0532201913da9b8890
 	gpuQuerySupport, ret := dev.GpmQueryDeviceSupport()
 
@@ -199,7 +198,7 @@ func (inst *instance) collectGPMMetrics() ([]GPMMetrics, error) {
 // It "SIGSEGV: segmentation violation" in cgo execution.
 // Returns nil if it's not supported.
 // ref. https://github.com/NVIDIA/go-nvml/blob/main/examples/gpm-metrics/main.go
-func GetGPMMetrics(ctx context.Context, dev device.Device, metricIDs ...nvml.GpmMetricId) (map[nvml.GpmMetricId]float64, error) {
+func GetGPMMetrics(ctx context.Context, dev nvml.Device, metricIDs ...nvml.GpmMetricId) (map[nvml.GpmMetricId]float64, error) {
 	if len(metricIDs) == 0 {
 		return nil, fmt.Errorf("no metric IDs provided")
 	}

--- a/pkg/nvidia-query/nvml/gsp_firmware.go
+++ b/pkg/nvidia-query/nvml/gsp_firmware.go
@@ -3,7 +3,6 @@ package nvml
 import (
 	"fmt"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
 
@@ -16,7 +15,7 @@ type GSPFirmwareMode struct {
 	Supported bool   `json:"supported"`
 }
 
-func GetGSPFirmwareMode(uuid string, dev device.Device) (GSPFirmwareMode, error) {
+func GetGSPFirmwareMode(uuid string, dev nvml.Device) (GSPFirmwareMode, error) {
 	mode := GSPFirmwareMode{
 		UUID: uuid,
 	}

--- a/pkg/nvidia-query/nvml/instance.go
+++ b/pkg/nvidia-query/nvml/instance.go
@@ -3,7 +3,6 @@ package nvml
 import (
 	"fmt"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
 	"github.com/leptonai/gpud/pkg/log"
@@ -15,7 +14,7 @@ var _ InstanceV2 = &instanceV2{}
 type InstanceV2 interface {
 	NVMLExists() bool
 	Library() nvml_lib.Library
-	Devices() map[string]device.Device
+	Devices() map[string]nvml.Device
 	ProductName() string
 	GetMemoryErrorManagementCapabilities() MemoryErrorManagementCapabilities
 	Shutdown() error
@@ -59,14 +58,14 @@ func NewInstanceV2() (InstanceV2, error) {
 
 	// "NVIDIA Xid 79: GPU has fallen off the bus" may fail this syscall with:
 	// "error getting device handle for index '6': Unknown Error"
-	devices, err := nvmlLib.Device().GetDevices()
+	devices, err := nvmlLib.GetDevices()
 	if err != nil {
 		return nil, err
 	}
 	log.Logger.Infow("got devices from device library", "numDevices", len(devices))
 
 	productName := ""
-	dm := make(map[string]device.Device)
+	dm := make(map[string]nvml.Device)
 	if len(devices) > 0 {
 		name, ret := devices[0].GetName()
 		if ret != nvml.SUCCESS {
@@ -107,7 +106,7 @@ type instanceV2 struct {
 	driverMajor   int
 	cudaVersion   string
 
-	devices map[string]device.Device
+	devices map[string]nvml.Device
 
 	productName string
 	memMgmtCaps MemoryErrorManagementCapabilities
@@ -121,7 +120,7 @@ func (inst *instanceV2) Library() nvml_lib.Library {
 	return inst.nvmlLib
 }
 
-func (inst *instanceV2) Devices() map[string]device.Device {
+func (inst *instanceV2) Devices() map[string]nvml.Device {
 	return inst.devices
 }
 

--- a/pkg/nvidia-query/nvml/lib/default.go
+++ b/pkg/nvidia-query/nvml/lib/default.go
@@ -26,7 +26,7 @@ const (
 
 var clockEventsToInjectHwSlowdown = reasonHWSlowdown | reasonSwThermalSlowdown | reasonHWSlowdownThermal | reasonHWSlowdownPowerBrake
 
-func NewDefault() Library {
+func NewDefault(options ...OpOption) Library {
 	opts := []OpOption{}
 
 	if os.Getenv(EnvMockAllSuccess) == "true" {
@@ -54,5 +54,5 @@ func NewDefault() Library {
 		)
 	}
 
-	return New(opts...)
+	return New(append(opts, options...)...)
 }

--- a/pkg/nvidia-query/nvml/lib/default_test.go
+++ b/pkg/nvidia-query/nvml/lib/default_test.go
@@ -22,32 +22,6 @@ func TestNewDefaultNoEnvVars(t *testing.T) {
 	// Verify the library instance is created with default options
 	assert.NotNil(t, lib)
 	assert.NotNil(t, lib.NVML())
-	assert.NotNil(t, lib.Device())
-}
-
-// TestNewDefaultMockAllSuccess tests the NewDefault function when EnvMockAllSuccess is set
-func TestNewDefaultMockAllSuccess(t *testing.T) {
-	// Clean up environment variables first
-	cleanupEnvVars()
-	defer cleanupEnvVars()
-
-	// Set the environment variable
-	os.Setenv(EnvMockAllSuccess, "true")
-
-	// Create a new library instance
-	lib := NewDefault()
-
-	// Verify the library instance is created with mock interface
-	assert.NotNil(t, lib)
-
-	// Test that NVML functions succeed
-	ret := lib.NVML().Init()
-	assert.Equal(t, nvml.SUCCESS, ret)
-
-	// Test that device functions are available and succeed
-	devices, err := lib.Device().GetDevices()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, devices)
 }
 
 // TestNewDefaultMultipleEnvVars tests the NewDefault function when multiple environment variables are set
@@ -72,7 +46,7 @@ func TestNewDefaultMultipleEnvVars(t *testing.T) {
 	assert.Equal(t, nvml.SUCCESS, ret)
 
 	// Get devices to test modified functions
-	devices, err := lib.Device().GetDevices()
+	devices, err := lib.GetDevices()
 	require.NoError(t, err)
 	require.NotEmpty(t, devices)
 

--- a/pkg/nvidia-query/nvml/lib/options.go
+++ b/pkg/nvidia-query/nvml/lib/options.go
@@ -1,7 +1,6 @@
 package lib
 
 import (
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	nvinfo "github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
@@ -11,7 +10,6 @@ type Op struct {
 
 	initReturn        *nvml.Return
 	propertyExtractor nvinfo.PropertyExtractor
-	devicesToReturn   []device.Device
 
 	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g055e7c34f7f15b6ae9aac1dabd60870d
 	devGetRemappedRowsForAllDevs func() (corrRows int, uncRows int, isPending bool, failureOccurred bool, ret nvml.Return)
@@ -51,12 +49,6 @@ func WithInitReturn(initReturn nvml.Return) OpOption {
 func WithPropertyExtractor(propertyExtractor nvinfo.PropertyExtractor) OpOption {
 	return func(op *Op) {
 		op.propertyExtractor = propertyExtractor
-	}
-}
-
-func WithDevice(dev device.Device) OpOption {
-	return func(op *Op) {
-		op.devicesToReturn = append(op.devicesToReturn, dev)
 	}
 }
 

--- a/pkg/nvidia-query/nvml/lib/options_test.go
+++ b/pkg/nvidia-query/nvml/lib/options_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/leptonai/gpud/pkg/nvidia-query/nvml/testutil"
 )
 
 // TestApplyOptsDefault tests the default behavior of applyOpts when no options are provided
@@ -69,30 +67,6 @@ func TestWithPropertyExtractor(t *testing.T) {
 	assert.Equal(t, mockExtractor, op.propertyExtractor, "propertyExtractor should be set to the provided mock")
 }
 
-// TestWithDevice tests that WithDevice correctly adds to the devicesToReturn slice
-func TestWithDevice(t *testing.T) {
-	// Create a mock Device using testutil
-	mockDevice := testutil.NewMockDevice(&mock.Device{}, "test-arch", "test-brand", "test-cuda", "test-pci")
-
-	// Create an empty Op
-	op := &Op{}
-
-	// Apply the WithDevice option
-	op.applyOpts([]OpOption{WithDevice(mockDevice)})
-
-	// Verify that devicesToReturn contains our mock device
-	assert.Len(t, op.devicesToReturn, 1, "devicesToReturn should have one device")
-	assert.Equal(t, mockDevice, op.devicesToReturn[0], "devicesToReturn should contain the provided device")
-
-	// Add another device and verify both are present
-	mockDevice2 := testutil.NewMockDevice(&mock.Device{}, "test-arch2", "test-brand2", "test-cuda2", "test-pci2")
-	op.applyOpts([]OpOption{WithDevice(mockDevice2)})
-
-	assert.Len(t, op.devicesToReturn, 2, "devicesToReturn should have two devices")
-	assert.Equal(t, mockDevice, op.devicesToReturn[0], "First device should still be present")
-	assert.Equal(t, mockDevice2, op.devicesToReturn[1], "Second device should be added")
-}
-
 // TestWithDeviceGetRemappedRowsForAllDevs tests that WithDeviceGetRemappedRowsForAllDevs correctly sets the function
 func TestWithDeviceGetRemappedRowsForAllDevs(t *testing.T) {
 	// Create a test function
@@ -145,7 +119,6 @@ func TestMultipleOptions(t *testing.T) {
 	// Create mocks and test values
 	mockNVML := &mock.Interface{}
 	mockExtractor := &nvinfo.PropertyExtractorMock{}
-	mockDevice := testutil.NewMockDevice(&mock.Device{}, "test-arch", "test-brand", "test-cuda", "test-pci")
 	testReturn := nvml.ERROR_UNKNOWN
 
 	// Create test functions
@@ -165,7 +138,6 @@ func TestMultipleOptions(t *testing.T) {
 		WithNVML(mockNVML),
 		WithInitReturn(testReturn),
 		WithPropertyExtractor(mockExtractor),
-		WithDevice(mockDevice),
 		WithDeviceGetRemappedRowsForAllDevs(remappedRowsFunc),
 		WithDeviceGetCurrentClocksEventReasonsForAllDevs(clockEventsFunc),
 	})
@@ -175,8 +147,6 @@ func TestMultipleOptions(t *testing.T) {
 	assert.NotNil(t, op.initReturn, "initReturn should not be nil")
 	assert.Equal(t, testReturn, *op.initReturn, "initReturn should be set correctly")
 	assert.Equal(t, mockExtractor, op.propertyExtractor, "propertyExtractor should be set correctly")
-	assert.Len(t, op.devicesToReturn, 1, "devicesToReturn should have one device")
-	assert.Equal(t, mockDevice, op.devicesToReturn[0], "devicesToReturn should contain the provided device")
 	assert.NotNil(t, op.devGetRemappedRowsForAllDevs, "devGetRemappedRowsForAllDevs should be set")
 	assert.NotNil(t, op.devGetCurrentClocksEventReasonsForAllDevs, "devGetCurrentClocksEventReasonsForAllDevs should be set")
 

--- a/pkg/nvidia-query/nvml/memory.go
+++ b/pkg/nvidia-query/nvml/memory.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/dustin/go-humanize"
 )
@@ -35,7 +34,7 @@ func (mem Memory) GetUsedPercent() (float64, error) {
 	return strconv.ParseFloat(mem.UsedPercent, 64)
 }
 
-func GetMemory(uuid string, dev device.Device) (Memory, error) {
+func GetMemory(uuid string, dev nvml.Device) (Memory, error) {
 	mem := Memory{
 		UUID:      uuid,
 		Supported: true,

--- a/pkg/nvidia-query/nvml/nvlink.go
+++ b/pkg/nvidia-query/nvml/nvlink.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/leptonai/gpud/pkg/log"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
 
@@ -91,7 +90,7 @@ type NVLinkState struct {
 }
 
 // Queries the nvlink information.
-func GetNVLink(uuid string, dev device.Device) (NVLink, error) {
+func GetNVLink(uuid string, dev nvml.Device) (NVLink, error) {
 	nvlink := NVLink{
 		UUID:      uuid,
 		Supported: true,

--- a/pkg/nvidia-query/nvml/nvlink_test.go
+++ b/pkg/nvidia-query/nvml/nvlink_test.go
@@ -3,14 +3,13 @@ package nvml
 import (
 	"testing"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/assert"
 )
 
 // Mock device implementation
 type mockDevice struct {
-	device.Device
+	nvml.Device
 	nvLinkState           nvml.EnableState
 	nvLinkStateErr        nvml.Return
 	replayErrors          uint64

--- a/pkg/nvidia-query/nvml/persistence_mode.go
+++ b/pkg/nvidia-query/nvml/persistence_mode.go
@@ -3,7 +3,6 @@ package nvml
 import (
 	"fmt"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
 
@@ -29,7 +28,7 @@ type PersistenceMode struct {
 	Supported bool `json:"supported"`
 }
 
-func GetPersistenceMode(uuid string, dev device.Device) (PersistenceMode, error) {
+func GetPersistenceMode(uuid string, dev nvml.Device) (PersistenceMode, error) {
 	mode := PersistenceMode{
 		UUID:      uuid,
 		Supported: true,

--- a/pkg/nvidia-query/nvml/power.go
+++ b/pkg/nvidia-query/nvml/power.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
 
@@ -27,7 +26,7 @@ func (power Power) GetUsedPercent() (float64, error) {
 	return strconv.ParseFloat(power.UsedPercent, 64)
 }
 
-func GetPower(uuid string, dev device.Device) (Power, error) {
+func GetPower(uuid string, dev nvml.Device) (Power, error) {
 	power := Power{
 		UUID: uuid,
 	}

--- a/pkg/nvidia-query/nvml/power_test.go
+++ b/pkg/nvidia-query/nvml/power_test.go
@@ -3,7 +3,6 @@ package nvml
 import (
 	"testing"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	"github.com/stretchr/testify/assert"
@@ -191,7 +190,7 @@ func TestGetPower(t *testing.T) {
 }
 
 func TestGetPowerWithNilDevice(t *testing.T) {
-	var nilDevice device.Device = nil
+	var nilDevice nvml.Device = nil
 	testUUID := "GPU-NILTEST"
 
 	// We expect the function to panic with a nil device

--- a/pkg/nvidia-query/nvml/processes.go
+++ b/pkg/nvidia-query/nvml/processes.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/dustin/go-humanize"
 	"github.com/shirou/gopsutil/v4/process"
@@ -64,7 +63,7 @@ func (procs *Processes) YAML() ([]byte, error) {
 	return yaml.Marshal(procs)
 }
 
-func GetProcesses(uuid string, dev device.Device) (Processes, error) {
+func GetProcesses(uuid string, dev nvml.Device) (Processes, error) {
 	procs := Processes{
 		UUID:                                uuid,
 		GetComputeRunningProcessesSupported: true,

--- a/pkg/nvidia-query/nvml/processes_test.go
+++ b/pkg/nvidia-query/nvml/processes_test.go
@@ -3,13 +3,13 @@ package nvml
 import (
 	"testing"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetProcessesWithNilDevice(t *testing.T) {
-	var nilDevice device.Device = nil
+	var nilDevice nvml.Device = nil
 	testUUID := "GPU-NILTEST"
 
 	// We expect the function to panic with a nil device

--- a/pkg/nvidia-query/nvml/remapped_rows.go
+++ b/pkg/nvidia-query/nvml/remapped_rows.go
@@ -3,7 +3,6 @@ package nvml
 import (
 	"fmt"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
 	"github.com/leptonai/gpud/pkg/log"
@@ -42,7 +41,7 @@ type RemappedRows struct {
 	Supported bool `json:"supported"`
 }
 
-func GetRemappedRows(uuid string, dev device.Device) (RemappedRows, error) {
+func GetRemappedRows(uuid string, dev nvml.Device) (RemappedRows, error) {
 	remRws := RemappedRows{
 		UUID:      uuid,
 		Supported: true,

--- a/pkg/nvidia-query/nvml/remapped_rows_test.go
+++ b/pkg/nvidia-query/nvml/remapped_rows_test.go
@@ -3,7 +3,6 @@ package nvml
 import (
 	"testing"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	"github.com/stretchr/testify/assert"
@@ -205,7 +204,7 @@ func TestGetRemappedRows(t *testing.T) {
 }
 
 func TestGetRemappedRowsWithNilDevice(t *testing.T) {
-	var nilDevice device.Device = nil
+	var nilDevice nvml.Device = nil
 	testUUID := "GPU-NILTEST"
 
 	// We expect the function to panic with a nil device

--- a/pkg/nvidia-query/nvml/temperature.go
+++ b/pkg/nvidia-query/nvml/temperature.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
 	"github.com/leptonai/gpud/pkg/log"
@@ -47,7 +46,7 @@ func (temp Temperature) GetUsedPercentGPUMax() (float64, error) {
 	return strconv.ParseFloat(temp.UsedPercentGPUMax, 64)
 }
 
-func GetTemperature(uuid string, dev device.Device) (Temperature, error) {
+func GetTemperature(uuid string, dev nvml.Device) (Temperature, error) {
 	temp := Temperature{
 		UUID: uuid,
 	}

--- a/pkg/nvidia-query/nvml/temperature_test.go
+++ b/pkg/nvidia-query/nvml/temperature_test.go
@@ -3,7 +3,6 @@ package nvml
 import (
 	"testing"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	"github.com/stretchr/testify/assert"
@@ -319,7 +318,7 @@ func TestGetUsedPercentMethods(t *testing.T) {
 
 // TestGetTemperatureWithNilDevice tests the behavior of GetTemperature when passed a nil device.
 func TestGetTemperatureWithNilDevice(t *testing.T) {
-	var nilDevice device.Device = nil
+	var nilDevice nvml.Device = nil
 	testUUID := "GPU-NILTEST"
 
 	// We expect the function to panic with a nil device

--- a/pkg/nvidia-query/nvml/testutil/clock_speed.go
+++ b/pkg/nvidia-query/nvml/testutil/clock_speed.go
@@ -1,13 +1,12 @@
 package testutil
 
 import (
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 )
 
 // CreateClockSpeedDevice creates a new mock device specifically for clock speed testing
-func CreateClockSpeedDevice(graphicsClock uint32, graphicsClockRet nvml.Return, memClock uint32, memClockRet nvml.Return, uuid string) device.Device {
+func CreateClockSpeedDevice(graphicsClock uint32, graphicsClockRet nvml.Return, memClock uint32, memClockRet nvml.Return, uuid string) nvml.Device {
 	return &MockDevice{
 		Device: &mock.Device{
 			GetClockInfoFunc: func(clockType nvml.ClockType) (uint32, nvml.Return) {

--- a/pkg/nvidia-query/nvml/testutil/gpm.go
+++ b/pkg/nvidia-query/nvml/testutil/gpm.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 )
@@ -11,7 +10,7 @@ func CreateGPMSupportedDevice(
 	uuid string,
 	gpmDeviceSupport nvml.GpmSupport,
 	gpmDeviceSupportRet nvml.Return,
-) device.Device {
+) nvml.Device {
 	mockDevice := &mock.Device{
 		GpmQueryDeviceSupportFunc: func() (nvml.GpmSupport, nvml.Return) {
 			return gpmDeviceSupport, gpmDeviceSupportRet
@@ -28,7 +27,7 @@ func CreateGPMSupportedDevice(
 func CreateGPMSampleDevice(
 	uuid string,
 	sampleGetRet nvml.Return,
-) device.Device {
+) nvml.Device {
 	mockDevice := &mock.Device{
 		GpmQueryDeviceSupportFunc: func() (nvml.GpmSupport, nvml.Return) {
 			return nvml.GpmSupport{IsSupportedDevice: 1}, nvml.SUCCESS

--- a/pkg/nvidia-query/nvml/testutil/gsp_firmware.go
+++ b/pkg/nvidia-query/nvml/testutil/gsp_firmware.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 )
@@ -12,7 +11,7 @@ func CreateGSPFirmwareDevice(
 	gspEnabled bool,
 	gspSupported bool,
 	gspFirmwareRet nvml.Return,
-) device.Device {
+) nvml.Device {
 	mockDevice := &mock.Device{
 		GetGspFirmwareModeFunc: func() (bool, bool, nvml.Return) {
 			return gspEnabled, gspSupported, gspFirmwareRet

--- a/pkg/nvidia-query/nvml/testutil/memory.go
+++ b/pkg/nvidia-query/nvml/testutil/memory.go
@@ -1,13 +1,12 @@
 package testutil
 
 import (
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 )
 
 // CreateMemoryDevice creates a new mock device specifically for memory tests
-func CreateMemoryDevice(uuid string, memoryV2 nvml.Memory_v2, memoryV2Ret nvml.Return, memory nvml.Memory, memoryRet nvml.Return) device.Device {
+func CreateMemoryDevice(uuid string, memoryV2 nvml.Memory_v2, memoryV2Ret nvml.Return, memory nvml.Memory, memoryRet nvml.Return) nvml.Device {
 	mockDevice := &mock.Device{
 		GetMemoryInfo_v2Func: func() (nvml.Memory_v2, nvml.Return) {
 			return memoryV2, memoryV2Ret

--- a/pkg/nvidia-query/nvml/testutil/persistence_mode.go
+++ b/pkg/nvidia-query/nvml/testutil/persistence_mode.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 )
@@ -11,7 +10,7 @@ func CreatePersistenceModeDevice(
 	uuid string,
 	persistenceMode nvml.EnableState,
 	persistenceModeRet nvml.Return,
-) device.Device {
+) nvml.Device {
 	mockDevice := &mock.Device{
 		GetPersistenceModeFunc: func() (nvml.EnableState, nvml.Return) {
 			return persistenceMode, persistenceModeRet

--- a/pkg/nvidia-query/nvml/testutil/util.go
+++ b/pkg/nvidia-query/nvml/testutil/util.go
@@ -1,11 +1,11 @@
 package testutil
 
 import (
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 )
 
-var _ device.Device = (*MockDevice)(nil)
+var _ nvml.Device = (*MockDevice)(nil)
 
 type MockDevice struct {
 	*mock.Device
@@ -38,14 +38,6 @@ func (d *MockDevice) GetCudaComputeCapabilityAsString() (string, error) {
 	return d.CudaComputeCapability, nil
 }
 
-func (d *MockDevice) GetMigDevices() ([]device.MigDevice, error) {
-	return nil, nil
-}
-
-func (d *MockDevice) GetMigProfiles() ([]device.MigProfile, error) {
-	return nil, nil
-}
-
 func (d *MockDevice) GetPCIBusID() (string, error) {
 	return d.PCIBusID, nil
 }
@@ -60,12 +52,4 @@ func (d *MockDevice) IsMigCapable() (bool, error) {
 
 func (d *MockDevice) IsMigEnabled() (bool, error) {
 	return false, nil
-}
-
-func (d *MockDevice) VisitMigDevices(func(j int, m device.MigDevice) error) error {
-	return nil
-}
-
-func (d *MockDevice) VisitMigProfiles(func(p device.MigProfile) error) error {
-	return nil
 }

--- a/pkg/nvidia-query/nvml/testutil/util_test.go
+++ b/pkg/nvidia-query/nvml/testutil/util_test.go
@@ -79,15 +79,6 @@ func TestMockDevice(t *testing.T) {
 			assert.Equal(t, tt.uuid, uuid)
 			assert.Equal(t, nvml.SUCCESS, ret)
 
-			// Test MIG-related methods
-			migDevices, err := mockDevice.GetMigDevices()
-			assert.NoError(t, err)
-			assert.Empty(t, migDevices)
-
-			migProfiles, err := mockDevice.GetMigProfiles()
-			assert.NoError(t, err)
-			assert.Empty(t, migProfiles)
-
 			fabricAttached, err := mockDevice.IsFabricAttached()
 			assert.NoError(t, err)
 			assert.False(t, fabricAttached)
@@ -99,13 +90,6 @@ func TestMockDevice(t *testing.T) {
 			migEnabled, err := mockDevice.IsMigEnabled()
 			assert.NoError(t, err)
 			assert.False(t, migEnabled)
-
-			// Test visitor methods
-			err = mockDevice.VisitMigDevices(nil)
-			assert.NoError(t, err)
-
-			err = mockDevice.VisitMigProfiles(nil)
-			assert.NoError(t, err)
 		})
 	}
 }

--- a/pkg/nvidia-query/nvml/utilization.go
+++ b/pkg/nvidia-query/nvml/utilization.go
@@ -3,7 +3,6 @@ package nvml
 import (
 	"fmt"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
 
@@ -26,7 +25,7 @@ type Utilization struct {
 	Supported bool `json:"supported"`
 }
 
-func GetUtilization(uuid string, dev device.Device) (Utilization, error) {
+func GetUtilization(uuid string, dev nvml.Device) (Utilization, error) {
 	util := Utilization{
 		UUID:      uuid,
 		Supported: true,

--- a/pkg/nvidia-query/nvml/utilization_test.go
+++ b/pkg/nvidia-query/nvml/utilization_test.go
@@ -3,7 +3,6 @@ package nvml
 import (
 	"testing"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	"github.com/stretchr/testify/assert"
@@ -161,7 +160,7 @@ func TestUtilizationWithCustomMockDevice(t *testing.T) {
 // TestGetUtilizationWithNilDevice tests the behavior of GetUtilization when passed a nil device.
 // This is a defensive test to ensure proper error handling in case of nil devices.
 func TestGetUtilizationWithNilDevice(t *testing.T) {
-	var nilDevice device.Device = nil
+	var nilDevice nvml.Device = nil
 	testUUID := "GPU-NILTEST"
 
 	// We expect the function to panic with a nil device


### PR DESCRIPTION
@eahydra found that this code (relies on device lib) panics on certain VMs:

```
nvmlInterface := nvml.New()
ret := nvmlInterface.Init()
if ret != nvml.SUCCESS {
	panic(ret.String())
}
for {
	devLib := device.New(nvmlInterface)
	devices, err := devLib.GetDevices()
	if err != nil {
		panic(err)
	}

	for _, v := range devices {
		id, _ := v.GetUUID()
		fmt.Printf("process device %v\n", id)
		for link := 0; link < nvml.NVLINK_MAX_LINKS; link++ {
			values := []nvml.FieldValue{
				{FieldId: nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_RX}, // NVLink RX Data throughput + protocol overhead in KiB
				{FieldId: nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX}, // NVLink TX Data throughput + protocol overhead in KiB
			}
			ret = nvml.DeviceGetFieldValues(v, values)
			if ret == nvml.SUCCESS {
				for _, value := range values {
					if value.FieldId == nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX {
						fmt.Println(binary.NativeEndian.Uint64(value.Value[:]) * 1024)
					}
					if value.FieldId == nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_RX {
						fmt.Println(binary.NativeEndian.Uint64(value.Value[:]) * 1024)
					}
				}
			}
		}
	}

	time.Sleep(5 * time.Second)
}
```

Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
