### PR TITLE
feat(custom-plugins): add "gpud custom-plugins" command, define auto run mode const

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -12,14 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// RunModeType defines the run mode of a component.
-type RunModeType string
-
-const (
-	// RunModeTypeManual is the run mode that requires manual trigger to run the check.
-	RunModeTypeManual RunModeType = "manual"
-)
-
 // HealthStateType defines the health state of a component.
 type HealthStateType string
 
@@ -36,6 +28,17 @@ type ComponentType string
 const (
 	// ComponentTypeCustomPlugin represents a custom plugin of GPUd.
 	ComponentTypeCustomPlugin ComponentType = "custom-plugin"
+)
+
+// RunModeType defines the run mode of a component.
+type RunModeType string
+
+const (
+	// RunModeTypeAuto is the run mode that runs automatically with the specified interval
+	// when enabled as a component.
+	RunModeTypeAuto RunModeType = "auto"
+	// RunModeTypeManual is the run mode that requires manual trigger to run the check.
+	RunModeTypeManual RunModeType = "manual"
 )
 
 // HealthState represents the health state of a component.

--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -40,6 +40,8 @@ var (
 	pluginSpecsFile string
 
 	enablePluginAPI bool
+
+	customPluginsRun bool
 )
 
 const (
@@ -223,24 +225,26 @@ sudo rm /etc/systemd/system/gpud.service
 					Destination: &autoUpdateExitCode,
 					Value:       -1,
 				},
+				cli.StringFlag{
+					Name:        "plugin-specs-file",
+					Usage:       "sets the plugin specs file (leave empty for default, useful for testing)",
+					Destination: &pluginSpecsFile,
+					Hidden:      true,
+				},
 
 				// only for testing
 				cli.StringFlag{
 					Name:        "ibstat-command",
 					Usage:       "sets the ibstat command (leave empty for default, useful for testing)",
 					Destination: &ibstatCommand,
+					Value:       "ibstat",
 					Hidden:      true,
 				},
 				cli.StringFlag{
 					Name:        "ibstatus-command",
 					Usage:       "sets the ibstatus command (leave empty for default, useful for testing)",
 					Destination: &ibstatusCommand,
-					Hidden:      true,
-				},
-				cli.StringFlag{
-					Name:        "plugin-specs-file",
-					Usage:       "sets the plugin specs file (leave empty for default, useful for testing)",
-					Destination: &pluginSpecsFile,
+					Value:       "ibstatus",
 					Hidden:      true,
 				},
 				&cli.BoolFlag{
@@ -516,6 +520,41 @@ sudo gpud join
 				cli.StringFlag{
 					Name:  "gpu-product",
 					Usage: "specify the GPU shape of the machine",
+				},
+			},
+		},
+
+		// for diagnose + quick scanning
+		{
+			Name:    "custom-plugins",
+			Aliases: []string{"cs", "plugin", "plugins"},
+
+			Usage:  "checks/runs custom plugins",
+			Action: cmdCustomPlugins,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:        "log-level,l",
+					Usage:       "set the logging level [debug, info, warn, error, fatal, panic, dpanic]",
+					Destination: &logLevel,
+				},
+				&cli.BoolFlag{
+					Name:        "run,r",
+					Usage:       "run the custom plugins (default: false)",
+					Destination: &customPluginsRun,
+				},
+
+				// only for testing
+				cli.StringFlag{
+					Name:        "ibstat-command",
+					Usage:       "sets the ibstat command (leave empty for default, useful for testing)",
+					Destination: &ibstatCommand,
+					Hidden:      true,
+				},
+				cli.StringFlag{
+					Name:        "ibstatus-command",
+					Usage:       "sets the ibstatus command (leave empty for default, useful for testing)",
+					Destination: &ibstatusCommand,
+					Hidden:      true,
 				},
 			},
 		},

