### PR TITLE
fix(nvidia): treat missing product name as GPUs are NOT installed

### DIFF
--- a/components/accelerator/nvidia/bad-envs/component.go
+++ b/components/accelerator/nvidia/bad-envs/component.go
@@ -123,7 +123,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/bad-envs/component_test.go
+++ b/components/accelerator/nvidia/bad-envs/component_test.go
@@ -105,7 +105,7 @@ func (m *mockNVMLInstance) Devices() map[string]device.Device {
 }
 
 func (m *mockNVMLInstance) ProductName() string {
-	return ""
+	return "test"
 }
 
 func (m *mockNVMLInstance) Architecture() string {
@@ -404,7 +404,7 @@ func TestCheckWithNVMLNotExisting(t *testing.T) {
 	result := comp.Check()
 	checkResult := result.(*checkResult)
 	assert.Equal(t, apiv1.HealthStateTypeHealthy, checkResult.health)
-	assert.Equal(t, "NVIDIA NVML is not loaded", checkResult.reason)
+	assert.Equal(t, "NVIDIA NVML library is not loaded", checkResult.reason)
 }
 
 func TestCheckAllEnvVarsForCoverage(t *testing.T) {

--- a/components/accelerator/nvidia/clock-speed/component.go
+++ b/components/accelerator/nvidia/clock-speed/component.go
@@ -104,7 +104,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/clock-speed/component_test.go
+++ b/components/accelerator/nvidia/clock-speed/component_test.go
@@ -411,7 +411,7 @@ func TestComponent_Check_NVMLNotLoaded(t *testing.T) {
 
 	// Verify health state when NVML is not loaded
 	assert.Equal(t, apiv1.HealthStateTypeHealthy, data.health)
-	assert.Equal(t, "NVIDIA NVML is not loaded", data.reason)
+	assert.Equal(t, "NVIDIA NVML library is not loaded", data.reason)
 	assert.Nil(t, data.err)
 }
 

--- a/components/accelerator/nvidia/ecc/component.go
+++ b/components/accelerator/nvidia/ecc/component.go
@@ -106,7 +106,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/ecc/component_test.go
+++ b/components/accelerator/nvidia/ecc/component_test.go
@@ -677,7 +677,7 @@ func TestCheck_NvmlNotLoaded(t *testing.T) {
 	require.True(t, ok, "result should be of type *checkResult")
 
 	assert.Equal(t, apiv1.HealthStateTypeHealthy, data.health)
-	assert.Equal(t, "NVIDIA NVML is not loaded", data.reason)
+	assert.Equal(t, "NVIDIA NVML library is not loaded", data.reason)
 }
 
 func TestCheck_MultipleDevices(t *testing.T) {

--- a/components/accelerator/nvidia/fabric-manager/component.go
+++ b/components/accelerator/nvidia/fabric-manager/component.go
@@ -139,7 +139,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 	if !c.nvmlInstance.FabricManagerSupported() {

--- a/components/accelerator/nvidia/fabric-manager/component.go
+++ b/components/accelerator/nvidia/fabric-manager/component.go
@@ -147,6 +147,7 @@ func (c *component) Check() components.CheckResult {
 		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
+
 	if !c.nvmlInstance.FabricManagerSupported() {
 		cr.FabricManagerActive = false
 		cr.health = apiv1.HealthStateTypeHealthy

--- a/components/accelerator/nvidia/fabric-manager/component_test.go
+++ b/components/accelerator/nvidia/fabric-manager/component_test.go
@@ -573,7 +573,7 @@ func TestComponentCheck_NVMLInstance(t *testing.T) {
 			name:              "nvml does not exist",
 			nvmlInstance:      &mockNVMLInstance{exists: false, supportsFM: true},
 			expectedHealth:    apiv1.HealthStateTypeHealthy,
-			expectedReason:    "NVIDIA NVML is not loaded",
+			expectedReason:    "NVIDIA NVML library is not loaded",
 			checkFMExistsFunc: func() bool { return false },
 			checkFMActiveFunc: func() bool { return false },
 		},

--- a/components/accelerator/nvidia/fabric-manager/component_test.go
+++ b/components/accelerator/nvidia/fabric-manager/component_test.go
@@ -44,7 +44,7 @@ func TestComponentEvents(t *testing.T) {
 		ctx:    ctx,
 		cancel: cancel,
 
-		nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true},
+		nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true, productName: "Test GPU"},
 		checkFMExistsFunc: func() bool { return true },
 		checkFMActiveFunc: func() bool { return true },
 
@@ -197,7 +197,7 @@ func TestStatesWhenFabricManagerDoesNotExist(t *testing.T) {
 		ctx:    context.Background(),
 		cancel: func() {},
 
-		nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true},
+		nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true, productName: "Test GPU"},
 		checkFMExistsFunc: func() bool { return false },
 		checkFMActiveFunc: func() bool { return false },
 	}
@@ -281,7 +281,7 @@ func TestStatesWhenFabricManagerExistsButNotActive(t *testing.T) {
 	comp := &component{
 		ctx:               context.Background(),
 		cancel:            func() {},
-		nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true},
+		nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true, productName: "Test GPU"},
 		checkFMExistsFunc: func() bool { return true },
 		checkFMActiveFunc: func() bool { return false },
 	}
@@ -410,7 +410,7 @@ func TestStatesWhenFabricManagerExistsAndActive(t *testing.T) {
 		ctx:    context.Background(),
 		cancel: func() {},
 
-		nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true},
+		nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true, productName: "Test GPU"},
 		checkFMExistsFunc: func() bool { return true },
 		checkFMActiveFunc: func() bool { return true },
 	}
