### PR TITLE
feat(xid,sxid): use kmsg instead of dmesg

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -29,7 +29,7 @@ jobs:
           go-version-file: go.mod
       - name: run e2e tests
         run: |
-          ./scripts/tests-e2e.sh
+          KMSG_FILE_PATH=/dev/null ./scripts/tests-e2e.sh
       - name: run e2e tests (experimental)
         run: |
-          ENABLE_EXPERIMENTAL_FEATURES=true ./scripts/tests-e2e.sh
+          ENABLE_EXPERIMENTAL_FEATURES=true KMSG_FILE_PATH=/dev/null ./scripts/tests-e2e.sh

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -29,7 +29,7 @@ jobs:
           go-version-file: go.mod
       - name: run unit tests
         run: |
-          ./scripts/tests-unit.sh
+          KMSG_FILE_PATH=/dev/null ./scripts/tests-unit.sh
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/components/accelerator/nvidia/sxid/component_test.go
+++ b/components/accelerator/nvidia/sxid/component_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/leptonai/gpud/components"
 	"github.com/leptonai/gpud/pkg/common"
-	pkg_dmesg "github.com/leptonai/gpud/pkg/dmesg"
 	"github.com/leptonai/gpud/pkg/eventstore"
 	pkghost "github.com/leptonai/gpud/pkg/host"
+	"github.com/leptonai/gpud/pkg/kmsg"
 	"github.com/leptonai/gpud/pkg/sqlite"
 )
 