--- a/cmd/gpud/command/custom-plugins.go
+++ b/cmd/gpud/command/custom-plugins.go
@@ -1,0 +1,129 @@
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/urfave/cli"
+
+	apiv1 "github.com/leptonai/gpud/api/v1"
+	"github.com/leptonai/gpud/components"
+	nvidiacommon "github.com/leptonai/gpud/pkg/config/common"
+	customplugins "github.com/leptonai/gpud/pkg/custom-plugins"
+	custompluginstestdata "github.com/leptonai/gpud/pkg/custom-plugins/testdata"
+	"github.com/leptonai/gpud/pkg/log"
+	nvidianvml "github.com/leptonai/gpud/pkg/nvidia-query/nvml"
+)
+
+func cmdCustomPlugins(cliContext *cli.Context) error {
+	zapLvl, err := log.ParseLogLevel(logLevel)
+	if err != nil {
+		return err
+	}
+	log.Logger = log.CreateLogger(zapLvl, logFile)
+
+	args := cliContext.Args()
+	var specs customplugins.Specs
+	if len(args) == 0 {
+		log.Logger.Infow("using example specs")
+		specs = custompluginstestdata.ExampleSpecs()
+	} else {
+		specs, err = customplugins.LoadSpecs(args[0])
+		if err != nil {
+			return err
+		}
+	}
+
+	// execute "init" type plugins first
+	sort.Slice(specs, func(i, j int) bool {
+		// "init" type first
+		if specs[i].Type == "init" && specs[j].Type == "init" {
+			return i < j
+		}
+		return specs[i].Type == "init"
+	})
+
+	println()
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_CENTER)
+	table.SetRowLine(true)
+	table.SetAutoWrapText(false)
+	table.SetHeader([]string{"Component", "Type", "Run Mode", "Timeout", "Interval", "Valid"})
+	for _, spec := range specs {
+		verr := spec.Validate()
+		s := checkMark + " valid"
+		if verr != nil {
+			s = warningSign + " invalid"
+		}
+		table.Append([]string{spec.ComponentName(), spec.Type, spec.RunMode, spec.Timeout.Duration.String(), spec.Interval.Duration.String(), s})
+	}
+	table.Render()
+	println()
+
+	if verr := specs.Validate(); verr != nil {
+		return verr
+	}
+
+	if !customPluginsRun {
+		log.Logger.Infow("custom plugins are not run, only validating the specs")
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	nvmlInstance, err := nvidianvml.New()
+	if err != nil {
+		return err
+	}
+
+	gpudInstance := &components.GPUdInstance{
+		RootCtx:      ctx,
+		NVMLInstance: nvmlInstance,
+		NVIDIAToolOverwrites: nvidiacommon.ToolOverwrites{
+			IbstatCommand:   ibstatCommand,
+			IbstatusCommand: ibstatusCommand,
+		},
+	}
+
+	results, err := specs.ExecuteInOrder(gpudInstance)
+	if err != nil {
+		return err
+	}
+
+	println()
+	table = tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_CENTER)
+	table.SetRowLine(true)
+	table.SetAutoWrapText(false)
+	table.SetHeader([]string{"Component", "Health State", "Summary", "Error", "Run Mode", "Extra Info"})
+	for k, v := range results {
+		healthState := checkMark + " " + string(apiv1.HealthStateTypeHealthy)
+		if v.HealthStateType() != apiv1.HealthStateTypeHealthy {
+			healthState = warningSign + " " + string(v.HealthStateType())
+		}
+
+		err := ""
+		runMode := ""
+		extraInfo := ""
+
+		states := v.HealthStates()
+		if len(states) > 0 {
+			err = states[0].Error
+			runMode = string(states[0].RunMode)
+
+			b, _ := json.Marshal(states[0].ExtraInfo)
+			extraInfo = string(b)
+		}
+
+		table.Append([]string{k, healthState, v.Summary(), err, runMode, extraInfo})
+	}
+	table.Render()
+	println()
+
+	return nil
+}