@@ -476,7 +476,7 @@ func TestCheckAllBranches(t *testing.T) {
 			comp := &component{
 				ctx:               context.Background(),
 				cancel:            func() {},
-				nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true},
+				nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true, productName: "Test GPU"},
 				checkFMExistsFunc: func() bool { return tc.fmExists },
 				checkFMActiveFunc: func() bool { return tc.fmActive },
 			}
@@ -571,7 +571,7 @@ func TestComponentCheck_NVMLInstance(t *testing.T) {
 		},
 		{
 			name:              "nvml does not exist",
-			nvmlInstance:      &mockNVMLInstance{exists: false, supportsFM: true},
+			nvmlInstance:      &mockNVMLInstance{exists: false, supportsFM: true, productName: "Test GPU"},
 			expectedHealth:    apiv1.HealthStateTypeHealthy,
 			expectedReason:    "NVIDIA NVML library is not loaded",
 			checkFMExistsFunc: func() bool { return false },
@@ -587,7 +587,7 @@ func TestComponentCheck_NVMLInstance(t *testing.T) {
 		},
 		{
 			name:              "nvml exists but FM executable not found",
-			nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true},
+			nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true, productName: "Test GPU"},
 			expectedHealth:    apiv1.HealthStateTypeHealthy,
 			expectedReason:    "nv-fabricmanager executable not found",
 			checkFMExistsFunc: func() bool { return false },
@@ -595,7 +595,7 @@ func TestComponentCheck_NVMLInstance(t *testing.T) {
 		},
 		{
 			name:              "nvml exists, FM executable found but not active",
-			nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true},
+			nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true, productName: "Test GPU"},
 			expectedHealth:    apiv1.HealthStateTypeUnhealthy,
 			expectedReason:    "nv-fabricmanager found but fabric manager service is not active",
 			checkFMExistsFunc: func() bool { return true },
