### PR TITLE
test(metrics/syncer): make start/stop tests less flaky for slow CI

### DIFF
--- a/pkg/metrics/syncer/syncer_test.go
+++ b/pkg/metrics/syncer/syncer_test.go
@@ -242,7 +242,7 @@ func TestStartStop(t *testing.T) {
 
 		ctx := context.Background()
 		scrapeInterval := time.Second
-		purgeInterval := 10 * time.Second
+		purgeInterval := time.Second
 		retainDuration := 1 * time.Hour
 
 		s := NewSyncer(ctx, scraper, store, scrapeInterval, purgeInterval, retainDuration)

--- a/pkg/metrics/syncer/syncer_test.go
+++ b/pkg/metrics/syncer/syncer_test.go
@@ -241,8 +241,8 @@ func TestStartStop(t *testing.T) {
 		store := newMockStore(nil, nil, nil)
 
 		ctx := context.Background()
-		scrapeInterval := 50 * time.Millisecond
-		purgeInterval := 100 * time.Millisecond
+		scrapeInterval := time.Second
+		purgeInterval := 10 * time.Second
 		retainDuration := 1 * time.Hour
 
 		s := NewSyncer(ctx, scraper, store, scrapeInterval, purgeInterval, retainDuration)
@@ -274,7 +274,8 @@ func TestStartStop(t *testing.T) {
 		currentScrapeCount := scraper.getScrapeCount()
 		currentPurgeCount := store.getPurgeCount()
 
-		time.Sleep(200 * time.Millisecond)
+		// enough time for sync ticker to cancel
+		time.Sleep(5 * scrapeInterval)
 
 		require.Equal(t, currentScrapeCount, scraper.getScrapeCount(), "Scrape count should not increase after stopping")
 		require.Equal(t, currentPurgeCount, store.getPurgeCount(), "Purge count should not increase after stopping")


### PR DESCRIPTION
```
{"level":"info","ts":"2025-04-01T15:31:45Z","caller":"syncer/syncer.go:70","msg":"purged metrics","purged":0}
    syncer_test.go:279:
        	Error Trace:	/home/runner/work/gpud/gpud/pkg/metrics/syncer/syncer_test.go:279
        	Error:      	Not equal:
        	            	expected: 59
        	            	actual  : 60
        	Test:       	TestStartStop/StartStop
        	Messages:   	Scrape count should not increase after stopping
--- FAIL: TestStartStop (3.20s)
    --- FAIL: TestStartStop/StartStop (3.20s)
```

Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
