### PR TITLE
feat(server/nvml): exit on successful NVML refresh loops (GPU device only)

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -222,7 +222,7 @@ func New(ctx context.Context, config *lepconfig.Config, endpoint string, cliUID 
 		}
 	}()
 
-	nvmlInstance, err := nvidianvml.New()
+	nvmlInstance, err := nvidianvml.NewWithExitOnSuccessfulLoad(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create NVML instance: %w", err)
 	}


### PR DESCRIPTION
Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