--- a/components/accelerator/nvidia/bad-envs/component.go
+++ b/components/accelerator/nvidia/bad-envs/component.go
@@ -176,6 +176,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/clock-speed/component.go
+++ b/components/accelerator/nvidia/clock-speed/component.go
@@ -152,6 +152,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/ecc/component.go
+++ b/components/accelerator/nvidia/ecc/component.go
@@ -167,6 +167,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/fabric-manager/component.go
+++ b/components/accelerator/nvidia/fabric-manager/component.go
@@ -216,6 +216,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/gpm/component.go
+++ b/components/accelerator/nvidia/gpm/component.go
@@ -227,6 +227,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/gsp-firmware-mode/component.go
+++ b/components/accelerator/nvidia/gsp-firmware-mode/component.go
@@ -148,6 +148,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/hw-slowdown/component.go
+++ b/components/accelerator/nvidia/hw-slowdown/component.go
@@ -348,6 +348,10 @@ type checkResult struct {
 	suggestedActions *apiv1.SuggestedActions
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/infiniband/component.go
+++ b/components/accelerator/nvidia/infiniband/component.go
@@ -349,6 +349,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/info/component.go
+++ b/components/accelerator/nvidia/info/component.go
@@ -268,6 +268,10 @@ type Product struct {
 	Architecture string `json:"architecture"`
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/memory/component.go
+++ b/components/accelerator/nvidia/memory/component.go
@@ -164,6 +164,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/nccl/component.go
+++ b/components/accelerator/nvidia/nccl/component.go
@@ -183,6 +183,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/nvlink/component.go
+++ b/components/accelerator/nvidia/nvlink/component.go
@@ -159,6 +159,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/peermem/component.go
+++ b/components/accelerator/nvidia/peermem/component.go
@@ -183,6 +183,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/persistence-mode/component.go
+++ b/components/accelerator/nvidia/persistence-mode/component.go
@@ -148,6 +148,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/power/component.go
+++ b/components/accelerator/nvidia/power/component.go
@@ -162,6 +162,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/processes/component.go
+++ b/components/accelerator/nvidia/processes/component.go
@@ -151,6 +151,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/remapped-rows/component.go
+++ b/components/accelerator/nvidia/remapped-rows/component.go
@@ -257,6 +257,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/sxid/component.go
+++ b/components/accelerator/nvidia/sxid/component.go
@@ -259,6 +259,10 @@ type FoundError struct {
 	SXidError
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/temperature/component.go
+++ b/components/accelerator/nvidia/temperature/component.go
@@ -181,6 +181,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/utilization/component.go
+++ b/components/accelerator/nvidia/utilization/component.go
@@ -152,6 +152,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/accelerator/nvidia/xid/component.go
+++ b/components/accelerator/nvidia/xid/component.go
@@ -268,6 +268,10 @@ type FoundError struct {
 	XidError
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/containerd/pod/component.go
+++ b/components/containerd/pod/component.go
@@ -189,6 +189,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/cpu/component.go
+++ b/components/cpu/component.go
@@ -264,6 +264,10 @@ type Usage struct {
 	LoadAvg15Min string `json:"load_avg_15min"`
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/disk/component.go
+++ b/components/disk/component.go
@@ -273,6 +273,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil || len(cr.ExtPartitions) == 0 {
 		return ""

--- a/components/docker/container/component.go
+++ b/components/docker/container/component.go
@@ -187,6 +187,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/fd/component.go
+++ b/components/fd/component.go
@@ -287,6 +287,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/fuse/component.go
+++ b/components/fuse/component.go
@@ -234,6 +234,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/info/component.go
+++ b/components/info/component.go
@@ -265,6 +265,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/kernel-module/component.go
+++ b/components/kernel-module/component.go
@@ -146,6 +146,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/kubelet/pod/component.go
+++ b/components/kubelet/pod/component.go
@@ -173,6 +173,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/library/component.go
+++ b/components/library/component.go
@@ -203,6 +203,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/memory/component.go
+++ b/components/memory/component.go
@@ -209,6 +209,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/network/latency/component.go
+++ b/components/network/latency/component.go
@@ -162,6 +162,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/os/component.go
+++ b/components/os/component.go
@@ -212,6 +212,10 @@ type Uptimes struct {
 	BootTimeUnixSeconds uint64 `json:"boot_time_unix_seconds"`
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/pci/component.go
+++ b/components/pci/component.go
@@ -224,6 +224,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/registry_test.go
+++ b/components/registry_test.go
@@ -51,6 +51,10 @@ func (m *mockComponent) Close() error {
 // mockCheckResult implements the CheckResult interface for testing
 type mockCheckResult struct{}
 
+func (r *mockCheckResult) ComponentName() string {
+	return "mock-component"
+}
+
 func (r *mockCheckResult) String() string {
 	return "mock check result"
 }

--- a/components/tailscale/component.go
+++ b/components/tailscale/component.go
@@ -137,6 +137,10 @@ type checkResult struct {
 	reason string
 }
 
+func (cr *checkResult) ComponentName() string {
+	return Name
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/components/types.go
+++ b/components/types.go
@@ -65,6 +65,9 @@ type HealthSettable interface {
 // CheckResult is the data type that represents the result of
 // a component health state check.
 type CheckResult interface {
+	// ComponentName returns the name of the component that produced this check result.
+	ComponentName() string
+
 	// String returns a string representation of the data.
 	// Describes the data in a human-readable format.
 	fmt.Stringer

--- a/docs/PLUGINS.draft.md
+++ b/docs/PLUGINS.draft.md
@@ -1,0 +1,140 @@
+
+## Examples: test plugins locally
+
+To validate sample/example configuration
+
+```bash
+gpud cs
+```
+
+```text
++-----------------------------------+-----------+----------+---------+----------+---------+
+|             COMPONENT             |   TYPE    | RUN MODE | TIMEOUT | INTERVAL |  VALID  |
++-----------------------------------+-----------+----------+---------+----------+---------+
+|           test-healthy            | component |   auto   |  1m0s   |  10m0s   | ✔ valid |
++-----------------------------------+-----------+----------+---------+----------+---------+
+|          test-unhealthy           | component |   auto   |  1m0s   |  10m0s   | ✔ valid |
++-----------------------------------+-----------+----------+---------+----------+---------+
+| test-unhealthy-with-missing-field | component |   auto   |  1m0s   |  10m0s   | ✔ valid |
++-----------------------------------+-----------+----------+---------+----------+---------+
+|              exit-0               | component |   auto   |  1m0s   | 1h40m0s  | ✔ valid |
++-----------------------------------+-----------+----------+---------+----------+---------+
+|              exit-1               | component |   auto   |  1m0s   | 1h40m0s  | ✔ valid |
++-----------------------------------+-----------+----------+---------+----------+---------+
+```
+
+To run and see the results of the sample configuration:
+
+```bash
+gpud cs -r
+```
+
+```text
+### Component "test-healthy" output
+
+hello world no JSON yet
+{"name": "test", "result": "healthy", "passed": true, "action": "reboot me 1", "suggestion": "reboot me 2"}
+thank you
+
+
+
+### Component "test-unhealthy" output
+
+hello world no JSON yet
+{"name": "test", "result": "unhealthy", "passed": false, "action": "reboot me 1", "suggestion": "reboot me 2"}
+done
+
+
+
+### Component "test-unhealthy-with-missing-field" output
+
+hello world no JSON yet
+{"name": "test", "result": "unhealthy", "passed": false}
+done
+
+
+
+### Component "exit-0" output
+
+{"description": "calling exit 0"}
+
+
+
+### Component "exit-1" output
+
+{"description": "calling exit 1"}
+
+
+
+### Results
+
++-----------------------------------+--------------+---------------------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------+
+|             COMPONENT             | HEALTH STATE |                   SUMMARY                   |     ERROR     | RUN MODE |                                               EXTRA INFO                                                |
++-----------------------------------+--------------+---------------------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------+
+|           test-healthy            |  ✔ Healthy   |                     ok                      |               |   auto   |  {"action":"reboot me 1","name":"test","passed":"true","result":"healthy","suggestion":"reboot me 2"}   |
++-----------------------------------+--------------+---------------------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------+
+|          test-unhealthy           | ✘ Unhealthy  |          unexpected plugin output           |               |   auto   | {"action":"reboot me 1","name":"test","passed":"false","result":"unhealthy","suggestion":"reboot me 2"} |
++-----------------------------------+--------------+---------------------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------+
+| test-unhealthy-with-missing-field | ✘ Unhealthy  |          unexpected plugin output           |               |   auto   |                   {"name":"test","nothere":"","passed":"false","result":"unhealthy"}                    |
++-----------------------------------+--------------+---------------------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------+
+|              exit-0               |  ✔ Healthy   |                     ok                      |               |   auto   |                                    {"description":"calling exit 0"}                                     |
++-----------------------------------+--------------+---------------------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------+
+|              exit-1               | ✘ Unhealthy  | error executing state plugin (exit code: 1) | exit status 1 |   auto   |                                    {"description":"calling exit 1"}                                     |
++-----------------------------------+--------------+---------------------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------+
+```
+
+To validate and run your own configuration:
+
+```bash
+gpud cs ./pkg/custom-plugins/testdata/plugins.plaintext.2.regex.yaml
+gpud cs ./pkg/custom-plugins/testdata/plugins.plaintext.2.regex.yaml -r
+```
+
+To start GPUd with the local plugin configuration file:
+
+```bash
+gpud run \
+--enable-auto-update=false \
+--plugin-specs-file=./pkg/custom-plugins/testdata/plugins.plaintext.2.regex.yaml
+```
+
+To trigger the registered plugin manually (works for any component):
+
+```bash
+curl -s -kL https://localhost:15132/v1/components/trigger-check?componentName=exit-1 | jq
+```
+
+```json
+[
+  {
+    "time": "...",
+    "component": "exit-1",
+    "component_type": "custom-plugin",
+    "name": "exit-1",
+    "run_mode": "auto",
+    "health": "Unhealthy",
+    "reason": "error executing state plugin (exit code: 1)",
+    "error": "exit status 1",
+    "suggested_actions": {
+      "description": "reboot me",
+      "repair_actions": [
+        "REBOOT_SYSTEM"
+      ]
+    },
+    "extra_info": {
+      "action": "reboot me",
+      "description": "about to fail with exit code 1"
+    }
+  }
+]
+```
+
+Other endpoints:
+
+```bash
+curl -kL https://localhost:15132/healthz
+curl -kL https://localhost:15132/v1/states | jq | less
+curl -kL https://localhost:15132/v1/metrics | jq | less
+curl -kL https://localhost:15132/v1/events | jq | less
+curl -kL https://localhost:15132/metrics
+```

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -445,7 +445,7 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 				Type:       pkgcustomplugins.SpecTypeComponent,
 
 				// should not run, only registers
-				RunMode: pkgcustomplugins.SpecModeManual,
+				RunMode: string(apiv1.RunModeTypeManual),
 
 				HealthStatePlugin: &pkgcustomplugins.Plugin{
 					Steps: []pkgcustomplugins.Step{
@@ -503,7 +503,7 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to marshal spec")
 				fmt.Println("currently registered custom plugin (expect run_mode: manual)", "name", curSpec.PluginName, "componentName", componentName, "spec", string(b))
 
-				Expect(curSpec.RunMode).Should(Equal(string(pkgcustomplugins.SpecModeManual)), "expected manual mode")
+				Expect(curSpec.RunMode).Should(Equal(string(apiv1.RunModeTypeManual)), "expected manual mode")
 			}
 			Expect(csPlugins[customComponentName]).NotTo(BeNil(), "expected to be registered")
 		})
@@ -521,7 +521,7 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to get custom plugins")
 			Expect(len(resp)).To(Equal(1), "expected 1 response")
 			Expect(string(resp[0].ComponentType)).To(Equal(string(apiv1.ComponentTypeCustomPlugin)), "expected component type to be custom plugin")
-			Expect(string(resp[0].RunMode)).To(Equal(string(pkgcustomplugins.SpecModeManual)), "expected manual mode")
+			Expect(string(resp[0].RunMode)).To(Equal(string(apiv1.RunModeTypeManual)), "expected manual mode")
 
 			fmt.Printf("%+v\n", resp)
 		})
@@ -539,7 +539,7 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 			Expect(states[0].States).To(HaveLen(1), "expected states to have 1 state")
 			Expect(states[0].States[0].Health).To(Equal(apiv1.HealthStateTypeUnhealthy), "expected health state to be unhealthy")
 			Expect(string(states[0].States[0].ComponentType)).To(Equal(string(apiv1.ComponentTypeCustomPlugin)), "expected component type to be custom plugin")
-			Expect(string(states[0].States[0].RunMode)).To(Equal(string(pkgcustomplugins.SpecModeManual)), "expected run mode to be manual")
+			Expect(string(states[0].States[0].RunMode)).To(Equal(string(apiv1.RunModeTypeManual)), "expected run mode to be manual")
 		})
 
 		randSfx2, err := randStr(10)

--- a/pkg/custom-plugins/component.go
+++ b/pkg/custom-plugins/component.go
@@ -257,6 +257,10 @@ type checkResult struct {
 	suggestedActions *apiv1.SuggestedActions
 }
 
+func (cr *checkResult) ComponentName() string {
+	return cr.componentName
+}
+
 func (cr *checkResult) String() string {
 	if cr == nil {
 		return ""

--- a/pkg/custom-plugins/component.go
+++ b/pkg/custom-plugins/component.go
@@ -66,7 +66,7 @@ func (c *component) Name() string { return c.spec.ComponentName() }
 func (c *component) Start() error {
 	log.Logger.Infow("starting custom plugin", "type", c.spec.Type, "component", c.Name(), "plugin", c.spec.PluginName)
 
-	if c.spec.RunMode == SpecModeManual {
+	if c.spec.RunMode == string(apiv1.RunModeTypeManual) {
 		log.Logger.Infow("custom plugin is in manual mode, skipping start", "type", c.spec.Type, "component", c.Name(), "plugin", c.spec.PluginName)
 		return nil
 	}
@@ -262,7 +262,7 @@ func (cr *checkResult) String() string {
 		return ""
 	}
 
-	return string(cr.out) + "\n\n" + fmt.Sprintf("(exit code %d)", cr.exitCode)
+	return string(cr.out) + "\n" + fmt.Sprintf("(exit code %d)", cr.exitCode)
 }
 
 func (cr *checkResult) Summary() string {

--- a/pkg/custom-plugins/execute.go
+++ b/pkg/custom-plugins/execute.go
@@ -1,0 +1,41 @@
+package customplugins
+
+import (
+	"sort"
+
+	"github.com/leptonai/gpud/components"
+	"github.com/leptonai/gpud/pkg/log"
+)
+
+// ExecuteInOrder executes all the plugins in the specs, in sequence.
+// This is ONLY used for dry-run plugins from the spec.
+func (specs Specs) ExecuteInOrder(gpudInstance *components.GPUdInstance) (map[string]components.CheckResult, error) {
+	results := make(map[string]components.CheckResult)
+
+	// execute "init" type plugins first
+	sort.Slice(specs, func(i, j int) bool {
+		// "init" type first
+		if specs[i].Type == "init" && specs[j].Type == "init" {
+			return i < j
+		}
+		return specs[i].Type == "init"
+	})
+
+	for _, spec := range specs {
+		initFunc := spec.NewInitFunc()
+		if initFunc == nil {
+			continue
+		}
+
+		comp, err := initFunc(gpudInstance)
+		if err != nil {
+			return nil, err
+		}
+
+		checkResult := comp.Check()
+		results[comp.Name()] = checkResult
+		_ = comp.Close()
+		log.Logger.Infow("executed custom plugin", "component", comp.Name())
+	}
+	return results, nil
+}

--- a/pkg/custom-plugins/execute.go
+++ b/pkg/custom-plugins/execute.go
@@ -9,9 +9,7 @@ import (
 
 // ExecuteInOrder executes all the plugins in the specs, in sequence.
 // This is ONLY used for dry-run plugins from the spec.
-func (specs Specs) ExecuteInOrder(gpudInstance *components.GPUdInstance) (map[string]components.CheckResult, error) {
-	results := make(map[string]components.CheckResult)
-
+func (specs Specs) ExecuteInOrder(gpudInstance *components.GPUdInstance) ([]components.CheckResult, error) {
 	// execute "init" type plugins first
 	sort.Slice(specs, func(i, j int) bool {
 		// "init" type first
@@ -21,6 +19,7 @@ func (specs Specs) ExecuteInOrder(gpudInstance *components.GPUdInstance) (map[st
 		return specs[i].Type == "init"
 	})
 
+	results := make([]components.CheckResult, 0, len(specs))
 	for _, spec := range specs {
 		initFunc := spec.NewInitFunc()
 		if initFunc == nil {
@@ -33,8 +32,9 @@ func (specs Specs) ExecuteInOrder(gpudInstance *components.GPUdInstance) (map[st
 		}
 
 		checkResult := comp.Check()
-		results[comp.Name()] = checkResult
 		_ = comp.Close()
+
+		results = append(results, checkResult)
 		log.Logger.Infow("executed custom plugin", "component", comp.Name())
 	}
 	return results, nil

--- a/pkg/custom-plugins/execute_test.go
+++ b/pkg/custom-plugins/execute_test.go
@@ -22,8 +22,8 @@ func TestComponentSpecsExecuteInOrder(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 5, len(results))
 
-	for k, v := range results {
-		t.Logf("%q: %q", k, v.Summary())
+	for _, rs := range results {
+		t.Logf("%q: %q", rs.ComponentName(), rs.Summary())
 	}
 }
 

--- a/pkg/custom-plugins/execute_test.go
+++ b/pkg/custom-plugins/execute_test.go
@@ -1,0 +1,46 @@
+package customplugins
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/leptonai/gpud/components"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComponentSpecsExecuteInOrder(t *testing.T) {
+	testFile := filepath.Join("testdata", "plugins.plaintext.2.regex.yaml")
+	specs, err := LoadSpecs(testFile)
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	results, err := specs.ExecuteInOrder(&components.GPUdInstance{RootCtx: ctx})
+	assert.NoError(t, err)
+	assert.Equal(t, 5, len(results))
+
+	for k, v := range results {
+		t.Logf("%q: %q", k, v.Summary())
+	}
+}
+
+// TestExecuteInOrderWithCanceledContext tests the behavior when the context is canceled
+func TestExecuteInOrderWithCanceledContext(t *testing.T) {
+	testFile := filepath.Join("testdata", "plugins.plaintext.2.regex.yaml")
+	specs, err := LoadSpecs(testFile)
+	assert.NoError(t, err)
+
+	// Create a context that's already canceled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	// Since we're canceling the context, but the ExecuteInOrder function doesn't currently check
+	// for context cancellation between plugin executions, this should still succeed
+	// This test is added for completeness and to document the current behavior
+	results, err := specs.ExecuteInOrder(&components.GPUdInstance{RootCtx: ctx})
+	assert.NoError(t, err)
+	assert.Equal(t, 5, len(results))
+}

--- a/pkg/custom-plugins/spec_test.go
+++ b/pkg/custom-plugins/spec_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	apiv1 "github.com/leptonai/gpud/api/v1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -29,7 +30,7 @@ func TestLoad(t *testing.T) {
 	plugin := plugins[0]
 	assert.Equal(t, "nvidia-smi", plugin.PluginName)
 	assert.Equal(t, "bnZpZGlhLXNtaQo=", plugin.HealthStatePlugin.Steps[0].RunBashScript.Script)
-	assert.Equal(t, SpecModeManual, plugin.RunMode)
+	assert.Equal(t, string(apiv1.RunModeTypeManual), plugin.RunMode)
 	assert.Equal(t, metav1.Duration{Duration: 10 * time.Second}, plugin.Timeout)
 	assert.Equal(t, metav1.Duration{Duration: 1 * time.Minute}, plugin.Interval)
 }
@@ -302,7 +303,7 @@ func TestLoadPlaintextPlugins(t *testing.T) {
 	assert.Equal(t, "Run nvidia-smi", plugins[0].HealthStatePlugin.Steps[1].Name)
 	assert.Equal(t, "plaintext", plugins[0].HealthStatePlugin.Steps[1].RunBashScript.ContentType)
 	assert.Equal(t, "echo 'State script'", plugins[0].HealthStatePlugin.Steps[1].RunBashScript.Script)
-	assert.Equal(t, SpecModeManual, plugins[0].RunMode)
+	assert.Equal(t, string(apiv1.RunModeTypeManual), plugins[0].RunMode)
 	assert.Equal(t, metav1.Duration{Duration: 10 * time.Second}, plugins[0].Timeout)
 	assert.Equal(t, metav1.Duration{Duration: 1 * time.Minute}, plugins[0].Interval)
 
@@ -315,7 +316,7 @@ func TestLoadPlaintextPlugins(t *testing.T) {
 	assert.Equal(t, "Run python scripts", plugins[1].HealthStatePlugin.Steps[1].Name)
 	assert.Equal(t, "plaintext", plugins[1].HealthStatePlugin.Steps[1].RunBashScript.ContentType)
 	assert.Contains(t, plugins[1].HealthStatePlugin.Steps[1].RunBashScript.Script, "python3 test.py")
-	assert.Equal(t, SpecModeManual, plugins[1].RunMode)
+	assert.Equal(t, string(apiv1.RunModeTypeManual), plugins[1].RunMode)
 	assert.Equal(t, metav1.Duration{Duration: 10 * time.Second}, plugins[1].Timeout)
 	assert.Equal(t, metav1.Duration{Duration: 1 * time.Minute}, plugins[1].Interval)
 }
@@ -927,7 +928,7 @@ func TestHealthStatePlugin_executeAllSteps(t *testing.T) {
 						},
 					},
 				},
-				RunMode: SpecModeManual,
+				RunMode: string(apiv1.RunModeTypeManual),
 				Timeout: metav1.Duration{Duration: 10 * time.Second},
 			},
 			expectOutput: false,

--- a/pkg/custom-plugins/testdata/init.go
+++ b/pkg/custom-plugins/testdata/init.go
@@ -1,0 +1,28 @@
+package testdata
+
+import (
+	_ "embed"
+
+	customplugins "github.com/leptonai/gpud/pkg/custom-plugins"
+	"sigs.k8s.io/yaml"
+)
+
+//go:embed plugins.plaintext.2.regex.yaml
+var exampleSpecsYAML []byte
+
+var exampleSpecs customplugins.Specs
+
+func init() {
+	var err error
+	err = yaml.Unmarshal(exampleSpecsYAML, &exampleSpecs)
+	if err != nil {
+		panic(err)
+	}
+	if err = exampleSpecs.Validate(); err != nil {
+		panic(err)
+	}
+}
+
+func ExampleSpecs() customplugins.Specs {
+	return exampleSpecs
+}

--- a/pkg/custom-plugins/testdata/init_test.go
+++ b/pkg/custom-plugins/testdata/init_test.go
@@ -1,0 +1,12 @@
+package testdata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	specs := ExampleSpecs()
+	assert.NotNil(t, specs)
+}

--- a/pkg/custom-plugins/testdata/plugins.plaintext.1.yaml
+++ b/pkg/custom-plugins/testdata/plugins.plaintext.1.yaml
@@ -30,7 +30,7 @@
             uv run /tmp/hello.py
             rm -f /tmp/hello.py
 
-  run_mode: ""
+  run_mode: auto
   timeout: 1m
 
 
@@ -51,7 +51,7 @@
             echo "about to fail with exit code 1"
             exit 1
 
-  run_mode: ""
+  run_mode: auto
 
   timeout: 1m
   interval: 100m
@@ -124,7 +124,7 @@
             uv run /tmp/nvidia-smi-gpu-throttle.py
             rm -f /tmp/nvidia-smi-gpu-throttle.py
 
-  run_mode: ""
+  run_mode: auto
 
   timeout: 1m
   interval: 10m
@@ -193,7 +193,7 @@
             uv run /tmp/nvidia-smi-gpu-power-state.py
             rm -f /tmp/nvidia-smi-gpu-power-state.py
 
-  run_mode: ""
+  run_mode: auto
 
   timeout: 1m
   interval: 10m

--- a/pkg/custom-plugins/testdata/plugins.plaintext.2.regex.yaml
+++ b/pkg/custom-plugins/testdata/plugins.plaintext.2.regex.yaml
@@ -36,7 +36,7 @@
             echo '{"name": "test", "result": "healthy", "passed": true, "action": "reboot me 1", "suggestion": "reboot me 2"}'
             echo "thank you"
 
-  run_mode: ""
+  run_mode: auto
 
   timeout: 1m
   interval: 10m
@@ -80,7 +80,7 @@
             echo '{"name": "test", "result": "unhealthy", "passed": false, "action": "reboot me 1", "suggestion": "reboot me 2"}'
             echo "done"
 
-  run_mode: ""
+  run_mode: auto
 
   timeout: 1m
   interval: 10m
@@ -118,7 +118,53 @@
             echo '{"name": "test", "result": "unhealthy", "passed": false}'
             echo "done"
 
-  run_mode: ""
+  run_mode: auto
 
   timeout: 1m
   interval: 10m
+
+########################################
+- plugin_name: exit-0
+  type: component
+
+  health_state_plugin:
+    parser:
+      json_paths:
+        - query: $.description
+          field: description
+    steps:
+      - name: Exit 0
+        run_bash_script:
+          content_type: plaintext
+          script: |
+            echo '{"description": "calling exit 0"}'
+
+            exit 0
+
+  run_mode: auto
+
+  timeout: 1m
+  interval: 100m
+
+########################################
+- plugin_name: exit-1
+  type: component
+
+  health_state_plugin:
+    parser:
+      json_paths:
+        - query: $.description
+          field: description
+    steps:
+      - name: Exit 1
+        run_bash_script:
+          content_type: plaintext
+          script: |
+            echo '{"description": "calling exit 1"}'
+
+            exit 1
+
+  run_mode: auto
+
+  timeout: 1m
+  interval: 100m

--- a/pkg/custom-plugins/types.go
+++ b/pkg/custom-plugins/types.go
@@ -25,11 +25,6 @@ const (
 	SpecTypeComponent = "component"
 )
 
-const (
-	// SpecModeManual is the mode of the plugin that is used to run manually.
-	SpecModeManual = "manual"
-)
-
 // Specs is a list of plugin specs.
 type Specs []Spec
 
@@ -41,17 +36,25 @@ type Spec struct {
 	PluginName string `json:"plugin_name"`
 
 	// Type defines the plugin type.
+	// Possible values: "init", "component".
 	Type string `json:"type"`
 
+	// RunMode defines the run mode of the plugin.
+	// Possible values: "auto", "manual".
+	//
+	// RunMode is set to "auto" to run the plugin periodically, with the specified interval.
+	//
 	// RunMode is set to "manual" to run the plugin only when explicitly triggered.
 	// The manual mode plugin is only registered but not run periodically.
 	// - GPUd does not run this even once.
 	// - GPUd does not run this periodically.
 	//
-	// This "manual" mode is only applicable to "component" type plugins.
-	// The "init" type plugins are always run only once.
+	// This "auto" mode is only applicable to "component" type plugins.
+	// This "auto" mode is not applicable to "init" type plugins.
 	//
-	// If not set, the plugin is run periodically by default.
+	// The "init" type plugins are always run only once.
+	// This "manual" mode is only applicable to "component" type plugins.
+	// This "manual" mode is not applicable to "init" type plugins.
 	RunMode string `json:"run_mode"`
 
 	// HealthStatePlugin defines the plugin instructions

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -301,7 +301,7 @@ func TestProcessWithStdoutReaderUntilEOF(t *testing.T) {
 	if err := p.Close(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if scanner.Err() != nil {
+	if scanner.Err() != nil && !strings.Contains(scanner.Err().Error(), "file already closed") {
 		t.Fatal(scanner.Err())
 	}
 }


### PR DESCRIPTION
```
./bin/gpud cs
# or
# ./bin/gpud cs ./pkg/custom-plugins/testdata/plugins.plaintext.2.regex.yaml

+-----------------------------------+-----------+----------+---------+----------+---------+
|             COMPONENT             |   TYPE    | RUN MODE | TIMEOUT | INTERVAL |  VALID  |
+-----------------------------------+-----------+----------+---------+----------+---------+
|           test-healthy            | component |   auto   |  1m0s   |  10m0s   | ✔ valid |
+-----------------------------------+-----------+----------+---------+----------+---------+
|          test-unhealthy           | component |   auto   |  1m0s   |  10m0s   | ✔ valid |
+-----------------------------------+-----------+----------+---------+----------+---------+
| test-unhealthy-with-missing-field | component |   auto   |  1m0s   |  10m0s   | ✔ valid |
+-----------------------------------+-----------+----------+---------+----------+---------+
|              exit-0               | component |   auto   |  1m0s   | 1h40m0s  | ✔ valid |
+-----------------------------------+-----------+----------+---------+----------+---------+
|              exit-1               | component |   auto   |  1m0s   | 1h40m0s  | ✔ valid |
+-----------------------------------+-----------+----------+---------+----------+---------+

{"level":"info","ts":"2025-05-03T20:05:18+08:00","caller":"command/custom-plugins.go:62","msg":"custom plugins are not run, only validating the specs"}
```

```
./bin/gpud cs ./pkg/custom-plugins/testdata/plugins.plaintext.2.regex.yaml -r

+-----------------------------------+--------------+---------------------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------+
|             COMPONENT             | HEALTH STATE |                   SUMMARY                   |     ERROR     | RUN MODE |                                               EXTRA INFO                                                |
+-----------------------------------+--------------+---------------------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------+
|           test-healthy            |  ✔ Healthy   |                     ok                      |               |   auto   |  {"action":"reboot me 1","name":"test","passed":"true","result":"healthy","suggestion":"reboot me 2"}   |
+-----------------------------------+--------------+---------------------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------+
|          test-unhealthy           | ✘ Unhealthy  |          unexpected plugin output           |               |   auto   | {"action":"reboot me 1","name":"test","passed":"false","result":"unhealthy","suggestion":"reboot me 2"} |
+-----------------------------------+--------------+---------------------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------+
| test-unhealthy-with-missing-field | ✘ Unhealthy  |          unexpected plugin output           |               |   auto   |                   {"name":"test","nothere":"","passed":"false","result":"unhealthy"}                    |
+-----------------------------------+--------------+---------------------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------+
|              exit-0               |  ✔ Healthy   |                     ok                      |               |   auto   |                                    {"description":"calling exit 0"}                                     |
+-----------------------------------+--------------+---------------------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------+
|              exit-1               | ✘ Unhealthy  | error executing state plugin (exit code: 1) | exit status 1 |   auto   |                                    {"description":"calling exit 1"}                                     |
+-----------------------------------+--------------+---------------------------------------------+---------------+----------+---------------------------------------------------------------------------------------------------------+
```
