### PR TITLE
fix(disk): panic on gpud scan

### DIFF
--- a/components/disk/component.go
+++ b/components/disk/component.go
@@ -272,6 +272,10 @@ func (cr *checkResult) String() string {
 	table.SetHeader([]string{"Mount Point", "Total", "Free", "Used", "Used %"})
 
 	for _, p := range cr.ExtPartitions {
+		if p.Usage == nil {
+			continue
+		}
+
 		table.Append([]string{
 			p.MountPoint,
 			p.Usage.TotalHumanized,


### PR DESCRIPTION
```
{"level":"info","ts":"2025-04-24T09:58:59Z","caller":"disk/component.go:117","msg":"checking disk"}
{"level":"warn","ts":"2025-04-24T09:58:59Z","caller":"disk/component.go:198","msg":"no usage found for mount point","mount_point":"/var/lib/kubelet/pods/0b737df7-7b71-476d-8e6c-01716fa7be1d/volume-subpaths/metrics-config/nvidia-dcgm-exporter/1"}
{"level":"warn","ts":"2025-04-24T09:58:59Z","caller":"disk/component.go:198","msg":"no usage found for mount point","mount_point":"/var/lib/kubelet/pods/865df29e-1193-4e3a-b83d-1278e3714b00/volume-subpaths/nvidia-device-plugin-entrypoint/nvidia-device-plugin/0"}
{"level":"warn","ts":"2025-04-24T09:58:59Z","caller":"disk/component.go:198","msg":"no usage found for mount point","mount_point":"/var/lib/kubelet/pods/670c27b5-4efa-4b84-a5ce-68ba2d9dd781/volume-subpaths/nvidia-container-toolkit-entrypoint/nvidia-container-toolkit-ctr/0"}
{"level":"warn","ts":"2025-04-24T09:58:59Z","caller":"disk/component.go:198","msg":"no usage found for mount point","mount_point":"/var/lib/kubelet/pods/338d5f75-9bb2-4626-94e4-4cfe41fed567/volume-subpaths/host-root/gpu-feature-discovery-imex-init/2"}
{"level":"warn","ts":"2025-04-24T09:58:59Z","caller":"disk/component.go:198","msg":"no usage found for mount point","mount_point":"/var/lib/kubelet/pods/7edc0726-8e79-4893-b4db-cafe8c2011c5/volume-subpaths/tigera-ca-bundle/calico-node/9"}
✔ found 6 ext4 partition(s) and 2 block device(s)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x153e9f2]

goroutine 1 [running]:
github.com/leptonai/gpud/components/disk.(*checkResult).String(0xc000e74480)
        /root/gpud/components/disk/component.go:277 +0x1d2
github.com/leptonai/gpud/pkg/scan.printSummary({0x1e29a10, 0xc000e74480})
        /root/gpud/pkg/scan/scan.go:102 +0x110
github.com/leptonai/gpud/pkg/scan.Scan({0x1e2e440, 0xc0002b1030}, {0xc0000557d0, 0x1, 0x0?})
        /root/gpud/pkg/scan/scan.go:137 +0x1f4
github.com/leptonai/gpud/cmd/gpud/command.cmdScan(0xc000df2fe0?)
        /root/gpud/cmd/gpud/command/scan.go:30 +0x1d6
github.com/urfave/cli.HandleAction({0x1854280?, 0x1c3f970?}, 0x4?)
        /root/go/pkg/mod/github.com/urfave/cli@v1.22.16/app.go:524 +0x70
github.com/urfave/cli.Command.Run({{0x1b4403a, 0x4}, {0x0, 0x0}, {0xc000e144a0, 0x2, 0x2}, {0x1b99857, 0x29}, {0x0, ...}, ...}, ...)
        /root/go/pkg/mod/github.com/urfave/cli@v1.22.16/command.go:175 +0x676
github.com/urfave/cli.(*App).Run(0xc000461500, {0xc00003e120, 0x2, 0x2})
        /root/go/pkg/mod/github.com/urfave/cli@v1.22.16/app.go:277 +0xb1b
main.main()
        /root/gpud/cmd/gpud/main.go:12 +0x2d
```

Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
