### PR TITLE
fix(custom-plugins): fix non-zero exit code commands output parsing, rename "mode" to "run_mode", add e2e tests for manual mode plugin

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -431,7 +431,7 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 		pluginName, err := randStr(10)
 		Expect(err).NotTo(HaveOccurred(), "failed to rand str")
 
-		componentName := pkgcustomplugins.ConvertToComponentName(pluginName)
+		customComponentName := pkgcustomplugins.ConvertToComponentName(pluginName)
 
 		// register with manual mode first
 		randSfx1, err := randStr(10)
@@ -464,9 +464,16 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 							},
 						},
 						{
-							Name: "third-step",
+							Name: "third-step-1",
 							RunBashScript: &pkgcustomplugins.RunBashScript{
 								Script:      "echo 111 > " + fileToWrite1,
+								ContentType: "plaintext",
+							},
+						},
+						{
+							Name: "third-step-2",
+							RunBashScript: &pkgcustomplugins.RunBashScript{
+								Script:      "exit 1",
 								ContentType: "plaintext",
 							},
 						},
@@ -498,7 +505,7 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 
 				Expect(curSpec.RunMode).Should(Equal(pkgcustomplugins.SpecModeManual), "expected manual mode")
 			}
-			Expect(csPlugins[componentName]).NotTo(BeNil(), "expected to be registered")
+			Expect(csPlugins[customComponentName]).NotTo(BeNil(), "expected to be registered")
 		})
 
 		It("make sure the plugin has been not run as it's manual mode", func() {
@@ -510,7 +517,7 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 		})
 
 		It("trigger the plugin that is in manual mode", func() {
-			resp, err := clientv1.TriggerComponentCheck(rootCtx, "https://"+ep, componentName)
+			resp, err := clientv1.TriggerComponentCheck(rootCtx, "https://"+ep, customComponentName)
 			Expect(err).NotTo(HaveOccurred(), "failed to get custom plugins")
 			Expect(len(resp)).To(Equal(1), "expected 1 response")
 
@@ -520,6 +527,15 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 		It("make sure the plugin has been run manually", func() {
 			_, err := os.Stat(fileToWrite1)
 			Expect(err).NotTo(HaveOccurred(), "expected file to be created")
+		})
+
+		It("make sure the plugin has been failed as configured", func() {
+			states, err := clientv1.GetHealthStates(rootCtx, "https://"+ep, clientv1.WithComponent(customComponentName))
+			Expect(err).NotTo(HaveOccurred(), "failed to get states")
+			GinkgoLogr.Info("got states", "states", states)
+			Expect(states).ToNot(BeEmpty(), "expected states to not be empty")
+			Expect(states[0].States).To(HaveLen(1), "expected states to have 1 state")
+			Expect(states[0].States[0].Health).To(Equal(apiv1.HealthStateTypeUnhealthy), "expected health state to be unhealthy")
 		})
 
 		randSfx2, err := randStr(10)
@@ -610,7 +626,7 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 
 				Expect(curSpec.RunMode).Should(BeEmpty(), "expected empty run_mode")
 			}
-			Expect(csPlugins[componentName]).NotTo(BeNil(), "expected to be registered")
+			Expect(csPlugins[customComponentName]).NotTo(BeNil(), "expected to be registered")
 
 			// make sure the plugin has been run once by checking the file exists when the dry mode is disabled
 			// wait for the plugin to run
@@ -632,7 +648,7 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to read response body")
 			fmt.Println("/v1/states RESPONSE BODY:", string(body))
 
-			states, err := clientv1.GetHealthStates(rootCtx, "https://"+ep, clientv1.WithComponent(componentName))
+			states, err := clientv1.GetHealthStates(rootCtx, "https://"+ep, clientv1.WithComponent(customComponentName))
 			Expect(err).NotTo(HaveOccurred(), "failed to get states")
 			GinkgoLogr.Info("got states", "states", states)
 			Expect(states).ToNot(BeEmpty(), "expected states to not be empty")
@@ -645,7 +661,7 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 		})
 
 		It("deregister the custom plugin", func() {
-			derr := clientv1.DeregisterComponent(rootCtx, "https://"+ep, componentName)
+			derr := clientv1.DeregisterComponent(rootCtx, "https://"+ep, customComponentName)
 			Expect(derr).NotTo(HaveOccurred(), "failed to deregister custom plugin")
 		})
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -445,7 +445,7 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 				Type:       pkgcustomplugins.SpecTypeComponent,
 
 				// should not run, only registers
