### PR TITLE
feat(metrics, server): implement scraper, store, syncer for Prometheus metrics using sqlite as an experimental feature

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -30,3 +30,6 @@ jobs:
       - name: run e2e tests
         run: |
           ./scripts/tests-e2e.sh
+      - name: run e2e tests (experimental)
+        run: |
+          ENABLE_EXPERIMENTAL_FEATURES=true ./scripts/tests-e2e.sh

--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -54,6 +54,8 @@ var (
 	ibstatCommand string
 
 	checkInfiniBand bool
+
+	experimentalGlobalMetricsStore bool
 )
 
 const (
@@ -251,6 +253,13 @@ sudo rm /etc/systemd/system/gpud.service
 					Name:        "kubelet-ignore-connection-errors",
 					Usage:       "ignore connection errors to kubelet read-only port, useful when kubelet readOnlyPort is disabled (default: false)",
 					Destination: &kubeletIgnoreConnectionErrors,
+				},
+
+				// experimental
+				&cli.BoolFlag{
+					Name:        "experimental-global-metrics-store",
+					Usage:       "enable experimental global metrics store (default: false)",
+					Destination: &experimentalGlobalMetricsStore,
 				},
 
 				// only for testing

--- a/cmd/gpud/command/run.go
+++ b/cmd/gpud/command/run.go
@@ -84,6 +84,8 @@ func cmdRun(cliContext *cli.Context) error {
 	cfg.EnableAutoUpdate = enableAutoUpdate
 	cfg.AutoUpdateExitCode = autoUpdateExitCode
 
+	cfg.EnableGlobalMetricsStore = experimentalGlobalMetricsStore
+
 	if err := cfg.Validate(); err != nil {
 		return err
 	}

--- a/components/disk/metrics/metrics.go
+++ b/components/disk/metrics/metrics.go
@@ -8,6 +8,7 @@ import (
 
 	components_metrics "github.com/leptonai/gpud/pkg/gpud-metrics"
 	components_metrics_state "github.com/leptonai/gpud/pkg/gpud-metrics/state"
+	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -34,7 +35,7 @@ var (
 			Name:      "total_bytes",
 			Help:      "tracks the total bytes of the disk",
 		},
-		[]string{"mount_point"},
+		[]string{pkgmetrics.MetricComponentLabelKey, pkgmetrics.MetricLabelKey}, // label is mount point
 	)
 	totalBytesAverager = components_metrics.NewNoOpAverager()
 
@@ -45,7 +46,7 @@ var (
 			Name:      "free_bytes",
 			Help:      "tracks the current free bytes of the disk",
 		},
-		[]string{"mount_point"},
+		[]string{pkgmetrics.MetricComponentLabelKey, pkgmetrics.MetricLabelKey}, // label is mount point
 	)
 
 	usedBytes = prometheus.NewGaugeVec(
@@ -55,7 +56,7 @@ var (
 			Name:      "used_bytes",
 			Help:      "tracks the current free bytes of the disk",
 		},
-		[]string{"mount_point"},
+		[]string{pkgmetrics.MetricComponentLabelKey, pkgmetrics.MetricLabelKey}, // label is mount point
 	)
 	usedBytesAverager = components_metrics.NewNoOpAverager()
 	usedBytesAverage  = prometheus.NewGaugeVec(
@@ -65,7 +66,7 @@ var (
 			Name:      "used_bytes_avg",
 			Help:      "tracks the disk bytes usage with average for the last period",
 		},
-		[]string{"mount_point", "last_period"},
+		[]string{pkgmetrics.MetricComponentLabelKey, pkgmetrics.MetricLabelKey, "last_period"}, // label is mount point
 	)
 
 	usedBytesPercent = prometheus.NewGaugeVec(
@@ -75,7 +76,7 @@ var (
 			Name:      "used_bytes_percent",
 			Help:      "tracks the current disk bytes usage percentage",
 		},
-		[]string{"mount_point"},
+		[]string{pkgmetrics.MetricComponentLabelKey, pkgmetrics.MetricLabelKey}, // label is mount point
 	)
 	usedBytesPercentAverager = components_metrics.NewNoOpAverager()
 	usedBytesPercentAverage  = prometheus.NewGaugeVec(
@@ -85,7 +86,7 @@ var (
 			Name:      "used_bytes_percent_avg",
 			Help:      "tracks the disk bytes usage percentage with average for the last period",
 		},
-		[]string{"mount_point", "last_period"},
+		[]string{pkgmetrics.MetricComponentLabelKey, pkgmetrics.MetricLabelKey, "last_period"}, // label is mount point
 	)
 
 	usedInodesPercent = prometheus.NewGaugeVec(
@@ -95,7 +96,7 @@ var (
 			Name:      "used_inodes_percent",
 			Help:      "tracks the current disk inodes usage percentage",
 		},
-		[]string{"mount_point"},
+		[]string{pkgmetrics.MetricComponentLabelKey, pkgmetrics.MetricLabelKey}, // label is mount point
 	)
 )
 
