### PR TITLE
tests(metrics/syncer): remove flaky tests

### DIFF
--- a/pkg/metrics/syncer/syncer_test.go
+++ b/pkg/metrics/syncer/syncer_test.go
@@ -136,13 +136,6 @@ func (m *mockStore) getPurgeCount() int {
 	return m.purgeCount
 }
 
-func (m *mockStore) getLastPurgeTime() time.Time {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	return m.lastPurgeTime
-}
-
 func TestNewSyncer(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Test coverage is still 100%

```
=== RUN   TestStartStop/StartStop
{"level":"info","ts":"2025-04-07T08:54:44Z","caller":"syncer/syncer.go:58","msg":"start purging metrics"}
{"level":"info","ts":"2025-04-07T08:54:44Z","caller":"syncer/syncer.go:41","msg":"start scrap and sync metrics"}
{"level":"info","ts":"2025-04-07T08:54:45Z","caller":"syncer/syncer.go:70","msg":"purged metrics","purged":0}
{"level":"info","ts":"2025-04-07T08:54:46Z","caller":"syncer/syncer.go:70","msg":"purged metrics","purged":0}
{"level":"info","ts":"2025-04-07T08:54:47Z","caller":"syncer/syncer.go:85","msg":"stopping syncer"}
{"level":"info","ts":"2025-04-07T08:54:47Z","caller":"syncer/syncer.go:70","msg":"purged metrics","purged":0}
    syncer_test.go:280: 
        	Error Trace:	/home/runner/work/gpud/gpud/pkg/metrics/syncer/syncer_test.go:280
        	Error:      	Not equal: 
        	            	expected: 2
        	            	actual  : 3
        	Test:       	TestStartStop/StartStop
        	Messages:   	Scrape count should not increase after stopping
--- FAIL: TestStartStop (8.00s)
    --- FAIL: TestStartStop/StartStop (8.00s)
```