### PR TITLE
fix: panic on special environments

### DIFF
--- a/components/accelerator/nvidia/nvlink/component.go
+++ b/components/accelerator/nvidia/nvlink/component.go
@@ -112,16 +112,8 @@ func (c *component) Metrics(ctx context.Context, since time.Time) ([]components.
 	if err != nil {
 		return nil, fmt.Errorf("failed to read crc errors: %w", err)
 	}
-	rxBytes, err := nvidia_query_metrics_nvlink.ReadRxBytes(ctx, since)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read rx bytes: %w", err)
-	}
-	txBytes, err := nvidia_query_metrics_nvlink.ReadTxBytes(ctx, since)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read tx bytes: %w", err)
-	}
 
-	ms := make([]components.Metric, 0, len(featureEnableds)+len(replayErrors)+len(recoveryErrors)+len(crcErrors)+len(rxBytes)+len(txBytes))
+	ms := make([]components.Metric, 0, len(featureEnableds)+len(replayErrors)+len(recoveryErrors)+len(crcErrors))
 	for _, m := range featureEnableds {
 		ms = append(ms, components.Metric{
 			Metric: m,
@@ -147,22 +139,6 @@ func (c *component) Metrics(ctx context.Context, since time.Time) ([]components.
 		})
 	}
 	for _, m := range crcErrors {
-		ms = append(ms, components.Metric{
-			Metric: m,
-			ExtraInfo: map[string]string{
-				"gpu_id": m.MetricSecondaryName,
-			},
-		})
-	}
-	for _, m := range rxBytes {
-		ms = append(ms, components.Metric{
-			Metric: m,
-			ExtraInfo: map[string]string{
-				"gpu_id": m.MetricSecondaryName,
-			},
-		})
-	}
-	for _, m := range txBytes {
 		ms = append(ms, components.Metric{
 			Metric: m,
 			ExtraInfo: map[string]string{

--- a/pkg/nvidia-query/metrics/nvlink/metrics.go
+++ b/pkg/nvidia-query/metrics/nvlink/metrics.go
@@ -67,46 +67,6 @@ var (
 		[]string{"gpu_id"},
 	)
 	crcErrorsAverager = components_metrics.NewNoOpAverager()
-
-	txBytesTotal = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "",
-			Subsystem: SubSystem,
-			Name:      "tx_bytes_total",
-			Help:      "tracks the total number of bytes transmitted (cumulative) (aggregated for all links per GPU)",
-		},
-		[]string{"gpu_id"},
-	)
-	txBytesDelta = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "",
-			Subsystem: SubSystem,
-			Name:      "tx_bytes_delta",
-			Help:      "tracks the number of bytes transmitted since the last collection (aggregated for all links per GPU)",
-		},
-		[]string{"gpu_id"},
-	)
-	txBytesAverager = components_metrics.NewNoOpAverager()
-
-	rxBytesTotal = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "",
-			Subsystem: SubSystem,
-			Name:      "rx_bytes_total",
-			Help:      "tracks the total number of bytes received (cumulative) (aggregated for all links per GPU)",
-		},
-		[]string{"gpu_id"},
-	)
-	rxBytesDelta = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: "",
-			Subsystem: SubSystem,
-			Name:      "rx_bytes_delta",
-			Help:      "tracks the number of bytes received since the last collection (aggregated for all links per GPU)",
-		},
-		[]string{"gpu_id"},
-	)
-	rxBytesAverager = components_metrics.NewNoOpAverager()
 )
 
 func InitAveragers(dbRW *sql.DB, dbRO *sql.DB, tableName string) {
@@ -114,8 +74,6 @@ func InitAveragers(dbRW *sql.DB, dbRO *sql.DB, tableName string) {
 	replayErrorsAverager = components_metrics.NewAverager(dbRW, dbRO, tableName, SubSystem+"_replay_errors")
 	recoveryErrorsAverager = components_metrics.NewAverager(dbRW, dbRO, tableName, SubSystem+"_recovery_errors")
 	crcErrorsAverager = components_metrics.NewAverager(dbRW, dbRO, tableName, SubSystem+"_crc_errors")
-	rxBytesAverager = components_metrics.NewAverager(dbRW, dbRO, tableName, SubSystem+"_rx_bytes")
-	txBytesAverager = components_metrics.NewAverager(dbRW, dbRO, tableName, SubSystem+"_tx_bytes")
 }
 
 func ReadFeatureEnabled(ctx context.Context, since time.Time) (components_metrics_state.Metrics, error) {
@@ -132,14 +90,6 @@ func ReadRecoveryErrors(ctx context.Context, since time.Time) (components_metric
 
 func ReadCRCErrors(ctx context.Context, since time.Time) (components_metrics_state.Metrics, error) {
 	return crcErrorsAverager.Read(ctx, components_metrics.WithSince(since))
-}
-
-func ReadRxBytes(ctx context.Context, since time.Time) (components_metrics_state.Metrics, error) {
-	return rxBytesAverager.Read(ctx, components_metrics.WithSince(since))
-}
-
-func ReadTxBytes(ctx context.Context, since time.Time) (components_metrics_state.Metrics, error) {
-	return txBytesAverager.Read(ctx, components_metrics.WithSince(since))
 }
 
 func SetLastUpdateUnixSeconds(unixSeconds float64) {
@@ -210,62 +160,6 @@ func SetCRCErrors(ctx context.Context, gpuID string, errors uint64, currentTime 
 	return nil
 }
 
-func SetTxBytes(ctx context.Context, gpuID string, bytes float64, currentTime time.Time) error {
-	txBytesTotal.WithLabelValues(gpuID).Set(bytes)
-
-	last, ok, err := txBytesAverager.Last(ctx, components_metrics.WithMetricSecondaryName(gpuID))
-	if err != nil {
-		return err
-	}
-
-	var v float64
-	if ok { // previous value found, observe with delta
-		v = bytes - last
-	} else { // very first observe, just observe with the absolute value
-		v = bytes
-	}
-	txBytesDelta.WithLabelValues(gpuID).Set(v)
-
-	if err := txBytesAverager.Observe(
-		ctx,
-		bytes,
-		components_metrics.WithCurrentTime(currentTime),
-		components_metrics.WithMetricSecondaryName(gpuID),
-	); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func SetRxBytes(ctx context.Context, gpuID string, bytes float64, currentTime time.Time) error {
-	rxBytesTotal.WithLabelValues(gpuID).Set(bytes)
-
-	last, ok, err := rxBytesAverager.Last(ctx, components_metrics.WithMetricSecondaryName(gpuID))
-	if err != nil {
-		return err
-	}
-
-	var v float64
-	if ok { // previous value found, observe with delta
-		v = bytes - last
-	} else { // very first observe, just observe with the absolute value
-		v = bytes
-	}
-	rxBytesDelta.WithLabelValues(gpuID).Set(v)
-
-	if err := rxBytesAverager.Observe(
-		ctx,
-		bytes,
-		components_metrics.WithCurrentTime(currentTime),
-		components_metrics.WithMetricSecondaryName(gpuID),
-	); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func Register(reg *prometheus.Registry, dbRW *sql.DB, dbRO *sql.DB, tableName string) error {
 	InitAveragers(dbRW, dbRO, tableName)
 
@@ -282,18 +176,6 @@ func Register(reg *prometheus.Registry, dbRW *sql.DB, dbRO *sql.DB, tableName st
 		return err
 	}
 	if err := reg.Register(crcErrors); err != nil {
-		return err
-	}
-	if err := reg.Register(txBytesTotal); err != nil {
-		return err
-	}
-	if err := reg.Register(txBytesDelta); err != nil {
-		return err
-	}
-	if err := reg.Register(rxBytesTotal); err != nil {
-		return err
-	}
-	if err := reg.Register(rxBytesDelta); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/nvidia-query/nvml/nvlink_test.go
+++ b/pkg/nvidia-query/nvml/nvlink_test.go
@@ -11,18 +11,15 @@ import (
 // Mock device implementation
 type mockDevice struct {
 	device.Device
-	nvLinkState           nvml.EnableState
-	nvLinkStateErr        nvml.Return
-	replayErrors          uint64
-	replayErrorsErr       nvml.Return
-	recoveryErrors        uint64
-	recoveryErrorsErr     nvml.Return
-	crcErrors             uint64
-	crcErrorsErr          nvml.Return
-	fieldValuesErr        nvml.Return
-	rawRxBytes            uint64
-	rawTxBytes            uint64
-	utilizationCounterErr nvml.Return
+	nvLinkState       nvml.EnableState
+	nvLinkStateErr    nvml.Return
+	replayErrors      uint64
+	replayErrorsErr   nvml.Return
+	recoveryErrors    uint64
+	recoveryErrorsErr nvml.Return
+	crcErrors         uint64
+	crcErrorsErr      nvml.Return
+	fieldValuesErr    nvml.Return
 }
 
 func (m *mockDevice) GetNvLinkState(link int) (nvml.EnableState, nvml.Return) {
@@ -40,32 +37,6 @@ func (m *mockDevice) GetNvLinkErrorCounter(link int, counter nvml.NvLinkErrorCou
 	default:
 		return 0, nvml.ERROR_UNKNOWN
 	}
-}
-
-func (m *mockDevice) GetFieldValues(values []nvml.FieldValue) nvml.Return {
-	if m.fieldValuesErr != nvml.SUCCESS {
-		return m.fieldValuesErr
-	}
-
-	for i := range values {
-		switch values[i].FieldId {
-		case nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_TX:
-			// Mock the byte slice value - assuming little endian
-			for j := 0; j < 8; j++ {
-				values[i].Value[j] = byte((m.rawTxBytes >> (j * 8)) & 0xff)
-			}
-		case nvml.FI_DEV_NVLINK_THROUGHPUT_RAW_RX:
-			// Mock the byte slice value - assuming little endian
-			for j := 0; j < 8; j++ {
-				values[i].Value[j] = byte((m.rawRxBytes >> (j * 8)) & 0xff)
-			}
-		}
-	}
-	return nvml.SUCCESS
-}
-
-func (m *mockDevice) GetNvLinkUtilizationCounter(link int, counter int) (uint64, uint64, nvml.Return) {
-	return m.rawRxBytes, m.rawTxBytes, m.utilizationCounterErr
 }
 
 // TestNVLinkStatesAllFeatureEnabled tests the AllFeatureEnabled method
@@ -141,15 +112,11 @@ func TestGetNVLink(t *testing.T) {
 	// Override the NVML functions
 	origDeviceGetNvLinkState := nvml.DeviceGetNvLinkState
 	origDeviceGetNvLinkErrorCounter := nvml.DeviceGetNvLinkErrorCounter
-	origDeviceGetFieldValues := nvml.DeviceGetFieldValues
-	origDeviceGetNvLinkUtilizationCounter := nvml.DeviceGetNvLinkUtilizationCounter
 
 	defer func() {
 		// Restore original functions
 		nvml.DeviceGetNvLinkState = origDeviceGetNvLinkState
 		nvml.DeviceGetNvLinkErrorCounter = origDeviceGetNvLinkErrorCounter
-		nvml.DeviceGetFieldValues = origDeviceGetFieldValues
-		nvml.DeviceGetNvLinkUtilizationCounter = origDeviceGetNvLinkUtilizationCounter
 	}()
 
 	tests := []struct {
@@ -167,18 +134,15 @@ func TestGetNVLink(t *testing.T) {
 		{
 			name: "NVLink supported and working",
 			mockDev: &mockDevice{
-				nvLinkState:           nvml.FEATURE_ENABLED,
-				nvLinkStateErr:        nvml.SUCCESS,
-				replayErrors:          10,
-				replayErrorsErr:       nvml.SUCCESS,
-				recoveryErrors:        20,
-				recoveryErrorsErr:     nvml.SUCCESS,
-				crcErrors:             30,
-				crcErrorsErr:          nvml.SUCCESS,
-				rawTxBytes:            100,
-				rawRxBytes:            200,
-				fieldValuesErr:        nvml.SUCCESS,
-				utilizationCounterErr: nvml.SUCCESS,
+				nvLinkState:       nvml.FEATURE_ENABLED,
+				nvLinkStateErr:    nvml.SUCCESS,
+				replayErrors:      10,
+				replayErrorsErr:   nvml.SUCCESS,
+				recoveryErrors:    20,
+				recoveryErrorsErr: nvml.SUCCESS,
+				crcErrors:         30,
+				crcErrorsErr:      nvml.SUCCESS,
+				fieldValuesErr:    nvml.SUCCESS,
 			},
 			expectedSupported:      true,
 			expectedStatesCount:    nvml.NVLINK_MAX_LINKS,
@@ -200,63 +164,26 @@ func TestGetNVLink(t *testing.T) {
 		{
 			name: "NVLink state error but continue",
 			mockDev: &mockDevice{
-				nvLinkState:           nvml.FEATURE_ENABLED,
-				nvLinkStateErr:        nvml.ERROR_UNKNOWN,
-				replayErrors:          0,
-				replayErrorsErr:       nvml.SUCCESS,
-				recoveryErrors:        0,
-				recoveryErrorsErr:     nvml.SUCCESS,
-				crcErrors:             0,
-				crcErrorsErr:          nvml.SUCCESS,
-				rawTxBytes:            0,
-				rawRxBytes:            0,
-				fieldValuesErr:        nvml.SUCCESS,
-				utilizationCounterErr: nvml.SUCCESS,
+				nvLinkState:       nvml.FEATURE_ENABLED,
+				nvLinkStateErr:    nvml.ERROR_UNKNOWN,
+				replayErrors:      0,
+				replayErrorsErr:   nvml.SUCCESS,
+				recoveryErrors:    0,
+				recoveryErrorsErr: nvml.SUCCESS,
+				crcErrors:         0,
+				crcErrorsErr:      nvml.SUCCESS,
+				fieldValuesErr:    nvml.SUCCESS,
 			},
 			expectedSupported:   true,
 			expectedStatesCount: 0,
-		},
-		{
-			name: "Fallback to GetNvLinkUtilizationCounter",
-			mockDev: &mockDevice{
-				nvLinkState:           nvml.FEATURE_ENABLED,
-				nvLinkStateErr:        nvml.SUCCESS,
-				replayErrors:          10,
-				replayErrorsErr:       nvml.SUCCESS,
-				recoveryErrors:        20,
-				recoveryErrorsErr:     nvml.SUCCESS,
-				crcErrors:             30,
-				crcErrorsErr:          nvml.SUCCESS,
-				rawTxBytes:            100,
-				rawRxBytes:            200,
-				fieldValuesErr:        nvml.ERROR_UNKNOWN,
-				utilizationCounterErr: nvml.SUCCESS,
-			},
-			expectedSupported:      true,
-			expectedStatesCount:    nvml.NVLINK_MAX_LINKS,
-			expectedFeatureEnabled: true,
-			expectedReplayErrors:   10,
-			expectedRecoveryErrors: 20,
-			expectedCRCErrors:      30,
-			expectedRawTxBytes:     100 * 1024, // KiB to bytes
-			expectedRawRxBytes:     200 * 1024, // KiB to bytes
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Mock the NVML functions
-			nvml.DeviceGetNvLinkState = func(device nvml.Device, link int) (nvml.EnableState, nvml.Return) {
-				return tc.mockDev.GetNvLinkState(link)
-			}
 			nvml.DeviceGetNvLinkErrorCounter = func(device nvml.Device, link int, counter nvml.NvLinkErrorCounter) (uint64, nvml.Return) {
 				return tc.mockDev.GetNvLinkErrorCounter(link, counter)
-			}
-			nvml.DeviceGetFieldValues = func(device nvml.Device, values []nvml.FieldValue) nvml.Return {
-				return tc.mockDev.GetFieldValues(values)
-			}
-			nvml.DeviceGetNvLinkUtilizationCounter = func(device nvml.Device, link int, counter int) (uint64, uint64, nvml.Return) {
-				return tc.mockDev.GetNvLinkUtilizationCounter(link, counter)
 			}
 
 			nvlink, err := GetNVLink("test-uuid", tc.mockDev)

--- a/pkg/nvidia-query/nvml/nvlink_test.go
+++ b/pkg/nvidia-query/nvml/nvlink_test.go
@@ -110,20 +110,16 @@ func TestNVLinkStatesAllFeatureEnabled(t *testing.T) {
 func TestNVLinkStatesTotalCounters(t *testing.T) {
 	states := NVLinkStates{
 		{
-			Link:                 0,
-			ReplayErrors:         10,
-			RecoveryErrors:       20,
-			CRCErrors:            30,
-			ThroughputRawTxBytes: 100,
-			ThroughputRawRxBytes: 200,
+			Link:           0,
+			ReplayErrors:   10,
+			RecoveryErrors: 20,
+			CRCErrors:      30,
 		},
 		{
-			Link:                 1,
-			ReplayErrors:         15,
-			RecoveryErrors:       25,
-			CRCErrors:            35,
-			ThroughputRawTxBytes: 150,
-			ThroughputRawRxBytes: 250,
+			Link:           1,
+			ReplayErrors:   15,
+			RecoveryErrors: 25,
+			CRCErrors:      35,
 		},
 	}
 
@@ -137,14 +133,6 @@ func TestNVLinkStatesTotalCounters(t *testing.T) {
 
 	t.Run("TotalCRCErrors", func(t *testing.T) {
 		assert.Equal(t, uint64(65), states.TotalCRCErrors())
-	})
-
-	t.Run("TotalThroughputRawTxBytes", func(t *testing.T) {
-		assert.Equal(t, uint64(250), states.TotalThroughputRawTxBytes())
-	})
-
-	t.Run("TotalThroughputRawRxBytes", func(t *testing.T) {
-		assert.Equal(t, uint64(450), states.TotalThroughputRawRxBytes())
 	})
 }
 

--- a/pkg/nvidia-query/nvml/nvlink_test.go
+++ b/pkg/nvidia-query/nvml/nvlink_test.go
@@ -128,8 +128,6 @@ func TestGetNVLink(t *testing.T) {
 		expectedReplayErrors   uint64
 		expectedRecoveryErrors uint64
 		expectedCRCErrors      uint64
-		expectedRawTxBytes     uint64
-		expectedRawRxBytes     uint64
 	}{
 		{
 			name: "NVLink supported and working",
@@ -150,8 +148,6 @@ func TestGetNVLink(t *testing.T) {
 			expectedReplayErrors:   10,
 			expectedRecoveryErrors: 20,
 			expectedCRCErrors:      30,
-			expectedRawTxBytes:     100 * 1024, // KiB to bytes
-			expectedRawRxBytes:     200 * 1024, // KiB to bytes
 		},
 		{
 			name: "NVLink not supported",
@@ -203,8 +199,6 @@ func TestGetNVLink(t *testing.T) {
 					assert.Equal(t, tc.expectedReplayErrors, state.ReplayErrors)
 					assert.Equal(t, tc.expectedRecoveryErrors, state.RecoveryErrors)
 					assert.Equal(t, tc.expectedCRCErrors, state.CRCErrors)
-					assert.Equal(t, tc.expectedRawTxBytes, state.ThroughputRawTxBytes)
-					assert.Equal(t, tc.expectedRawRxBytes, state.ThroughputRawRxBytes)
 				}
 			}
 		})

--- a/pkg/nvidia-query/query.go
+++ b/pkg/nvidia-query/query.go
@@ -514,12 +514,6 @@ func setNVLinkMetrics(ctx context.Context, dev *nvml.DeviceInfo, now time.Time) 
 	if err := metrics_nvlink.SetCRCErrors(ctx, dev.UUID, dev.NVLink.States.TotalCRCErrors(), now); err != nil {
 		return err
 	}
-	if err := metrics_nvlink.SetRxBytes(ctx, dev.UUID, float64(dev.NVLink.States.TotalThroughputRawRxBytes()), now); err != nil {
-		return err
-	}
-	if err := metrics_nvlink.SetTxBytes(ctx, dev.UUID, float64(dev.NVLink.States.TotalThroughputRawTxBytes()), now); err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
During testing, it was found that gpud would panic randomly at any place, and the stack would point to the same place:

```go
runtime.throw({0x24db382?, 0xc0027c0808?})
	/usr/local/go/src/runtime/panic.go:1101 +0x48 fp=0xc002b122a0 sp=0xc002b12270 pc=0x497dc8
runtime.sigpanic()
	/usr/local/go/src/runtime/signal_unix.go:939 +0x1e5 fp=0xc002b122d0 sp=0xc002b122a0 pc=0x49a365
runtime.buildTypeAssertCache.func1(0x88?, 0x0?)
	/usr/local/go/src/runtime/iface.go:532 +0xc fp=0xc002b122f0 sp=0xc002b122d0 pc=0x42f14c
runtime.buildTypeAssertCache(0x24db33c?, 0x219d380, 0x0)
	/usr/local/go/src/runtime/iface.go:544 +0x1aa fp=0xc002b12370 sp=0xc002b122f0 pc=0x42f0ca
runtime.typeAssert(0x321c630, 0x219d380)
	/usr/local/go/src/runtime/iface.go:497 +0xae fp=0xc002b123a8 sp=0xc002b12370 pc=0x42ee6e
```

We all believe the interface type assertion cannot be failed. I found out that as long as function nvml.DeviceGetFieldValues is not called, there will be no panic.

I didn't delve into the root cause, but here's a guess: the machine with the problem was installed with NVIDIA 570 version driver, and when we called the nvml function, somehow the call stack or some memory was modified incorrectly. This is similar to heap corruption affecting the golang interface type switch cache.

We don't actually need nvlink tx/rx related data now, but there are other ways to get it later even if we need it.