@@ -122,7 +123,7 @@ func SetLastUpdateUnixSeconds(unixSeconds float64) {
 }
 
 func SetTotalBytes(ctx context.Context, mountPoint string, bytes float64, currentTime time.Time) error {
-	totalBytes.WithLabelValues(mountPoint).Set(bytes)
+	totalBytes.WithLabelValues("disk", mountPoint).Set(bytes)
 
 	if err := totalBytesAverager.Observe(
 		ctx,
@@ -137,11 +138,11 @@ func SetTotalBytes(ctx context.Context, mountPoint string, bytes float64, curren
 }
 
 func SetFreeBytes(mountPoint string, bytes float64) {
-	freeBytes.WithLabelValues(mountPoint).Set(bytes)
+	freeBytes.WithLabelValues("disk", mountPoint).Set(bytes)
 }
 
 func SetUsedBytes(ctx context.Context, mountPoint string, bytes float64, currentTime time.Time) error {
-	usedBytes.WithLabelValues(mountPoint).Set(bytes)
+	usedBytes.WithLabelValues("disk", mountPoint).Set(bytes)
 
 	if err := usedBytesAverager.Observe(
 		ctx,
@@ -161,14 +162,14 @@ func SetUsedBytes(ctx context.Context, mountPoint string, bytes float64, current
 		if err != nil {
 			return err
 		}
-		usedBytesAverage.WithLabelValues(mountPoint, duration.String()).Set(avg)
+		usedBytesAverage.WithLabelValues("disk", mountPoint, duration.String()).Set(avg)
 	}
 
 	return nil
 }
 
 func SetUsedBytesPercent(ctx context.Context, mountPoint string, pct float64, currentTime time.Time) error {
-	usedBytesPercent.WithLabelValues(mountPoint).Set(pct)
+	usedBytesPercent.WithLabelValues("disk", mountPoint).Set(pct)
 
 	if err := usedBytesPercentAverager.Observe(
 		ctx,
@@ -188,14 +189,14 @@ func SetUsedBytesPercent(ctx context.Context, mountPoint string, pct float64, cu
 		if err != nil {
 			return err
 		}
-		usedBytesPercentAverage.WithLabelValues(mountPoint, duration.String()).Set(avg)
+		usedBytesPercentAverage.WithLabelValues("disk", mountPoint, duration.String()).Set(avg)
 	}
 
 	return nil
 }
 
 func SetUsedInodesPercent(mountPoint string, pct float64) {
-	usedInodesPercent.WithLabelValues(mountPoint).Set(pct)
+	usedInodesPercent.WithLabelValues("disk", mountPoint).Set(pct)
 }
 
 func Register(reg *prometheus.Registry, dbRW *sql.DB, dbRO *sql.DB, tableName string) error {

--- a/components/fuse/metrics/metrics.go
+++ b/components/fuse/metrics/metrics.go
@@ -6,10 +6,11 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	components_metrics "github.com/leptonai/gpud/pkg/gpud-metrics"
 	components_metrics_state "github.com/leptonai/gpud/pkg/gpud-metrics/state"
-
-	"github.com/prometheus/client_golang/prometheus"
+	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
 )
 
 const SubSystem = "fuse"
@@ -31,7 +32,7 @@ var (
 			Name:      "connections_congested_percent_against_threshold",
 			Help:      "tracks the percentage of FUSE connections that are congested",
 		},
-		[]string{"device_name"},
+		[]string{pkgmetrics.MetricComponentLabelKey, pkgmetrics.MetricLabelKey}, // label is device name
 	)
 	connsCongestedPctAverager = components_metrics.NewNoOpAverager()
 
@@ -42,7 +43,7 @@ var (
 			Name:      "connections_max_background_percent_against_threshold",
 			Help:      "tracks the percentage of FUSE connections that are congested",
 		},
-		[]string{"device_name"},
+		[]string{pkgmetrics.MetricComponentLabelKey, pkgmetrics.MetricLabelKey}, // label is device name
 	)
 	connsMaxBackgroundPctAverager = components_metrics.NewNoOpAverager()
 )
@@ -65,7 +66,7 @@ func SetLastUpdateUnixSeconds(unixSeconds float64) {
 }
 
 func SetConnectionsCongestedPercent(ctx context.Context, deviceName string, pct float64, currentTime time.Time) error {
-	connsCongestedPct.WithLabelValues(deviceName).Set(pct)
+	connsCongestedPct.WithLabelValues("fuse", deviceName).Set(pct)
 
 	if err := connsCongestedPctAverager.Observe(
 		ctx,
@@ -80,7 +81,7 @@ func SetConnectionsCongestedPercent(ctx context.Context, deviceName string, pct 
 }
 
 func SetConnectionsMaxBackgroundPercent(ctx context.Context, deviceName string, pct float64, currentTime time.Time) error {
-	connsMaxBackgroundPct.WithLabelValues(deviceName).Set(pct)
+	connsMaxBackgroundPct.WithLabelValues("fuse", deviceName).Set(pct)
 
 	if err := connsMaxBackgroundPctAverager.Observe(
 		ctx,

--- a/components/memory/metrics/metrics.go
+++ b/components/memory/metrics/metrics.go
@@ -8,6 +8,7 @@ import (
 
 	components_metrics "github.com/leptonai/gpud/pkg/gpud-metrics"
 	components_metrics_state "github.com/leptonai/gpud/pkg/gpud-metrics/state"
+	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -27,32 +28,35 @@ var (
 		},
 	)
 
-	totalBytes = prometheus.NewGauge(
+	totalBytes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "",
 			Subsystem: SubSystem,
 			Name:      "total_bytes",
 			Help:      "tracks the total memory in bytes",
 		},
+		[]string{pkgmetrics.MetricComponentLabelKey},
 	)
 	totalBytesAverager = components_metrics.NewNoOpAverager()
 
-	availableBytes = prometheus.NewGauge(
+	availableBytes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "",
 			Subsystem: SubSystem,
 			Name:      "available_bytes",
 			Help:      "tracks the available memory in bytes",
 		},
+		[]string{pkgmetrics.MetricComponentLabelKey},
 	)
 
-	usedBytes = prometheus.NewGauge(
+	usedBytes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "",
 			Subsystem: SubSystem,
 			Name:      "used_bytes",
 			Help:      "tracks the used memory in bytes",
 		},
+		[]string{pkgmetrics.MetricComponentLabelKey},
 	)
 	usedBytesAverager = components_metrics.NewNoOpAverager()
 	usedBytesAverage  = prometheus.NewGaugeVec(
@@ -65,13 +69,14 @@ var (
 		[]string{"last_period"},
 	)
 
-	usedPercent = prometheus.NewGauge(
+	usedPercent = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "",
 			Subsystem: SubSystem,
 			Name:      "used_percent",
 			Help:      "tracks the percentage of memory used",
 		},
+		[]string{pkgmetrics.MetricComponentLabelKey},
 	)
 	usedPercentAverager = components_metrics.NewNoOpAverager()
 	usedPercentAverage  = prometheus.NewGaugeVec(
@@ -84,13 +89,14 @@ var (
 		[]string{"last_period"},
 	)
 
-	freeBytes = prometheus.NewGauge(
+	freeBytes = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "",
 			Subsystem: SubSystem,
 			Name:      "free_bytes",
 			Help:      "tracks the free memory in bytes",
 		},
+		[]string{pkgmetrics.MetricComponentLabelKey},
 	)
 )
 
@@ -117,7 +123,7 @@ func SetLastUpdateUnixSeconds(unixSeconds float64) {
 }
 
 func SetTotalBytes(ctx context.Context, bytes float64, currentTime time.Time) error {
-	totalBytes.Set(bytes)
+	totalBytes.WithLabelValues("memory").Set(bytes)
 
 	if err := totalBytesAverager.Observe(
 		ctx,
@@ -131,11 +137,11 @@ func SetTotalBytes(ctx context.Context, bytes float64, currentTime time.Time) er
 }
 
 func SetAvailableBytes(bytes float64) {
-	availableBytes.Set(bytes)
+	availableBytes.WithLabelValues("memory").Set(bytes)
 }
 
 func SetUsedBytes(ctx context.Context, bytes float64, currentTime time.Time) error {
-	usedBytes.Set(bytes)
+	usedBytes.WithLabelValues("memory").Set(bytes)
 
 	if err := usedBytesAverager.Observe(
 		ctx,
@@ -160,7 +166,7 @@ func SetUsedBytes(ctx context.Context, bytes float64, currentTime time.Time) err
 }
 
 func SetUsedPercent(ctx context.Context, pct float64, currentTime time.Time) error {
-	usedPercent.Set(pct)
+	usedPercent.WithLabelValues("memory").Set(pct)
 
 	if err := usedPercentAverager.Observe(ctx, pct, components_metrics.WithCurrentTime(currentTime)); err != nil {
 		return err
@@ -178,7 +184,7 @@ func SetUsedPercent(ctx context.Context, pct float64, currentTime time.Time) err
 }
 
 func SetFreeBytes(bytes float64) {
-	freeBytes.Set(bytes)
+	freeBytes.WithLabelValues("memory").Set(bytes)
 }
 
 func Register(reg *prometheus.Registry, dbRW *sql.DB, dbRO *sql.DB, tableName string) error {

--- a/components/network/latency/metrics/metrics.go
+++ b/components/network/latency/metrics/metrics.go
@@ -6,10 +6,11 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	components_metrics "github.com/leptonai/gpud/pkg/gpud-metrics"
 	components_metrics_state "github.com/leptonai/gpud/pkg/gpud-metrics/state"
-
-	"github.com/prometheus/client_golang/prometheus"
+	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
 )
 
 const SubSystem = "network_latency"
@@ -31,7 +32,7 @@ var (
 			Name:      "edge_in_milliseconds",
 			Help:      "tracks the edge latency in milliseconds",
 		},
-		[]string{"provider_region"},
+		[]string{pkgmetrics.MetricComponentLabelKey, pkgmetrics.MetricLabelKey}, // label is provider region
 	)
 	edgeInMillisecondsAverager = components_metrics.NewNoOpAverager()
 )
@@ -49,7 +50,7 @@ func SetLastUpdateUnixSeconds(unixSeconds float64) {
 }
 
 func SetEdgeInMilliseconds(ctx context.Context, providerRegion string, latencyInMilliseconds float64, currentTime time.Time) error {
-	edgeInMilliseconds.WithLabelValues(providerRegion).Set(latencyInMilliseconds)
+	edgeInMilliseconds.WithLabelValues("network-latency", providerRegion).Set(latencyInMilliseconds)
 
 	if err := edgeInMillisecondsAverager.Observe(
 		ctx,

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -222,7 +222,6 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 	})
 
 	Describe("/v1/metrics requests", func() {
-
 		It("request without compress", func() {
 			req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/v1/metrics", ep), nil)
 			Expect(err).NotTo(HaveOccurred(), "failed to create request")
@@ -264,7 +263,36 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 			err = json.Unmarshal(body, &metrics)
 			Expect(err).NotTo(HaveOccurred(), "failed to unmarshal response body")
 		})
+	})
 
+	Describe("/metrics requests", func() {
+		It("request prometheus metrics without compress", func() {
+			req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/metrics", ep), nil)
+			Expect(err).NotTo(HaveOccurred(), "failed to create request")
+
+			resp, err := client.Do(req)
+			Expect(err).NotTo(HaveOccurred(), "failed to make request")
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred(), "failed to read response body")
+			GinkgoLogr.Info("response size", "size", string(body))
+		})
+
+		It("request components metrics without compress", func() {
+			req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/metrics/components", ep), nil)
+			Expect(err).NotTo(HaveOccurred(), "failed to create request")
+
+			resp, err := client.Do(req)
+			Expect(err).NotTo(HaveOccurred(), "failed to make request")
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred(), "failed to read response body")
+			GinkgoLogr.Info("response size", "size", string(body))
+		})
 	})
 
 	Describe("states with client/v1", func() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,6 +63,9 @@ type Config struct {
 
 	// A list of nvidia tool command paths to overwrite the default paths.
 	NvidiaToolOverwrites nvidia_common.ToolOverwrites `json:"nvidia_tool_overwrites"`
+
+	// Enable experimental global metrics store
+	EnableGlobalMetricsStore bool `json:"enable_global_metrics_store"`
 }
 
 // Configures the local web configuration.

--- a/pkg/metrics/scraper/prometheus.go
+++ b/pkg/metrics/scraper/prometheus.go
@@ -1,0 +1,71 @@
+package scraper
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/leptonai/gpud/pkg/log"
+	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
+)
+
+var _ pkgmetrics.Scraper = &promScraper{}
+
+func NewPrometheusScraper(gatherer prometheus.Gatherer) (pkgmetrics.Scraper, error) {
+	return &promScraper{
+		gatherer: gatherer,
+	}, nil
+}
+
+type promScraper struct {
+	gatherer prometheus.Gatherer
+}
+
+func (s *promScraper) Scrape(_ context.Context) (pkgmetrics.Metrics, error) {
+	if s == nil || s.gatherer == nil {
+		return nil, nil
+	}
+
+	gathered, err := s.gatherer.Gather()
+	if err != nil {
+		return nil, err
+	}
+
+	log.Logger.Infow("scraping prometheus metrics")
+	now := time.Now().UTC().UnixMilli()
+
+	ms := make(pkgmetrics.Metrics, 0, len(gathered))
+	for _, metricFamily := range gathered {
+		for _, mtRaw := range metricFamily.GetMetric() {
+			m := pkgmetrics.Metric{
+				UnixMilliseconds: now,
+				Name:             metricFamily.GetName(),
+			}
+
+			for _, label := range mtRaw.GetLabel() {
+				switch label.GetName() {
+				case pkgmetrics.MetricComponentLabelKey:
+					m.Component = label.GetValue()
+				case pkgmetrics.MetricLabelKey:
+					m.Label = label.GetValue()
+				}
+			}
+			if m.Component == "" {
+				continue
+			}
+
+			// for now, only support counter and gauge
+			switch {
+			case mtRaw.GetCounter() != nil:
+				m.Value = mtRaw.GetCounter().GetValue()
+			case mtRaw.GetGauge() != nil:
+				m.Value = mtRaw.GetGauge().GetValue()
+			}
+
+			ms = append(ms, m)
+		}
+	}
+
+	return ms, nil
+}

