### PR TITLE
feat(gpud): add "gpud compact" command to VACUUM sqlite database (manual)

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -404,6 +404,11 @@ sudo rm /etc/systemd/system/gpud.service
 				},
 			},
 		},
+		{
+			Name:   "compact",
+			Usage:  "compact the GPUd state database to reduce the size in disk (GPUd must be stopped)",
+			Action: cmdCompact,
+		},
 
 		// for diagnose + quick scanning
 		{

--- a/cmd/gpud/command/compact.go
+++ b/cmd/gpud/command/compact.go
@@ -57,7 +57,7 @@ func cmdCompact(cliContext *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to read state file size: %w", err)
 	}
-	log.Logger.Infow("state file size before compact", "size", humanize.Bytes(uint64(dbSize)))
+	log.Logger.Infow("state file size before compact", "size", humanize.Bytes(dbSize))
 
 	if err := sqlite.Compact(rootCtx, dbRW); err != nil {
 		return fmt.Errorf("failed to compact state file: %w", err)
@@ -67,7 +67,7 @@ func cmdCompact(cliContext *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to read state file size: %w", err)
 	}
-	log.Logger.Infow("state file size after compact", "size", humanize.Bytes(uint64(dbSize)))
+	log.Logger.Infow("state file size after compact", "size", humanize.Bytes(dbSize))
 
 	fmt.Printf("%s successfully compacted state file\n", checkMark)
 	return nil

--- a/cmd/gpud/command/compact.go
+++ b/cmd/gpud/command/compact.go
@@ -1,0 +1,74 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/urfave/cli"
+
+	"github.com/leptonai/gpud/pkg/config"
+	"github.com/leptonai/gpud/pkg/log"
+	"github.com/leptonai/gpud/pkg/netutil"
+	"github.com/leptonai/gpud/pkg/sqlite"
+	"github.com/leptonai/gpud/pkg/systemd"
+)
+
+func cmdCompact(cliContext *cli.Context) error {
+	if systemd.SystemctlExists() {
+		active, err := systemd.IsActive("gpud.service")
+		if err != nil {
+			return err
+		}
+		if active {
+			return fmt.Errorf("gpud is running (must be stopped before running compact)")
+		}
+	}
+
+	portOpen := netutil.IsPortOpen(config.DefaultGPUdPort)
+	if portOpen {
+		return fmt.Errorf("gpud is running on port %d (must be stopped before running compact)", config.DefaultGPUdPort)
+	}
+
+	log.Logger.Infow("successfully checked gpud is not running")
+
+	rootCtx, rootCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer rootCancel()
+
+	stateFile, err := config.DefaultStateFile()
+	if err != nil {
+		return fmt.Errorf("failed to get state file: %w", err)
+	}
+
+	dbRW, err := sqlite.Open(stateFile)
+	if err != nil {
+		return fmt.Errorf("failed to open state file: %w", err)
+	}
+	defer dbRW.Close()
+
+	dbRO, err := sqlite.Open(stateFile, sqlite.WithReadOnly(true))
+	if err != nil {
+		return fmt.Errorf("failed to open state file: %w", err)
+	}
+	defer dbRO.Close()
+
+	dbSize, err := sqlite.ReadDBSize(rootCtx, dbRO)
+	if err != nil {
+		return fmt.Errorf("failed to read state file size: %w", err)
+	}
+	log.Logger.Infow("state file size before compact", "size", humanize.Bytes(uint64(dbSize)))
+
+	if err := sqlite.Compact(rootCtx, dbRW); err != nil {
+		return fmt.Errorf("failed to compact state file: %w", err)
+	}
+
+	dbSize, err = sqlite.ReadDBSize(rootCtx, dbRO)
+	if err != nil {
+		return fmt.Errorf("failed to read state file size: %w", err)
+	}
+	log.Logger.Infow("state file size after compact", "size", humanize.Bytes(uint64(dbSize)))
+
+	fmt.Printf("%s successfully compacted state file\n", checkMark)
+	return nil
+}


### PR DESCRIPTION
> {"level":"info","ts":"2025-04-27T02:22:47Z","caller":"command/compact.go:34","msg":"successfully checked gpud is not running"}
{"level":"info","ts":"2025-04-27T02:22:47Z","caller":"command/compact.go:60","msg":"state file size before compact","size":"36 MB"}
{"level":"info","ts":"2025-04-27T02:22:47Z","caller":"sqlite/sqlite.go:83","msg":"compacting state database"}
{"level":"info","ts":"2025-04-27T02:22:47Z","caller":"sqlite/sqlite.go:88","msg":"successfully compacted state database"}
{"level":"info","ts":"2025-04-27T02:22:47Z","caller":"command/compact.go:70","msg":"state file size after compact","size":"33 MB"}