### PR TITLE
feat(nvidia/infiniband): use "ibstat" partial output, "ibstatus" fallback (if needed)

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -36,6 +36,7 @@ var (
 	autoUpdateExitCode int
 
 	ibstatCommand   string
+	ibstatusCommand string
 	pluginSpecsFile string
 
 	enablePluginAPI bool
@@ -215,6 +216,12 @@ sudo rm /etc/systemd/system/gpud.service
 					Name:        "ibstat-command",
 					Usage:       "sets the ibstat command (leave empty for default, useful for testing)",
 					Destination: &ibstatCommand,
+					Hidden:      true,
+				},
+				cli.StringFlag{
+					Name:        "ibstatus-command",
+					Usage:       "sets the ibstatus command (leave empty for default, useful for testing)",
+					Destination: &ibstatusCommand,
 					Hidden:      true,
 				},
 				cli.StringFlag{
@@ -433,6 +440,12 @@ sudo rm /etc/systemd/system/gpud.service
 					Name:        "ibstat-command",
 					Usage:       "sets the ibstat command (leave empty for default, useful for testing)",
 					Destination: &ibstatCommand,
+					Hidden:      true,
+				},
+				cli.StringFlag{
+					Name:        "ibstatus-command",
+					Usage:       "sets the ibstatus command (leave empty for default, useful for testing)",
+					Destination: &ibstatusCommand,
 					Hidden:      true,
 				},
 			},