-				Mode: pkgcustomplugins.SpecModeManual,
+				RunMode: pkgcustomplugins.SpecModeManual,
 
 				HealthStatePlugin: &pkgcustomplugins.Plugin{
 					Steps: []pkgcustomplugins.Step{
@@ -490,13 +490,13 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 			GinkgoLogr.Info("got custom plugins", "custom plugins", csPlugins)
 			for componentName, curSpec := range csPlugins {
 				Expect(componentName).Should(Equal(curSpec.ComponentName()))
-				GinkgoLogr.Info("currently registered custom plugin (expect mode: manual)", "name", curSpec.PluginName, "componentName", componentName)
+				GinkgoLogr.Info("currently registered custom plugin (expect run_mode: manual)", "name", curSpec.PluginName, "componentName", componentName)
 
 				b, err := json.Marshal(curSpec)
 				Expect(err).NotTo(HaveOccurred(), "failed to marshal spec")
-				fmt.Println("currently registered custom plugin (expect mode: manual)", "name", curSpec.PluginName, "componentName", componentName, "spec", string(b))
+				fmt.Println("currently registered custom plugin (expect run_mode: manual)", "name", curSpec.PluginName, "componentName", componentName, "spec", string(b))
 
-				Expect(curSpec.Mode).Should(Equal(pkgcustomplugins.SpecModeManual), "expected manual mode")
+				Expect(curSpec.RunMode).Should(Equal(pkgcustomplugins.SpecModeManual), "expected manual mode")
 			}
 			Expect(csPlugins[componentName]).NotTo(BeNil(), "expected to be registered")
 		})
@@ -535,7 +535,7 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 				PluginName: pluginName,
 				Type:       pkgcustomplugins.SpecTypeComponent,
 
