### PR TITLE
feat(containerd): do not set unhealthy if containerd CRI is not enabled, "containerd --version" as fallback in machine info

### DIFF
--- a/components/containerd/pod/component.go
+++ b/components/containerd/pod/component.go
@@ -160,7 +160,8 @@ func (c *component) Check() components.CheckResult {
 				// e.g.,
 				// rpc error: code = Unimplemented desc = unknown service runtime.v1.RuntimeService
 				if st.Code() == codes.Unimplemented {
-					cr.reason = "containerd didn't enable CRI"
+					cr.health = apiv1.HealthStateTypeHealthy
+					cr.reason = "containerd installed and active but containerd CRI is not enabled"
 				} else {
 					cr.reason = fmt.Sprintf("failed gRPC call to the containerd socket %s", st.Message())
 				}

--- a/components/containerd/pod/component.go
+++ b/components/containerd/pod/component.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	"github.com/olekukonko/tablewriter"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	apiv1 "github.com/leptonai/gpud/api/v1"
 	"github.com/leptonai/gpud/components"
@@ -152,23 +150,13 @@ func (c *component) Check() components.CheckResult {
 		cr.Pods, cr.err = c.listAllSandboxesFunc(cctx, c.endpoint)
 		ccancel()
 		if cr.err != nil {
-			cr.health = apiv1.HealthStateTypeUnhealthy
-
-			st, ok := status.FromError(cr.err)
-			if ok {
-				// this is the error from "ListSandboxStatus"
-				// e.g.,
-				// rpc error: code = Unimplemented desc = unknown service runtime.v1.RuntimeService
-				if st.Code() == codes.Unimplemented {
-					cr.health = apiv1.HealthStateTypeHealthy
-					cr.reason = "containerd installed and active but containerd CRI is not enabled"
-				} else {
-					cr.reason = fmt.Sprintf("failed gRPC call to the containerd socket %s", st.Message())
-				}
+			if pkgcontainerd.IsErrUnimplemented(cr.err) {
+				cr.health = apiv1.HealthStateTypeHealthy
+				cr.reason = "containerd installed and active but containerd CRI is not enabled"
 			} else {
+				cr.health = apiv1.HealthStateTypeUnhealthy
 				cr.reason = fmt.Sprintf("error listing pod sandbox status: %v", cr.err)
 			}
-
 			return cr
 		}
 	}

--- a/components/containerd/pod/component_test.go
+++ b/components/containerd/pod/component_test.go
@@ -1823,12 +1823,10 @@ func TestCheckOnceListSandboxGrpcError(t *testing.T) {
 	assert.NotNil(t, comp.lastCheckResult)
 	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, comp.lastCheckResult.health) // Should be unhealthy due to the error
 	assert.NotNil(t, comp.lastCheckResult.err)
-	fmt.Println("comp.lastCheckResult.err", comp.lastCheckResult.reason, comp.lastCheckResult.err)
 
-	assert.Equal(t, testGrpcError, comp.lastCheckResult.err)
-	// Check the specific reason set for gRPC errors (lines 165-167)
-	assert.Contains(t, comp.lastCheckResult.reason, "failed gRPC call to the containerd socket")
-	assert.Contains(t, comp.lastCheckResult.reason, "service temporary unavailable")
+	// Based on the component.go implementation (lines 151-156), non-Unimplemented errors
+	// will have a reason message format like "error listing pod sandbox status: %v"
+	assert.Contains(t, comp.lastCheckResult.reason, "error listing pod sandbox status")
 }
 
 // TestCheckOnceSocketNotExists tests the socket existence check in CheckOnce

--- a/pkg/containerd/cri.go
+++ b/pkg/containerd/cri.go
@@ -201,8 +201,8 @@ func CheckContainerdRunning(ctx context.Context) bool {
 	return false
 }
 
-// CheckVersion checks the version of the containerd runtime.
-func CheckVersion(ctx context.Context, endpoint string) (string, error) {
+// GetVersion gets the version of the containerd runtime.
+func GetVersion(ctx context.Context, endpoint string) (string, error) {
 	conn, err := connect(ctx, endpoint)
 	if err != nil {
 		return "", err

--- a/pkg/containerd/cri.go
+++ b/pkg/containerd/cri.go
@@ -6,13 +6,17 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"os/exec"
+	"regexp"
 	"sort"
 	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 
 	pkgfile "github.com/leptonai/gpud/pkg/file"
@@ -213,10 +217,44 @@ func GetVersion(ctx context.Context, endpoint string) (string, error) {
 	runtimeClient := runtimeapi.NewRuntimeServiceClient(conn)
 	version, err := runtimeClient.Version(ctx, &runtimeapi.VersionRequest{})
 	if err != nil {
-		return "", err
+		if !IsErrUnimplemented(err) {
+			return "", err
+		}
+		return GetVersionFromCli(ctx)
 	}
 
 	return version.RuntimeVersion, nil
+}
+
+// GetVersionFromCli reads the containerd version from the command "containerd --version".
+// e.g.,
+// "containerd containerd.io 1.7.25 bcc810d6b9066471b0b6fa75f557a15a1cbf31bb"
+func GetVersionFromCli(ctx context.Context) (string, error) {
+	containerdPath, err := pkgfile.LocateExecutable("containerd")
+	if err != nil {
+		return "", err
+	}
+
+	out, err := exec.CommandContext(ctx, containerdPath, "--version").Output()
+	if err != nil {
+		return "", err
+	}
+	return parseContainerdVersion(string(out))
+}
+
+// only matches "1.7.25" when "containerd containerd.io 1.7.25 bcc810d6b9066471b0b6fa75f557a15a1cbf31bb"
+const regexContainerdVersion = `\s+(\d+\.\d+\.\d+)(?:\s+|$)`
+
+var reContainerdVersion = regexp.MustCompile(regexContainerdVersion)
+
+// parseContainerdVersion parses the containerd version from the output of "containerd --version".
+// Returns "1.7.25" when given the input "containerd containerd.io 1.7.25 bcc810d6b9066471b0b6fa75f557a15a1cbf31bb".
+func parseContainerdVersion(out string) (string, error) {
+	matches := reContainerdVersion.FindStringSubmatch(out)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("invalid containerd version output: %s", out)
+	}
+	return matches[1], nil
 }
 
 // ListAllSandboxes lists all sandboxes from the containerd runtime.
@@ -326,4 +364,15 @@ type PodSandboxContainerStatus struct {
 	Image     string `json:"image,omitempty"`
 	CreatedAt int64  `json:"created_at,omitempty"`
 	State     string `json:"state,omitempty"`
+}
+
+// IsErrUnimplemented checks if the error is due to the unimplemented service.
+// e.g.,
+// rpc error: code = Unimplemented desc = unknown service runtime.v1.RuntimeService
+func IsErrUnimplemented(err error) bool {
+	st, ok := status.FromError(err)
+	if ok {
+		return st.Code() == codes.Unimplemented
+	}
+	return false
 }

--- a/pkg/machine-info/machine_info.go
+++ b/pkg/machine-info/machine_info.go
@@ -41,7 +41,7 @@ func GetMachineInfo(nvmlInstance nvidianvml.Instance) (apiv1.MachineInfo, error)
 	defer cancel()
 
 	if pkgcontainerd.CheckContainerdInstalled() && pkgcontainerd.CheckContainerdRunning(ctx) {
-		version, err := pkgcontainerd.CheckVersion(ctx, pkgcontainerd.DefaultContainerRuntimeEndpoint)
+		version, err := pkgcontainerd.GetVersion(ctx, pkgcontainerd.DefaultContainerRuntimeEndpoint)
 		if err != nil {
 			log.Logger.Warnw("failed to check containerd version", "error", err)
 		} else {

--- a/pkg/machine-info/machine_info.go
+++ b/pkg/machine-info/machine_info.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/shirou/gopsutil/v4/cpu"
@@ -45,6 +46,9 @@ func GetMachineInfo(nvmlInstance nvidianvml.Instance) (apiv1.MachineInfo, error)
 		if err != nil {
 			log.Logger.Warnw("failed to check containerd version", "error", err)
 		} else {
+			if !strings.HasPrefix(version, "containerd://") {
+				version = "containerd://" + version
+			}
 			info.ContainerRuntimeVersion = version
 		}
 	}


### PR DESCRIPTION
Fix the following /states response:

```json
    "component": "containerd-pod",
    "states": [
      {
        "component": "containerd-pod",
        "name": "containerd-pod",
        "health": "Unhealthy",
        "reason": "containerd didn't enable CRI",
        "error": "rpc error: code = Unimplemented desc = unknown service runtime.v1.RuntimeService",
        "extra_info": {
          "data": "{\"containerd_service_active\":true}",
          "encoding": "json"
        }
      }
    ]
```