@@ -603,7 +603,7 @@ func TestComponentCheck_NVMLInstance(t *testing.T) {
 		},
 		{
 			name:              "nvml exists, FM executable found and active",
-			nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true},
+			nvmlInstance:      &mockNVMLInstance{exists: true, supportsFM: true, productName: "Test GPU"},
 			expectedHealth:    apiv1.HealthStateTypeHealthy,
 			expectedReason:    "fabric manager found and active",
 			checkFMExistsFunc: func() bool { return true },
@@ -684,4 +684,28 @@ func TestCheck_FabricManagerNotSupported(t *testing.T) {
 	assert.Equal(t, Name, states[0].Name)
 	assert.Equal(t, apiv1.HealthStateTypeHealthy, states[0].Health)
 	assert.Equal(t, "Test GPU does not support fabric manager", states[0].Reason)
+}
+
+func TestCheckWithEmptyProductName(t *testing.T) {
+	// Create mock NVML instance with empty product name
+	mockNVML := &mockNVMLInstance{
+		exists:      true,
+		supportsFM:  false,
+		productName: "", // empty product name
+	}
+
+	// Create component with mock
+	c := &component{
+		ctx:          context.Background(),
+		nvmlInstance: mockNVML,
+	}
+
+	// Call Check
+	result := c.Check()
+
+	// Assert on result
+	checkResult, ok := result.(*checkResult)
+	assert.True(t, ok)
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, checkResult.health)
+	assert.Equal(t, "NVIDIA NVML is loaded but GPU is not detected (missing product name)", checkResult.reason)
 }

