### PR TITLE
fix(nvidia-query): require non-empty GPU device name from NVML to mar…

### DIFF
--- a/pkg/nvidia-query/detect.go
+++ b/pkg/nvidia-query/detect.go
@@ -22,7 +22,7 @@ func GPUsInstalled(ctx context.Context) (bool, error) {
 	if len(pciDevices) == 0 {
 		return false, nil
 	}
-	log.Logger.Debugw("nvidia PCI devices found", "devices", len(pciDevices))
+	log.Logger.Infow("nvidia PCI devices found", "devices", len(pciDevices))
 
 	// now that we have the NVIDIA PCI devices,
 	// call NVML C-based API for NVML API
@@ -34,9 +34,9 @@ func GPUsInstalled(ctx context.Context) (bool, error) {
 		}
 		return false, err
 	}
-	log.Logger.Debugw("detected nvidia gpu", "gpuDeviceName", gpuDeviceName)
+	log.Logger.Infow("detected nvidia gpu", "gpuDeviceName", gpuDeviceName)
 
-	return true, nil
+	return gpuDeviceName != "", nil
 }
 
 // Lists all PCI devices that are compatible with NVIDIA.


### PR DESCRIPTION
…k GPUs are installed

Fix the following issue:

```
{"level":"debug","ts":"2025-04-21T15:04:15Z","msg":"auto-detected systemd -- configuring systemd component"}
{"level":"debug","ts":"2025-04-21T15:04:15Z","msg":"starting command","command":["bash","/tmp/gpud-2177508235.bash"]}
{"level":"debug","ts":"2025-04-21T15:04:15Z","msg":"process exited successfully"}
{"level":"debug","ts":"2025-04-21T15:04:15Z","msg":"nvidia PCI devices found","devices":14}
{"level":"info","ts":"2025-04-21T15:04:15Z","msg":"initializing nvml library"}
{"level":"debug","ts":"2025-04-21T15:04:15Z","msg":"detected nvidia gpu","gpuDeviceName":""}
{"level":"info","ts":"2025-04-21T15:04:15Z","msg":"initializing nvml library"}
gpud: failed to parse driver version (expected at least 2 parts):
````