@@ -152,9 +152,7 @@ func TestSXIDComponent_Events(t *testing.T) {
 
 	component := New(ctx, rebootEventStore, store)
 	assert.NotNil(t, component)
-	watcher, err := pkg_dmesg.NewWatcher()
-	assert.NoError(t, err)
-	go component.start(watcher, 1*time.Second)
+	go component.start(make(<-chan kmsg.Message, 1), 1*time.Second)
 	defer func() {
 		if err := component.Close(); err != nil {
 			t.Error("failed to close component")
@@ -206,9 +204,7 @@ func TestSXIDComponent_States(t *testing.T) {
 	component := New(ctx, rebootEventStore, store)
 
 	assert.NotNil(t, component)
-	watcher, err := pkg_dmesg.NewWatcher()
-	assert.NoError(t, err)
-	go component.start(watcher, 100*time.Millisecond)
+	go component.start(make(<-chan kmsg.Message, 1), 100*time.Millisecond)
 	defer func() {
 		if err := component.Close(); err != nil {
 			t.Error("failed to close component")

--- a/components/accelerator/nvidia/sxid/helper_test.go
+++ b/components/accelerator/nvidia/sxid/helper_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func createSXidEvent(eventTime time.Time, sxid uint64, eventType common.EventType, suggestedAction common.RepairActionType) components.Event {
-	sxidErr := sxidErrorFromDmesg{
+	sxidErr := sxidErrorEventDetail{
 		SXid:       sxid,
 		DataSource: "test",
 		DeviceUUID: "PCI:0000:9b:00",
@@ -23,9 +23,9 @@ func createSXidEvent(eventTime time.Time, sxid uint64, eventType common.EventTyp
 	}
 	sxidData, _ := json.Marshal(sxidErr)
 	ret := components.Event{
-		Name:      EventNameErroSXid,
+		Name:      EventNameErrorSXid,
 		Type:      eventType,
-		ExtraInfo: map[string]string{EventKeyErroSXidData: string(sxidData)},
+		ExtraInfo: map[string]string{EventKeyErrorSXidData: string(sxidData)},
 	}
 	if !eventTime.IsZero() {
 		ret.Time = metav1.Time{Time: eventTime}
@@ -99,9 +99,9 @@ func TestStateUpdateBasedOnEvents(t *testing.T) {
 	t.Run("invalid sxid", func(t *testing.T) {
 		events := []components.Event{
 			{
-				Name:      EventNameErroSXid,
+				Name:      EventNameErrorSXid,
 				Type:      common.EventTypeFatal,
-				ExtraInfo: map[string]string{EventKeyErroSXidData: "invalid json"},
+				ExtraInfo: map[string]string{EventKeyErrorSXidData: "invalid json"},
 			},
 		}
 		state := EvolveHealthyState(events)
@@ -114,7 +114,7 @@ func TestSXidErrorFromDmesgJSON(t *testing.T) {
 	testTime := metav1.Time{Time: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)}
 
 	t.Run("successful marshaling", func(t *testing.T) {
-		sxidErr := sxidErrorFromDmesg{
+		sxidErr := sxidErrorEventDetail{
 			Time:       testTime,
 			DataSource: "test-source",
 			DeviceUUID: "test-uuid",
@@ -130,7 +130,7 @@ func TestSXidErrorFromDmesgJSON(t *testing.T) {
 		assert.NotNil(t, jsonBytes)
 
 		// Verify JSON structure by unmarshaling
-		var unmarshaled sxidErrorFromDmesg
+		var unmarshaled sxidErrorEventDetail
 		err = json.Unmarshal(jsonBytes, &unmarshaled)
 		assert.NoError(t, err)
 		assert.Equal(t, sxidErr.Time.UTC(), unmarshaled.Time.UTC())
@@ -142,7 +142,7 @@ func TestSXidErrorFromDmesgJSON(t *testing.T) {
 	})
 
 	t.Run("minimal fields", func(t *testing.T) {
-		sxidErr := sxidErrorFromDmesg{
+		sxidErr := sxidErrorEventDetail{
 			Time:       testTime,
 			DataSource: "test-source",
 			DeviceUUID: "test-uuid",
@@ -153,7 +153,7 @@ func TestSXidErrorFromDmesgJSON(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, jsonBytes)
 
-		var unmarshaled sxidErrorFromDmesg
+		var unmarshaled sxidErrorEventDetail
 		err = json.Unmarshal(jsonBytes, &unmarshaled)
 		assert.NoError(t, err)
 		assert.Equal(t, sxidErr.Time.UTC(), unmarshaled.Time.UTC())

--- a/components/accelerator/nvidia/sxid/matcher.go
+++ b/components/accelerator/nvidia/sxid/matcher.go
@@ -17,22 +17,22 @@ const (
 	// ref.
 	// "D.4 Non-Fatal NVSwitch SXid Errors"
 	// https://docs.nvidia.com/datacenter/tesla/pdf/fabric-manager-user-guide.pdf
-	RegexNVSwitchSXidDmesg = `SXid.*?: (\d+),`
+	RegexNVSwitchSXidKMessage = `SXid.*?: (\d+),`
 
 	// Regex to extract PCI device ID from NVSwitch SXid messages
 	RegexNVSwitchSXidDeviceUUID = `SXid \((PCI:[0-9a-fA-F:\.]+)\)`
 )
 
 var (
-	compiledRegexNVSwitchSXidDmesg      = regexp.MustCompile(RegexNVSwitchSXidDmesg)
+	compiledRegexNVSwitchSXidKMessage   = regexp.MustCompile(RegexNVSwitchSXidKMessage)
 	compiledRegexNVSwitchSXidDeviceUUID = regexp.MustCompile(RegexNVSwitchSXidDeviceUUID)
 )
 
-// Extracts the nvidia NVSwitch SXid error code from the dmesg log line.
+// ExtractNVSwitchSXid extracts the nvidia NVSwitch SXid error code from the dmesg log line.
 // Returns 0 if the error code is not found.
 // https://docs.nvidia.com/datacenter/tesla/pdf/fabric-manager-user-guide.pdf
 func ExtractNVSwitchSXid(line string) int {
-	if match := compiledRegexNVSwitchSXidDmesg.FindStringSubmatch(line); match != nil {
+	if match := compiledRegexNVSwitchSXidKMessage.FindStringSubmatch(line); match != nil {
 		if id, err := strconv.Atoi(match[1]); err == nil {
 			return id
 		}
@@ -55,11 +55,11 @@ type SXidError struct {
 	Detail     *sxid.Detail `json:"detail,omitempty"`
 }
 
-func (sxidErr SXidError) YAML() ([]byte, error) {
+func (sxidErr *SXidError) YAML() ([]byte, error) {
 	return yaml.Marshal(sxidErr)
 }
 
-// Returns a matching xid error object if found.
+// Match returns a matching xid error object if found.
 // Otherwise, returns nil.
 func Match(line string) *SXidError {
 	extractedID := ExtractNVSwitchSXid(line)

--- a/components/accelerator/nvidia/xid/component_test.go
+++ b/components/accelerator/nvidia/xid/component_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/leptonai/gpud/components"
 	"github.com/leptonai/gpud/pkg/common"
-	pkg_dmesg "github.com/leptonai/gpud/pkg/dmesg"
 	"github.com/leptonai/gpud/pkg/eventstore"
 	pkghost "github.com/leptonai/gpud/pkg/host"
+	"github.com/leptonai/gpud/pkg/kmsg"
 	"github.com/leptonai/gpud/pkg/sqlite"
 )
 
@@ -153,9 +153,7 @@ func TestXIDComponent_Events(t *testing.T) {
 
 	component := New(ctx, rebootEventStore, store)
 	assert.NotNil(t, component)
-	watcher, err := pkg_dmesg.NewWatcher()
-	assert.NoError(t, err)
-	go component.start(watcher, 1*time.Second)
+	go component.start(make(chan kmsg.Message, 1), 1*time.Second)
 	defer func() {
 		if err := component.Close(); err != nil {
 			t.Error("failed to close component")
@@ -206,9 +204,7 @@ func TestXIDComponent_States(t *testing.T) {
 
 	component := New(ctx, rebootEventStore, store)
 	assert.NotNil(t, component)
-	watcher, err := pkg_dmesg.NewWatcher()
-	assert.NoError(t, err)
-	go component.start(watcher, 100*time.Millisecond)
+	go component.start(make(<-chan kmsg.Message, 1), 100*time.Millisecond)
 	defer func() {
 		if err := component.Close(); err != nil {
 			t.Error("failed to close component")

--- a/components/accelerator/nvidia/xid/helper_test.go
+++ b/components/accelerator/nvidia/xid/helper_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func createXidEvent(eventTime time.Time, xid uint64, eventType common.EventType, suggestedAction common.RepairActionType) components.Event {
-	xidErr := xidErrorFromDmesg{
+	xidErr := xidErrorEventDetail{
 		Xid:        xid,
 		DataSource: "test",
 		DeviceUUID: "PCI:0000:9b:00",
@@ -114,7 +114,7 @@ func TestXidErrorFromDmesgJSON(t *testing.T) {
 	testTime := metav1.Time{Time: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)}
 
 	t.Run("successful marshaling", func(t *testing.T) {
-		xidErr := xidErrorFromDmesg{
+		xidErr := xidErrorEventDetail{
 			Time:       testTime,
 			DataSource: "test-source",
 			DeviceUUID: "test-uuid",
@@ -130,7 +130,7 @@ func TestXidErrorFromDmesgJSON(t *testing.T) {
 		assert.NotNil(t, jsonBytes)
 
 		// Verify JSON structure by unmarshaling
-		var unmarshaled xidErrorFromDmesg
+		var unmarshaled xidErrorEventDetail
 		err = json.Unmarshal(jsonBytes, &unmarshaled)
 		assert.NoError(t, err)
 		assert.Equal(t, xidErr.Time.UTC(), unmarshaled.Time.UTC())
@@ -142,7 +142,7 @@ func TestXidErrorFromDmesgJSON(t *testing.T) {
 	})
 
 	t.Run("minimal fields", func(t *testing.T) {
-		xidErr := xidErrorFromDmesg{
+		xidErr := xidErrorEventDetail{
 			Time:       testTime,
 			DataSource: "test-source",
 			DeviceUUID: "test-uuid",
@@ -153,7 +153,7 @@ func TestXidErrorFromDmesgJSON(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, jsonBytes)
 
-		var unmarshaled xidErrorFromDmesg
+		var unmarshaled xidErrorEventDetail
 		err = json.Unmarshal(jsonBytes, &unmarshaled)
 		assert.NoError(t, err)
 		assert.Equal(t, xidErr.Time.UTC(), unmarshaled.Time.UTC())

--- a/components/accelerator/nvidia/xid/matcher.go
+++ b/components/accelerator/nvidia/xid/matcher.go
@@ -17,7 +17,7 @@ const (
 	//
 	// ref.
 	// https://docs.nvidia.com/deploy/pdf/XID_Errors.pdf
-	RegexNVRMXidDmesg = `NVRM: Xid.*?: (\d+),`
+	RegexNVRMXidKMessage = `NVRM: Xid.*?: (\d+),`
 
 	// Regex to extract PCI device ID from NVRM Xid messages
 	// Matches both formats: (0000:03:00) and (PCI:0000:05:00)
@@ -25,15 +25,15 @@ const (
 )
 
 var (
-	compiledRegexNVRMXidDmesg      = regexp.MustCompile(RegexNVRMXidDmesg)
+	compiledRegexNVRMXidKMessage   = regexp.MustCompile(RegexNVRMXidKMessage)
 	compiledRegexNVRMXidDeviceUUID = regexp.MustCompile(RegexNVRMXidDeviceUUID)
 )
 
-// Extracts the nvidia Xid error code from the dmesg log line.
+// ExtractNVRMXid extracts the nvidia Xid error code from the dmesg log line.
 // Returns 0 if the error code is not found.
 // https://docs.nvidia.com/deploy/pdf/XID_Errors.pdf
 func ExtractNVRMXid(line string) int {
-	if match := compiledRegexNVRMXidDmesg.FindStringSubmatch(line); match != nil {
+	if match := compiledRegexNVRMXidKMessage.FindStringSubmatch(line); match != nil {
 		if id, err := strconv.Atoi(match[1]); err == nil {
 			return id
 		}
@@ -58,11 +58,11 @@ type XidError struct {
 	Detail     *xid.Detail `json:"detail,omitempty"`
 }
 
-func (xidErr XidError) YAML() ([]byte, error) {
+func (xidErr *XidError) YAML() ([]byte, error) {
 	return yaml.Marshal(xidErr)
 }
 
-// Returns a matching xid error object if found.
+// Match returns a matching xid error object if found.
 // Otherwise, returns nil.
 func Match(line string) *XidError {
 	extractedID := ExtractNVRMXid(line)

--- a/pkg/kmsg/events.go
+++ b/pkg/kmsg/events.go
@@ -23,13 +23,7 @@ func StartWatch(matchFunc func(line string) (eventName string, message string)) 
 	if err != nil {
 		return nil, err
 	}
-	kmsgCh := make(chan Message, 1024)
-	go func() {
-		werr := kmsgWatcher.Watch(kmsgCh)
-		if werr != nil {
-			log.Logger.Errorw("failed to watch kmsg", "err", werr)
-		}
-	}()
+	kmsgCh := kmsgWatcher.StartWatch()
 	go func() {
 		for m := range kmsgCh {
 			ev, msg := matchFunc(m.Message)


### PR DESCRIPTION
1. Fix kmsg package incorrectly calculate boot time.
2. Use kmsg instead of dmesg in xid and sxid components.
3. Improve logs

for #512 