### PR TITLE
feat(fd, cpu, memory, remapped-rows, info, containerd, kubelet, docker, tailscale): do not mark unhealthy in case of context errors, fix degraded status set for "fd"

### DIFF
--- a/components/accelerator/nvidia/remapped-rows/component_test.go
+++ b/components/accelerator/nvidia/remapped-rows/component_test.go
@@ -136,13 +136,27 @@ func TestDataGetReason(t *testing.T) {
 	reason := nilData.getReason()
 	assert.Equal(t, "no remapped rows data", reason)
 
-	// Test with error
+	// Test with generic error
 	errorData := &Data{
 		err: errors.New("test error"),
 	}
 	reason = errorData.getReason()
 	assert.Contains(t, reason, "failed to get remapped rows data")
 	assert.Contains(t, reason, "test error")
+
+	// Test with context.DeadlineExceeded error
+	deadlineData := &Data{
+		err: context.DeadlineExceeded,
+	}
+	reason = deadlineData.getReason()
+	assert.Equal(t, "check failed with context deadline exceeded -- transient error, please retry", reason)
+
+	// Test with context.Canceled error
+	canceledData := &Data{
+		err: context.Canceled,
+	}
+	reason = canceledData.getReason()
+	assert.Equal(t, "check failed with context canceled -- transient error, please retry", reason)
 
 	// Test with data that has no row remapping support
 	noSupportData := &Data{
@@ -242,13 +256,29 @@ func TestRegisterCollectors(t *testing.T) {
 
 // Test the Data.getHealth method
 func TestDataGetHealth(t *testing.T) {
-	// Test with error
+	// Test with generic error
 	errorData := &Data{
 		err: errors.New("test error"),
 	}
 	health, healthy := errorData.getHealth()
 	assert.Equal(t, components.StateUnhealthy, health)
 	assert.False(t, healthy)
+
+	// Test with context.DeadlineExceeded error
+	deadlineData := &Data{
+		err: context.DeadlineExceeded,
+	}
+	health, healthy = deadlineData.getHealth()
+	assert.Equal(t, components.StateHealthy, health)
+	assert.True(t, healthy)
+
+	// Test with context.Canceled error
+	canceledData := &Data{
+		err: context.Canceled,
+	}
+	health, healthy = canceledData.getHealth()
+	assert.Equal(t, components.StateHealthy, health)
+	assert.True(t, healthy)
 
 	// Test with no row remapping support
 	noSupportData := &Data{

--- a/components/cpu/component.go
+++ b/components/cpu/component.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -263,6 +264,11 @@ func (i *Info) getReason() string {
 		return "no cpu info found"
 	}
 	if i.err != nil {
+		// if the context is canceled or timeout, we assume the next course of action is unknown
+		// thus, treating it as healthy (or transient failure)
+		if errors.Is(i.err, context.DeadlineExceeded) || errors.Is(i.err, context.Canceled) {
+			return fmt.Sprintf("check failed with %s -- transient error, please retry", i.err)
+		}
 		return fmt.Sprintf("failed to get CPU information -- %s", i.err)
 	}
 
@@ -272,6 +278,14 @@ func (i *Info) getReason() string {
 
 func (i *Info) getHealth() (string, bool) {
 	healthy := i == nil || i.err == nil
+
+	// if the context is canceled or timeout, we assume the next course of action is unknown
+	// thus, treating it as healthy (or transient failure)
+	if !healthy && (errors.Is(i.err, context.DeadlineExceeded) || errors.Is(i.err, context.Canceled)) {
+		log.Logger.Warnw("check canceled or timeout -- transient error, please retry", "error", i.err)
+		healthy = true
+	}
+
 	health := components.StateHealthy
 	if !healthy {
 		health = components.StateUnhealthy
@@ -291,6 +305,11 @@ func (c *Cores) getReason() string {
 		return "no cpu cores found"
 	}
 	if c.err != nil {
+		// if the context is canceled or timeout, we assume the next course of action is unknown
+		// thus, treating it as healthy (or transient failure)
+		if errors.Is(c.err, context.DeadlineExceeded) || errors.Is(c.err, context.Canceled) {
+			return fmt.Sprintf("check failed with %s -- transient error, please retry", c.err)
+		}
 		return fmt.Sprintf("failed to get CPU cores -- %s", c.err)
 	}
 
@@ -299,6 +318,14 @@ func (c *Cores) getReason() string {
 
 func (c *Cores) getHealth() (string, bool) {
 	healthy := c == nil || c.err == nil
+
+	// if the context is canceled or timeout, we assume the next course of action is unknown
+	// thus, treating it as healthy (or transient failure)
+	if !healthy && (errors.Is(c.err, context.DeadlineExceeded) || errors.Is(c.err, context.Canceled)) {
+		log.Logger.Warnw("check canceled or timeout -- transient error, please retry", "error", c.err)
+		healthy = true
+	}
+
 	health := components.StateHealthy
 	if !healthy {
 		health = components.StateUnhealthy
@@ -331,6 +358,11 @@ func (u *Usage) getReason() string {
 		return "no cpu usage found"
 	}
 	if u.err != nil {
+		// if the context is canceled or timeout, we assume the next course of action is unknown
+		// thus, treating it as healthy (or transient failure)
+		if errors.Is(u.err, context.DeadlineExceeded) || errors.Is(u.err, context.Canceled) {
+			return fmt.Sprintf("check failed with %s -- transient error, please retry", u.err)
+		}
 		return fmt.Sprintf("failed to get CPU usage -- %s", u.err)
 	}
 
@@ -340,6 +372,14 @@ func (u *Usage) getReason() string {
 
 func (u *Usage) getHealth() (string, bool) {
 	healthy := u == nil || u.err == nil
+
+	// if the context is canceled or timeout, we assume the next course of action is unknown
+	// thus, treating it as healthy (or transient failure)
+	if !healthy && (errors.Is(u.err, context.DeadlineExceeded) || errors.Is(u.err, context.Canceled)) {
+		log.Logger.Warnw("check canceled or timeout -- transient error, please retry", "error", u.err)
+		healthy = true
+	}
+
 	health := components.StateHealthy
 	if !healthy {
 		health = components.StateUnhealthy

--- a/components/fd/component.go
+++ b/components/fd/component.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -373,9 +374,16 @@ func (d *Data) getReason() string {
 	if d == nil {
 		return "no file descriptors data"
 	}
+
 	if d.err != nil {
+		// if the context is canceled or timeout, we assume the next course of action is unknown
+		// thus, treating it as healthy (or transient failure)
+		if errors.Is(d.err, context.DeadlineExceeded) || errors.Is(d.err, context.Canceled) {
+			return fmt.Sprintf("check failed with %s -- transient error, please retry", d.err)
+		}
 		return fmt.Sprintf("failed to get file descriptors data -- %s", d.err)
 	}
+
 	reason := fmt.Sprintf("current file descriptors: %d, threshold: %d, used_percent: %s",
 		d.Usage,
 		d.ThresholdAllocatedFileHandles,
@@ -390,6 +398,14 @@ func (d *Data) getReason() string {
 
 func (d *Data) getHealth() (string, bool) {
 	healthy := d == nil || d.err == nil
+
+	// if the context is canceled or timeout, we assume the next course of action is unknown
+	// thus, treating it as healthy (or transient failure)
+	if d != nil && !healthy && (errors.Is(d.err, context.DeadlineExceeded) || errors.Is(d.err, context.Canceled)) {
+		log.Logger.Warnw("check canceled or timeout -- transient error, please retry", "error", d.err)
+		healthy = true
+	}
+
 	health := components.StateHealthy
 	if !healthy {
 		health = components.StateUnhealthy

--- a/components/kubelet/pod/component.go
+++ b/components/kubelet/pod/component.go
@@ -162,6 +162,12 @@ func (d *Data) getReason() string {
 	}
 
 	if d.err != nil {
+		// if the context is canceled or timeout, we assume the next course of action is unknown
+		// thus, treating it as healthy (or transient failure)
+		if errors.Is(d.err, context.DeadlineExceeded) || errors.Is(d.err, context.Canceled) {
+			return fmt.Sprintf("check failed with %s -- transient error, please retry", d.err)
+		}
+
 		if d.connErr {
 			// e.g.,
 			// Get "http://localhost:10255/pods": dial tcp [::1]:10255: connect: connection refused
@@ -176,9 +182,18 @@ func (d *Data) getReason() string {
 
 func (d *Data) getHealth(ignoreConnErr bool) (string, bool) {
 	healthy := d == nil || d.err == nil
+
 	if d != nil && d.err != nil && d.connErr && ignoreConnErr {
 		healthy = true
 	}
+
+	// if the context is canceled or timeout, we assume the next course of action is unknown
+	// thus, treating it as healthy (or transient failure)
+	if d != nil && !healthy && (errors.Is(d.err, context.DeadlineExceeded) || errors.Is(d.err, context.Canceled)) {
+		log.Logger.Warnw("check canceled or timeout -- transient error, please retry", "error", d.err)
+		healthy = true
+	}
+
 	health := components.StateHealthy
 	if !healthy {
 		health = components.StateUnhealthy

--- a/components/kubelet/pod/component_test.go
+++ b/components/kubelet/pod/component_test.go
@@ -242,6 +242,24 @@ func Test_describeReason(t *testing.T) {
 			},
 			expected: "failed to list pods from kubelet read-only port -- some error",
 		},
+		{
+			name: "context deadline exceeded error",
+			data: Data{
+				NodeName: "test-node",
+				Pods:     []PodStatus{{ID: "test-pod"}},
+				err:      context.DeadlineExceeded,
+			},
+			expected: "check failed with context deadline exceeded -- transient error, please retry",
+		},
+		{
+			name: "context canceled error",
+			data: Data{
+				NodeName: "test-node",
+				Pods:     []PodStatus{{ID: "test-pod"}},
+				err:      context.Canceled,
+			},
+			expected: "check failed with context canceled -- transient error, please retry",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -294,6 +312,24 @@ func Test_getHealth(t *testing.T) {
 			ignoreConnErr:   true,
 			expectedHealth:  "Unhealthy",
 			expectedHealthy: false,
+		},
+		{
+			name: "context deadline exceeded error",
+			data: Data{
+				err: context.DeadlineExceeded,
+			},
+			ignoreConnErr:   false,
+			expectedHealth:  "Healthy",
+			expectedHealthy: true,
+		},
+		{
+			name: "context canceled error",
+			data: Data{
+				err: context.Canceled,
+			},
+			ignoreConnErr:   false,
+			expectedHealth:  "Healthy",
+			expectedHealthy: true,
 		},
 	}
 

--- a/components/memory/component.go
+++ b/components/memory/component.go
@@ -242,6 +242,7 @@ func (d *Data) getReason() string {
 	if d == nil {
 		return "no memory data"
 	}
+
 	if d.err != nil {
 		// if the context is canceled or timeout, we assume the next course of action is unknown
 		// thus, treating it as healthy (or transient failure)
@@ -250,6 +251,7 @@ func (d *Data) getReason() string {
 		}
 		return fmt.Sprintf("failed to get memory data -- %s", d.err)
 	}
+
 	return fmt.Sprintf("using %s out of total %s", humanize.Bytes(d.UsedBytes), humanize.Bytes(d.TotalBytes))
 }
 
@@ -258,7 +260,7 @@ func (d *Data) getHealth() (string, bool) {
 
 	// if the context is canceled or timeout, we assume the next course of action is unknown
 	// thus, treating it as healthy (or transient failure)
-	if !healthy && (errors.Is(d.err, context.DeadlineExceeded) || errors.Is(d.err, context.Canceled)) {
+	if d != nil && !healthy && (errors.Is(d.err, context.DeadlineExceeded) || errors.Is(d.err, context.Canceled)) {
 		log.Logger.Warnw("check canceled or timeout -- transient error, please retry", "error", d.err)
 		healthy = true
 	}

--- a/components/memory/component_test.go
+++ b/components/memory/component_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -16,6 +17,16 @@ func TestDataGetReason(t *testing.T) {
 	// Test with error
 	d = &Data{err: assert.AnError}
 	assert.Contains(t, d.getReason(), "failed to get memory data")
+
+	// Test with context.DeadlineExceeded error
+	d = &Data{err: context.DeadlineExceeded}
+	assert.Contains(t, d.getReason(), "check failed with context deadline exceeded")
+	assert.Contains(t, d.getReason(), "transient error, please retry")
+
+	// Test with context.Canceled error
+	d = &Data{err: context.Canceled}
+	assert.Contains(t, d.getReason(), "check failed with context canceled")
+	assert.Contains(t, d.getReason(), "transient error, please retry")
 
 	// Test with valid data
 	d = &Data{
@@ -38,6 +49,27 @@ func TestDataGetHealth(t *testing.T) {
 	health, healthy = d.getHealth()
 	assert.Equal(t, "Unhealthy", health)
 	assert.False(t, healthy)
+
+	// Test with context.DeadlineExceeded error - should be treated as healthy
+	d = &Data{err: context.DeadlineExceeded}
+	health, healthy = d.getHealth()
+	assert.Equal(t, "Healthy", health)
+	assert.True(t, healthy, "Context deadline exceeded should be treated as healthy")
+
+	// Test with context.Canceled error - should be treated as healthy
+	d = &Data{err: context.Canceled}
+	health, healthy = d.getHealth()
+	assert.Equal(t, "Healthy", health)
+	assert.True(t, healthy, "Context canceled should be treated as healthy")
+
+	// Test with valid data
+	d = &Data{
+		TotalBytes: 16 * 1024 * 1024 * 1024,
+		UsedBytes:  8 * 1024 * 1024 * 1024,
+	}
+	health, healthy = d.getHealth()
+	assert.Equal(t, "Healthy", health)
+	assert.True(t, healthy)
 }
 
 func TestDataGetStates(t *testing.T) {
@@ -74,6 +106,55 @@ func TestDataGetStates(t *testing.T) {
 	var decodedData Data
 	err = json.Unmarshal([]byte(jsonData), &decodedData)
 	assert.NoError(t, err)
+}
+
+func TestDataGetStatesWithErrors(t *testing.T) {
+	// Test with regular error
+	t.Run("With regular error", func(t *testing.T) {
+		d := &Data{
+			err: assert.AnError,
+			ts:  time.Now(),
+		}
+		states, err := d.getStates()
+		assert.NoError(t, err)
+		assert.Len(t, states, 1)
+		assert.Equal(t, Name, states[0].Name)
+		assert.Equal(t, "Unhealthy", states[0].Health)
+		assert.False(t, states[0].Healthy)
+		assert.Contains(t, states[0].Reason, "failed to get memory data")
+	})
+
+	// Test with context deadline exceeded error
+	t.Run("With context deadline exceeded", func(t *testing.T) {
+		d := &Data{
+			err: context.DeadlineExceeded,
+			ts:  time.Now(),
+		}
+		states, err := d.getStates()
+		assert.NoError(t, err)
+		assert.Len(t, states, 1)
+		assert.Equal(t, Name, states[0].Name)
+		assert.Equal(t, "Healthy", states[0].Health)
+		assert.True(t, states[0].Healthy)
+		assert.Contains(t, states[0].Reason, "check failed with context deadline exceeded")
+		assert.Contains(t, states[0].Reason, "transient error, please retry")
+	})
+
+	// Test with context canceled error
+	t.Run("With context canceled", func(t *testing.T) {
+		d := &Data{
+			err: context.Canceled,
+			ts:  time.Now(),
+		}
+		states, err := d.getStates()
+		assert.NoError(t, err)
+		assert.Len(t, states, 1)
+		assert.Equal(t, Name, states[0].Name)
+		assert.Equal(t, "Healthy", states[0].Health)
+		assert.True(t, states[0].Healthy)
+		assert.Contains(t, states[0].Reason, "check failed with context canceled")
+		assert.Contains(t, states[0].Reason, "transient error, please retry")
+	})
 }
 
 func TestDataGetStatesNil(t *testing.T) {

--- a/components/tailscale/component.go
+++ b/components/tailscale/component.go
@@ -155,7 +155,7 @@ func (d *Data) getHealth() (string, bool) {
 
 	// if the context is canceled or timeout, we assume the next course of action is unknown
 	// thus, treating it as healthy (or transient failure)
-	if !healthy && (errors.Is(d.err, context.DeadlineExceeded) || errors.Is(d.err, context.Canceled)) {
+	if d != nil && !healthy && (errors.Is(d.err, context.DeadlineExceeded) || errors.Is(d.err, context.Canceled)) {
 		log.Logger.Warnw("check canceled or timeout -- transient error, please retry", "error", d.err)
 		healthy = true
 	}

--- a/components/tailscale/component_test.go
+++ b/components/tailscale/component_test.go
@@ -262,6 +262,20 @@ func TestDataGetReason(t *testing.T) {
 			expectedReason: "tailscaled check failed -- test error",
 		},
 		{
+			name: "context deadline exceeded",
+			data: &Data{
+				err: context.DeadlineExceeded,
+			},
+			expectedReason: "check failed with context deadline exceeded -- transient error, please retry",
+		},
+		{
+			name: "context canceled",
+			data: &Data{
+				err: context.Canceled,
+			},
+			expectedReason: "check failed with context canceled -- transient error, please retry",
+		},
+		{
 			name: "service active",
 			data: &Data{
 				TailscaledServiceActive: true,
@@ -305,6 +319,22 @@ func TestDataGetHealth(t *testing.T) {
 			},
 			expectedHealth:  components.StateUnhealthy,
 			expectedHealthy: false,
+		},
+		{
+			name: "context deadline exceeded",
+			data: &Data{
+				err: context.DeadlineExceeded,
+			},
+			expectedHealth:  components.StateHealthy,
+			expectedHealthy: true,
+		},
+		{
+			name: "context canceled",
+			data: &Data{
+				err: context.Canceled,
+			},
+			expectedHealth:  components.StateHealthy,
+			expectedHealthy: true,
 		},
 		{
 			name: "no error",


### PR DESCRIPTION
- **fix(cpu): only log context errors in /states**
- **feat(memory): handle context errors**
- **fix(tailscale): handle context errors (only logs)**
- **feat(fd): handle context errors, fix gethealth**
- **feat(info): handle context errors**
- **fix(remapped-rows): handle context errors**
- **fix(kubelet/pod): handle context errors**
- **feat(containerd): handle context errors**
- **feat(kernel-module, docker): handle context errors**