--- a/components/accelerator/nvidia/gpm/component.go
+++ b/components/accelerator/nvidia/gpm/component.go
@@ -150,7 +150,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/gpm/component_test.go
+++ b/components/accelerator/nvidia/gpm/component_test.go
@@ -714,7 +714,7 @@ func TestCheck_NVMLNotLoaded(t *testing.T) {
 	result := component.Check()
 
 	assert.Equal(t, apiv1.HealthStateTypeHealthy, result.HealthState())
-	assert.Equal(t, "NVIDIA NVML is not loaded", result.Summary())
+	assert.Equal(t, "NVIDIA NVML library is not loaded", result.Summary())
 }
 
 func TestData_String(t *testing.T) {

--- a/components/accelerator/nvidia/gsp-firmware-mode/component.go
+++ b/components/accelerator/nvidia/gsp-firmware-mode/component.go
@@ -102,7 +102,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/hw-slowdown/component.go
+++ b/components/accelerator/nvidia/hw-slowdown/component.go
@@ -152,7 +152,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/hw-slowdown/component_test.go
+++ b/components/accelerator/nvidia/hw-slowdown/component_test.go
@@ -1114,7 +1114,8 @@ func TestCheckEdgeCases(t *testing.T) {
 		{
 			name: "driver version error",
 			nvmlInstance: &mockNVMLInstance{
-				nvmlExists: true,
+				nvmlExists:  true,
+				productName: "Test GPU",
 				devices: map[string]device.Device{
 					"gpu-0": testutil.NewMockDevice(
 						&mock.Device{
@@ -1135,7 +1136,8 @@ func TestCheckEdgeCases(t *testing.T) {
 		{
 			name: "parse driver version error",
 			nvmlInstance: &mockNVMLInstance{
-				nvmlExists: true,
+				nvmlExists:  true,
+				productName: "Test GPU",
 				devices: map[string]device.Device{
 					"gpu-0": testutil.NewMockDevice(
 						&mock.Device{
@@ -1159,7 +1161,8 @@ func TestCheckEdgeCases(t *testing.T) {
 		{
 			name: "driver version does not support clock events",
 			nvmlInstance: &mockNVMLInstance{
-				nvmlExists: true,
+				nvmlExists:  true,
+				productName: "Test GPU",
 				devices: map[string]device.Device{
 					"gpu-0": testutil.NewMockDevice(
 						&mock.Device{
@@ -1186,7 +1189,8 @@ func TestCheckEdgeCases(t *testing.T) {
 		{
 			name: "clock events not supported for device",
 			nvmlInstance: &mockNVMLInstance{
-				nvmlExists: true,
+				nvmlExists:  true,
+				productName: "Test GPU",
 				devices: map[string]device.Device{
 					"gpu-0": testutil.NewMockDevice(
 						&mock.Device{
@@ -1216,7 +1220,8 @@ func TestCheckEdgeCases(t *testing.T) {
 		{
 			name: "error getting clock events supported",
 			nvmlInstance: &mockNVMLInstance{
-				nvmlExists: true,
+				nvmlExists:  true,
+				productName: "Test GPU",
 				devices: map[string]device.Device{
 					"gpu-0": testutil.NewMockDevice(
 						&mock.Device{
@@ -1246,7 +1251,8 @@ func TestCheckEdgeCases(t *testing.T) {
 		{
 			name: "error getting clock events",
 			nvmlInstance: &mockNVMLInstance{
-				nvmlExists: true,
+				nvmlExists:  true,
+				productName: "Test GPU",
 				devices: map[string]device.Device{
 					"gpu-0": testutil.NewMockDevice(
 						&mock.Device{

--- a/components/accelerator/nvidia/hw-slowdown/component_test.go
+++ b/components/accelerator/nvidia/hw-slowdown/component_test.go
@@ -1109,7 +1109,7 @@ func TestCheckEdgeCases(t *testing.T) {
 				nvmlExists: false,
 			},
 			expectHealthy: true,
-			expectReason:  "NVIDIA NVML is not loaded",
+			expectReason:  "NVIDIA NVML library is not loaded",
 		},
 		{
 			name: "driver version error",

--- a/components/accelerator/nvidia/infiniband/component.go
+++ b/components/accelerator/nvidia/infiniband/component.go
@@ -146,7 +146,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 	if c.getIbstatOutputFunc == nil {

--- a/components/accelerator/nvidia/infiniband/component_test.go
+++ b/components/accelerator/nvidia/infiniband/component_test.go
@@ -686,7 +686,7 @@ func (m *mockNVMLInstance) Library() nvmllib.Library {
 }
 
 func (m *mockNVMLInstance) ProductName() string {
-	return ""
+	return "test"
 }
 
 func (m *mockNVMLInstance) Architecture() string {

--- a/components/accelerator/nvidia/info/component.go
+++ b/components/accelerator/nvidia/info/component.go
@@ -106,7 +106,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/info/component_test.go
+++ b/components/accelerator/nvidia/info/component_test.go
@@ -895,7 +895,7 @@ func TestCheckOnce_NVMLNotExists(t *testing.T) {
 	// Verify the results
 	assert.NotNil(t, cr)
 	assert.Equal(t, apiv1.HealthStateTypeHealthy, cr.health)
-	assert.Equal(t, "NVIDIA NVML is not loaded", cr.reason)
+	assert.Equal(t, "NVIDIA NVML library is not loaded", cr.reason)
 	assert.Nil(t, cr.err)
 
 	// Verify the mock was called

--- a/components/accelerator/nvidia/memory/component.go
+++ b/components/accelerator/nvidia/memory/component.go
@@ -104,7 +104,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/memory/component_test.go
+++ b/components/accelerator/nvidia/memory/component_test.go
@@ -668,5 +668,5 @@ func TestCheckOnce_NvmlNotExists(t *testing.T) {
 
 	require.NotNil(t, data, "data should not be nil")
 	assert.Equal(t, apiv1.HealthStateTypeHealthy, data.health, "data should be marked healthy")
-	assert.Equal(t, "NVIDIA NVML is not loaded", data.reason)
+	assert.Equal(t, "NVIDIA NVML library is not loaded", data.reason)
 }

--- a/components/accelerator/nvidia/nccl/component.go
+++ b/components/accelerator/nvidia/nccl/component.go
@@ -125,7 +125,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/nccl/component_test.go
+++ b/components/accelerator/nvidia/nccl/component_test.go
@@ -159,6 +159,7 @@ func TestCheck(t *testing.T) {
 		// Mock nvmlInstance that returns true for NVMLExists
 		mockNvml := new(mockNVMLInstance)
 		mockNvml.On("NVMLExists").Return(true)
+		mockNvml.On("ProductName").Return("Test GPU")
 		mockNvml.On("Devices").Return(map[string]device.Device{})
 		mockNvml.On("GetMemoryErrorManagementCapabilities").Return(nvidianvml.MemoryErrorManagementCapabilities{})
 
@@ -176,6 +177,7 @@ func TestCheck(t *testing.T) {
 		// Mock nvmlInstance that returns true for NVMLExists
 		mockNvml := new(mockNVMLInstance)
 		mockNvml.On("NVMLExists").Return(true)
+		mockNvml.On("ProductName").Return("Test GPU")
 		mockNvml.On("Devices").Return(map[string]device.Device{})
 		mockNvml.On("GetMemoryErrorManagementCapabilities").Return(nvidianvml.MemoryErrorManagementCapabilities{})
 
@@ -199,6 +201,7 @@ func TestCheck(t *testing.T) {
 		// Mock nvmlInstance that returns true for NVMLExists
 		mockNvml := new(mockNVMLInstance)
 		mockNvml.On("NVMLExists").Return(true)
+		mockNvml.On("ProductName").Return("Test GPU")
 		mockNvml.On("Devices").Return(map[string]device.Device{})
 		mockNvml.On("GetMemoryErrorManagementCapabilities").Return(nvidianvml.MemoryErrorManagementCapabilities{})
 
@@ -226,6 +229,7 @@ func TestCheck(t *testing.T) {
 		// Mock nvmlInstance that returns true for NVMLExists
 		mockNvml := new(mockNVMLInstance)
 		mockNvml.On("NVMLExists").Return(true)
+		mockNvml.On("ProductName").Return("Test GPU")
 		mockNvml.On("Devices").Return(map[string]device.Device{})
 		mockNvml.On("GetMemoryErrorManagementCapabilities").Return(nvidianvml.MemoryErrorManagementCapabilities{})
 

--- a/components/accelerator/nvidia/nvlink/component.go
+++ b/components/accelerator/nvidia/nvlink/component.go
@@ -104,7 +104,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/nvlink/component_test.go
+++ b/components/accelerator/nvidia/nvlink/component_test.go
@@ -567,7 +567,7 @@ func TestCheckOnce_NVMLNotLoaded(t *testing.T) {
 	require.True(t, ok)
 
 	assert.Equal(t, apiv1.HealthStateTypeHealthy, data.health)
-	assert.Equal(t, "NVIDIA NVML is not loaded", data.reason)
+	assert.Equal(t, "NVIDIA NVML library is not loaded", data.reason)
 }
 
 func TestData_getLastHealthStates(t *testing.T) {

--- a/components/accelerator/nvidia/peermem/component.go
+++ b/components/accelerator/nvidia/peermem/component.go
@@ -136,7 +136,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/peermem/component_test.go
+++ b/components/accelerator/nvidia/peermem/component_test.go
@@ -35,7 +35,7 @@ func (m *mockNVMLInstance) Devices() map[string]device.Device {
 }
 
 func (m *mockNVMLInstance) ProductName() string {
-	return ""
+	return "test"
 }
 
 func (m *mockNVMLInstance) Architecture() string {

--- a/components/accelerator/nvidia/persistence-mode/component.go
+++ b/components/accelerator/nvidia/persistence-mode/component.go
@@ -102,7 +102,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/persistence-mode/component_test.go
+++ b/components/accelerator/nvidia/persistence-mode/component_test.go
@@ -359,7 +359,7 @@ func TestCheck_NVMLNotExists(t *testing.T) {
 	require.True(t, ok, "result should be of type *checkResult")
 
 	assert.Equal(t, apiv1.HealthStateTypeHealthy, data.health)
-	assert.Equal(t, "NVIDIA NVML is not loaded", data.reason)
+	assert.Equal(t, "NVIDIA NVML library is not loaded", data.reason)
 }
 
 func TestLastHealthStates_WithData(t *testing.T) {

--- a/components/accelerator/nvidia/power/component.go
+++ b/components/accelerator/nvidia/power/component.go
@@ -104,7 +104,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/processes/component.go
+++ b/components/accelerator/nvidia/processes/component.go
@@ -104,7 +104,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/processes/component_test.go
+++ b/components/accelerator/nvidia/processes/component_test.go
@@ -423,7 +423,7 @@ func TestCheckEdgeCases(t *testing.T) {
 		data, ok := result.(*checkResult)
 		require.True(t, ok)
 		assert.Equal(t, apiv1.HealthStateTypeHealthy, data.health)
-		assert.Equal(t, "NVIDIA NVML is not loaded", data.reason)
+		assert.Equal(t, "NVIDIA NVML library is not loaded", data.reason)
 	})
 
 	t.Run("multiple devices", func(t *testing.T) {

--- a/components/accelerator/nvidia/remapped-rows/component.go
+++ b/components/accelerator/nvidia/remapped-rows/component.go
@@ -129,7 +129,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/sxid/component.go
+++ b/components/accelerator/nvidia/sxid/component.go
@@ -194,7 +194,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/temperature/component.go
+++ b/components/accelerator/nvidia/temperature/component.go
@@ -105,7 +105,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/utilization/component.go
+++ b/components/accelerator/nvidia/utilization/component.go
@@ -104,7 +104,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/components/accelerator/nvidia/utilization/component_test.go
+++ b/components/accelerator/nvidia/utilization/component_test.go
@@ -557,7 +557,7 @@ func TestCheck_NVMLNotExists(t *testing.T) {
 	require.True(t, ok, "result should be of type *checkResult")
 
 	assert.Equal(t, apiv1.HealthStateTypeHealthy, data.health)
-	assert.Equal(t, "NVIDIA NVML is not loaded", data.reason)
+	assert.Equal(t, "NVIDIA NVML library is not loaded", data.reason)
 	assert.Empty(t, data.Utilizations)
 }
 

--- a/components/accelerator/nvidia/xid/component.go
+++ b/components/accelerator/nvidia/xid/component.go
@@ -194,7 +194,12 @@ func (c *component) Check() components.CheckResult {
 	}
 	if !c.nvmlInstance.NVMLExists() {
 		cr.health = apiv1.HealthStateTypeHealthy
-		cr.reason = "NVIDIA NVML is not loaded"
+		cr.reason = "NVIDIA NVML library is not loaded"
+		return cr
+	}
+	if c.nvmlInstance.ProductName() == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
 	}
 

--- a/pkg/nvidia-query/nvml/instance.go
+++ b/pkg/nvidia-query/nvml/instance.go
@@ -15,7 +15,7 @@ var _ Instance = &instance{}
 
 // Instance is the interface for the NVML library connector.
 type Instance interface {
-	// NVMLExists returns true if NVML is installed.
+	// NVMLExists returns true if the NVML library is installed.
 	NVMLExists() bool
 
 	// Library returns the NVML library.
@@ -26,6 +26,8 @@ type Instance interface {
 	Devices() map[string]device.Device
 
 	// ProductName returns the product name of the GPU.
+	// Note that some machines have nvml library but the driver is not installed,
+	// returning empty value for the GPU product name.
 	ProductName() string
 
 	// Architecture returns the architecture of the GPU.


### PR DESCRIPTION
where the loaded NVML library/API returns no error
on get product name, and returns an empty value,
causing gpud to incorrectly report that GPU are installed

c.f., https://github.com/leptonai/gpud/pull/689