-				Mode: "",
+				RunMode: "",
 
 				HealthStatePlugin: &pkgcustomplugins.Plugin{
 					Steps: []pkgcustomplugins.Step{
@@ -602,13 +602,13 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 			GinkgoLogr.Info("got custom plugins", "custom plugins", csPlugins)
 			for componentName, curSpec := range csPlugins {
 				Expect(componentName).Should(Equal(curSpec.ComponentName()))
-				GinkgoLogr.Info("currently registered custom plugin (expect mode: '')", "name", curSpec.PluginName, "componentName", componentName)
+				GinkgoLogr.Info("currently registered custom plugin (expect run_mode: '')", "name", curSpec.PluginName, "componentName", componentName)
 
 				b, err := json.Marshal(curSpec)
 				Expect(err).NotTo(HaveOccurred(), "failed to marshal spec")
-				fmt.Println("currently registered custom plugin (expect mode: '')", "name", curSpec.PluginName, "componentName", componentName, "spec", string(b))
+				fmt.Println("currently registered custom plugin (expect run_mode: '')", "name", curSpec.PluginName, "componentName", componentName, "spec", string(b))
 
-				Expect(curSpec.Mode).Should(BeEmpty(), "expected empty mode")
+				Expect(curSpec.RunMode).Should(BeEmpty(), "expected empty run_mode")
 			}
 			Expect(csPlugins[componentName]).NotTo(BeNil(), "expected to be registered")
 

--- a/pkg/custom-plugins/component.go
+++ b/pkg/custom-plugins/component.go
@@ -154,6 +154,9 @@ func (c *component) Check() components.CheckResult {
 		}
 	}
 
+	// we still parsed the output above
+	// even when the command/script had failed
+	// e.g., command failed with non-zero exit code
 	if cr.err != nil {
 		cr.health = apiv1.HealthStateTypeUnhealthy
 		cr.reason = fmt.Sprintf("error executing state plugin -- %s (exit code: %d)", cr.err, cr.exitCode)

--- a/pkg/custom-plugins/component.go
+++ b/pkg/custom-plugins/component.go
@@ -160,9 +160,12 @@ func (c *component) Check() components.CheckResult {
 		return cr
 	}
 
-	cr.health = apiv1.HealthStateTypeHealthy
-	cr.reason = "ok"
-	log.Logger.Debugw("successfully executed plugin", "exitCode", cr.exitCode, "output", string(cr.out))
+	// no invalid output found or no error occurred, thus healthy
+	if cr.reason == "" {
+		cr.health = apiv1.HealthStateTypeHealthy
+		cr.reason = "ok"
+		log.Logger.Debugw("successfully executed plugin", "exitCode", cr.exitCode, "output", string(cr.out))
+	}
 
 	return cr
 }

--- a/pkg/custom-plugins/component.go
+++ b/pkg/custom-plugins/component.go
@@ -156,7 +156,7 @@ func (c *component) Check() components.CheckResult {
 
 	if cr.err != nil {
 		cr.health = apiv1.HealthStateTypeUnhealthy
-		cr.reason = fmt.Sprintf("error executing state plugin -- %s (output: %s)", cr.err, string(cr.out))
+		cr.reason = fmt.Sprintf("error executing state plugin -- %s (exit code: %d)", cr.err, cr.exitCode)
 		return cr
 	}
 

--- a/pkg/custom-plugins/component.go
+++ b/pkg/custom-plugins/component.go
@@ -65,7 +65,7 @@ func (c *component) Name() string { return c.spec.ComponentName() }
 func (c *component) Start() error {
 	log.Logger.Infow("starting custom plugin", "type", c.spec.Type, "component", c.Name(), "plugin", c.spec.PluginName)
 
-	if c.spec.Mode == SpecModeManual {
+	if c.spec.RunMode == SpecModeManual {
 		log.Logger.Infow("custom plugin is in manual mode, skipping start", "type", c.spec.Type, "component", c.Name(), "plugin", c.spec.PluginName)
 		return nil
 	}

--- a/pkg/custom-plugins/spec_test.go
+++ b/pkg/custom-plugins/spec_test.go
@@ -29,7 +29,7 @@ func TestLoad(t *testing.T) {
 	plugin := plugins[0]
 	assert.Equal(t, "nvidia-smi", plugin.PluginName)
 	assert.Equal(t, "bnZpZGlhLXNtaQo=", plugin.HealthStatePlugin.Steps[0].RunBashScript.Script)
-	assert.Equal(t, SpecModeManual, plugin.Mode)
+	assert.Equal(t, SpecModeManual, plugin.RunMode)
 	assert.Equal(t, metav1.Duration{Duration: 10 * time.Second}, plugin.Timeout)
 	assert.Equal(t, metav1.Duration{Duration: 1 * time.Minute}, plugin.Interval)
 }
@@ -302,7 +302,7 @@ func TestLoadPlaintextPlugins(t *testing.T) {
 	assert.Equal(t, "Run nvidia-smi", plugins[0].HealthStatePlugin.Steps[1].Name)
 	assert.Equal(t, "plaintext", plugins[0].HealthStatePlugin.Steps[1].RunBashScript.ContentType)
 	assert.Equal(t, "echo 'State script'", plugins[0].HealthStatePlugin.Steps[1].RunBashScript.Script)
-	assert.Equal(t, SpecModeManual, plugins[0].Mode)
+	assert.Equal(t, SpecModeManual, plugins[0].RunMode)
 	assert.Equal(t, metav1.Duration{Duration: 10 * time.Second}, plugins[0].Timeout)
 	assert.Equal(t, metav1.Duration{Duration: 1 * time.Minute}, plugins[0].Interval)
 
@@ -315,7 +315,7 @@ func TestLoadPlaintextPlugins(t *testing.T) {
 	assert.Equal(t, "Run python scripts", plugins[1].HealthStatePlugin.Steps[1].Name)
 	assert.Equal(t, "plaintext", plugins[1].HealthStatePlugin.Steps[1].RunBashScript.ContentType)
 	assert.Contains(t, plugins[1].HealthStatePlugin.Steps[1].RunBashScript.Script, "python3 test.py")
-	assert.Equal(t, SpecModeManual, plugins[1].Mode)
+	assert.Equal(t, SpecModeManual, plugins[1].RunMode)
 	assert.Equal(t, metav1.Duration{Duration: 10 * time.Second}, plugins[1].Timeout)
 	assert.Equal(t, metav1.Duration{Duration: 1 * time.Minute}, plugins[1].Interval)
 }
@@ -586,6 +586,8 @@ func TestLoadMultiStepPlaintextPlugin(t *testing.T) {
 	testYAML := `
 - plugin_name: "multi-step-plugin"
   type: "component"
+  run_run_mode: manual
+
   health_state_plugin:
     steps:
       - name: "Install Python"
@@ -601,7 +603,6 @@ func TestLoadMultiStepPlaintextPlugin(t *testing.T) {
           content_type: plaintext
           script: nvidia-smi
 
-  mode: manual
 
   timeout: 10s
   interval: 1m`
@@ -926,7 +927,7 @@ func TestHealthStatePlugin_executeAllSteps(t *testing.T) {
 						},
 					},
 				},
-				Mode:    SpecModeManual,
+				RunMode: SpecModeManual,
 				Timeout: metav1.Duration{Duration: 10 * time.Second},
 			},
 			expectOutput: false,

--- a/pkg/custom-plugins/testdata/plugins.base64.yaml
+++ b/pkg/custom-plugins/testdata/plugins.base64.yaml
@@ -8,7 +8,7 @@
           content_type: base64
           script: bnZpZGlhLXNtaQo=
 
-  mode: manual
+  run_mode: manual
 
   timeout: 10s
   interval: 1m

--- a/pkg/custom-plugins/testdata/plugins.manual.yaml
+++ b/pkg/custom-plugins/testdata/plugins.manual.yaml
@@ -1,0 +1,23 @@
+########################################
+# demonstrates a plugin that fails with an exit code 1 ONLY when triggered manually
+- plugin_name: manual-exit-1
+  type: component
+
+  health_state_plugin:
+    parser:
+      json_paths:
+        - query: $.description
+          field: description
+    steps:
+      - name: Exit 1
+        run_bash_script:
+          content_type: plaintext
+          script: |
+            echo '{"description": "triggered to fail with exit code 1"}'
+
+            exit 1
+
+  run_mode: "manual" # set to "manual" to only trigger manually
+
+  timeout: 1m
+  interval: 100m

--- a/pkg/custom-plugins/testdata/plugins.plaintext.0.yaml
+++ b/pkg/custom-plugins/testdata/plugins.plaintext.0.yaml
@@ -15,7 +15,7 @@
           content_type: plaintext
           script: echo 'State script'
 
-  mode: manual
+  run_mode: manual
 
   timeout: 10s
   interval: 1m
@@ -38,7 +38,7 @@
           script: |
             python3 test.py
 
-  mode: manual
+  run_mode: manual
 
   timeout: 10s
   interval: 1m

--- a/pkg/custom-plugins/testdata/plugins.plaintext.1.yaml
+++ b/pkg/custom-plugins/testdata/plugins.plaintext.1.yaml
@@ -30,7 +30,7 @@
             uv run /tmp/hello.py
             rm -f /tmp/hello.py
 
-  mode: ""
+  run_mode: ""
   timeout: 1m
 
 
@@ -51,7 +51,7 @@
             echo "about to fail with exit code 1"
             exit 1
 
-  mode: ""
+  run_mode: ""
 
   timeout: 1m
   interval: 100m
@@ -124,7 +124,7 @@
             uv run /tmp/nvidia-smi-gpu-throttle.py
             rm -f /tmp/nvidia-smi-gpu-throttle.py
 
-  mode: ""
+  run_mode: ""
 
   timeout: 1m
   interval: 10m
@@ -193,7 +193,7 @@
             uv run /tmp/nvidia-smi-gpu-power-state.py
             rm -f /tmp/nvidia-smi-gpu-power-state.py
 
-  mode: ""
+  run_mode: ""
 
   timeout: 1m
   interval: 10m

--- a/pkg/custom-plugins/testdata/plugins.plaintext.2.regex.yaml
+++ b/pkg/custom-plugins/testdata/plugins.plaintext.2.regex.yaml
@@ -25,7 +25,7 @@
             echo '{"name": "test", "result": "healthy", "passed": true}'
             echo "thank you"
 
-  mode: ""
+  run_mode: ""
 
   timeout: 1m
   interval: 10m
@@ -58,7 +58,7 @@
             echo '{"name": "test", "result": "unhealthy", "passed": false}'
             echo "done"
 
-  mode: ""
+  run_mode: ""
 
   timeout: 1m
   interval: 10m
@@ -96,7 +96,7 @@
             echo '{"name": "test", "result": "unhealthy", "passed": false}'
             echo "done"
 
-  mode: ""
+  run_mode: ""
 
   timeout: 1m
   interval: 10m

--- a/pkg/custom-plugins/types.go
+++ b/pkg/custom-plugins/types.go
@@ -23,7 +23,9 @@ const (
 	// SpecTypeComponent is the type of the plugin that is used to run as a component.
 	// Meant to be run periodically.
 	SpecTypeComponent = "component"
+)
 
+const (
 	// SpecModeManual is the mode of the plugin that is used to run manually.
 	SpecModeManual = "manual"
 )
@@ -41,15 +43,16 @@ type Spec struct {
 	// Type defines the plugin type.
 	Type string `json:"type"`
 
-	// Mode is set to "manual" to only when explicitly triggered.
-	// The plugin is only registered but not run periodically.
-	// GPUd does not run this even once.
-	// GPUd does not run this periodically.
+	// RunMode is set to "manual" to run the plugin only when explicitly triggered.
+	// The manual mode plugin is only registered but not run periodically.
+	// - GPUd does not run this even once.
+	// - GPUd does not run this periodically.
+	//
 	// This "manual" mode is only applicable to "component" type plugins.
 	// The "init" type plugins are always run only once.
 	//
 	// If not set, the plugin is run periodically by default.
-	Mode string `json:"mode"`
+	RunMode string `json:"run_mode"`
 
 	// HealthStatePlugin defines the plugin instructions
 	// to evaluate the health state of this plugin,

--- a/pkg/process/runner_exclusive.go
+++ b/pkg/process/runner_exclusive.go
@@ -84,6 +84,9 @@ func (er *exclusiveRunner) RunUntilCompletion(ctx context.Context, script string
 			if rerr != nil {
 				log.Logger.Errorw("failed to read output file after the process failed", "error", rerr)
 			}
+			if len(output) == 0 {
+				output = nil
+			}
 
 			return output, p.ExitCode(), err
 		}

--- a/pkg/process/runner_exclusive.go
+++ b/pkg/process/runner_exclusive.go
@@ -77,7 +77,8 @@ func (er *exclusiveRunner) RunUntilCompletion(ctx context.Context, script string
 
 	case err := <-p.Wait():
 		if err != nil {
-			return nil, p.ExitCode(), err
+			output, _ := os.ReadFile(tmpFile.Name())
+			return output, p.ExitCode(), err
 		}
 		log.Logger.Infow("process exited", "pid", p.PID(), "exitCode", p.ExitCode())
 	}


### PR DESCRIPTION
(to be more distinct from "type" field)