--- a/cmd/gpud/command/run.go
+++ b/cmd/gpud/command/run.go
@@ -44,6 +44,7 @@ func cmdRun(cliContext *cli.Context) error {
 
 	configOpts := []config.OpOption{
 		config.WithIbstatCommand(ibstatCommand),
+		config.WithIbstatusCommand(ibstatusCommand),
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)

--- a/cmd/gpud/command/scan.go
+++ b/cmd/gpud/command/scan.go
@@ -20,6 +20,7 @@ func cmdScan(cliContext *cli.Context) error {
 
 	opts := []scan.OpOption{
 		scan.WithIbstatCommand(ibstatCommand),
+		scan.WithIbstatusCommand(ibstatusCommand),
 	}
 	if zapLvl.Level() <= zap.DebugLevel { // e.g., info, warn, error
 		opts = append(opts, scan.WithDebug(true))

--- a/components/accelerator/nvidia/infiniband/component.go
+++ b/components/accelerator/nvidia/infiniband/component.go
@@ -180,6 +180,12 @@ func (c *component) Check() components.CheckResult {
 			cr.health = apiv1.HealthStateTypeUnhealthy
 			cr.reason = "ibstat command failed"
 			log.Logger.Errorw(cr.reason, "error", cr.err)
+
+			if cr.IbstatOutput != nil && len(cr.IbstatOutput.Parsed) > 0 {
+				cr.health = apiv1.HealthStateTypeHealthy
+				cr.reason = "ibstat command failed with partial output"
+				log.Logger.Errorw(cr.reason, "error", cr.err)
+			}
 		}
 		return cr
 	}

--- a/components/accelerator/nvidia/infiniband/component.go
+++ b/components/accelerator/nvidia/infiniband/component.go
@@ -144,9 +144,9 @@ func (c *component) Check() components.CheckResult {
 	// nothing specified for this machine, gpud MUST skip the ib check
 	thresholds := c.getThresholdsFunc()
 	if thresholds.IsZero() {
-		cr.reason = reasonThresholdNotSetSkipped
-		cr.health = apiv1.HealthStateTypeHealthy
-		return cr
+		// cr.reason = reasonThresholdNotSetSkipped
+		// cr.health = apiv1.HealthStateTypeHealthy
+		// return cr
 	}
 
 	if c.nvmlInstance == nil {

--- a/components/accelerator/nvidia/infiniband/component.go
+++ b/components/accelerator/nvidia/infiniband/component.go
@@ -178,7 +178,7 @@ func (c *component) Check() components.CheckResult {
 		// this fallback is only used when the "ibstat" command fails
 		// then we don't care if this fallback "ibstatus" command fails
 		// as long as the following "ibstat" command succeeds
-		log.Logger.Errorw("ibstatus command failed", "error", cr.errIbstatus)
+		log.Logger.Warnw("ibstatus command failed", "error", cr.errIbstatus)
 	}
 
 	// "ibstat" may fail if there's a port device that is wrongly mapped (e.g., exit 255)

--- a/components/accelerator/nvidia/infiniband/component.go
+++ b/components/accelerator/nvidia/infiniband/component.go
@@ -144,9 +144,9 @@ func (c *component) Check() components.CheckResult {
 	// nothing specified for this machine, gpud MUST skip the ib check
 	thresholds := c.getThresholdsFunc()
 	if thresholds.IsZero() {
-		// cr.reason = reasonThresholdNotSetSkipped
-		// cr.health = apiv1.HealthStateTypeHealthy
-		// return cr
+		cr.reason = reasonThresholdNotSetSkipped
+		cr.health = apiv1.HealthStateTypeHealthy
+		return cr
 	}
 
 	if c.nvmlInstance == nil {

--- a/components/accelerator/nvidia/infiniband/component.go
+++ b/components/accelerator/nvidia/infiniband/component.go
@@ -40,8 +40,9 @@ type component struct {
 	eventBucket eventstore.Bucket
 	kmsgSyncer  *kmsg.Syncer
 
-	getIbstatOutputFunc func(ctx context.Context, ibstatCommands []string) (*infiniband.IbstatOutput, error)
-	getThresholdsFunc   func() infiniband.ExpectedPortStates
+	getIbstatOutputFunc   func(ctx context.Context, ibstatCommands []string) (*infiniband.IbstatOutput, error)
+	getIbstatusOutputFunc func(ctx context.Context, ibstatusCommands []string) (*infiniband.IbstatusOutput, error)
+	getThresholdsFunc     func() infiniband.ExpectedPortStates
 
 	lastMu          sync.RWMutex
 	lastCheckResult *checkResult
@@ -50,12 +51,13 @@ type component struct {
 func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 	cctx, ccancel := context.WithCancel(gpudInstance.RootCtx)
 	c := &component{
-		ctx:                 cctx,
-		cancel:              ccancel,
-		nvmlInstance:        gpudInstance.NVMLInstance,
-		toolOverwrites:      gpudInstance.NVIDIAToolOverwrites,
-		getIbstatOutputFunc: infiniband.GetIbstatOutput,
-		getThresholdsFunc:   GetDefaultExpectedPortStates,
+		ctx:                   cctx,
+		cancel:                ccancel,
+		nvmlInstance:          gpudInstance.NVMLInstance,
+		toolOverwrites:        gpudInstance.NVIDIAToolOverwrites,
+		getIbstatOutputFunc:   infiniband.GetIbstatOutput,
+		getIbstatusOutputFunc: infiniband.GetIbstatusOutput,
+		getThresholdsFunc:     GetDefaultExpectedPortStates,
 	}
 
 	if gpudInstance.EventStore != nil && runtime.GOOS == "linux" {
@@ -163,36 +165,56 @@ func (c *component) Check() components.CheckResult {
 		return cr
 	}
 
-	if c.getIbstatOutputFunc == nil {
+	if c.getIbstatOutputFunc == nil || c.getIbstatusOutputFunc == nil {
 		cr.health = apiv1.HealthStateTypeHealthy
 		cr.reason = "ibstat checker not found"
 		return cr
 	}
 
+	// only used for fallback, if ibstat command fails
+	// so we don't care if this fallback fails
+	// as long as the following "ibstat" command succeeds
 	cctx, ccancel := context.WithTimeout(c.ctx, 15*time.Second)
-	cr.IbstatOutput, cr.err = c.getIbstatOutputFunc(cctx, []string{c.toolOverwrites.IbstatCommand})
+	cr.IbstatusOutput, cr.errIbstatus = c.getIbstatusOutputFunc(cctx, []string{c.toolOverwrites.IbstatusCommand})
 	ccancel()
-	if cr.err != nil {
-		if errors.Is(cr.err, infiniband.ErrNoIbstatCommand) {
+	if cr.errIbstatus != nil {
+		log.Logger.Errorw("ibstatus command failed", "error", cr.errIbstatus)
+	}
+
+	cctx, ccancel = context.WithTimeout(c.ctx, 15*time.Second)
+	cr.IbstatOutput, cr.errIbstat = c.getIbstatOutputFunc(cctx, []string{c.toolOverwrites.IbstatCommand})
+	ccancel()
+	if cr.errIbstat != nil {
+		if errors.Is(cr.errIbstat, infiniband.ErrNoIbstatCommand) {
 			cr.health = apiv1.HealthStateTypeHealthy
 			cr.reason = "ibstat command not found"
 		} else {
 			cr.health = apiv1.HealthStateTypeUnhealthy
 			cr.reason = "ibstat command failed"
-			log.Logger.Errorw(cr.reason, "error", cr.err)
-
-			if cr.IbstatOutput != nil && len(cr.IbstatOutput.Parsed) > 0 {
-				cr.health = apiv1.HealthStateTypeHealthy
-				cr.reason = "ibstat command failed with partial output"
-				log.Logger.Errorw(cr.reason, "error", cr.err)
-			}
+			log.Logger.Errorw(cr.reason, "error", cr.errIbstat)
 		}
-		return cr
 	}
 
-	if cr.IbstatOutput == nil {
-		cr.reason = reasonMissingIbstatOutput
+	if cr.IbstatOutput != nil {
+		// whether ibstat command failed or not (e.g., one port device is wrongly mapped)
+		// but we got the entire/partial output from "ibstat" command
+		// thus we use the data from "ibstat" command to evaluate
+		// ok to error as long as it meets the thresholds
+		// which means we may overwrite the error above
+		// (e.g., "ibstat" command exited 255 but still meets the thresholds)
+		cr.reason, cr.health = evaluateIbstatOutputAgainstThresholds(cr.IbstatOutput, thresholds)
+	} else if cr.IbstatusOutput != nil {
+		// ibstat command failed and no output
+		// we only fallback to the second data source "ibstatus"
+		// if the first "ibstat" command has no output
+		cr.reason, cr.health = evaluateIbstatusOutputAgainstThresholds(cr.IbstatusOutput, thresholds)
+	}
+
+	if cr.errIbstat == nil && cr.IbstatOutput == nil &&
+		cr.errIbstatus == nil && cr.IbstatusOutput == nil {
+		cr.reason = reasonMissingIbstatIbstatusOutput
 		cr.health = apiv1.HealthStateTypeHealthy
+		log.Logger.Errorw(cr.reason)
 		return cr
 	}
 
@@ -203,8 +225,6 @@ func (c *component) Check() components.CheckResult {
 		cr.health = apiv1.HealthStateTypeHealthy
 		return cr
 	}
-
-	cr.reason, cr.health = evaluateIbstatOutputAgainstThresholds(cr.IbstatOutput, thresholds)
 
 	// we only care about unhealthy events, no need to persist healthy events
 	if cr.health == apiv1.HealthStateTypeHealthy {
@@ -235,10 +255,10 @@ func (c *component) Check() components.CheckResult {
 	found, err := c.eventBucket.Find(cctx, ev)
 	ccancel()
 	if err != nil {
-		cr.err = err
+		cr.errIbstat = err
 		cr.health = apiv1.HealthStateTypeUnhealthy
 		cr.reason = "error finding ibstat event"
-		log.Logger.Errorw(cr.reason, "error", cr.err)
+		log.Logger.Errorw(cr.reason, "error", cr.errIbstat)
 		return cr
 	}
 
@@ -249,12 +269,12 @@ func (c *component) Check() components.CheckResult {
 
 	// insert event
 	cctx, ccancel = context.WithTimeout(c.ctx, 15*time.Second)
-	cr.err = c.eventBucket.Insert(cctx, ev)
+	cr.errIbstat = c.eventBucket.Insert(cctx, ev)
 	ccancel()
-	if cr.err != nil {
+	if cr.errIbstat != nil {
 		cr.health = apiv1.HealthStateTypeUnhealthy
 		cr.reason = "error inserting ibstat event"
-		log.Logger.Errorw(cr.reason, "error", cr.err)
+		log.Logger.Errorw(cr.reason, "error", cr.errIbstat)
 		return cr
 	}
 
@@ -265,36 +285,56 @@ var (
 	// nothing specified for this machine, gpud MUST skip the ib check
 	reasonThresholdNotSetSkipped = "ports or rate threshold not set, skipping"
 
-	reasonMissingIbstatOutput = "missing ibstat output (skipped evaluation)"
-	reasonMissingEventBucket  = "missing event storage (skipped evaluation)"
-	reasonNoIbIssueFound      = "no infiniband issue found (in ibstat)"
+	reasonMissingIbstatIbstatusOutput = "missing ibstat/ibstatus output (skipped evaluation)"
+	reasonMissingEventBucket          = "missing event storage (skipped evaluation)"
+	reasonNoIbIssueFoundFromIbstat    = "no infiniband issue found (in ibstat)"
+	reasonNoIbIssueFoundFromIbstatus  = "no infiniband issue found (in ibstatus)"
 )
 
 // Returns the output evaluation reason and its health state.
 // We DO NOT auto-detect infiniband devices/PCI buses, strictly rely on the user-specified config.
-func evaluateIbstatOutputAgainstThresholds(o *infiniband.IbstatOutput, thresholds infiniband.ExpectedPortStates) (string, apiv1.HealthStateType) {
+func evaluateIbstatOutputAgainstThresholds(ibstatOut *infiniband.IbstatOutput, thresholds infiniband.ExpectedPortStates) (string, apiv1.HealthStateType) {
 	if thresholds.IsZero() {
 		return reasonThresholdNotSetSkipped, apiv1.HealthStateTypeHealthy
 	}
 
 	atLeastPorts := thresholds.AtLeastPorts
 	atLeastRate := thresholds.AtLeastRate
-	if err := o.Parsed.CheckPortsAndRate(atLeastPorts, atLeastRate); err != nil {
+	if err := ibstatOut.Parsed.CheckPortsAndRate(atLeastPorts, atLeastRate); err != nil {
 		return err.Error(), apiv1.HealthStateTypeUnhealthy
 	}
 
-	return reasonNoIbIssueFound, apiv1.HealthStateTypeHealthy
+	return reasonNoIbIssueFoundFromIbstat, apiv1.HealthStateTypeHealthy
+}
+
+// Returns the output evaluation reason and its health state.
+// We DO NOT auto-detect infiniband devices/PCI buses, strictly rely on the user-specified config.
+func evaluateIbstatusOutputAgainstThresholds(ibstatusOut *infiniband.IbstatusOutput, thresholds infiniband.ExpectedPortStates) (string, apiv1.HealthStateType) {
+	if thresholds.IsZero() {
+		return reasonThresholdNotSetSkipped, apiv1.HealthStateTypeHealthy
+	}
+
+	atLeastPorts := thresholds.AtLeastPorts
+	atLeastRate := thresholds.AtLeastRate
+	if err := ibstatusOut.Parsed.CheckPortsAndRate(atLeastPorts, atLeastRate); err != nil {
+		return err.Error(), apiv1.HealthStateTypeUnhealthy
+	}
+
+	return reasonNoIbIssueFoundFromIbstatus, apiv1.HealthStateTypeHealthy
 }
 
 var _ components.CheckResult = &checkResult{}
 
 type checkResult struct {
-	IbstatOutput *infiniband.IbstatOutput `json:"ibstat_output"`
+	IbstatOutput   *infiniband.IbstatOutput   `json:"ibstat_output"`
+	IbstatusOutput *infiniband.IbstatusOutput `json:"ibstatus_output"`
 
 	// timestamp of the last check
 	ts time.Time
-	// error from the last check
-	err error
+	// error from the last check with "ibstat" command
+	errIbstat error
+	// error from the last check with "ibstatus" command
+	errIbstatus error
 
 	// tracks the healthy evaluation result of the last check
 	health apiv1.HealthStateType
@@ -306,25 +346,50 @@ func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""
 	}
-	if cr.IbstatOutput == nil {
+	if cr.IbstatOutput == nil && cr.IbstatusOutput == nil {
 		return "no data"
 	}
 
-	buf := bytes.NewBuffer(nil)
-	table := tablewriter.NewWriter(buf)
-	table.SetAlignment(tablewriter.ALIGN_CENTER)
-	table.SetHeader([]string{"Port Name", "Port1 State", "Port1 Physical State", "Port1 Rate"})
-	for _, card := range cr.IbstatOutput.Parsed {
-		table.Append([]string{
-			card.Name,
-			card.Port1.State,
-			card.Port1.PhysicalState,
-			fmt.Sprintf("%d", card.Port1.Rate),
-		})
-	}
-	table.Render()
+	out := ""
 
-	return buf.String()
+	if cr.IbstatOutput != nil {
+		buf := bytes.NewBuffer(nil)
+		table := tablewriter.NewWriter(buf)
+		table.SetAlignment(tablewriter.ALIGN_CENTER)
+		table.SetHeader([]string{"Port Device Name", "Port1 State", "Port1 Physical State", "Port1 Rate"})
+		for _, card := range cr.IbstatOutput.Parsed {
+			table.Append([]string{
+				card.Device,
+				card.Port1.State,
+				card.Port1.PhysicalState,
+				fmt.Sprintf("%d", card.Port1.Rate),
+			})
+		}
+		table.Render()
+
+		out += buf.String() + "\n\n"
+	}
+
+	if cr.IbstatusOutput != nil {
+		buf := bytes.NewBuffer(nil)
+		table := tablewriter.NewWriter(buf)
+		table.SetAlignment(tablewriter.ALIGN_CENTER)
+		table.SetHeader([]string{"Device", "State", "Physical State", "Rate", "Link Layer"})
+		for _, dev := range cr.IbstatusOutput.Parsed {
+			table.Append([]string{
+				dev.Device,
+				dev.State,
+				dev.PhysicalState,
+				dev.Rate,
+				dev.LinkLayer,
+			})
+		}
+		table.Render()
+
+		out += buf.String() + "\n\n"
+	}
+
+	return out
 }
 
 func (cr *checkResult) Summary() string {
@@ -342,10 +407,16 @@ func (cr *checkResult) HealthStateType() apiv1.HealthStateType {
 }
 
 func (cr *checkResult) getError() string {
-	if cr == nil || cr.err == nil {
+	if cr == nil {
 		return ""
 	}
-	return cr.err.Error()
+	if cr.errIbstat != nil {
+		return cr.errIbstat.Error()
+	}
+	if cr.errIbstatus != nil {
+		return cr.errIbstatus.Error()
+	}
+	return ""
 }
 
 func (cr *checkResult) HealthStates() apiv1.HealthStates {

--- a/components/accelerator/nvidia/infiniband/component_test.go
+++ b/components/accelerator/nvidia/infiniband/component_test.go
@@ -69,7 +69,7 @@ func TestEvaluate(t *testing.T) {
 				Raw: "",
 				Parsed: infiniband.IBStatCards{
 					{
-						Name: "mlx5_0",
+						Device: "mlx5_0",
 						Port1: infiniband.IBStatPort{
 							State:         "Active",
 							PhysicalState: "LinkUp",
@@ -77,7 +77,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 					{
-						Name: "mlx5_1",
+						Device: "mlx5_1",
 						Port1: infiniband.IBStatPort{
 							State:         "Active",
 							PhysicalState: "LinkUp",
@@ -90,7 +90,7 @@ func TestEvaluate(t *testing.T) {
 				AtLeastPorts: 2,
 				AtLeastRate:  200,
 			},
-			wantReason: reasonNoIbIssueFound,
+			wantReason: reasonNoIbIssueFoundFromIbstat,
 			wantHealth: apiv1.HealthStateTypeHealthy,
 		},
 		{
@@ -99,7 +99,7 @@ func TestEvaluate(t *testing.T) {
 				Raw: "",
 				Parsed: infiniband.IBStatCards{
 					{
-						Name: "mlx5_0",
+						Device: "mlx5_0",
 						Port1: infiniband.IBStatPort{
 							State:         "Active",
 							PhysicalState: "LinkUp",
@@ -121,7 +121,7 @@ func TestEvaluate(t *testing.T) {
 				Raw: "",
 				Parsed: infiniband.IBStatCards{
 					{
-						Name: "mlx5_0",
+						Device: "mlx5_0",
 						Port1: infiniband.IBStatPort{
 							State:         "Active",
 							PhysicalState: "LinkUp",
@@ -129,7 +129,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 					{
-						Name: "mlx5_1",
+						Device: "mlx5_1",
 						Port1: infiniband.IBStatPort{
 							State:         "Active",
 							PhysicalState: "LinkUp",
@@ -151,7 +151,7 @@ func TestEvaluate(t *testing.T) {
 				Raw: "",
 				Parsed: infiniband.IBStatCards{
 					{
-						Name: "mlx5_0",
+						Device: "mlx5_0",
 						Port1: infiniband.IBStatPort{
 							State:         "Down",
 							PhysicalState: "Disabled",
@@ -159,7 +159,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 					{
-						Name: "mlx5_1",
+						Device: "mlx5_1",
 						Port1: infiniband.IBStatPort{
 							State:         "Down",
 							PhysicalState: "Disabled",
@@ -194,7 +194,7 @@ func TestEvaluate(t *testing.T) {
 				Raw: "",
 				Parsed: infiniband.IBStatCards{
 					{
-						Name: "mlx5_0",
+						Device: "mlx5_0",
 						Port1: infiniband.IBStatPort{
 							State:         "Inactive",
 							PhysicalState: "LinkUp",
@@ -202,7 +202,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 					{
-						Name: "mlx5_1",
+						Device: "mlx5_1",
 						Port1: infiniband.IBStatPort{
 							State:         "Inactive",
 							PhysicalState: "LinkUp",
@@ -215,7 +215,7 @@ func TestEvaluate(t *testing.T) {
 				AtLeastPorts: 2,
 				AtLeastRate:  200,
 			},
-			wantReason: reasonNoIbIssueFound,
+			wantReason: reasonNoIbIssueFoundFromIbstat,
 			wantHealth: apiv1.HealthStateTypeHealthy,
 		},
 		{
@@ -224,7 +224,7 @@ func TestEvaluate(t *testing.T) {
 				Raw: "",
 				Parsed: infiniband.IBStatCards{
 					{
-						Name: "mlx5_0",
+						Device: "mlx5_0",
 						Port1: infiniband.IBStatPort{
 							State:         "Active",
 							PhysicalState: "LinkUp",
@@ -232,7 +232,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 					{
-						Name: "mlx5_1",
+						Device: "mlx5_1",
 						Port1: infiniband.IBStatPort{
 							State:         "Down",
 							PhysicalState: "Disabled",
@@ -240,7 +240,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 					{
-						Name: "mlx5_2",
+						Device: "mlx5_2",
 						Port1: infiniband.IBStatPort{
 							State:         "Inactive",
 							PhysicalState: "LinkUp",
@@ -262,7 +262,7 @@ func TestEvaluate(t *testing.T) {
 				Raw: "",
 				Parsed: infiniband.IBStatCards{
 					{
-						Name: "mlx5_0",
+						Device: "mlx5_0",
 						Port1: infiniband.IBStatPort{
 							State:         "Active",
 							PhysicalState: "LinkUp",
@@ -270,7 +270,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 					{
-						Name: "mlx5_1",
+						Device: "mlx5_1",
 						Port1: infiniband.IBStatPort{
 							State:         "Active",
 							PhysicalState: "LinkUp",
@@ -278,7 +278,7 @@ func TestEvaluate(t *testing.T) {
 						},
 					},
 					{
-						Name: "mlx5_2",
+						Device: "mlx5_2",
 						Port1: infiniband.IBStatPort{
 							State:         "Active",
 							PhysicalState: "LinkUp",
@@ -300,7 +300,7 @@ func TestEvaluate(t *testing.T) {
 				Raw: "",
 				Parsed: infiniband.IBStatCards{
 					{
-						Name: "mlx5_0",
+						Device: "mlx5_0",
 						Port1: infiniband.IBStatPort{
 							State:         "Active",
 							PhysicalState: "LinkUp",
@@ -378,7 +378,7 @@ func TestEvaluateWithTestData(t *testing.T) {
 				AtLeastPorts: 8,   // Number of 400Gb/s ports in the test data
 				AtLeastRate:  400, // Expected rate for H100 cards
 			},
-			wantReason: reasonNoIbIssueFound,
+			wantReason: reasonNoIbIssueFoundFromIbstat,
 			wantHealth: apiv1.HealthStateTypeHealthy,
 		},
 		{
@@ -387,7 +387,7 @@ func TestEvaluateWithTestData(t *testing.T) {
 				AtLeastPorts: 12,  // Total number of ports in test data
 				AtLeastRate:  100, // Minimum rate that includes all ports
 			},
-			wantReason: reasonNoIbIssueFound,
+			wantReason: reasonNoIbIssueFoundFromIbstat,
 			wantHealth: apiv1.HealthStateTypeHealthy,
 		},
 		{
@@ -764,7 +764,7 @@ func mockGetIbstatOutput(ctx context.Context, ibstatCommands []string) (*infinib
 		Raw: "mock output",
 		Parsed: infiniband.IBStatCards{
 			{
-				Name: "mlx5_0",
+				Device: "mlx5_0",
 				Port1: infiniband.IBStatPort{
 					State:         "Active",
 					PhysicalState: "LinkUp",
@@ -821,9 +821,9 @@ func TestLastHealthStates(t *testing.T) {
 
 	// Test with data
 	mockData := &checkResult{
-		health: apiv1.HealthStateTypeUnhealthy,
-		reason: "test reason",
-		err:    fmt.Errorf("test error"),
+		health:    apiv1.HealthStateTypeUnhealthy,
+		reason:    "test reason",
+		errIbstat: fmt.Errorf("test error"),
 	}
 	c.lastMu.Lock()
 	c.lastCheckResult = mockData
@@ -853,7 +853,7 @@ func TestDataString(t *testing.T) {
 		IbstatOutput: &infiniband.IbstatOutput{
 			Parsed: infiniband.IBStatCards{
 				{
-					Name: "mlx5_0",
+					Device: "mlx5_0",
 					Port1: infiniband.IBStatPort{
 						State:         "Active",
 						PhysicalState: "LinkUp",
@@ -906,7 +906,7 @@ func TestDataGetError(t *testing.T) {
 	assert.Equal(t, "", cr.getError())
 
 	// Test with error
-	cr = &checkResult{err: errors.New("test error")}
+	cr = &checkResult{errIbstat: errors.New("test error")}
 	assert.Equal(t, "test error", cr.getError())
 }
 
@@ -922,6 +922,9 @@ func TestComponentCheckErrorCases(t *testing.T) {
 		cancel: ccancel,
 		getIbstatOutputFunc: func(ctx context.Context, ibstatCommands []string) (*infiniband.IbstatOutput, error) {
 			return nil, errors.New("ibstat error")
+		},
+		getIbstatusOutputFunc: func(ctx context.Context, ibstatusCommands []string) (*infiniband.IbstatusOutput, error) {
+			return nil, errors.New("ibstatus error")
 		},
 		getThresholdsFunc: mockGetThresholds,
 		nvmlInstance:      &mockNVMLInstance{exists: true, productName: "Tesla V100"},
@@ -948,7 +951,7 @@ func TestComponentCheckErrorCases(t *testing.T) {
 	data, ok = result.(*checkResult)
 	require.True(t, ok)
 	assert.Equal(t, apiv1.HealthStateTypeHealthy, data.health)
-	assert.Equal(t, reasonMissingIbstatOutput, data.reason)
+	assert.Equal(t, reasonMissingIbstatIbstatusOutput, data.reason)
 
 	// Test case: ibstat command not found
 	c = &component{
@@ -1372,7 +1375,7 @@ func TestComponentCheckOrder(t *testing.T) {
 				Raw: "mock output",
 				Parsed: infiniband.IBStatCards{
 					{
-						Name: "mlx5_0",
+						Device: "mlx5_0",
 						Port1: infiniband.IBStatPort{
 							State:         "Active",
 							PhysicalState: "LinkUp",

--- a/components/accelerator/nvidia/infiniband/testdata/ibstat.39.0.a100.failed.ibpanic.exit-255.0
+++ b/components/accelerator/nvidia/infiniband/testdata/ibstat.39.0.a100.failed.ibpanic.exit-255.0
@@ -1,0 +1,138 @@
+CA 'mlx5_0'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411eb
+        System image GUID: 0xb83fd203006e2704
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13247
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411eb
+                Link layer: InfiniBand
+CA 'mlx5_1'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411ec
+        System image GUID: 0xa088c203003a8710
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13246
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411ec
+                Link layer: InfiniBand
+CA 'mlx5_2'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411ed
+        System image GUID: 0xb83fd203006e6e88
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13259
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411ed
+                Link layer: InfiniBand
+CA 'mlx5_3'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411ee
+        System image GUID: 0xb83fd203006e6e50
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13276
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411ee
+                Link layer: InfiniBand
+CA 'mlx5_4'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411ef
+        System image GUID: 0xb83fd203006e6e80
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13301
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411ef
+                Link layer: InfiniBand
+CA 'mlx5_5'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411f0
+        System image GUID: 0xb83fd203006e6e7c
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13300
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411f0
+                Link layer: InfiniBand
+CA 'mlx5_6'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411f1
+        System image GUID: 0xb83fd203006e6e38
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13302
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411f1
+                Link layer: InfiniBand
+CA 'mlx5_7'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411f2
+        System image GUID: 0xb83fd203006e277c
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13305
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411f2
+                Link layer: InfiniBand
+ibpanic: [1400444] main: stat of IB device 'mlx5_8' failed: No such file or directory
+

--- a/pkg/config/common/config.go
+++ b/pkg/config/common/config.go
@@ -1,5 +1,6 @@
 package common
 
 type ToolOverwrites struct {
-	IbstatCommand string `json:"ibstat_command"`
+	IbstatCommand   string `json:"ibstat_command"`
+	IbstatusCommand string `json:"ibstatus_command"`
 }

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -48,7 +48,8 @@ func DefaultConfig(ctx context.Context, opts ...OpOption) (*Config, error) {
 		Pprof:            false,
 		EnableAutoUpdate: true,
 		NvidiaToolOverwrites: nvidiacommon.ToolOverwrites{
-			IbstatCommand: options.IbstatCommand,
+			IbstatCommand:   options.IbstatCommand,
+			IbstatusCommand: options.IbstatusCommand,
 		},
 	}
 

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -18,6 +18,9 @@ func (op *Op) ApplyOpts(opts []OpOption) error {
 	if op.IbstatCommand == "" {
 		op.IbstatCommand = "ibstat"
 	}
+	if op.IbstatusCommand == "" {
+		op.IbstatusCommand = "ibstatus"
+	}
 
 	return nil
 }
@@ -26,5 +29,12 @@ func (op *Op) ApplyOpts(opts []OpOption) error {
 func WithIbstatCommand(p string) OpOption {
 	return func(op *Op) {
 		op.IbstatCommand = p
+	}
+}
+
+// Specifies the ibstat binary path to overwrite the default path.
+func WithIbstatusCommand(p string) OpOption {
+	return func(op *Op) {
+		op.IbstatusCommand = p
 	}
 }

--- a/pkg/nvidia-query/infiniband/check_thresholds.go
+++ b/pkg/nvidia-query/infiniband/check_thresholds.go
@@ -1,0 +1,52 @@
+package infiniband
+
+// IBPort is the port of the IB card.
+type IBPort struct {
+	Device        string
+	State         string
+	PhysicalState string
+	Rate          int
+}
+
+// CheckPortsAndRate returns the map from the physical state to each IB port names that matches the expected values.
+// The specified rate is the threshold for "Port 1"."Rate", where it evaluates with ">=" operator
+// (e.g., count all the cards whose rate is >= 400).
+//
+// If the `expectedPhysicalState` is empty, it matches all states.
+// If the `expectedPhysicalState` are multiple states, it matches all states with OR operator.
+// If the `expectedState` is empty, it matches all states.
+func CheckPortsAndRate(ports []IBPort, expectedPhysicalStates []string, expectedState string, atLeastRate int) (map[string][]string, []string) {
+	expStates := make(map[string]struct{})
+	for _, s := range expectedPhysicalStates {
+		expStates[s] = struct{}{}
+	}
+
+	all, names := make(map[string][]string), make([]string, 0)
+	for _, card := range ports {
+		// e.g.,
+		// expected "Physical state: LinkUp"
+		// but got "Physical state: Disabled" or "Physical state: Polling"
+		_, found := expStates[card.PhysicalState]
+		if len(expStates) > 0 && !found {
+			continue
+		}
+
+		// e.g.,
+		// expected "State: Active"
+		// but got "State: Down"
+		if expectedState != "" && card.State != expectedState {
+			continue
+		}
+
+		if atLeastRate > card.Rate {
+			continue
+		}
+
+		if _, ok := all[card.PhysicalState]; !ok {
+			all[card.PhysicalState] = make([]string, 0)
+		}
+		all[card.PhysicalState] = append(all[card.PhysicalState], card.Device)
+		names = append(names, card.Device)
+	}
+	return all, names
+}

--- a/pkg/nvidia-query/infiniband/check_thresholds_test.go
+++ b/pkg/nvidia-query/infiniband/check_thresholds_test.go
@@ -1,0 +1,127 @@
+package infiniband
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckPortsAndRate(t *testing.T) {
+	tt := []struct {
+		fileName               string
+		expectedPhysicalStates []string
+		expectedState          string
+		expectedAtLeastRate    int
+		expectedCount          int
+		expectedPortNames      []string
+	}{
+		{
+			fileName:               "testdata/ibstat.47.0.a100.all.active.0",
+			expectedPhysicalStates: []string{"LinkUp"},
+			expectedState:          "Active",
+			expectedAtLeastRate:    200,
+			expectedCount:          9,
+			expectedPortNames:      []string{"mlx5_0", "mlx5_1", "mlx5_2", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_7", "mlx5_8"},
+		},
+		{
+			fileName:               "testdata/ibstat.47.0.a100.all.active.0",
+			expectedPhysicalStates: []string{"LinkUp"},
+			expectedState:          "Active",
+			expectedAtLeastRate:    100,
+			expectedCount:          9,
+			expectedPortNames:      []string{"mlx5_0", "mlx5_1", "mlx5_2", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_7", "mlx5_8"},
+		},
+		{
+			fileName:               "testdata/ibstat.47.0.h100.all.active.0",
+			expectedPhysicalStates: []string{"LinkUp"},
+			expectedState:          "Active",
+			expectedAtLeastRate:    400,
+			expectedCount:          8,
+			expectedPortNames:      []string{"mlx5_0", "mlx5_10", "mlx5_11", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_9"},
+		},
+		{
+			fileName:               "testdata/ibstat.47.0.h100.all.active.1",
+			expectedPhysicalStates: []string{"LinkUp"},
+			expectedState:          "Active",
+			expectedAtLeastRate:    400,
+			expectedCount:          8,
+			expectedPortNames:      []string{"mlx5_0", "mlx5_10", "mlx5_11", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_9"},
+		},
+		{
+			fileName:               "testdata/ibstat.47.0.h100.some.down.0",
+			expectedPhysicalStates: []string{"LinkUp"},
+			expectedState:          "Active",
+			expectedAtLeastRate:    400,
+			expectedCount:          8,
+			expectedPortNames:      []string{"mlx5_0", "mlx5_10", "mlx5_11", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_9"},
+		},
+		{
+			fileName:               "testdata/ibstat.47.0.h100.some.down.1",
+			expectedAtLeastRate:    400,
+			expectedPhysicalStates: []string{"LinkUp"},
+			expectedState:          "Active",
+			expectedCount:          6,
+			expectedPortNames:      []string{"mlx5_0", "mlx5_10", "mlx5_3", "mlx5_4", "mlx5_6", "mlx5_9"},
+		},
+		{
+			fileName:               "testdata/ibstat.47.0.h100.some.down.with.polling.1",
+			expectedPhysicalStates: []string{"Disabled", "Polling"},
+			expectedState:          "",
+			expectedAtLeastRate:    0,
+			expectedCount:          2,
+			expectedPortNames:      []string{"mlx5_11", "mlx5_5"},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.fileName, func(t *testing.T) {
+			content, err := os.ReadFile(tc.fileName)
+			if err != nil {
+				t.Fatalf("Failed to read file %s: %v", tc.fileName, err)
+			}
+			parsed, err := ParseIBStat(string(content))
+			if err != nil {
+				t.Fatalf("Failed to parse ibstat file %s: %v", tc.fileName, err)
+			}
+			_, matched := CheckPortsAndRate(
+				parsed.IBPorts(),
+				tc.expectedPhysicalStates,
+				tc.expectedState,
+				tc.expectedAtLeastRate,
+			)
+			if len(matched) != tc.expectedCount {
+				t.Errorf("Expected %d cards, got %d", tc.expectedCount, len(matched))
+			}
+			if !reflect.DeepEqual(matched, tc.expectedPortNames) {
+				t.Errorf("Expected %v, got %v", tc.expectedPortNames, matched)
+			}
+		})
+	}
+}
+
+func TestCheckPortsAndRateWithState(t *testing.T) {
+	ports := []IBPort{
+		{
+			Device:        "mlx5_0",
+			State:         "Active",
+			PhysicalState: "LinkUp",
+			Rate:          200,
+		},
+		{
+			Device:        "mlx5_1",
+			State:         "Down",
+			PhysicalState: "LinkUp",
+			Rate:          200,
+		},
+	}
+
+	// Test with a specific state
+	_, matchedActive := CheckPortsAndRate(ports, []string{"LinkUp"}, "Active", 200)
+	assert.Equal(t, 1, len(matchedActive), "Should match only the Active state port")
+	assert.Equal(t, "mlx5_0", matchedActive[0], "Device mlx5_0 should be matched")
+
+	// Test with a specific state that doesn't match
+	_, matchedNone := CheckPortsAndRate(ports, []string{"LinkUp"}, "Init", 200)
+	assert.Equal(t, 0, len(matchedNone), "Should not match any port")
+}

--- a/pkg/nvidia-query/infiniband/default_test.go
+++ b/pkg/nvidia-query/infiniband/default_test.go
@@ -107,3 +107,49 @@ func TestSupportsInfinibandPortRate(t *testing.T) {
 		})
 	}
 }
+
+func TestExpectedPortStatesIsZero(t *testing.T) {
+	tests := []struct {
+		name     string
+		eps      *ExpectedPortStates
+		expected bool
+	}{
+		{
+			name:     "nil pointer",
+			eps:      nil,
+			expected: true,
+		},
+		{
+			name:     "zero ports and zero rate",
+			eps:      &ExpectedPortStates{AtLeastPorts: 0, AtLeastRate: 0},
+			expected: true,
+		},
+		{
+			name:     "negative ports and zero rate",
+			eps:      &ExpectedPortStates{AtLeastPorts: -1, AtLeastRate: 0},
+			expected: true,
+		},
+		{
+			name:     "zero ports and positive rate",
+			eps:      &ExpectedPortStates{AtLeastPorts: 0, AtLeastRate: 100},
+			expected: true,
+		},
+		{
+			name:     "positive ports and zero rate",
+			eps:      &ExpectedPortStates{AtLeastPorts: 1, AtLeastRate: 0},
+			expected: true,
+		},
+		{
+			name:     "positive ports and positive rate",
+			eps:      &ExpectedPortStates{AtLeastPorts: 1, AtLeastRate: 100},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.eps.IsZero()
+			assert.Equal(t, tt.expected, result, "IsZero() returned unexpected result")
+		})
+	}
+}

--- a/pkg/nvidia-query/infiniband/ibstat.go
+++ b/pkg/nvidia-query/infiniband/ibstat.go
@@ -16,7 +16,7 @@ import (
 	"github.com/leptonai/gpud/pkg/process"
 )
 
-var ErrNoIbstatCommand = errors.New("ibstat not found. cannot check ib state")
+var ErrNoIbstatCommand = errors.New("ibstat not found, cannot check ib state")
 
 func GetIbstatOutput(ctx context.Context, ibstatCommands []string) (*IbstatOutput, error) {
 	if len(ibstatCommands) == 0 || strings.TrimSpace(ibstatCommands[0]) == "" {
@@ -112,7 +112,6 @@ func ValidateIbstatOutput(s string) error {
 type IbstatOutput struct {
 	Parsed IBStatCards `json:"parsed,omitempty"`
 	Raw    string      `json:"raw"`
-	Errors []string    `json:"errors,omitempty"`
 }
 
 type IBStatCards []IBStatCard

--- a/pkg/nvidia-query/infiniband/ibstat.go
+++ b/pkg/nvidia-query/infiniband/ibstat.go
@@ -116,80 +116,8 @@ type IbstatOutput struct {
 
 type IBStatCards []IBStatCard
 
-// match returns the map from the physical state to each IB port names that matches the expected values.
-// The specified rate is the threshold for "Port 1"."Rate", where it evaluates with ">=" operator
-// (e.g., count all the cards whose rate is >= 400).
-//
-// If the `expectedPhysicalState` is empty, it matches all states.
-// If the `expectedPhysicalState` are multiple states, it matches all states with OR operator.
-// If the `expectedState` is empty, it matches all states.
-func (cards IBStatCards) match(expectedPhysicalStates []string, expectedState string, atLeastRate int) (map[string][]string, []string) {
-	expStates := make(map[string]struct{})
-	for _, s := range expectedPhysicalStates {
-		expStates[s] = struct{}{}
-	}
-
-	all, names := make(map[string][]string), make([]string, 0)
-	for _, card := range cards {
-		// e.g.,
-		// expected "Physical state: LinkUp"
-		// but got "Physical state: Disabled" or "Physical state: Polling"
-		_, found := expStates[card.Port1.PhysicalState]
-		if len(expStates) > 0 && !found {
-			continue
-		}
-
-		// e.g.,
-		// expected "State: Active"
-		// but got "State: Down"
-		if expectedState != "" && card.Port1.State != expectedState {
-			continue
-		}
-
-		if atLeastRate > card.Port1.Rate {
-			continue
-		}
-
-		if _, ok := all[card.Port1.PhysicalState]; !ok {
-			all[card.Port1.PhysicalState] = make([]string, 0)
-		}
-		all[card.Port1.PhysicalState] = append(all[card.Port1.PhysicalState], card.Name)
-		names = append(names, card.Name)
-	}
-	return all, names
-}
-
-// CheckPortsAndRate checks if the number of active IB ports matches expectations
-func (cards IBStatCards) CheckPortsAndRate(atLeastPorts int, atLeastRate int) error {
-	if atLeastPorts == 0 && atLeastRate == 0 {
-		return nil
-	}
-
-	// select all "up" devices, and count the ones that match the expected rate with ">="
-	_, portNamesWithLinkUp := cards.match([]string{"LinkUp"}, "", atLeastRate)
-	if len(portNamesWithLinkUp) >= atLeastPorts {
-		return nil
-	}
-
-	errMsg := fmt.Sprintf("only %d ports (>= %d Gb/s) are active, expect at least %d", len(portNamesWithLinkUp), atLeastRate, atLeastPorts)
-	log.Logger.Warnw(errMsg, "totalPorts", len(cards), "atLeastPorts", atLeastPorts, "atLeastRateGbPerSec", atLeastRate)
-
-	pm, portNamesWithDisabledOrPolling := cards.match([]string{"Disabled", "Polling"}, "", 0) // atLeastRate is ignored
-	if len(portNamesWithDisabledOrPolling) > 0 {
-		// some ports must be missing -- construct error message accordingly
-		msgs := make([]string, 0)
-		for state, names := range pm {
-			msgs = append(msgs, fmt.Sprintf("%d device(s) found %s (%s)", len(names), state, strings.Join(names, ", ")))
-		}
-		sort.Strings(msgs)
-		errMsg += fmt.Sprintf("; %s", strings.Join(msgs, "; "))
-	}
-
-	return errors.New(errMsg)
-}
-
 type IBStatCard struct {
-	Name            string     `json:"CA name"`
+	Device          string     `json:"CA name"`
 	Type            string     `json:"CA type"`
 	NumPorts        string     `json:"Number of ports"`
 	FirmwareVersion string     `json:"Firmware version"`
@@ -205,6 +133,48 @@ type IBStatPort struct {
 	Rate          int    `json:"Rate"`
 	BaseLid       int    `json:"Base lid"`
 	LinkLayer     string `json:"Link layer"`
+}
+
+func (cards IBStatCards) IBPorts() []IBPort {
+	ibports := make([]IBPort, 0)
+	for _, card := range cards {
+		ibports = append(ibports, IBPort{
+			Device:        card.Device,
+			PhysicalState: card.Port1.PhysicalState,
+			State:         card.Port1.State,
+			Rate:          card.Port1.Rate,
+		})
+	}
+	return ibports
+}
+
+// CheckPortsAndRate checks if the number of active IB ports matches expectations
+func (cards IBStatCards) CheckPortsAndRate(atLeastPorts int, atLeastRate int) error {
+	if atLeastPorts == 0 && atLeastRate == 0 {
+		return nil
+	}
+
+	// select all "up" devices, and count the ones that match the expected rate with ">="
+	_, portNamesWithLinkUp := CheckPortsAndRate(cards.IBPorts(), []string{"LinkUp"}, "", atLeastRate)
+	if len(portNamesWithLinkUp) >= atLeastPorts {
+		return nil
+	}
+
+	errMsg := fmt.Sprintf("only %d ports (>= %d Gb/s) are active, expect at least %d", len(portNamesWithLinkUp), atLeastRate, atLeastPorts)
+	log.Logger.Warnw(errMsg, "totalPorts", len(cards), "atLeastPorts", atLeastPorts, "atLeastRateGbPerSec", atLeastRate)
+
+	pm, portNamesWithDisabledOrPolling := CheckPortsAndRate(cards.IBPorts(), []string{"Disabled", "Polling"}, "", 0) // atLeastRate is ignored
+	if len(portNamesWithDisabledOrPolling) > 0 {
+		// some ports must be missing -- construct error message accordingly
+		msgs := make([]string, 0)
+		for state, names := range pm {
+			msgs = append(msgs, fmt.Sprintf("%d device(s) found %s (%s)", len(names), state, strings.Join(names, ", ")))
+		}
+		sort.Strings(msgs)
+		errMsg += fmt.Sprintf("; %s", strings.Join(msgs, "; "))
+	}
+
+	return errors.New(errMsg)
 }
 
 var (

--- a/pkg/nvidia-query/infiniband/ibstatus.go
+++ b/pkg/nvidia-query/infiniband/ibstatus.go
@@ -24,8 +24,6 @@ type IbstatusOutput struct {
 var ErrNoIbstatusCommand = errors.New("ibstatus not found, cannot check ib state")
 
 func GetIbstatusOutput(ctx context.Context, ibstatusCommands []string) (*IbstatusOutput, error) {
-	fmt.Printf("[DEBUG] GetIbstatusOutput: %q\n", ibstatusCommands)
-
 	if len(ibstatusCommands) == 0 || strings.TrimSpace(ibstatusCommands[0]) == "" {
 		return nil, ErrNoIbstatusCommand
 	}

--- a/pkg/nvidia-query/infiniband/ibstatus.go
+++ b/pkg/nvidia-query/infiniband/ibstatus.go
@@ -58,12 +58,6 @@ func GetIbstatusOutput(ctx context.Context, ibstatusCommands []string) (*Ibstatu
 	// still parse the partial output
 	// even if the ibstat command failed
 	if len(o.Raw) > 0 {
-		println()
-		println()
-		fmt.Printf("[DEBUG] ibstatus output:\n\n%q\n\n", o.Raw)
-		println()
-		println()
-
 		o.Parsed, parseErr = ParseIBStatus(o.Raw)
 		if parseErr != nil {
 			log.Logger.Warnw("failed to parse ibstatus output", "exitCode", p.ExitCode(), "rawInputSize", len(o.Raw), "error", parseErr)
@@ -182,11 +176,6 @@ func ParseIBStatus(input string) (IBStatuses, error) {
 	if len(input) == 0 {
 		return nil, ErrIbstatusOutputEmpty
 	}
-
-	// in case the input has un-escaped characters
-	input = strings.ReplaceAll(input, `\n`, `
-`)
-	input = strings.ReplaceAll(input, `\t`, `    `)
 
 	scanner := bufio.NewScanner(strings.NewReader(input))
 

--- a/pkg/nvidia-query/infiniband/ibstatus.go
+++ b/pkg/nvidia-query/infiniband/ibstatus.go
@@ -24,6 +24,8 @@ type IbstatusOutput struct {
 var ErrNoIbstatusCommand = errors.New("ibstatus not found, cannot check ib state")
 
 func GetIbstatusOutput(ctx context.Context, ibstatusCommands []string) (*IbstatusOutput, error) {
+	fmt.Printf("[DEBUG] GetIbstatusOutput: %q\n", ibstatusCommands)
+
 	if len(ibstatusCommands) == 0 || strings.TrimSpace(ibstatusCommands[0]) == "" {
 		return nil, ErrNoIbstatusCommand
 	}

--- a/pkg/nvidia-query/infiniband/ibstatus.go
+++ b/pkg/nvidia-query/infiniband/ibstatus.go
@@ -1,0 +1,164 @@
+package infiniband
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+
+	pkgfile "github.com/leptonai/gpud/pkg/file"
+	"github.com/leptonai/gpud/pkg/log"
+	"github.com/leptonai/gpud/pkg/process"
+)
+
+type IbstatusOutput struct {
+	Parsed IBStatuses `json:"parsed,omitempty"`
+	Raw    string     `json:"raw"`
+}
+
+var ErrNoIbstatusCommand = errors.New("ibstatus not found, cannot check ib state")
+
+func GetIbstatusOutput(ctx context.Context, ibstatusCommands []string) (*IbstatusOutput, error) {
+	if len(ibstatusCommands) == 0 || strings.TrimSpace(ibstatusCommands[0]) == "" {
+		return nil, ErrNoIbstatusCommand
+	}
+	if _, err := pkgfile.LocateExecutable(strings.Split(ibstatusCommands[0], " ")[0]); err != nil {
+		return nil, ErrNoIbstatusCommand
+	}
+
+	cmdOpts := []process.OpOption{
+		process.WithCommand(ibstatusCommands...),
+	}
+	if ibstatusCommands[0] != "ibstatus" {
+		// more complicated commands (like mocked ibstat custom commands)
+		cmdOpts = append(cmdOpts, process.WithRunAsBashScript())
+	}
+
+	p, runErr := process.New(cmdOpts...)
+	if runErr != nil {
+		return nil, runErr
+	}
+	defer func() {
+		if err := p.Close(ctx); err != nil {
+			log.Logger.Warnw("failed to abort command", "err", err)
+		}
+	}()
+	b, runErr := p.StartAndWaitForCombinedOutput(ctx)
+	o := &IbstatusOutput{
+		Raw: strings.TrimSpace(string(b)),
+	}
+
+	var parseErr error
+
+	// still parse the partial output
+	// even if the ibstat command failed
+	if len(o.Raw) > 0 {
+		o.Parsed, parseErr = ParseIBStatus(o.Raw)
+		if parseErr != nil {
+			log.Logger.Warnw("failed to parse ibstatus output", "exitCode", p.ExitCode(), "rawInputSize", len(o.Raw), "error", parseErr)
+		} else {
+			log.Logger.Infow("ibstatus parsed", "exitCode", p.ExitCode(), "rawInputSize", len(o.Raw))
+		}
+	}
+
+	if runErr != nil {
+		return o, runErr
+	}
+	if parseErr != nil {
+		return o, fmt.Errorf("failed to parse ibstatus output: %w", parseErr)
+	}
+	if len(o.Raw) == 0 {
+		return o, ErrIbstatusOutputEmpty
+	}
+
+	return o, nil
+}
+
+type IBStatuses []IBStatus
+
+type IBStatus struct {
+	Device        string `json:"device"`
+	DefaultGID    string `json:"default gid"`
+	DefaultLID    string `json:"default lid"`
+	SMLID         string `json:"sm lid"`
+	State         string `json:"state"`
+	PhysicalState string `json:"phys state"`
+	Rate          string `json:"rate"`
+	BaseLid       string `json:"base lid"`
+	LinkLayer     string `json:"link_layer"`
+}
+
+var (
+	ErrIbstatusOutputEmpty         = errors.New("ibstatus returned empty output")
+	ErrIbstatusOutputNoDeviceFound = errors.New("parsed ibstatus output does not contain any device")
+)
+
+// ParseIBStatus parses ibstatus output and returns YAML representation.
+// Returns ErrIbstatusOutputEmpty if the input is empty.
+func ParseIBStatus(input string) (IBStatuses, error) {
+	if len(input) == 0 {
+		return nil, ErrIbstatusOutputEmpty
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(input))
+
+	lines := make([]string, 0)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		// "Infiniband device 'mlx5_0' port 1 status:"
+		// becomes
+		// "mlx5_0:"
+		if strings.HasPrefix(line, "Infiniband device '") {
+			line = strings.TrimSpace(line)
+			line = strings.TrimPrefix(line, "Infiniband device '")
+			line = strings.TrimSuffix(line, "' port 1 status:")
+			line += ":"
+			lines = append(lines, line)
+			continue
+		}
+
+		// keep indentation for remaining lines
+		//
+		// 'state:           4: ACTIVE'
+		// becomes
+		// 'state:           4: ACTIVE'
+		//
+		// otherwise, "mapping values are not allowed in this context"
+		split := strings.SplitN(line, ":", 2)
+		if len(split) == 2 {
+			line = split[0] + ":" + " \"" + strings.TrimSpace(split[1]) + "\""
+		}
+
+		lines = append(lines, line)
+	}
+
+	txt := strings.Join(lines, "\n")
+
+	// Convert to YAML
+	statuses := map[string]IBStatus{}
+	if err := yaml.Unmarshal([]byte(txt), &statuses); err != nil {
+		return nil, err
+	}
+	if len(statuses) == 0 {
+		return nil, ErrIbstatusOutputNoDeviceFound
+	}
+
+	converted := IBStatuses{}
+	for k, v := range statuses {
+		v.Device = k
+		converted = append(converted, v)
+	}
+	sort.Slice(converted, func(i, j int) bool {
+		return converted[i].Device < converted[j].Device
+	})
+
+	return converted, nil
+}

--- a/pkg/nvidia-query/infiniband/ibstatus.go
+++ b/pkg/nvidia-query/infiniband/ibstatus.go
@@ -58,6 +58,12 @@ func GetIbstatusOutput(ctx context.Context, ibstatusCommands []string) (*Ibstatu
 	// still parse the partial output
 	// even if the ibstat command failed
 	if len(o.Raw) > 0 {
+		println()
+		println()
+		fmt.Println("[DEBUG] ibstatus output", o.Raw)
+		println()
+		println()
+
 		o.Parsed, parseErr = ParseIBStatus(o.Raw)
 		if parseErr != nil {
 			log.Logger.Warnw("failed to parse ibstatus output", "exitCode", p.ExitCode(), "rawInputSize", len(o.Raw), "error", parseErr)

--- a/pkg/nvidia-query/infiniband/ibstatus.go
+++ b/pkg/nvidia-query/infiniband/ibstatus.go
@@ -58,6 +58,12 @@ func GetIbstatusOutput(ctx context.Context, ibstatusCommands []string) (*Ibstatu
 	// still parse the partial output
 	// even if the ibstat command failed
 	if len(o.Raw) > 0 {
+		println()
+		println()
+		fmt.Printf("[DEBUG] ibstatus output:\n\n%q\n\n", o.Raw)
+		println()
+		println()
+
 		o.Parsed, parseErr = ParseIBStatus(o.Raw)
 		if parseErr != nil {
 			log.Logger.Warnw("failed to parse ibstatus output", "exitCode", p.ExitCode(), "rawInputSize", len(o.Raw), "error", parseErr)

--- a/pkg/nvidia-query/infiniband/ibstatus.go
+++ b/pkg/nvidia-query/infiniband/ibstatus.go
@@ -60,7 +60,7 @@ func GetIbstatusOutput(ctx context.Context, ibstatusCommands []string) (*Ibstatu
 	if len(o.Raw) > 0 {
 		println()
 		println()
-		fmt.Println("[DEBUG] ibstatus output", o.Raw)
+		fmt.Printf("[DEBUG] ibstatus output:\n\n%q\n\n", o.Raw)
 		println()
 		println()
 

--- a/pkg/nvidia-query/infiniband/ibstatus.go
+++ b/pkg/nvidia-query/infiniband/ibstatus.go
@@ -58,12 +58,6 @@ func GetIbstatusOutput(ctx context.Context, ibstatusCommands []string) (*Ibstatu
 	// still parse the partial output
 	// even if the ibstat command failed
 	if len(o.Raw) > 0 {
-		println()
-		println()
-		fmt.Printf("[DEBUG] ibstatus output:\n\n%q\n\n", o.Raw)
-		println()
-		println()
-
 		o.Parsed, parseErr = ParseIBStatus(o.Raw)
 		if parseErr != nil {
 			log.Logger.Warnw("failed to parse ibstatus output", "exitCode", p.ExitCode(), "rawInputSize", len(o.Raw), "error", parseErr)
@@ -182,6 +176,11 @@ func ParseIBStatus(input string) (IBStatuses, error) {
 	if len(input) == 0 {
 		return nil, ErrIbstatusOutputEmpty
 	}
+
+	// in case the input has un-escaped characters
+	input = strings.ReplaceAll(input, `\n`, `
+`)
+	input = strings.ReplaceAll(input, `\t`, `    `)
 
 	scanner := bufio.NewScanner(strings.NewReader(input))
 

--- a/pkg/nvidia-query/infiniband/ibstatus_test.go
+++ b/pkg/nvidia-query/infiniband/ibstatus_test.go
@@ -1,0 +1,231 @@
+package infiniband
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIBStatus(t *testing.T) {
+	t.Parallel()
+
+	input, err := os.ReadFile("testdata/ibstatus.39.0.a100.all.active.0")
+	require.NoError(t, err)
+
+	parsed, err := ParseIBStatus(string(input))
+	require.NoError(t, err)
+
+	require.NotEmpty(t, parsed)
+	require.Equal(t, len(parsed), 9)
+
+	for i := 0; i < 8; i++ {
+		require.Equal(t, "mlx5_"+strconv.Itoa(i), parsed[i].Device)
+		require.Equal(t, "4: ACTIVE", parsed[i].State)
+		require.Equal(t, "5: LinkUp", parsed[i].PhysicalState)
+		require.Equal(t, "200 Gb/sec (4X HDR)", parsed[i].Rate)
+		require.Equal(t, "InfiniBand", parsed[i].LinkLayer)
+	}
+
+	require.Equal(t, "mlx5_8", parsed[8].Device)
+	require.Equal(t, "4: ACTIVE", parsed[8].State)
+	require.Equal(t, "5: LinkUp", parsed[8].PhysicalState)
+	require.Equal(t, "40 Gb/sec (4X QDR)", parsed[8].Rate)
+	require.Equal(t, "Ethernet", parsed[8].LinkLayer)
+}
+
+func TestParseIBStatusEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := ParseIBStatus("")
+	require.Error(t, err)
+	require.Equal(t, ErrIbstatusOutputEmpty, err)
+	require.Nil(t, parsed)
+}
+
+func TestParseIBStatusInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	invalidInput := "This is not a valid ibstatus output"
+	parsed, err := ParseIBStatus(invalidInput)
+	require.Error(t, err)
+	require.Nil(t, parsed)
+}
+
+func TestParseIBStatusNoDeviceFound(t *testing.T) {
+	t.Parallel()
+
+	// Create an empty YAML object
+	noDeviceInput := `{}`
+	parsed, err := ParseIBStatus(noDeviceInput)
+	require.Error(t, err)
+	require.Equal(t, ErrIbstatusOutputNoDeviceFound, err)
+	require.Nil(t, parsed)
+}
+
+func TestGetIbstatusOutputNoCommand(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	output, err := GetIbstatusOutput(ctx, []string{})
+	require.Error(t, err)
+	require.Equal(t, ErrNoIbstatusCommand, err)
+	require.Nil(t, output)
+
+	output, err = GetIbstatusOutput(ctx, []string{""})
+	require.Error(t, err)
+	require.Equal(t, ErrNoIbstatusCommand, err)
+	require.Nil(t, output)
+}
+
+// TestParseIBStatusMixedStates tests parsing output with both active and down states
+func TestParseIBStatusMixedStates(t *testing.T) {
+	t.Parallel()
+
+	mixedStatesInput := `Infiniband device 'mlx5_0' port 1 status:
+        default gid:     fe80:0000:0000:0000:0015:5dff:fd34:11eb
+        base lid:        0x33bf
+        sm lid:          0x1
+        state:           4: ACTIVE
+        phys state:      5: LinkUp
+        rate:            200 Gb/sec (4X HDR)
+        link_layer:      InfiniBand
+
+Infiniband device 'mlx5_1' port 1 status:
+        default gid:     fe80:0000:0000:0000:0015:5dff:fd34:11ec
+        base lid:        0x0
+        sm lid:          0x0
+        state:           1: DOWN
+        phys state:      2: Disabled
+        rate:            200 Gb/sec (4X HDR)
+        link_layer:      InfiniBand`
+
+	parsed, err := ParseIBStatus(mixedStatesInput)
+	require.NoError(t, err)
+	require.NotEmpty(t, parsed)
+	require.Equal(t, 2, len(parsed))
+
+	// Check first device (active)
+	require.Equal(t, "mlx5_0", parsed[0].Device)
+	require.Equal(t, "4: ACTIVE", parsed[0].State)
+	require.Equal(t, "5: LinkUp", parsed[0].PhysicalState)
+
+	// Check second device (down)
+	require.Equal(t, "mlx5_1", parsed[1].Device)
+	require.Equal(t, "1: DOWN", parsed[1].State)
+	require.Equal(t, "2: Disabled", parsed[1].PhysicalState)
+}
+
+// TestParseIBStatusIncompleteFields tests parsing output with some missing fields
+func TestParseIBStatusIncompleteFields(t *testing.T) {
+	t.Parallel()
+
+	incompleteInput := `Infiniband device 'mlx5_0' port 1 status:
+        default gid:     fe80:0000:0000:0000:0015:5dff:fd34:11eb
+        state:           4: ACTIVE
+        phys state:      5: LinkUp
+        link_layer:      InfiniBand`
+
+	parsed, err := ParseIBStatus(incompleteInput)
+	require.NoError(t, err)
+	require.NotEmpty(t, parsed)
+	require.Equal(t, 1, len(parsed))
+
+	// Check that parsed fields are correct and missing fields are empty
+	require.Equal(t, "mlx5_0", parsed[0].Device)
+	require.Equal(t, "4: ACTIVE", parsed[0].State)
+	require.Equal(t, "5: LinkUp", parsed[0].PhysicalState)
+	require.Equal(t, "InfiniBand", parsed[0].LinkLayer)
+	require.Equal(t, "fe80:0000:0000:0000:0015:5dff:fd34:11eb", parsed[0].DefaultGID)
+	require.Equal(t, "", parsed[0].DefaultLID)
+	require.Equal(t, "", parsed[0].SMLID)
+	require.Equal(t, "", parsed[0].Rate)
+	require.Equal(t, "", parsed[0].BaseLid)
+}
+
+// TestGetIbstatusOutputWithMockedCommand tests GetIbstatusOutput with a mocked command
+func TestGetIbstatusOutputWithMockedCommand(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	// Create a temporary shell script that outputs valid ibstatus format
+	tmpScript := `#!/bin/bash
+echo 'Infiniband device '"'"'mlx5_0'"'"' port 1 status:
+        default gid:     fe80:0000:0000:0000:0015:5dff:fd34:11eb
+        base lid:        0x33bf
+        sm lid:          0x1
+        state:           4: ACTIVE
+        phys state:      5: LinkUp
+        rate:            200 Gb/sec (4X HDR)
+        link_layer:      InfiniBand'
+`
+	tmpFile := "/tmp/mock_ibstatus.sh"
+	err := os.WriteFile(tmpFile, []byte(tmpScript), 0755)
+	require.NoError(t, err)
+	defer os.Remove(tmpFile)
+
+	output, err := GetIbstatusOutput(ctx, []string{tmpFile})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	require.NotEmpty(t, output.Raw)
+	require.NotEmpty(t, output.Parsed)
+	require.Equal(t, 1, len(output.Parsed))
+	require.Equal(t, "mlx5_0", output.Parsed[0].Device)
+}
+
+// TestGetIbstatusOutputWithNonExistentCommand tests behavior when command doesn't exist
+func TestGetIbstatusOutputWithNonExistentCommand(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	output, err := GetIbstatusOutput(ctx, []string{"non_existent_command"})
+	require.Error(t, err)
+	require.Equal(t, ErrNoIbstatusCommand, err)
+	require.Nil(t, output)
+}
+
+// TestGetIbstatusOutputWithFailingCommand tests behavior when command fails but returns output
+func TestGetIbstatusOutputWithFailingCommand(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	// Create a temporary script that outputs error data and exits with error
+	tmpScript := `#!/bin/bash
+echo 'Error output'
+exit 1
+`
+	tmpFile := "/tmp/failing_ibstatus.sh"
+	err := os.WriteFile(tmpFile, []byte(tmpScript), 0755)
+	require.NoError(t, err)
+	defer os.Remove(tmpFile)
+
+	output, err := GetIbstatusOutput(ctx, []string{tmpFile})
+	require.Error(t, err)
+	require.NotNil(t, output)
+	require.Equal(t, "Error output", output.Raw)
+}
+
+// TestParseIBStatusWithSpecialCharacters tests parsing output with special characters
+func TestParseIBStatusWithSpecialCharacters(t *testing.T) {
+	t.Parallel()
+
+	specialCharsInput := `Infiniband device 'mlx5_0' port 1 status:
+        default gid:     fe80:0000:0000:0000:0015:5dff:fd34:11eb
+        base lid:        0x33bf
+        sm lid:          0x1
+        state:           4: ACTIVE (with special characters)
+        phys state:      5: LinkUp [status]
+        rate:            200 Gb/sec (4X HDR) high speed
+        link_layer:      InfiniBand`
+
+	parsed, err := ParseIBStatus(specialCharsInput)
+	require.NoError(t, err)
+	require.NotEmpty(t, parsed)
+	require.Equal(t, 1, len(parsed))
+	require.Equal(t, "mlx5_0", parsed[0].Device)
+	require.Equal(t, "4: ACTIVE (with special characters)", parsed[0].State)
+	require.Equal(t, "5: LinkUp [status]", parsed[0].PhysicalState)
+	require.Equal(t, "200 Gb/sec (4X HDR) high speed", parsed[0].Rate)
+}

--- a/pkg/nvidia-query/infiniband/testdata/ibstat.39.0.a100.failed.ibpanic.exit-255.0
+++ b/pkg/nvidia-query/infiniband/testdata/ibstat.39.0.a100.failed.ibpanic.exit-255.0
@@ -1,0 +1,138 @@
+CA 'mlx5_0'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411eb
+        System image GUID: 0xb83fd203006e2704
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13247
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411eb
+                Link layer: InfiniBand
+CA 'mlx5_1'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411ec
+        System image GUID: 0xa088c203003a8710
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13246
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411ec
+                Link layer: InfiniBand
+CA 'mlx5_2'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411ed
+        System image GUID: 0xb83fd203006e6e88
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13259
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411ed
+                Link layer: InfiniBand
+CA 'mlx5_3'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411ee
+        System image GUID: 0xb83fd203006e6e50
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13276
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411ee
+                Link layer: InfiniBand
+CA 'mlx5_4'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411ef
+        System image GUID: 0xb83fd203006e6e80
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13301
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411ef
+                Link layer: InfiniBand
+CA 'mlx5_5'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411f0
+        System image GUID: 0xb83fd203006e6e7c
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13300
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411f0
+                Link layer: InfiniBand
+CA 'mlx5_6'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411f1
+        System image GUID: 0xb83fd203006e6e38
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13302
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411f1
+                Link layer: InfiniBand
+CA 'mlx5_7'
+        CA type: MT4124
+        Number of ports: 1
+        Firmware version: 20.41.1000
+        Hardware version: 0
+        Node GUID: 0x00155dfffe3411f2
+        System image GUID: 0xb83fd203006e277c
+        Port 1:
+                State: Active
+                Physical state: LinkUp
+                Rate: 200
+                Base lid: 13305
+                LMC: 0
+                SM lid: 1
+                Capability mask: 0xa651ec48
+                Port GUID: 0x00155dfffd3411f2
+                Link layer: InfiniBand
+ibpanic: [1400444] main: stat of IB device 'mlx5_8' failed: No such file or directory
+

--- a/pkg/nvidia-query/infiniband/testdata/ibstatus.39.0.a100.all.active.0
+++ b/pkg/nvidia-query/infiniband/testdata/ibstatus.39.0.a100.all.active.0
@@ -1,0 +1,81 @@
+Infiniband device 'mlx5_0' port 1 status:
+        default gid:     fe80:0000:0000:0000:0015:5dff:fd34:11eb
+        base lid:        0x33bf
+        sm lid:          0x1
+        state:           4: ACTIVE
+        phys state:      5: LinkUp
+        rate:            200 Gb/sec (4X HDR)
+        link_layer:      InfiniBand
+
+Infiniband device 'mlx5_1' port 1 status:
+        default gid:     fe80:0000:0000:0000:0015:5dff:fd34:11ec
+        base lid:        0x33be
+        sm lid:          0x1
+        state:           4: ACTIVE
+        phys state:      5: LinkUp
+        rate:            200 Gb/sec (4X HDR)
+        link_layer:      InfiniBand
+
+Infiniband device 'mlx5_2' port 1 status:
+        default gid:     fe80:0000:0000:0000:0015:5dff:fd34:11ed
+        base lid:        0x33cb
+        sm lid:          0x1
+        state:           4: ACTIVE
+        phys state:      5: LinkUp
+        rate:            200 Gb/sec (4X HDR)
+        link_layer:      InfiniBand
+
+Infiniband device 'mlx5_3' port 1 status:
+        default gid:     fe80:0000:0000:0000:0015:5dff:fd34:11ee
+        base lid:        0x33dc
+        sm lid:          0x1
+        state:           4: ACTIVE
+        phys state:      5: LinkUp
+        rate:            200 Gb/sec (4X HDR)
+        link_layer:      InfiniBand
+
+Infiniband device 'mlx5_4' port 1 status:
+        default gid:     fe80:0000:0000:0000:0015:5dff:fd34:11ef
+        base lid:        0x33f5
+        sm lid:          0x1
+        state:           4: ACTIVE
+        phys state:      5: LinkUp
+        rate:            200 Gb/sec (4X HDR)
+        link_layer:      InfiniBand
+
+Infiniband device 'mlx5_5' port 1 status:
+        default gid:     fe80:0000:0000:0000:0015:5dff:fd34:11f0
+        base lid:        0x33f4
+        sm lid:          0x1
+        state:           4: ACTIVE
+        phys state:      5: LinkUp
+        rate:            200 Gb/sec (4X HDR)
+        link_layer:      InfiniBand
+
+Infiniband device 'mlx5_6' port 1 status:
+        default gid:     fe80:0000:0000:0000:0015:5dff:fd34:11f1
+        base lid:        0x33f6
+        sm lid:          0x1
+        state:           4: ACTIVE
+        phys state:      5: LinkUp
+        rate:            200 Gb/sec (4X HDR)
+        link_layer:      InfiniBand
+
+Infiniband device 'mlx5_7' port 1 status:
+        default gid:     fe80:0000:0000:0000:0015:5dff:fd34:11f2
+        base lid:        0x33f9
+        sm lid:          0x1
+        state:           4: ACTIVE
+        phys state:      5: LinkUp
+        rate:            200 Gb/sec (4X HDR)
+        link_layer:      InfiniBand
+
+Infiniband device 'mlx5_8' port 1 status:
+        default gid:     unknown
+        base lid:        0x0
+        sm lid:          0x0
+        state:           4: ACTIVE
+        phys state:      5: LinkUp
+        rate:            40 Gb/sec (4X QDR)
+        link_layer:      Ethernet
+

--- a/pkg/scan/options.go
+++ b/pkg/scan/options.go
@@ -1,8 +1,9 @@
 package scan
 
 type Op struct {
-	ibstatCommand string
-	debug         bool
+	ibstatCommand   string
+	ibstatusCommand string
+	debug           bool
 }
 
 type OpOption func(*Op)
@@ -15,6 +16,9 @@ func (op *Op) applyOpts(opts []OpOption) error {
 	if op.ibstatCommand == "" {
 		op.ibstatCommand = "ibstat"
 	}
+	if op.ibstatusCommand == "" {
+		op.ibstatusCommand = "ibstatus"
+	}
 
 	return nil
 }
@@ -23,6 +27,13 @@ func (op *Op) applyOpts(opts []OpOption) error {
 func WithIbstatCommand(p string) OpOption {
 	return func(op *Op) {
 		op.ibstatCommand = p
+	}
+}
+
+// Specifies the ibstatus binary path to overwrite the default path.
+func WithIbstatusCommand(p string) OpOption {
+	return func(op *Op) {
+		op.ibstatusCommand = p
 	}
 }
 

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -141,7 +141,8 @@ func Scan(ctx context.Context, opts ...OpOption) error {
 
 		NVMLInstance: nvmlInstance,
 		NVIDIAToolOverwrites: nvidiacommon.ToolOverwrites{
-			IbstatCommand: op.ibstatCommand,
+			IbstatCommand:   op.ibstatCommand,
+			IbstatusCommand: op.ibstatusCommand,
 		},
 
 		EventStore:       nil,

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -9,7 +9,9 @@ import (
 	apiv1 "github.com/leptonai/gpud/api/v1"
 	"github.com/leptonai/gpud/components"
 	nvidiacommon "github.com/leptonai/gpud/pkg/config/common"
+	"github.com/leptonai/gpud/pkg/log"
 	pkgmachineinfo "github.com/leptonai/gpud/pkg/machine-info"
+	nvidiainfiniband "github.com/leptonai/gpud/pkg/nvidia-query/infiniband"
 	nvidianvml "github.com/leptonai/gpud/pkg/nvidia-query/nvml"
 
 	componentsacceleratornvidiabadenvs "github.com/leptonai/gpud/components/accelerator/nvidia/bad-envs"
@@ -125,6 +127,14 @@ func Scan(ctx context.Context, opts ...OpOption) error {
 	}
 	fmt.Printf("\n%s machine info\n", checkMark)
 	mi.RenderTable(os.Stdout)
+
+	if mi.GPUInfo != nil && mi.GPUInfo.Product != "" {
+		threshold, err := nvidiainfiniband.SupportsInfinibandPortRate(mi.GPUInfo.Product)
+		if err == nil {
+			log.Logger.Infow("setting default expected port states", "product", mi.GPUInfo.Product, "at_least_ports", threshold.AtLeastPorts, "at_least_rate", threshold.AtLeastRate)
+			componentsacceleratornvidiainfiniband.SetDefaultExpectedPortStates(threshold)
+		}
+	}
 
 	gpudInstance := &components.GPUdInstance{
 		RootCtx: ctx,


### PR DESCRIPTION
Example:

```
...

CA 'mlx5_7'
	CA type: ...
	Number of ports: 1
	Firmware version: ...
	Hardware version: 0
	Node GUID: ...
	System image GUID: ...
	Port 1:
		State: Active
		Physical state: LinkUp
		Rate: 200
		Base lid: 13305
		LMC: 0
		SM lid: 1
		Capability mask: ...
		Port GUID: ...
		Link layer: InfiniBand
ibpanic: [1323906] main: stat of IB device 'mlx5_8' failed: No such file or directory
```