--- a/pkg/metrics/scraper/prometheus_test.go
+++ b/pkg/metrics/scraper/prometheus_test.go
@@ -1,0 +1,268 @@
+package scraper
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
+)
+
+func TestPrometheusScraper(t *testing.T) {
+	t.Parallel()
+
+	lastUpdateUnixSeconds := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: "gpud",
+			Name:      "last_update_unix_seconds",
+			Help:      "tracks the last update time in unix seconds",
+		},
+	)
+	currentCelsius := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: "test",
+			Name:      "current_celsius",
+			Help:      "tracks the current temperature in celsius",
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey, pkgmetrics.MetricLabelKey},
+	)
+	slowdownUsedPercent := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: "test",
+			Name:      "slowdown_used_percent",
+			Help:      "tracks the percentage of slowdown used",
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey, pkgmetrics.MetricLabelKey},
+	)
+	insertUpdateTotal := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "sqlite",
+			Subsystem: "insert_update",
+			Name:      "total",
+			Help:      "total number of inserts and updates",
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey},
+	)
+
+	reg := prometheus.NewRegistry()
+	require.NoError(t, reg.Register(lastUpdateUnixSeconds))
+	require.NoError(t, reg.Register(currentCelsius))
+	require.NoError(t, reg.Register(slowdownUsedPercent))
+	require.NoError(t, reg.Register(insertUpdateTotal))
+
+	scraper, err := NewPrometheusScraper(reg)
+	require.NoError(t, err)
+	require.NotNil(t, scraper)
+
+	// should not be included since the component label does not exist
+	lastUpdateUnixSeconds.Set(123)
+	currentCelsius.WithLabelValues("gpud-temerature-0", "GPU-0").Set(100)
+	slowdownUsedPercent.WithLabelValues("gpud-clock-events-0", "GPU-0").Set(98)
+	insertUpdateTotal.WithLabelValues("gpud-db-0").Inc()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ms, err := scraper.Scrape(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, ms)
+	require.Equal(t, 3, len(ms))
+
+	sort.Slice(ms, func(i, j int) bool {
+		return ms[i].Name < ms[j].Name
+	})
+
+	require.Equal(t, "gpud-db-0", ms[0].Component)
+	require.Equal(t, "sqlite_insert_update_total", ms[0].Name)
+	require.Equal(t, "", ms[0].Label)
+	require.Equal(t, float64(1), ms[0].Value)
+
+	require.Equal(t, "gpud-temerature-0", ms[1].Component)
+	require.Equal(t, "test_current_celsius", ms[1].Name)
+	require.Equal(t, "GPU-0", ms[1].Label)
+	require.Equal(t, float64(100), ms[1].Value)
+
+	require.Equal(t, "gpud-clock-events-0", ms[2].Component)
+	require.Equal(t, "test_slowdown_used_percent", ms[2].Name)
+	require.Equal(t, "GPU-0", ms[2].Label)
+	require.Equal(t, float64(98), ms[2].Value)
+}
+
+// mockGathererWithError implements prometheus.Gatherer interface and always returns an error
+type mockGathererWithError struct {
+	err error
+}
+
+func (m *mockGathererWithError) Gather() ([]*dto.MetricFamily, error) {
+	return nil, m.err
+}
+
+func TestPrometheusScraper_GatherError(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock gatherer that always returns an error
+	expectedErr := errors.New("gather error")
+	mockGatherer := &mockGathererWithError{err: expectedErr}
+
+	// Create scraper with our error-returning gatherer
+	scraper := &promScraper{
+		gatherer: mockGatherer,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Call Scrape and verify it returns the expected error
+	metrics, err := scraper.Scrape(ctx)
+	require.Error(t, err)
+	require.Equal(t, expectedErr, err)
+	require.Nil(t, metrics)
+}
+
+func TestPrometheusScraper_NilGatherer(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a scraper with nil gatherer
+	scraper := &promScraper{
+		gatherer: nil,
+	}
+
+	// Call Scrape and verify it returns nil without error
+	metrics, err := scraper.Scrape(ctx)
+	require.NoError(t, err)
+	require.Nil(t, metrics)
+}
+
+func TestPrometheusScraper_NilScraper(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a nil scraper
+	var scraper *promScraper
+
+	// Call Scrape and verify it returns nil without error
+	metrics, err := scraper.Scrape(ctx)
+	require.NoError(t, err)
+	require.Nil(t, metrics)
+}
+
+func TestPrometheusScraper_EmptyMetrics(t *testing.T) {
+	t.Parallel()
+
+	// Create an empty registry
+	reg := prometheus.NewRegistry()
+
+	scraper, err := NewPrometheusScraper(reg)
+	require.NoError(t, err)
+	require.NotNil(t, scraper)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Scrape with no metrics registered
+	ms, err := scraper.Scrape(ctx)
+	require.NoError(t, err)
+	require.Empty(t, ms)
+}
+
+func TestPrometheusScraper_MultipleMetricTypes(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+
+	// Add a counter
+	counter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "test",
+			Subsystem: "operations",
+			Name:      "total",
+			Help:      "Total operations performed",
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey},
+	)
+	require.NoError(t, reg.Register(counter))
+	counter.WithLabelValues("component1").Inc()
+
+	// Add a gauge
+	gauge := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "test",
+			Subsystem: "resources",
+			Name:      "utilization",
+			Help:      "Resource utilization",
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey, pkgmetrics.MetricLabelKey},
+	)
+	require.NoError(t, reg.Register(gauge))
+	gauge.WithLabelValues("component1", "resource1").Set(75.5)
+
+	// Add a histogram
+	histogram := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "test",
+			Subsystem: "latency",
+			Name:      "seconds",
+			Help:      "Request latency distribution",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey},
+	)
+	require.NoError(t, reg.Register(histogram))
+	histogram.WithLabelValues("component1").Observe(0.57)
+
+	// Add a summary
+	summary := prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace: "test",
+			Subsystem: "response",
+			Name:      "time_seconds",
+			Help:      "Response time summary",
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey},
+	)
+	require.NoError(t, reg.Register(summary))
+	summary.WithLabelValues("component1").Observe(0.123)
+
+	scraper, err := NewPrometheusScraper(reg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Scrape and verify metrics
+	ms, err := scraper.Scrape(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, ms)
+
+	// Should have more than 4 metrics because histograms and summaries
+	// generate multiple underlying metrics
+	require.True(t, len(ms) >= 4, "Expected at least 4 metrics, got %d", len(ms))
+
+	// Verify the counter and gauge are included
+	var foundCounter, foundGauge bool
+	for _, m := range ms {
+		if m.Name == "test_operations_total" && m.Component == "component1" {
+			foundCounter = true
+			require.Equal(t, float64(1), m.Value)
+		}
+		if m.Name == "test_resources_utilization" && m.Component == "component1" && m.Label == "resource1" {
+			foundGauge = true
+			require.Equal(t, 75.5, m.Value)
+		}
+	}
+	require.True(t, foundCounter, "Counter metric not found")
+	require.True(t, foundGauge, "Gauge metric not found")
+}

--- a/pkg/metrics/scraper/prometheus_test.go
+++ b/pkg/metrics/scraper/prometheus_test.go
@@ -64,7 +64,7 @@ func TestPrometheusScraper(t *testing.T) {
 
 	// should not be included since the component label does not exist
 	lastUpdateUnixSeconds.Set(123)
-	currentCelsius.WithLabelValues("gpud-temerature-0", "GPU-0").Set(100)
+	currentCelsius.WithLabelValues("gpud-temp-0", "GPU-0").Set(100)
 	slowdownUsedPercent.WithLabelValues("gpud-clock-events-0", "GPU-0").Set(98)
 	insertUpdateTotal.WithLabelValues("gpud-db-0").Inc()
 
@@ -85,7 +85,7 @@ func TestPrometheusScraper(t *testing.T) {
 	require.Equal(t, "", ms[0].Label)
 	require.Equal(t, float64(1), ms[0].Value)
 
-	require.Equal(t, "gpud-temerature-0", ms[1].Component)
+	require.Equal(t, "gpud-temp-0", ms[1].Component)
 	require.Equal(t, "test_current_celsius", ms[1].Name)
 	require.Equal(t, "GPU-0", ms[1].Label)
 	require.Equal(t, float64(100), ms[1].Value)

--- a/pkg/metrics/store/sqlite.go
+++ b/pkg/metrics/store/sqlite.go
@@ -1,0 +1,227 @@
+// Package store provides the persistent storage layer for the metrics.
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/leptonai/gpud/pkg/log"
+	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
+	pkgsqlite "github.com/leptonai/gpud/pkg/sqlite"
+)
+
+var _ pkgmetrics.Store = &sqliteStore{}
+
+type sqliteStore struct {
+	dbRW  *sql.DB
+	dbRO  *sql.DB
+	table string
+}
+
+func NewSQLiteStore(ctx context.Context, dbRW *sql.DB, dbRO *sql.DB, table string) (pkgmetrics.Store, error) {
+	if err := CreateTable(ctx, dbRW, table); err != nil {
+		return nil, err
+	}
+	return &sqliteStore{
+		dbRW:  dbRW,
+		dbRO:  dbRO,
+		table: table,
+	}, nil
+}
+
+func (s *sqliteStore) Record(ctx context.Context, ms ...pkgmetrics.Metric) error {
+	return insert(ctx, s.dbRW, s.table, ms...)
+}
+
+func (s *sqliteStore) Read(ctx context.Context, since time.Time) (pkgmetrics.Metrics, error) {
+	return read(ctx, s.dbRO, s.table, since)
+}
+
+func (s *sqliteStore) Purge(ctx context.Context, before time.Time) (int, error) {
+	return purge(ctx, s.dbRW, s.table, before)
+}
+
+const (
+	// DefaultTableName is the default table name for the metrics.
+	DefaultTableName = "gpud_metrics"
+
+	// ColumnUnixMilliseconds represents the Unix timestamp of the metric.
+	ColumnUnixMilliseconds = "unix_milliseconds"
+
+	// ColumnComponentName represents the name of the component this metric
+	// belongs to.
+	ColumnComponentName = "component_name"
+
+	// ColumnMetricName represents the name of the metric.
+	ColumnMetricName = "metric_name"
+
+	// ColumnMetricLabel represents the label of the metric
+	// such as GPU ID, etc. (as a secondary metric name).
+	ColumnMetricLabel = "metric_label"
+
+	// ColumnMetricValue represents the numeric value of the metric.
+	ColumnMetricValue = "metric_value"
+)
+
+var (
+	ErrEmptyTableName     = errors.New("table name is empty")
+	ErrEmptyComponentName = errors.New("component name is empty")
+	ErrEmptyMetricName    = errors.New("metric name is empty")
+)
+
+func CreateTable(ctx context.Context, dbRW *sql.DB, table string) error {
+	if table == "" {
+		return ErrEmptyTableName
+	}
+
+	_, err := dbRW.ExecContext(ctx, fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+	%s INTEGER NOT NULL,
+	%s TEXT NOT NULL,
+	%s TEXT NOT NULL,
+	%s TEXT,
+	%s REAL NOT NULL,
+	PRIMARY KEY (%s, %s, %s, %s)
+) WITHOUT ROWID;`,
+		table,
+		ColumnUnixMilliseconds, ColumnComponentName, ColumnMetricName, ColumnMetricLabel, ColumnMetricValue, // columns
+		ColumnUnixMilliseconds, ColumnComponentName, ColumnMetricName, ColumnMetricLabel, // primary keys
+	))
+	return err
+}
+
+func insert(ctx context.Context, dbRW *sql.DB, table string, ms ...pkgmetrics.Metric) error {
+	if table == "" {
+		return ErrEmptyTableName
+	}
+
+	if len(ms) == 0 {
+		return nil
+	}
+
+	// Validate all metrics first
+	for _, m := range ms {
+		if m.Component == "" {
+			return ErrEmptyComponentName
+		}
+		if m.Name == "" {
+			return ErrEmptyMetricName
+		}
+	}
+
+	// Build the query with placeholders for all metrics
+	query := fmt.Sprintf(
+		"INSERT OR REPLACE INTO %s (%s, %s, %s, %s, %s) VALUES ",
+		table,
+		ColumnUnixMilliseconds,
+		ColumnComponentName,
+		ColumnMetricName,
+		ColumnMetricLabel,
+		ColumnMetricValue,
+	)
+
+	// Create proper placeholders with commas between value sets
+	placeholders := make([]string, len(ms))
+	for i := range placeholders {
+		placeholders[i] = "(?, ?, ?, ?, ?)"
+	}
+	query += strings.Join(placeholders, ", ")
+
+	args := make([]interface{}, 0, len(ms)*5)
+	for _, m := range ms {
+		args = append(args, m.UnixMilliseconds, m.Component, m.Name, m.Label, m.Value)
+	}
+
+	log.Logger.Infow("inserting metrics", "metrics", len(ms))
+	start := time.Now()
+	_, err := dbRW.ExecContext(ctx, query, args...)
+	pkgsqlite.RecordInsertUpdate(time.Since(start).Seconds())
+
+	return err
+}
+
+// read returns the metric data in the ascending order of unix seconds
+// meaning the first element is the oldest event.
+// It returns nil if no record is found ("database/sql.ErrNoRows").
+func read(ctx context.Context, dbRO *sql.DB, table string, since time.Time) (pkgmetrics.Metrics, error) {
+	if table == "" {
+		return nil, ErrEmptyTableName
+	}
+
+	query := fmt.Sprintf(`
+SELECT %s, %s, %s, %s, %s
+FROM %s
+WHERE %s >= ?
+ORDER BY %s ASC;`,
+		ColumnUnixMilliseconds,
+		ColumnComponentName,
+		ColumnMetricName,
+		ColumnMetricLabel,
+		ColumnMetricValue,
+		table,
+		ColumnUnixMilliseconds,
+		ColumnUnixMilliseconds,
+	)
+
+	start := time.Now()
+	defer func() {
+		pkgsqlite.RecordSelect(time.Since(start).Seconds())
+	}()
+
+	queryRows, err := dbRO.QueryContext(ctx, query, since.UnixMilli())
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer queryRows.Close()
+
+	rows := make(pkgmetrics.Metrics, 0)
+	for queryRows.Next() {
+		m := pkgmetrics.Metric{}
+		var label sql.NullString
+		if err := queryRows.Scan(&m.UnixMilliseconds, &m.Component, &m.Name, &label, &m.Value); err != nil {
+			return nil, err
+		}
+		if label.Valid && label.String != "" {
+			m.Label = label.String
+		}
+		rows = append(rows, m)
+	}
+	if err := queryRows.Err(); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// purge purges the data for the corresponding component that is older
+// than the given time.
+func purge(ctx context.Context, dbRW *sql.DB, table string, before time.Time) (int, error) {
+	if table == "" {
+		return 0, ErrEmptyTableName
+	}
+
+	query := fmt.Sprintf(`
+DELETE FROM %s WHERE %s < ?;`, table, ColumnUnixMilliseconds)
+
+	start := time.Now()
+	rs, err := dbRW.ExecContext(ctx, query, before.UnixMilli())
+	pkgsqlite.RecordDelete(time.Since(start).Seconds())
+
+	if err != nil {
+		return 0, err
+	}
+
+	affected, err := rs.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(affected), nil
+}

--- a/pkg/metrics/store/sqlite.go
+++ b/pkg/metrics/store/sqlite.go
@@ -16,6 +16,34 @@ import (
 	pkgsqlite "github.com/leptonai/gpud/pkg/sqlite"
 )
 
+const (
+	// DefaultTableName is the default table name for the metrics.
+	DefaultTableName = "gpud_metrics"
+
+	// ColumnUnixMilliseconds represents the Unix timestamp of the metric.
+	ColumnUnixMilliseconds = "unix_milliseconds"
+
+	// ColumnComponentName represents the name of the component this metric
+	// belongs to.
+	ColumnComponentName = "component_name"
+
+	// ColumnMetricName represents the name of the metric.
+	ColumnMetricName = "metric_name"
+
+	// ColumnMetricLabel represents the label of the metric
+	// such as GPU ID, etc. (as a secondary metric name).
+	ColumnMetricLabel = "metric_label"
+
+	// ColumnMetricValue represents the numeric value of the metric.
+	ColumnMetricValue = "metric_value"
+)
+
+var (
+	ErrEmptyTableName     = errors.New("table name is empty")
+	ErrEmptyComponentName = errors.New("component name is empty")
+	ErrEmptyMetricName    = errors.New("metric name is empty")
+)
+
 var _ pkgmetrics.Store = &sqliteStore{}
 
 type sqliteStore struct {
@@ -46,34 +74,6 @@ func (s *sqliteStore) Read(ctx context.Context, since time.Time) (pkgmetrics.Met
 func (s *sqliteStore) Purge(ctx context.Context, before time.Time) (int, error) {
 	return purge(ctx, s.dbRW, s.table, before)
 }
-
-const (
-	// DefaultTableName is the default table name for the metrics.
-	DefaultTableName = "gpud_metrics"
-
-	// ColumnUnixMilliseconds represents the Unix timestamp of the metric.
-	ColumnUnixMilliseconds = "unix_milliseconds"
-
-	// ColumnComponentName represents the name of the component this metric
-	// belongs to.
-	ColumnComponentName = "component_name"
-
-	// ColumnMetricName represents the name of the metric.
-	ColumnMetricName = "metric_name"
-
-	// ColumnMetricLabel represents the label of the metric
-	// such as GPU ID, etc. (as a secondary metric name).
-	ColumnMetricLabel = "metric_label"
-
-	// ColumnMetricValue represents the numeric value of the metric.
-	ColumnMetricValue = "metric_value"
-)
-
-var (
-	ErrEmptyTableName     = errors.New("table name is empty")
-	ErrEmptyComponentName = errors.New("component name is empty")
-	ErrEmptyMetricName    = errors.New("metric name is empty")
-)
 
 func CreateTable(ctx context.Context, dbRW *sql.DB, table string) error {
 	if table == "" {

--- a/pkg/metrics/store/sqlite_test.go
+++ b/pkg/metrics/store/sqlite_test.go
@@ -1,0 +1,782 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
+	pkgsqlite "github.com/leptonai/gpud/pkg/sqlite"
+)
+
+func TestSQLiteNewStore(t *testing.T) {
+	// Setup test database
+	dbRW, dbRO, cleanup := pkgsqlite.OpenTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Test creating a new store
+	store, err := NewSQLiteStore(ctx, dbRW, dbRO, "test_metrics")
+	require.NoError(t, err)
+	require.NotNil(t, store)
+
+	// Test with empty table name
+	_, err = NewSQLiteStore(ctx, dbRW, dbRO, "")
+	assert.Equal(t, ErrEmptyTableName, err)
+}
+
+func TestSQLiteStore_Record(t *testing.T) {
+	// Setup test database
+	dbRW, dbRO, cleanup := pkgsqlite.OpenTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create a new store
+	store, err := NewSQLiteStore(ctx, dbRW, dbRO, "test_metrics")
+	require.NoError(t, err)
+
+	// Create test metrics
+	now := time.Now().UnixMilli()
+	metrics := []pkgmetrics.Metric{
+		{
+			UnixMilliseconds: now,
+			Component:        "test-component",
+			Name:             "metric1",
+			Value:            42.0,
+		},
+		{
+			UnixMilliseconds: now,
+			Component:        "test-component",
+			Name:             "metric2",
+			Label:            "gpu0",
+			Value:            123.45,
+		},
+	}
+
+	// Record metrics
+	for _, m := range metrics {
+		err := store.Record(ctx, m)
+		require.NoError(t, err)
+	}
+
+	// Test record with empty component name
+	err = store.Record(ctx, pkgmetrics.Metric{
+		UnixMilliseconds: now,
+		Name:             "metric3",
+		Value:            789.0,
+	})
+	assert.Error(t, err)
+
+	// Test record with empty metric name
+	err = store.Record(ctx, pkgmetrics.Metric{
+		UnixMilliseconds: now,
+		Component:        "test-component",
+		Value:            789.0,
+	})
+	assert.Error(t, err)
+
+	// Test updating existing metric
+	updatedMetric := pkgmetrics.Metric{
+		UnixMilliseconds: now,
+		Component:        "test-component",
+		Name:             "metric1",
+		Value:            99.9,
+	}
+	err = store.Record(ctx, updatedMetric)
+	require.NoError(t, err)
+
+	// Verify the update worked by reading it back
+	results, err := store.Read(ctx, time.Unix(0, 0))
+	require.NoError(t, err)
+	found := false
+	for _, m := range results {
+		if m.Component == "test-component" && m.Name == "metric1" {
+			assert.Equal(t, 99.9, m.Value)
+			found = true
+		}
+	}
+	assert.True(t, found, "Updated metric not found in results")
+}
+
+func TestSQLiteStore_Read(t *testing.T) {
+	// Setup test database
+	dbRW, dbRO, cleanup := pkgsqlite.OpenTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create a new store
+	store, err := NewSQLiteStore(ctx, dbRW, dbRO, "test_metrics")
+	require.NoError(t, err)
+
+	// Generate timestamps for testing
+	now := time.Now()
+	timestamp1 := now.Add(-2 * time.Hour).UnixMilli()
+	timestamp2 := now.Add(-1 * time.Hour).UnixMilli()
+	timestamp3 := now.UnixMilli()
+
+	// Create and record test metrics
+	metrics := []pkgmetrics.Metric{
+		{
+			UnixMilliseconds: timestamp1,
+			Component:        "component1",
+			Name:             "metric1",
+			Value:            10.0,
+		},
+		{
+			UnixMilliseconds: timestamp2,
+			Component:        "component1",
+			Name:             "metric1",
+			Value:            20.0,
+		},
+		{
+			UnixMilliseconds: timestamp3,
+			Component:        "component1",
+			Name:             "metric1",
+			Value:            30.0,
+		},
+		{
+			UnixMilliseconds: timestamp2,
+			Component:        "component1",
+			Name:             "metric2",
+			Label:            "label1",
+			Value:            100.0,
+		},
+		{
+			UnixMilliseconds: timestamp3,
+			Component:        "component1",
+			Name:             "metric2",
+			Label:            "label1",
+			Value:            200.0,
+		},
+		{
+			UnixMilliseconds: timestamp3,
+			Component:        "component2",
+			Name:             "metric3",
+			Value:            300.0,
+		},
+	}
+
+	for _, m := range metrics {
+		err := store.Record(ctx, m)
+		require.NoError(t, err)
+	}
+
+	// Test reading all metrics
+	rs, err := store.Read(ctx, time.Time{})
+	require.NoError(t, err)
+	assert.Len(t, rs, 6)
+
+	// Test reading metrics since a specific time
+	rs, err = store.Read(ctx, now.Add(-30*time.Minute))
+	require.NoError(t, err)
+	assert.Len(t, rs, 3)
+
+	// Test reading metrics since a specific time that should include some older entries
+	rs, err = store.Read(ctx, now.Add(-90*time.Minute))
+	require.NoError(t, err)
+	assert.Len(t, rs, 5)
+
+	// Verify sorting order is by timestamp (ascending)
+	if len(rs) >= 3 {
+		assert.LessOrEqual(t, rs[0].UnixMilliseconds, rs[1].UnixMilliseconds)
+		assert.LessOrEqual(t, rs[1].UnixMilliseconds, rs[2].UnixMilliseconds)
+	}
+}
+
+func TestSQLiteStore_ReadEmpty(t *testing.T) {
+	// Setup test database
+	dbRW, dbRO, cleanup := pkgsqlite.OpenTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create a new store with a unique table name
+	store, err := NewSQLiteStore(ctx, dbRW, dbRO, "empty_metrics")
+	require.NoError(t, err)
+
+	// Reading from an empty store should return empty results, not an error
+	rs, err := store.Read(ctx, time.Time{})
+	require.NoError(t, err)
+	assert.Empty(t, rs)
+}
+
+func TestSQLiteStore_Purge(t *testing.T) {
+	// Setup test database
+	dbRW, dbRO, cleanup := pkgsqlite.OpenTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create a new store
+	tableName := "purge_test_metrics"
+	store, err := NewSQLiteStore(ctx, dbRW, dbRO, tableName)
+	require.NoError(t, err)
+
+	// Generate timestamps for testing
+	now := time.Now()
+	timestamp1 := now.Add(-3 * time.Hour).UnixMilli()
+	timestamp2 := now.Add(-2 * time.Hour).UnixMilli()
+	timestamp3 := now.Add(-1 * time.Hour).UnixMilli()
+	timestamp4 := now.UnixMilli()
+
+	// Create and record test metrics
+	metrics := []pkgmetrics.Metric{
+		{
+			UnixMilliseconds: timestamp1,
+			Component:        "component1",
+			Name:             "metric1",
+			Value:            10.0,
+		},
+		{
+			UnixMilliseconds: timestamp2,
+			Component:        "component1",
+			Name:             "metric2",
+			Value:            20.0,
+		},
+		{
+			UnixMilliseconds: timestamp3,
+			Component:        "component2",
+			Name:             "metric3",
+			Value:            30.0,
+		},
+		{
+			UnixMilliseconds: timestamp4,
+			Component:        "component2",
+			Name:             "metric4",
+			Value:            40.0,
+		},
+	}
+
+	for _, m := range metrics {
+		err := store.Record(ctx, m)
+		require.NoError(t, err)
+	}
+
+	// Verify all records exist
+	rs, err := store.Read(ctx, time.Time{})
+	require.NoError(t, err)
+	assert.Len(t, rs, 4)
+
+	// Purge records older than 2.5 hours
+	affected, err := purge(ctx, dbRW, tableName, now.Add(-150*time.Minute))
+	require.NoError(t, err)
+	assert.Equal(t, 1, affected)
+
+	// Verify purged records are gone
+	rs, err = store.Read(ctx, time.Time{})
+	require.NoError(t, err)
+	assert.Len(t, rs, 3)
+
+	// Purge records older than 30 minutes
+	affected, err = purge(ctx, dbRW, tableName, now.Add(-30*time.Minute))
+	require.NoError(t, err)
+	assert.Equal(t, 2, affected)
+
+	// Verify only the most recent records remain
+	rs, err = store.Read(ctx, time.Time{})
+	require.NoError(t, err)
+	assert.Len(t, rs, 1)
+	assert.Equal(t, timestamp4, rs[0].UnixMilliseconds)
+}
+
+func TestSQLiteInsertAndReadLast(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dbRW, dbRO, cleanup := pkgsqlite.OpenTestDB(t)
+	defer cleanup()
+
+	tableName := "test_metrics"
+
+	err := CreateTable(ctx, dbRW, tableName)
+	require.NoError(t, err, "failed to create table")
+
+	// Insert test metrics with different timestamps
+	now := time.Now()
+	metrics := []pkgmetrics.Metric{
+		{
+			UnixMilliseconds: now.Add(-2 * time.Hour).UnixMilli(),
+			Component:        "component1",
+			Name:             "metric1",
+			Value:            10.0,
+		},
+		{
+			UnixMilliseconds: now.Add(-1 * time.Hour).UnixMilli(),
+			Component:        "component1",
+			Name:             "metric1",
+			Value:            20.0,
+		},
+		{
+			UnixMilliseconds: now.UnixMilli(),
+			Component:        "component1",
+			Name:             "metric1",
+			Value:            30.0,
+		},
+	}
+
+	// Insert the metrics
+	for _, m := range metrics {
+		err := insert(ctx, dbRW, tableName, m)
+		require.NoError(t, err)
+	}
+
+	// Read metrics and verify they're in order
+	results, err := read(ctx, dbRO, tableName, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+
+	// Verify ascending order
+	assert.Equal(t, float64(10.0), results[0].Value)
+	assert.Equal(t, float64(20.0), results[1].Value)
+	assert.Equal(t, float64(30.0), results[2].Value)
+}
+
+func TestSQLiteCreateTable(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dbRW, _, cleanup := pkgsqlite.OpenTestDB(t)
+	defer cleanup()
+
+	// Test successful table creation
+	err := CreateTable(ctx, dbRW, "test_metrics")
+	require.NoError(t, err)
+
+	// Test with empty table name
+	err = CreateTable(ctx, dbRW, "")
+	assert.Equal(t, ErrEmptyTableName, err)
+}
+
+func TestSQLiteInsert(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dbRW, _, cleanup := pkgsqlite.OpenTestDB(t)
+	defer cleanup()
+
+	tableName := "test_metrics"
+	err := CreateTable(ctx, dbRW, tableName)
+	require.NoError(t, err)
+
+	// Create a test metric
+	now := time.Now().UnixMilli()
+	metric := pkgmetrics.Metric{
+		UnixMilliseconds: now,
+		Component:        "test-component",
+		Name:             "test-metric",
+		Label:            "test-label",
+		Value:            42.0,
+	}
+
+	// Test successful insert
+	err = insert(ctx, dbRW, tableName, metric)
+	require.NoError(t, err)
+
+	// Test invalid inputs
+	// Empty table name
+	err = insert(ctx, dbRW, "", metric)
+	assert.Equal(t, ErrEmptyTableName, err)
+
+	// Empty component name
+	invalidMetric := metric
+	invalidMetric.Component = ""
+	err = insert(ctx, dbRW, tableName, invalidMetric)
+	assert.Equal(t, ErrEmptyComponentName, err)
+
+	// Empty metric name
+	invalidMetric = metric
+	invalidMetric.Name = ""
+	err = insert(ctx, dbRW, tableName, invalidMetric)
+	assert.Equal(t, ErrEmptyMetricName, err)
+
+	// Test replace functionality
+	updatedMetric := metric
+	updatedMetric.Value = 100.0
+	err = insert(ctx, dbRW, tableName, updatedMetric)
+	require.NoError(t, err)
+}
+
+func TestSQLiteRead(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dbRW, dbRO, cleanup := pkgsqlite.OpenTestDB(t)
+	defer cleanup()
+
+	tableName := "test_metrics"
+	err := CreateTable(ctx, dbRW, tableName)
+	require.NoError(t, err)
+
+	// Create test metrics
+	now := time.Now()
+	oldTimestamp := now.Add(-1 * time.Hour).UnixMilli()
+	currentTimestamp := now.UnixMilli()
+
+	metrics := []pkgmetrics.Metric{
+		{
+			UnixMilliseconds: oldTimestamp,
+			Component:        "component1",
+			Name:             "metric1",
+			Value:            10.0,
+		},
+		{
+			UnixMilliseconds: currentTimestamp,
+			Component:        "component1",
+			Name:             "metric1",
+			Value:            20.0,
+		},
+		{
+			UnixMilliseconds: currentTimestamp,
+			Component:        "component2",
+			Name:             "metric2",
+			Label:            "label1",
+			Value:            30.0,
+		},
+	}
+
+	// Insert test metrics
+	for _, m := range metrics {
+		err := insert(ctx, dbRW, tableName, m)
+		require.NoError(t, err)
+	}
+
+	// Test reading all metrics
+	results, err := read(ctx, dbRO, tableName, time.Time{})
+	require.NoError(t, err)
+	assert.Len(t, results, 3)
+
+	// Test reading with timestamp filter
+	results, err = read(ctx, dbRO, tableName, now.Add(-30*time.Minute))
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+
+	// Test empty table name
+	results, err = read(ctx, dbRO, "", time.Time{})
+	assert.Equal(t, ErrEmptyTableName, err)
+	assert.Nil(t, results)
+}
+
+func TestSQLitePurge(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dbRW, _, cleanup := pkgsqlite.OpenTestDB(t)
+	defer cleanup()
+
+	tableName := "test_metrics"
+	err := CreateTable(ctx, dbRW, tableName)
+	require.NoError(t, err)
+
+	// Create test metrics with different timestamps
+	now := time.Now()
+	oldTimestamp1 := now.Add(-2 * time.Hour).UnixMilli()
+	oldTimestamp2 := now.Add(-1 * time.Hour).UnixMilli()
+	currentTimestamp := now.UnixMilli()
+
+	metrics := []pkgmetrics.Metric{
+		{
+			UnixMilliseconds: oldTimestamp1,
+			Component:        "component1",
+			Name:             "metric1",
+			Value:            10.0,
+		},
+		{
+			UnixMilliseconds: oldTimestamp2,
+			Component:        "component1",
+			Name:             "metric2",
+			Value:            20.0,
+		},
+		{
+			UnixMilliseconds: currentTimestamp,
+			Component:        "component2",
+			Name:             "metric3",
+			Value:            30.0,
+		},
+	}
+
+	// Insert test metrics
+	for _, m := range metrics {
+		err := insert(ctx, dbRW, tableName, m)
+		require.NoError(t, err)
+	}
+
+	// Test purging metrics older than 90 minutes
+	affected, err := purge(ctx, dbRW, tableName, now.Add(-90*time.Minute))
+	require.NoError(t, err)
+	assert.Equal(t, 1, affected)
+
+	// Test purging metrics older than 30 minutes
+	affected, err = purge(ctx, dbRW, tableName, now.Add(-30*time.Minute))
+	require.NoError(t, err)
+	assert.Equal(t, 1, affected)
+
+	// Test purging with empty table name
+	affected, err = purge(ctx, dbRW, "", time.Time{})
+	assert.Equal(t, ErrEmptyTableName, err)
+	assert.Equal(t, 0, affected)
+}
+
+// Test reading from a non-existent table to check error handling
+func TestSQLiteReadNonExistentTable(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, dbRO, cleanup := pkgsqlite.OpenTestDB(t)
+	defer cleanup()
+
+	// Try reading from a table that doesn't exist
+	results, err := read(ctx, dbRO, "nonexistent_table", time.Time{})
+	require.Error(t, err)
+	assert.Nil(t, results)
+}
+
+// Test null label handling in Read function
+func TestSQLiteReadNullLabel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dbRW, dbRO, cleanup := pkgsqlite.OpenTestDB(t)
+	defer cleanup()
+
+	tableName := "test_metrics_null_label"
+	err := CreateTable(ctx, dbRW, tableName)
+	require.NoError(t, err)
+
+	// Create test metrics with and without labels
+	now := time.Now()
+	metrics := []pkgmetrics.Metric{
+		{
+			UnixMilliseconds: now.UnixMilli(),
+			Component:        "component1",
+			Name:             "metric1",
+			Label:            "", // Empty label
+			Value:            10.0,
+		},
+		{
+			UnixMilliseconds: now.UnixMilli(),
+			Component:        "component2",
+			Name:             "metric2",
+			Label:            "label2",
+			Value:            20.0,
+		},
+	}
+
+	// Insert test metrics
+	for _, m := range metrics {
+		err := insert(ctx, dbRW, tableName, m)
+		require.NoError(t, err)
+	}
+
+	// Read the metrics back
+	results, err := read(ctx, dbRO, tableName, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	// Verify labels are preserved correctly
+	for _, result := range results {
+		if result.Component == "component1" {
+			assert.Equal(t, "", result.Label)
+		} else if result.Component == "component2" {
+			assert.Equal(t, "label2", result.Label)
+		}
+	}
+}
+
+// Test invalid database operations
+func TestSQLiteInvalidDatabaseOperations(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a db connection and immediately close it to simulate errors
+	dbRW, _, cleanup := pkgsqlite.OpenTestDB(t)
+	cleanup() // Close the DB immediately
+
+	// Operations on closed DB should error
+	err := CreateTable(ctx, dbRW, "test_metrics")
+	assert.Error(t, err)
+
+	metric := pkgmetrics.Metric{
+		UnixMilliseconds: time.Now().UnixMilli(),
+		Component:        "test-component",
+		Name:             "test-metric",
+		Value:            42.0,
+	}
+
+	err = insert(ctx, dbRW, "test_metrics", metric)
+	assert.Error(t, err)
+
+	affected, err := purge(ctx, dbRW, "test_metrics", time.Now())
+	assert.Error(t, err)
+	assert.Equal(t, 0, affected)
+}
+
+// TestBatchInsert tests the batch insertion of multiple metrics at once
+func TestSQLiteBatchInsert(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	dbRW, dbRO, cleanup := pkgsqlite.OpenTestDB(t)
+	defer cleanup()
+
+	tableName := "test_batch_metrics"
+	err := CreateTable(ctx, dbRW, tableName)
+	require.NoError(t, err, "failed to create table")
+
+	// Create a batch of test metrics
+	now := time.Now()
+	baseTime := now.UnixMilli()
+	batchMetrics := []pkgmetrics.Metric{
+		{
+			UnixMilliseconds: baseTime,
+			Component:        "component1",
+			Name:             "metric1",
+			Label:            "GPU-0",
+			Value:            10.5,
+		},
+		{
+			UnixMilliseconds: baseTime,
+			Component:        "component1",
+			Name:             "metric2",
+			Label:            "GPU-0",
+			Value:            20.7,
+		},
+		{
+			UnixMilliseconds: baseTime,
+			Component:        "component2",
+			Name:             "metric1",
+			Label:            "GPU-1",
+			Value:            30.2,
+		},
+		{
+			UnixMilliseconds: baseTime + 100,
+			Component:        "component2",
+			Name:             "metric2",
+			Label:            "GPU-1",
+			Value:            40.9,
+		},
+		{
+			UnixMilliseconds: baseTime + 200,
+			Component:        "component3",
+			Name:             "metric3",
+			Label:            "",
+			Value:            50.1,
+		},
+	}
+
+	// Test batch insert
+	err = insert(ctx, dbRW, tableName, batchMetrics...)
+	require.NoError(t, err, "batch insert failed")
+
+	// Read all metrics back and verify
+	results, err := read(ctx, dbRO, tableName, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, results, len(batchMetrics), "should have same number of metrics as inserted")
+
+	// Create a map of expected values for easier verification
+	expectedMap := make(map[string]float64)
+	for _, m := range batchMetrics {
+		key := keyFromMetric(m)
+		expectedMap[key] = m.Value
+	}
+
+	// Verify all metrics were inserted correctly
+	for _, m := range results {
+		key := keyFromMetric(m)
+		expectedValue, exists := expectedMap[key]
+		assert.True(t, exists, "metric should exist: %s", key)
+		assert.Equal(t, expectedValue, m.Value, "metric value should match for %s", key)
+	}
+
+	// Test empty batch insert - should be a no-op
+	err = insert(ctx, dbRW, tableName)
+	require.NoError(t, err, "empty batch insert should succeed")
+
+	// Test batch with validation error
+	invalidBatch := []pkgmetrics.Metric{
+		{
+			UnixMilliseconds: baseTime + 300,
+			Component:        "component4",
+			Name:             "metric4",
+			Value:            60.3,
+		},
+		{
+			UnixMilliseconds: baseTime + 400,
+			Component:        "", // Invalid: empty component
+			Name:             "metric5",
+			Value:            70.4,
+		},
+	}
+
+	err = insert(ctx, dbRW, tableName, invalidBatch...)
+	assert.Equal(t, ErrEmptyComponentName, err, "should fail on empty component name")
+
+	// Ensure first batch is still intact by reading again
+	results, err = read(ctx, dbRO, tableName, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, results, len(batchMetrics), "should still have original metrics")
+
+	// Test batch update (replace) by inserting metrics with same keys but different values
+	updatedBatch := []pkgmetrics.Metric{
+		{
+			UnixMilliseconds: baseTime,
+			Component:        "component1",
+			Name:             "metric1",
+			Label:            "GPU-0",
+			Value:            100.5, // Updated value
+		},
+		{
+			UnixMilliseconds: baseTime,
+			Component:        "component1",
+			Name:             "metric2",
+			Label:            "GPU-0",
+			Value:            200.7, // Updated value
+		},
+	}
+
+	err = insert(ctx, dbRW, tableName, updatedBatch...)
+	require.NoError(t, err, "update batch insert failed")
+
+	// Verify updates were applied
+	results, err = read(ctx, dbRO, tableName, time.Time{})
+	require.NoError(t, err)
+	require.Len(t, results, len(batchMetrics), "should have same number of metrics as before")
+
+	// Check updated values
+	for _, m := range results {
+		if m.Component == "component1" && m.Name == "metric1" && m.Label == "GPU-0" {
+			assert.Equal(t, 100.5, m.Value, "value should be updated")
+		} else if m.Component == "component1" && m.Name == "metric2" && m.Label == "GPU-0" {
+			assert.Equal(t, 200.7, m.Value, "value should be updated")
+		}
+	}
+}
+
+// Helper function to create a unique key from a metric for testing
+func keyFromMetric(m pkgmetrics.Metric) string {
+	return fmt.Sprintf("%d:%s:%s:%s", m.UnixMilliseconds, m.Component, m.Name, m.Label)
+}

--- a/pkg/metrics/syncer/syncer.go
+++ b/pkg/metrics/syncer/syncer.go
@@ -1,0 +1,88 @@
+// Package syncer provides a syncer for the metrics.
+package syncer
+
+import (
+	"context"
+	"time"
+
+	"github.com/leptonai/gpud/pkg/log"
+	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
+)
+
+type Syncer struct {
+	ctx            context.Context
+	cancel         context.CancelFunc
+	scraper        pkgmetrics.Scraper
+	store          pkgmetrics.Store
+	scrapeInterval time.Duration
+	purgeInterval  time.Duration
+	retainDuration time.Duration
+}
+
+func NewSyncer(ctx context.Context, scraper pkgmetrics.Scraper, store pkgmetrics.Store, scrapeInterval time.Duration, purgeInterval time.Duration, retainDuration time.Duration) *Syncer {
+	cctx, cancel := context.WithCancel(ctx)
+	s := &Syncer{
+		ctx:            cctx,
+		cancel:         cancel,
+		scraper:        scraper,
+		store:          store,
+		scrapeInterval: scrapeInterval,
+		purgeInterval:  purgeInterval,
+		retainDuration: retainDuration,
+	}
+	return s
+}
+
+func (s *Syncer) Start() {
+	go func() {
+		ticker := time.NewTicker(s.scrapeInterval)
+		defer ticker.Stop()
+
+		log.Logger.Infow("start scrap and sync metrics")
+		for {
+			select {
+			case <-s.ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			if err := s.sync(); err != nil {
+				log.Logger.Errorw("failed to sync metrics", "error", err)
+			}
+		}
+	}()
+	go func() {
+		ticker := time.NewTicker(s.purgeInterval)
+		defer ticker.Stop()
+
+		log.Logger.Infow("start purging metrics")
+		for {
+			select {
+			case <-s.ctx.Done():
+				return
+			case <-ticker.C:
+			}
+
+			before := time.Now().UTC().Add(-s.retainDuration)
+			if purged, err := s.store.Purge(s.ctx, before); err != nil {
+				log.Logger.Errorw("failed to purge metrics", "error", err)
+			} else {
+				log.Logger.Infow("purged metrics", "purged", purged)
+			}
+		}
+	}()
+}
+
+func (s *Syncer) sync() error {
+	ms, err := s.scraper.Scrape(s.ctx)
+	if err != nil {
+		return err
+	}
+	return s.store.Record(s.ctx, ms...)
+}
+
+func (s *Syncer) Stop() {
+	log.Logger.Infow("stopping syncer")
+
+	s.cancel()
+}

--- a/pkg/metrics/syncer/syncer_test.go
+++ b/pkg/metrics/syncer/syncer_test.go
@@ -1,0 +1,353 @@
+package syncer
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
+)
+
+// mockScraper implements the pkgmetrics.Scraper interface for testing
+type mockScraper struct {
+	metrics pkgmetrics.Metrics
+	err     error
+	scrapes int
+	mu      sync.Mutex
+}
+
+func newMockScraper(metrics pkgmetrics.Metrics, err error) *mockScraper {
+	return &mockScraper{
+		metrics: metrics,
+		err:     err,
+	}
+}
+
+func (m *mockScraper) Scrape(ctx context.Context) (pkgmetrics.Metrics, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.scrapes++
+	return m.metrics, m.err
+}
+
+func (m *mockScraper) getScrapeCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.scrapes
+}
+
+// mockStore implements the pkgmetrics.Store interface for testing
+type mockStore struct {
+	records       []pkgmetrics.Metric
+	recordErr     error
+	purgeCount    int
+	purged        int
+	purgeErr      error
+	readErr       error
+	lastPurgeTime time.Time
+	mu            sync.Mutex
+}
+
+func newMockStore(recordErr, purgeErr, readErr error) *mockStore {
+	return &mockStore{
+		records:   make([]pkgmetrics.Metric, 0),
+		recordErr: recordErr,
+		purgeErr:  purgeErr,
+		readErr:   readErr,
+	}
+}
+
+func (m *mockStore) Record(ctx context.Context, ms ...pkgmetrics.Metric) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.recordErr != nil {
+		return m.recordErr
+	}
+
+	m.records = append(m.records, ms...)
+	return nil
+}
+
+func (m *mockStore) Read(ctx context.Context, since time.Time) (pkgmetrics.Metrics, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.readErr != nil {
+		return nil, m.readErr
+	}
+
+	result := make(pkgmetrics.Metrics, 0)
+	for _, metric := range m.records {
+		if metric.UnixMilliseconds >= since.UnixMilli() {
+			result = append(result, metric)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockStore) Purge(ctx context.Context, before time.Time) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.purgeCount++
+	m.lastPurgeTime = before
+
+	if m.purgeErr != nil {
+		return 0, m.purgeErr
+	}
+
+	// Simulate purging records
+	remain := make([]pkgmetrics.Metric, 0)
+	purged := 0
+
+	for _, metric := range m.records {
+		if metric.UnixMilliseconds >= before.UnixMilli() {
+			remain = append(remain, metric)
+		} else {
+			purged++
+		}
+	}
+
+	m.records = remain
+	m.purged = purged
+
+	return purged, nil
+}
+
+func (m *mockStore) getRecordCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return len(m.records)
+}
+
+func (m *mockStore) getPurgeCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.purgeCount
+}
+
+func (m *mockStore) getLastPurgeTime() time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.lastPurgeTime
+}
+
+func TestNewSyncer(t *testing.T) {
+	t.Parallel()
+
+	// Set up test dependencies
+	scraper := newMockScraper(nil, nil)
+	store := newMockStore(nil, nil, nil)
+
+	// Test with valid parameters
+	ctx := context.Background()
+	syncInterval := 10 * time.Millisecond
+	purgeInterval := 50 * time.Millisecond
+	retainDuration := 1 * time.Hour
+
+	s := NewSyncer(ctx, scraper, store, syncInterval, purgeInterval, retainDuration)
+
+	require.NotNil(t, s, "syncer should not be nil")
+	require.Equal(t, syncInterval, s.scrapeInterval)
+	require.Equal(t, purgeInterval, s.purgeInterval)
+	require.Equal(t, retainDuration, s.retainDuration)
+	require.NotNil(t, s.ctx, "context should not be nil")
+	require.NotNil(t, s.cancel, "cancel function should not be nil")
+}
+
+func TestSync(t *testing.T) {
+	t.Parallel()
+
+	// Create test metrics
+	now := time.Now().UnixMilli()
+	testMetrics := pkgmetrics.Metrics{
+		{
+			UnixMilliseconds: now,
+			Component:        "test-component",
+			Name:             "metric1",
+			Value:            42.0,
+		},
+		{
+			UnixMilliseconds: now,
+			Component:        "test-component",
+			Name:             "metric2",
+			Label:            "gpu0",
+			Value:            123.45,
+		},
+	}
+
+	// Test case 1: Successful sync
+	t.Run("SuccessfulSync", func(t *testing.T) {
+		scraper := newMockScraper(testMetrics, nil)
+		store := newMockStore(nil, nil, nil)
+
+		ctx := context.Background()
+		s := NewSyncer(ctx, scraper, store, time.Second, time.Second, time.Hour)
+
+		err := s.sync()
+		require.NoError(t, err)
+		require.Equal(t, 1, scraper.getScrapeCount())
+		require.Equal(t, len(testMetrics), store.getRecordCount())
+	})
+
+	// Test case 2: Scrape error
+	t.Run("ScrapeError", func(t *testing.T) {
+		expectedErr := errors.New("scrape error")
+		scraper := newMockScraper(nil, expectedErr)
+		store := newMockStore(nil, nil, nil)
+
+		ctx := context.Background()
+		s := NewSyncer(ctx, scraper, store, time.Second, time.Second, time.Hour)
+
+		err := s.sync()
+		require.Error(t, err)
+		require.Equal(t, expectedErr, err)
+		require.Equal(t, 1, scraper.getScrapeCount())
+		require.Equal(t, 0, store.getRecordCount())
+	})
+
+	// Test case 3: Store error
+	t.Run("StoreError", func(t *testing.T) {
+		expectedErr := errors.New("store error")
+		scraper := newMockScraper(testMetrics, nil)
+		store := newMockStore(expectedErr, nil, nil)
+
+		ctx := context.Background()
+		s := NewSyncer(ctx, scraper, store, time.Second, time.Second, time.Hour)
+
+		err := s.sync()
+		require.Error(t, err)
+		require.Equal(t, expectedErr, err)
+		require.Equal(t, 1, scraper.getScrapeCount())
+		require.Equal(t, 0, store.getRecordCount())
+	})
+}
+
+func TestStartStop(t *testing.T) {
+	// Test case: Start and Stop
+	t.Run("StartStop", func(t *testing.T) {
+		scraper := newMockScraper(pkgmetrics.Metrics{}, nil)
+		store := newMockStore(nil, nil, nil)
+
+		ctx := context.Background()
+		scrapeInterval := 50 * time.Millisecond
+		purgeInterval := 100 * time.Millisecond
+		retainDuration := 1 * time.Hour
+
+		s := NewSyncer(ctx, scraper, store, scrapeInterval, purgeInterval, retainDuration)
+
+		// Start the syncer
+		s.Start()
+
+		// Wait for some time to allow scraping and purging to occur
+		time.Sleep(250 * time.Millisecond)
+
+		// Stop the syncer
+		s.Stop()
+
+		// Assert that scraping occurred at least once
+		require.GreaterOrEqual(t, scraper.getScrapeCount(), 1)
+
+		// Assert that purging occurred at least once
+		require.GreaterOrEqual(t, store.getPurgeCount(), 1)
+
+		// Verify that the last purge time is about retainDuration ago
+		lastPurgeTime := store.getLastPurgeTime()
+		require.NotEqual(t, time.Time{}, lastPurgeTime)
+
+		// Check that the purge was called with a time approximately retainDuration ago
+		purgeTimeDiff := time.Until(lastPurgeTime.Add(retainDuration))
+		require.InDelta(t, 0, purgeTimeDiff.Seconds(), 1, "Purge time should be approximately retainDuration ago")
+
+		// Wait a bit more and verify counters don't increase after stopping
+		currentScrapeCount := scraper.getScrapeCount()
+		currentPurgeCount := store.getPurgeCount()
+
+		time.Sleep(200 * time.Millisecond)
+
+		require.Equal(t, currentScrapeCount, scraper.getScrapeCount(), "Scrape count should not increase after stopping")
+		require.Equal(t, currentPurgeCount, store.getPurgeCount(), "Purge count should not increase after stopping")
+	})
+
+	// Test context cancellation
+	t.Run("ContextCancellation", func(t *testing.T) {
+		scraper := newMockScraper(pkgmetrics.Metrics{}, nil)
+		store := newMockStore(nil, nil, nil)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		s := NewSyncer(ctx, scraper, store, 50*time.Millisecond, 100*time.Millisecond, time.Hour)
+
+		// Start the syncer
+		s.Start()
+
+		// Wait for some activity
+		time.Sleep(150 * time.Millisecond)
+
+		// Get current counts
+		currentScrapeCount := scraper.getScrapeCount()
+		currentPurgeCount := store.getPurgeCount()
+
+		// Cancel the parent context
+		cancel()
+
+		// Wait a bit more
+		time.Sleep(200 * time.Millisecond)
+
+		// Verify no more activity after context cancellation
+		require.Equal(t, currentScrapeCount, scraper.getScrapeCount(), "Scrape count should not increase after context cancellation")
+		require.Equal(t, currentPurgeCount, store.getPurgeCount(), "Purge count should not increase after context cancellation")
+	})
+}
+
+func TestSyncerWithErrors(t *testing.T) {
+	t.Run("ScrapeErrors", func(t *testing.T) {
+		scraper := newMockScraper(nil, errors.New("scrape error"))
+		store := newMockStore(nil, nil, nil)
+
+		ctx := context.Background()
+		s := NewSyncer(ctx, scraper, store, 50*time.Millisecond, 200*time.Millisecond, time.Hour)
+
+		// Start the syncer
+		s.Start()
+
+		// Even with errors, the syncer should continue running
+		time.Sleep(200 * time.Millisecond)
+
+		// Verify that scrape was attempted multiple times despite errors
+		require.GreaterOrEqual(t, scraper.getScrapeCount(), 2)
+
+		// Stop the syncer
+		s.Stop()
+	})
+
+	t.Run("PurgeErrors", func(t *testing.T) {
+		scraper := newMockScraper(pkgmetrics.Metrics{}, nil)
+		store := newMockStore(nil, errors.New("purge error"), nil)
+
+		ctx := context.Background()
+		s := NewSyncer(ctx, scraper, store, 200*time.Millisecond, 50*time.Millisecond, time.Hour)
+
+		// Start the syncer
+		s.Start()
+
+		// Even with errors, the syncer should continue running
+		time.Sleep(200 * time.Millisecond)
+
+		// Verify that purge was attempted multiple times despite errors
+		require.GreaterOrEqual(t, store.getPurgeCount(), 2)
+
+		// Stop the syncer
+		s.Stop()
+	})
+}

--- a/pkg/metrics/type.go
+++ b/pkg/metrics/type.go
@@ -5,6 +5,14 @@ import (
 	"time"
 )
 
+const (
+	// MetricComponentLabelKey is the key for the component of the metric.
+	MetricComponentLabelKey = "gpud_component"
+
+	// MetricLabelKey is the key for the label of the metric.
+	MetricLabelKey = "gpud_metric_label"
+)
+
 // Metric represents a metric row in the database table.
 type Metric struct {
 	// UnixMilliseconds represents the Unix timestamp of the metric.
@@ -39,11 +47,3 @@ type Store interface {
 	// Purge purges the metrics data points before the given time.
 	Purge(ctx context.Context, before time.Time) (int, error)
 }
-
-const (
-	// MetricComponentLabelKey is the key for the component of the metric.
-	MetricComponentLabelKey = "gpud_component"
-
-	// MetricLabelKey is the key for the label of the metric.
-	MetricLabelKey = "gpud_metric_label"
-)

--- a/pkg/metrics/type.go
+++ b/pkg/metrics/type.go
@@ -1,0 +1,49 @@
+package metrics
+
+import (
+	"context"
+	"time"
+)
+
+// Metric represents a metric row in the database table.
+type Metric struct {
+	// UnixMilliseconds represents the Unix timestamp of the metric.
+	UnixMilliseconds int64 `json:"unix_milliseconds"`
+	// Component represents the name of the component this metric belongs to.
+	Component string `json:"component"`
+	// Name represents the name of the metric.
+	Name string `json:"name"`
+	// Label represents the label of the metric such as GPU ID, etc..
+	Label string `json:"label,omitempty"`
+	// Value represents the numeric value of the metric.
+	Value float64 `json:"value"`
+}
+
+// Metrics is a slice of Metric.
+type Metrics []Metric
+
+// Scraper defines the metrics scraper interface.
+type Scraper interface {
+	Scrape(context.Context) (Metrics, error)
+}
+
+// Store defines the metrics store interface.
+type Store interface {
+	// Record records metric data points.
+	Record(ctx context.Context, ms ...Metric) error
+
+	// Returns all the data points since the given time.
+	// If since is zero, returns all metrics.
+	Read(ctx context.Context, since time.Time) (Metrics, error)
+
+	// Purge purges the metrics data points before the given time.
+	Purge(ctx context.Context, before time.Time) (int, error)
+}
+
+const (
+	// MetricComponentLabelKey is the key for the component of the metric.
+	MetricComponentLabelKey = "gpud_component"
+
+	// MetricLabelKey is the key for the label of the metric.
+	MetricLabelKey = "gpud_metric_label"
+)

--- a/pkg/metrics/utils.go
+++ b/pkg/metrics/utils.go
@@ -1,0 +1,42 @@
+package metrics
+
+import (
+	"sort"
+
+	v1 "github.com/leptonai/gpud/api/v1"
+	"github.com/leptonai/gpud/components"
+	components_metrics_state "github.com/leptonai/gpud/pkg/gpud-metrics/state"
+)
+
+func ConvertToLeptonMetrics(ms Metrics) v1.LeptonMetrics {
+	aggregated := make(map[string][]components.Metric)
+	for _, m := range ms {
+		if m.Component == "" {
+			continue
+		}
+		if _, ok := aggregated[m.Component]; !ok {
+			aggregated[m.Component] = make([]components.Metric, 0)
+		}
+
+		aggregated[m.Component] = append(aggregated[m.Component], components.Metric{
+			Metric: components_metrics_state.Metric{
+				UnixSeconds:         m.UnixMilliseconds,
+				MetricName:          m.Name,
+				MetricSecondaryName: m.Label,
+				Value:               m.Value,
+			},
+		})
+	}
+
+	converted := make(v1.LeptonMetrics, 0, len(ms))
+	for component, ms := range aggregated {
+		sort.Slice(ms, func(i, j int) bool {
+			return ms[i].Metric.UnixSeconds < ms[j].Metric.UnixSeconds
+		})
+		converted = append(converted, v1.LeptonComponentMetrics{
+			Component: component,
+			Metrics:   ms,
+		})
+	}
+	return converted
+}

--- a/pkg/metrics/utils_test.go
+++ b/pkg/metrics/utils_test.go
@@ -1,0 +1,178 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/leptonai/gpud/api/v1"
+)
+
+func TestConvertToLeptonMetrics_Empty(t *testing.T) {
+	ms := Metrics{}
+	result := ConvertToLeptonMetrics(ms)
+	assert.Empty(t, result, "empty metrics should return empty result")
+}
+
+func TestConvertToLeptonMetrics_EmptyComponent(t *testing.T) {
+	// Metrics with empty component should be skipped
+	ms := Metrics{
+		{
+			UnixMilliseconds: 1000,
+			Component:        "", // Empty component
+			Name:             "metric1",
+			Value:            10.5,
+		},
+		{
+			UnixMilliseconds: 2000,
+			Component:        "component1",
+			Name:             "metric2",
+			Value:            20.5,
+		},
+	}
+
+	result := ConvertToLeptonMetrics(ms)
+	require.Len(t, result, 1, "should have only one component metrics")
+	assert.Equal(t, "component1", result[0].Component)
+	require.Len(t, result[0].Metrics, 1, "should have one metric")
+	assert.Equal(t, "metric2", result[0].Metrics[0].Metric.MetricName)
+	assert.Equal(t, int64(2000), result[0].Metrics[0].Metric.UnixSeconds)
+	assert.Equal(t, 20.5, result[0].Metrics[0].Metric.Value)
+}
+
+func TestConvertToLeptonMetrics_SingleComponent(t *testing.T) {
+	now := time.Now().UnixMilli()
+
+	ms := Metrics{
+		{
+			UnixMilliseconds: now,
+			Component:        "component1",
+			Name:             "metric1",
+			Value:            10.5,
+		},
+		{
+			UnixMilliseconds: now + 1000,
+			Component:        "component1",
+			Name:             "metric2",
+			Label:            "gpu0",
+			Value:            20.5,
+		},
+	}
+
+	result := ConvertToLeptonMetrics(ms)
+	require.Len(t, result, 1, "should have one component metrics")
+	assert.Equal(t, "component1", result[0].Component)
+	require.Len(t, result[0].Metrics, 2, "should have two metrics")
+
+	// Check first metric
+	assert.Equal(t, "metric1", result[0].Metrics[0].Metric.MetricName)
+	assert.Equal(t, "", result[0].Metrics[0].Metric.MetricSecondaryName)
+	assert.Equal(t, now, result[0].Metrics[0].Metric.UnixSeconds)
+	assert.Equal(t, 10.5, result[0].Metrics[0].Metric.Value)
+
+	// Check second metric
+	assert.Equal(t, "metric2", result[0].Metrics[1].Metric.MetricName)
+	assert.Equal(t, "gpu0", result[0].Metrics[1].Metric.MetricSecondaryName)
+	assert.Equal(t, now+1000, result[0].Metrics[1].Metric.UnixSeconds)
+	assert.Equal(t, 20.5, result[0].Metrics[1].Metric.Value)
+}
+
+func TestConvertToLeptonMetrics_MultipleComponents(t *testing.T) {
+	now := time.Now().UnixMilli()
+
+	ms := Metrics{
+		{
+			UnixMilliseconds: now,
+			Component:        "component1",
+			Name:             "metric1",
+			Value:            10.5,
+		},
+		{
+			UnixMilliseconds: now + 1000,
+			Component:        "component2",
+			Name:             "metric2",
+			Label:            "gpu0",
+			Value:            20.5,
+		},
+		{
+			UnixMilliseconds: now + 2000,
+			Component:        "component1",
+			Name:             "metric3",
+			Label:            "gpu1",
+			Value:            30.5,
+		},
+	}
+
+	result := ConvertToLeptonMetrics(ms)
+	require.Len(t, result, 2, "should have two component metrics")
+
+	// Components may be in any order, so find them by name
+	var comp1, comp2 v1.LeptonComponentMetrics
+	for _, c := range result {
+		if c.Component == "component1" {
+			comp1 = c
+		} else if c.Component == "component2" {
+			comp2 = c
+		}
+	}
+
+	// Check component1
+	assert.Equal(t, "component1", comp1.Component)
+	require.Len(t, comp1.Metrics, 2, "component1 should have two metrics")
+
+	// Check metrics are sorted by timestamp
+	assert.Equal(t, now, comp1.Metrics[0].Metric.UnixSeconds)
+	assert.Equal(t, "metric1", comp1.Metrics[0].Metric.MetricName)
+	assert.Equal(t, 10.5, comp1.Metrics[0].Metric.Value)
+
+	assert.Equal(t, now+2000, comp1.Metrics[1].Metric.UnixSeconds)
+	assert.Equal(t, "metric3", comp1.Metrics[1].Metric.MetricName)
+	assert.Equal(t, "gpu1", comp1.Metrics[1].Metric.MetricSecondaryName)
+	assert.Equal(t, 30.5, comp1.Metrics[1].Metric.Value)
+
+	// Check component2
+	assert.Equal(t, "component2", comp2.Component)
+	require.Len(t, comp2.Metrics, 1, "component2 should have one metric")
+	assert.Equal(t, "metric2", comp2.Metrics[0].Metric.MetricName)
+	assert.Equal(t, "gpu0", comp2.Metrics[0].Metric.MetricSecondaryName)
+	assert.Equal(t, now+1000, comp2.Metrics[0].Metric.UnixSeconds)
+	assert.Equal(t, 20.5, comp2.Metrics[0].Metric.Value)
+}
+
+func TestConvertToLeptonMetrics_SortingByTimestamp(t *testing.T) {
+	// Test that metrics within a component are sorted by timestamp
+	now := time.Now().UnixMilli()
+
+	// Create metrics with unsorted timestamps
+	ms := Metrics{
+		{
+			UnixMilliseconds: now + 2000, // Third timestamp
+			Component:        "component1",
+			Name:             "metric3",
+			Value:            30.5,
+		},
+		{
+			UnixMilliseconds: now, // First timestamp
+			Component:        "component1",
+			Name:             "metric1",
+			Value:            10.5,
+		},
+		{
+			UnixMilliseconds: now + 1000, // Second timestamp
+			Component:        "component1",
+			Name:             "metric2",
+			Value:            20.5,
+		},
+	}
+
+	result := ConvertToLeptonMetrics(ms)
+	require.Len(t, result, 1, "should have one component metrics")
+	require.Len(t, result[0].Metrics, 3, "should have three metrics")
+
+	// Verify metrics are sorted by timestamp
+	assert.Equal(t, now, result[0].Metrics[0].Metric.UnixSeconds, "first metric should have earliest timestamp")
+	assert.Equal(t, now+1000, result[0].Metrics[1].Metric.UnixSeconds, "second metric should have middle timestamp")
+	assert.Equal(t, now+2000, result[0].Metrics[2].Metric.UnixSeconds, "third metric should have latest timestamp")
+}

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -12,11 +12,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	lep_components "github.com/leptonai/gpud/components"
 	lep_config "github.com/leptonai/gpud/pkg/config"
 	gpud_manager "github.com/leptonai/gpud/pkg/gpud-manager"
+	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
 
-	"github.com/gin-gonic/gin"
 	"sigs.k8s.io/yaml"
 )
 
@@ -26,9 +27,11 @@ type globalHandler struct {
 
 	componentNamesMu sync.RWMutex
 	componentNames   []string
+
+	metricsStore pkgmetrics.Store
 }
 
-func newGlobalHandler(cfg *lep_config.Config, components map[string]lep_components.Component) *globalHandler {
+func newGlobalHandler(cfg *lep_config.Config, components map[string]lep_components.Component, metricsStore pkgmetrics.Store) *globalHandler {
 	var componentNames []string
 	for name := range components {
 		componentNames = append(componentNames, name)
@@ -39,6 +42,7 @@ func newGlobalHandler(cfg *lep_config.Config, components map[string]lep_componen
 		cfg:            cfg,
 		components:     components,
 		componentNames: componentNames,
+		metricsStore:   metricsStore,
 	}
 }
 


### PR DESCRIPTION
```
disk_free_bytes{gpud_component="disk",gpud_metric_label="/"} 2.407153664e+10
# HELP disk_last_update_unix_seconds tracks the last update time in unix seconds
# TYPE disk_last_update_unix_seconds gauge
disk_last_update_unix_seconds 1.743255649e+09
# HELP disk_total_bytes tracks the total bytes of the disk
# TYPE disk_total_bytes gauge
disk_total_bytes{gpud_component="disk",gpud_metric_label="/"} 7.6887154688e+10
# HELP disk_used_bytes tracks the current free bytes of the disk
# TYPE disk_used_bytes gauge
disk_used_bytes{gpud_component="disk",gpud_metric_label="/"} 5.2798840832e+10
# HELP disk_used_bytes_avg tracks the disk bytes usage with average for the last period
# TYPE disk_used_bytes_avg gauge
disk_used_bytes_avg{gpud_component="disk",gpud_metric_label="/",last_period="5m0s"} 5.2745824256e+10
# HELP disk_used_bytes_percent tracks the current disk bytes usage percentage
# TYPE disk_used_bytes_percent gauge
disk_used_bytes_percent{gpud_component="disk",gpud_metric_label="/"} 68.6855490611[216](https://github.com/leptonai/gpud/actions/runs/14146180195/job/39633738807?pr=577#step:5:217)9
# HELP disk_used_bytes_percent_avg tracks the disk bytes usage percentage with average for the last period
# TYPE disk_used_bytes_percent_avg gauge
disk_used_bytes_percent_avg{gpud_component="disk",gpud_metric_label="/",last_period="5m0s"} 68.61658026228977
# HELP disk_used_inodes_percent tracks the current disk inodes usage percentage
# TYPE disk_used_inodes_percent gauge
disk_used_inodes_percent{gpud_component="disk",gpud_metric_label="/"} 9.353885135135135
```

> /v1/metrics RESPONSE BODY: [{"component":"memory","metrics":[{"unix_seconds":1743258494213,"metric_name":"memory_available_bytes","value":15634485248},{"unix_seconds":1743258494213,"metric_name":"memory_free_bytes","value":7808794624},{"unix_seconds":1743258494213,"metric_name":"memory_total_bytes","value":16766767104},{"unix_seconds":1743258494213,"metric_name":"memory_used_bytes","value":700407808},{"unix_seconds":1743258494213,"metric_name":"memory_used_percent","value":4.1773575290665645},{"unix_seconds":1743258574793,"metric_name":"memory_available_bytes","value":15569870848},{"unix_seconds":1743258574793,"metric_name":"memory_free_bytes","value":7730143232},{"unix_seconds":1743258574793,"metric_name":"memory_total_bytes","value":16766767104},{"unix_seconds":1743258574793,"metric_name":"memory_used_bytes","value":763338752},{"unix_seconds":1743258574793,"metric_name":"memory_used_percent","value":4.552688942747301}]},{"component":"network-latency","metrics":[{"unix_seconds":1743258494213,"metric_name":"network_latency_edge_in_milliseconds","metric_secondary_name":"Amsterdam (tailscale-derp)","value":85},{"unix_seconds":1743258494213,"metric_name":"network_latency_edge_in_milliseconds","metric_secondary_name":"Ashburn (tailscale-derp)","value":5},{"unix_seconds":1743258494213,"metric_name":"network_latency_edge_in_milliseconds","metric_secondary_name":"Bangalore (tailscale-derp)","value":197},{"unix_seconds":1743258494213,"metric_name":"network_latency_edge_in_milliseconds","metric_secondary_name":"Chicago (tailscale-derp)","value":20},