### PR TITLE
feat(pkg/disk): track up to 2-level depth lsblk children

### DIFF
--- a/pkg/disk/lsblk_flatten.go
+++ b/pkg/disk/lsblk_flatten.go
@@ -36,7 +36,7 @@ func (blks BlockDevices) Flatten() FlattenedBlockDevices {
 	all := make(map[string]FlattenedBlockDevice)
 
 	for _, blk1 := range blks {
-		blkParent := FlattenedBlockDevice{
+		blk1Flattened := FlattenedBlockDevice{
 			Name:       blk1.Name,
 			Type:       blk1.Type,
 			Size:       blk1.Size.Uint64,
@@ -51,18 +51,19 @@ func (blks BlockDevices) Flatten() FlattenedBlockDevices {
 			PartUUID:   blk1.PartUUID,
 		}
 		if blk1.ParentDeviceName != "" {
-			blkParent.Parents = []string{blk1.ParentDeviceName}
+			blk1Flattened.Parents = []string{blk1.ParentDeviceName}
 		}
-		all[blkParent.Name] = blkParent
+		all[blk1Flattened.Name] = blk1Flattened
 
+		// 2nd gen children
 		for _, blk2 := range blk1.Children {
-			parent := all[blkParent.Name]
-			parent.Children = append(parent.Children, blk2.Name)
-			all[blkParent.Name] = parent
+			parentDev := all[blk1Flattened.Name]
+			parentDev.Children = append(parentDev.Children, blk2.Name)
+			all[blk1Flattened.Name] = parentDev
 
 			// now flatten the child as its own entry
 			// but multiple children may share the same parent
-			blkChild := FlattenedBlockDevice{
+			blk2Flattened := FlattenedBlockDevice{
 				Name:       blk2.Name,
 				Type:       blk2.Type,
 				Size:       blk2.Size.Uint64,
@@ -75,13 +76,44 @@ func (blks BlockDevices) Flatten() FlattenedBlockDevices {
 				MountPoint: blk2.MountPoint,
 				FSType:     blk2.FSType,
 				PartUUID:   blk2.PartUUID,
-				Parents:    []string{blkParent.Name},
+				Parents:    []string{blk1Flattened.Name},
 			}
-			if prev, ok := all[blkChild.Name]; ok {
-				prev.Parents = append(prev.Parents, blkChild.Parents...)
-				all[blkChild.Name] = prev
+			if prev, ok := all[blk2Flattened.Name]; ok {
+				prev.Parents = append(prev.Parents, blk2Flattened.Parents...)
+				all[blk2Flattened.Name] = prev
 			} else {
-				all[blkChild.Name] = blkChild
+				all[blk2Flattened.Name] = blk2Flattened
+			}
+
+			// track up to 3rd gen children
+			for _, blk3 := range blk2.Children {
+				parentDev := all[blk2Flattened.Name]
+				parentDev.Children = append(parentDev.Children, blk3.Name)
+				all[blk2Flattened.Name] = parentDev
+
+				// now flatten the child as its own entry
+				// but multiple children may share the same parent
+				blk3Flattened := FlattenedBlockDevice{
+					Name:       blk3.Name,
+					Type:       blk3.Type,
+					Size:       blk3.Size.Uint64,
+					Rota:       blk3.Rota.Bool,
+					Serial:     blk3.Serial,
+					WWN:        blk3.WWN,
+					Vendor:     blk3.Vendor,
+					Model:      blk3.Model,
+					Rev:        blk3.Rev,
+					MountPoint: blk3.MountPoint,
+					FSType:     blk3.FSType,
+					PartUUID:   blk3.PartUUID,
+					Parents:    []string{blk2Flattened.Name},
+				}
+				if prev, ok := all[blk3Flattened.Name]; ok {
+					prev.Parents = append(prev.Parents, blk3Flattened.Parents...)
+					all[blk3Flattened.Name] = prev
+				} else {
+					all[blk3Flattened.Name] = blk3Flattened
+				}
 			}
 		}
 	}

--- a/pkg/disk/lsblk_flatten.go
+++ b/pkg/disk/lsblk_flatten.go
@@ -36,86 +36,7 @@ func (blks BlockDevices) Flatten() FlattenedBlockDevices {
 	all := make(map[string]FlattenedBlockDevice)
 
 	for _, blk1 := range blks {
-		blk1Flattened := FlattenedBlockDevice{
-			Name:       blk1.Name,
-			Type:       blk1.Type,
-			Size:       blk1.Size.Uint64,
-			Rota:       blk1.Rota.Bool,
-			Serial:     blk1.Serial,
-			WWN:        blk1.WWN,
-			Vendor:     blk1.Vendor,
-			Model:      blk1.Model,
-			Rev:        blk1.Rev,
-			MountPoint: blk1.MountPoint,
-			FSType:     blk1.FSType,
-			PartUUID:   blk1.PartUUID,
-		}
-		if blk1.ParentDeviceName != "" {
-			blk1Flattened.Parents = []string{blk1.ParentDeviceName}
-		}
-		all[blk1Flattened.Name] = blk1Flattened
-
-		// 2nd gen children
-		for _, blk2 := range blk1.Children {
-			parentDev := all[blk1Flattened.Name]
-			parentDev.Children = append(parentDev.Children, blk2.Name)
-			all[blk1Flattened.Name] = parentDev
-
-			// now flatten the child as its own entry
-			// but multiple children may share the same parent
-			blk2Flattened := FlattenedBlockDevice{
-				Name:       blk2.Name,
-				Type:       blk2.Type,
-				Size:       blk2.Size.Uint64,
-				Rota:       blk2.Rota.Bool,
-				Serial:     blk2.Serial,
-				WWN:        blk2.WWN,
-				Vendor:     blk2.Vendor,
-				Model:      blk2.Model,
-				Rev:        blk2.Rev,
-				MountPoint: blk2.MountPoint,
-				FSType:     blk2.FSType,
-				PartUUID:   blk2.PartUUID,
-				Parents:    []string{blk1Flattened.Name},
-			}
-			if prev, ok := all[blk2Flattened.Name]; ok {
-				prev.Parents = append(prev.Parents, blk2Flattened.Parents...)
-				all[blk2Flattened.Name] = prev
-			} else {
-				all[blk2Flattened.Name] = blk2Flattened
-			}
-
-			// track up to 3rd gen children
-			for _, blk3 := range blk2.Children {
-				parentDev := all[blk2Flattened.Name]
-				parentDev.Children = append(parentDev.Children, blk3.Name)
-				all[blk2Flattened.Name] = parentDev
-
-				// now flatten the child as its own entry
-				// but multiple children may share the same parent
-				blk3Flattened := FlattenedBlockDevice{
-					Name:       blk3.Name,
-					Type:       blk3.Type,
-					Size:       blk3.Size.Uint64,
-					Rota:       blk3.Rota.Bool,
-					Serial:     blk3.Serial,
-					WWN:        blk3.WWN,
-					Vendor:     blk3.Vendor,
-					Model:      blk3.Model,
-					Rev:        blk3.Rev,
-					MountPoint: blk3.MountPoint,
-					FSType:     blk3.FSType,
-					PartUUID:   blk3.PartUUID,
-					Parents:    []string{blk2Flattened.Name},
-				}
-				if prev, ok := all[blk3Flattened.Name]; ok {
-					prev.Parents = append(prev.Parents, blk3Flattened.Parents...)
-					all[blk3Flattened.Name] = prev
-				} else {
-					all[blk3Flattened.Name] = blk3Flattened
-				}
-			}
-		}
+		flattenBlockDevice(blk1, "", 0, all)
 	}
 
 	flattened := make(FlattenedBlockDevices, 0, len(all))
@@ -126,6 +47,58 @@ func (blks BlockDevices) Flatten() FlattenedBlockDevices {
 		return flattened[i].Name < flattened[j].Name
 	})
 	return flattened
+}
+
+// flattenBlockDevice recursively processes a block device and its children
+// up to maxDepth (2 levels deep), adding them to the all map.
+func flattenBlockDevice(blk BlockDevice, parentName string, depth int, all map[string]FlattenedBlockDevice) {
+	// Flatten the current device
+	flattened := FlattenedBlockDevice{
+		Name:       blk.Name,
+		Type:       blk.Type,
+		Size:       blk.Size.Uint64,
+		Rota:       blk.Rota.Bool,
+		Serial:     blk.Serial,
+		WWN:        blk.WWN,
+		Vendor:     blk.Vendor,
+		Model:      blk.Model,
+		Rev:        blk.Rev,
+		MountPoint: blk.MountPoint,
+		FSType:     blk.FSType,
+		PartUUID:   blk.PartUUID,
+	}
+
+	// Add parent from function parameter
+	if parentName != "" {
+		flattened.Parents = []string{parentName}
+	} else if blk.ParentDeviceName != "" {
+		// For top-level devices that might have a parent
+		flattened.Parents = []string{blk.ParentDeviceName}
+	}
+
+	// Update or add the device to the map
+	if prev, ok := all[flattened.Name]; ok {
+		// If device already exists, merge parents
+		if len(flattened.Parents) > 0 {
+			prev.Parents = append(prev.Parents, flattened.Parents...)
+		}
+		all[flattened.Name] = prev
+	} else {
+		all[flattened.Name] = flattened
+	}
+
+	// Process children if we haven't reached max depth (2)
+	if depth < 2 {
+		for _, child := range blk.Children {
+			// Update parent's children list
+			parentDev := all[flattened.Name]
+			parentDev.Children = append(parentDev.Children, child.Name)
+			all[flattened.Name] = parentDev
+
+			// Recursively process the child
+			flattenBlockDevice(child, flattened.Name, depth+1, all)
+		}
+	}
 }
 
 func (blks FlattenedBlockDevices) RenderTable(wr io.Writer) {

--- a/pkg/disk/lsblk_flatten_test.go
+++ b/pkg/disk/lsblk_flatten_test.go
@@ -10,10 +10,11 @@ import (
 func TestParseFlatten(t *testing.T) {
 	t.Parallel()
 
-	for _, f := range []string{
-		// "lsblk.1.json",
-		// "lsblk.2.json",
-		"lsblk.3.json",
+	for f, expectedDevs := range map[string]int{
+		"lsblk.1.json": 23,
+		"lsblk.2.json": 10,
+		"lsblk.3.json": 20,
+		"lsblk.4.json": 39,
 	} {
 		dat, err := os.ReadFile("testdata/" + f)
 		require.NoError(t, err)
@@ -21,6 +22,9 @@ func TestParseFlatten(t *testing.T) {
 		blks, err := parseLsblkJSON(dat)
 		require.NoError(t, err)
 
-		blks.Flatten().RenderTable(os.Stdout)
+		flattened := blks.Flatten()
+		require.Equal(t, expectedDevs, len(flattened))
+
+		flattened.RenderTable(os.Stdout)
 	}
 }

--- a/pkg/disk/testdata/lsblk.4.json
+++ b/pkg/disk/testdata/lsblk.4.json
@@ -1,0 +1,546 @@
+{
+    "blockdevices": [
+        {
+            "name": "loop1",
+            "maj:min": "7:1",
+            "rm": false,
+            "size": "63.8M",
+            "ro": true,
+            "type": "loop",
+            "mountpoints": [
+                "/snap/core20/2501"
+            ]
+        },
+        {
+            "name": "loop2",
+            "maj:min": "7:2",
+            "rm": false,
+            "size": "87M",
+            "ro": true,
+            "type": "loop",
+            "mountpoints": [
+                "/snap/lxd/27037"
+            ]
+        },
+        {
+            "name": "loop3",
+            "maj:min": "7:3",
+            "rm": false,
+            "size": "89.4M",
+            "ro": true,
+            "type": "loop",
+            "mountpoints": [
+                "/snap/lxd/31333"
+            ]
+        },
+        {
+            "name": "loop4",
+            "maj:min": "7:4",
+            "rm": false,
+            "size": "40.4M",
+            "ro": true,
+            "type": "loop",
+            "mountpoints": [
+                "/snap/snapd/20671"
+            ]
+        },
+        {
+            "name": "loop5",
+            "maj:min": "7:5",
+            "rm": false,
+            "size": "50.9M",
+            "ro": true,
+            "type": "loop",
+            "mountpoints": [
+                "/snap/snapd/24505"
+            ]
+        },
+        {
+            "name": "loop6",
+            "maj:min": "7:6",
+            "rm": false,
+            "size": "2G",
+            "ro": false,
+            "type": "loop",
+            "mountpoints": [
+                "/opt/weka/logs"
+            ]
+        },
+        {
+            "name": "loop7",
+            "maj:min": "7:7",
+            "rm": false,
+            "size": "825.9M",
+            "ro": true,
+            "type": "loop",
+            "mountpoints": [
+                null
+            ]
+        },
+        {
+            "name": "loop8",
+            "maj:min": "7:8",
+            "rm": false,
+            "size": "232.8M",
+            "ro": true,
+            "type": "loop",
+            "mountpoints": [
+                null
+            ]
+        },
+        {
+            "name": "loop9",
+            "maj:min": "7:9",
+            "rm": false,
+            "size": "5.7M",
+            "ro": true,
+            "type": "loop",
+            "mountpoints": [
+                null
+            ]
+        },
+        {
+            "name": "loop10",
+            "maj:min": "7:10",
+            "rm": false,
+            "size": "1M",
+            "ro": true,
+            "type": "loop",
+            "mountpoints": [
+                null
+            ]
+        },
+        {
+            "name": "loop11",
+            "maj:min": "7:11",
+            "rm": false,
+            "size": "5.8M",
+            "ro": true,
+            "type": "loop",
+            "mountpoints": [
+                null
+            ]
+        },
+        {
+            "name": "loop12",
+            "maj:min": "7:12",
+            "rm": false,
+            "size": "15.8M",
+            "ro": true,
+            "type": "loop",
+            "mountpoints": [
+                null
+            ]
+        },
+        {
+            "name": "loop13",
+            "maj:min": "7:13",
+            "rm": false,
+            "size": "18.4M",
+            "ro": true,
+            "type": "loop",
+            "mountpoints": [
+                null
+            ]
+        },
+        {
+            "name": "loop14",
+            "maj:min": "7:14",
+            "rm": false,
+            "size": "110M",
+            "ro": true,
+            "type": "loop",
+            "mountpoints": [
+                null
+            ]
+        },
+        {
+            "name": "loop15",
+            "maj:min": "7:15",
+            "rm": false,
+            "size": "1000M",
+            "ro": false,
+            "type": "loop",
+            "mountpoints": [
+                null
+            ]
+        },
+        {
+            "name": "loop16",
+            "maj:min": "7:16",
+            "rm": false,
+            "size": "63.8M",
+            "ro": true,
+            "type": "loop",
+            "mountpoints": [
+                "/snap/core20/2571"
+            ]
+        },
+        {
+            "name": "sda",
+            "maj:min": "8:0",
+            "rm": false,
+            "size": "1.7T",
+            "ro": false,
+            "type": "disk",
+            "mountpoints": [
+                null
+            ],
+            "children": [
+                {
+                    "name": "sda1",
+                    "maj:min": "8:1",
+                    "rm": false,
+                    "size": "1G",
+                    "ro": false,
+                    "type": "part",
+                    "mountpoints": [
+                        "/boot/efi"
+                    ]
+                },
+                {
+                    "name": "sda2",
+                    "maj:min": "8:2",
+                    "rm": false,
+                    "size": "2G",
+                    "ro": false,
+                    "type": "part",
+                    "mountpoints": [
+                        "/boot"
+                    ]
+                },
+                {
+                    "name": "sda3",
+                    "maj:min": "8:3",
+                    "rm": false,
+                    "size": "1.7T",
+                    "ro": false,
+                    "type": "part",
+                    "mountpoints": [
+                        null
+                    ],
+                    "children": [
+                        {
+                            "name": "ubuntu--vg-ubuntu--lv",
+                            "maj:min": "253:0",
+                            "rm": false,
+                            "size": "100G",
+                            "ro": false,
+                            "type": "lvm",
+                            "mountpoints": [
+                                "/"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "sdb",
+            "maj:min": "8:16",
+            "rm": true,
+            "size": "0B",
+            "ro": false,
+            "type": "disk",
+            "mountpoints": [
+                null
+            ]
+        },
+        {
+            "name": "nvme0n1",
+            "maj:min": "259:1",
+            "rm": false,
+            "size": "7T",
+            "ro": false,
+            "type": "disk",
+            "mountpoints": [
+                null
+            ],
+            "children": [
+                {
+                    "name": "nvme0n1p1",
+                    "maj:min": "259:2",
+                    "rm": false,
+                    "size": "7T",
+                    "ro": false,
+                    "type": "part",
+                    "mountpoints": [
+                        null
+                    ],
+                    "children": [
+                        {
+                            "name": "md0",
+                            "maj:min": "9:0",
+                            "rm": false,
+                            "size": "55.9T",
+                            "ro": false,
+                            "type": "raid0",
+                            "mountpoints": [
+                                "/raid"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "nvme1n1",
+            "maj:min": "259:4",
+            "rm": false,
+            "size": "7T",
+            "ro": false,
+            "type": "disk",
+            "mountpoints": [
+                null
+            ],
+            "children": [
+                {
+                    "name": "nvme1n1p1",
+                    "maj:min": "259:5",
+                    "rm": false,
+                    "size": "7T",
+                    "ro": false,
+                    "type": "part",
+                    "mountpoints": [
+                        null
+                    ],
+                    "children": [
+                        {
+                            "name": "md0",
+                            "maj:min": "9:0",
+                            "rm": false,
+                            "size": "55.9T",
+                            "ro": false,
+                            "type": "raid0",
+                            "mountpoints": [
+                                "/raid"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "nvme2n1",
+            "maj:min": "259:8",
+            "rm": false,
+            "size": "7T",
+            "ro": false,
+            "type": "disk",
+            "mountpoints": [
+                null
+            ],
+            "children": [
+                {
+                    "name": "nvme2n1p1",
+                    "maj:min": "259:11",
+                    "rm": false,
+                    "size": "7T",
+                    "ro": false,
+                    "type": "part",
+                    "mountpoints": [
+                        null
+                    ],
+                    "children": [
+                        {
+                            "name": "md0",
+                            "maj:min": "9:0",
+                            "rm": false,
+                            "size": "55.9T",
+                            "ro": false,
+                            "type": "raid0",
+                            "mountpoints": [
+                                "/raid"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "nvme3n1",
+            "maj:min": "259:9",
+            "rm": false,
+            "size": "7T",
+            "ro": false,
+            "type": "disk",
+            "mountpoints": [
+                null
+            ],
+            "children": [
+                {
+                    "name": "nvme3n1p1",
+                    "maj:min": "259:10",
+                    "rm": false,
+                    "size": "7T",
+                    "ro": false,
+                    "type": "part",
+                    "mountpoints": [
+                        null
+                    ],
+                    "children": [
+                        {
+                            "name": "md0",
+                            "maj:min": "9:0",
+                            "rm": false,
+                            "size": "55.9T",
+                            "ro": false,
+                            "type": "raid0",
+                            "mountpoints": [
+                                "/raid"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "nvme4n1",
+            "maj:min": "259:13",
+            "rm": false,
+            "size": "7T",
+            "ro": false,
+            "type": "disk",
+            "mountpoints": [
+                null
+            ],
+            "children": [
+                {
+                    "name": "nvme4n1p1",
+                    "maj:min": "259:14",
+                    "rm": false,
+                    "size": "7T",
+                    "ro": false,
+                    "type": "part",
+                    "mountpoints": [
+                        null
+                    ],
+                    "children": [
+                        {
+                            "name": "md0",
+                            "maj:min": "9:0",
+                            "rm": false,
+                            "size": "55.9T",
+                            "ro": false,
+                            "type": "raid0",
+                            "mountpoints": [
+                                "/raid"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "nvme5n1",
+            "maj:min": "259:16",
+            "rm": false,
+            "size": "7T",
+            "ro": false,
+            "type": "disk",
+            "mountpoints": [
+                null
+            ],
+            "children": [
+                {
+                    "name": "nvme5n1p1",
+                    "maj:min": "259:17",
+                    "rm": false,
+                    "size": "7T",
+                    "ro": false,
+                    "type": "part",
+                    "mountpoints": [
+                        null
+                    ],
+                    "children": [
+                        {
+                            "name": "md0",
+                            "maj:min": "9:0",
+                            "rm": false,
+                            "size": "55.9T",
+                            "ro": false,
+                            "type": "raid0",
+                            "mountpoints": [
+                                "/raid"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "nvme6n1",
+            "maj:min": "259:19",
+            "rm": false,
+            "size": "7T",
+            "ro": false,
+            "type": "disk",
+            "mountpoints": [
+                null
+            ],
+            "children": [
+                {
+                    "name": "nvme6n1p1",
+                    "maj:min": "259:20",
+                    "rm": false,
+                    "size": "7T",
+                    "ro": false,
+                    "type": "part",
+                    "mountpoints": [
+                        null
+                    ],
+                    "children": [
+                        {
+                            "name": "md0",
+                            "maj:min": "9:0",
+                            "rm": false,
+                            "size": "55.9T",
+                            "ro": false,
+                            "type": "raid0",
+                            "mountpoints": [
+                                "/raid"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "nvme7n1",
+            "maj:min": "259:22",
+            "rm": false,
+            "size": "7T",
+            "ro": false,
+            "type": "disk",
+            "mountpoints": [
+                null
+            ],
+            "children": [
+                {
+                    "name": "nvme7n1p1",
+                    "maj:min": "259:23",
+                    "rm": false,
+                    "size": "7T",
+                    "ro": false,
+                    "type": "part",
+                    "mountpoints": [
+                        null
+                    ],
+                    "children": [
+                        {
+                            "name": "md0",
+                            "maj:min": "9:0",
+                            "rm": false,
+                            "size": "55.9T",
+                            "ro": false,
+                            "type": "raid0",
+                            "mountpoints": [
+                                "/raid"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
e.g.,

```
+-----------------------+-------+--------+--------+-------------+-----------+-----------------------+
|         NAME          | TYPE  | FSTYPE |  SIZE  | MOUNT POINT |  PARENTS  |       CHILDREN        |
+-----------------------+-------+--------+--------+-------------+-----------+-----------------------+
| loop1                 | loop  |        | 64 MB  |             |           |                       |
| loop10                | loop  |        | 1.0 MB |             |           |                       |
| loop11                | loop  |        | 5.8 MB |             |           |                       |
| loop12                | loop  |        | 16 MB  |             |           |                       |
| loop13                | loop  |        | 18 MB  |             |           |                       |
| loop14                | loop  |        | 110 MB |             |           |                       |
| loop15                | loop  |        | 1.0 GB |             |           |                       |
| loop16                | loop  |        | 64 MB  |             |           |                       |
| loop2                 | loop  |        | 87 MB  |             |           |                       |
| loop3                 | loop  |        | 89 MB  |             |           |                       |
| loop4                 | loop  |        | 40 MB  |             |           |                       |
| loop5                 | loop  |        | 51 MB  |             |           |                       |
| loop6                 | loop  |        | 2.0 GB |             |           |                       |
| loop7                 | loop  |        | 826 MB |             |           |                       |
| loop8                 | loop  |        | 233 MB |             |           |                       |
| loop9                 | loop  |        | 5.7 MB |             |           |                       |
| md0                   | raid0 |        | 56 TB  |             | nvme0n1p1 |                       |
|                       |       |        |        |             | nvme1n1p1 |                       |
|                       |       |        |        |             | nvme2n1p1 |                       |
|                       |       |        |        |             | nvme3n1p1 |                       |
|                       |       |        |        |             | nvme4n1p1 |                       |
|                       |       |        |        |             | nvme5n1p1 |                       |
|                       |       |        |        |             | nvme6n1p1 |                       |
|                       |       |        |        |             | nvme7n1p1 |                       |
| nvme0n1               | disk  |        | 7.0 TB |             |           | nvme0n1p1             |
| nvme0n1p1             | part  |        | 7.0 TB |             | nvme0n1   | md0                   |
| nvme1n1               | disk  |        | 7.0 TB |             |           | nvme1n1p1             |
| nvme1n1p1             | part  |        | 7.0 TB |             | nvme1n1   | md0                   |
| nvme2n1               | disk  |        | 7.0 TB |             |           | nvme2n1p1             |
| nvme2n1p1             | part  |        | 7.0 TB |             | nvme2n1   | md0                   |
| nvme3n1               | disk  |        | 7.0 TB |             |           | nvme3n1p1             |
| nvme3n1p1             | part  |        | 7.0 TB |             | nvme3n1   | md0                   |
| nvme4n1               | disk  |        | 7.0 TB |             |           | nvme4n1p1             |
| nvme4n1p1             | part  |        | 7.0 TB |             | nvme4n1   | md0                   |
| nvme5n1               | disk  |        | 7.0 TB |             |           | nvme5n1p1             |
| nvme5n1p1             | part  |        | 7.0 TB |             | nvme5n1   | md0                   |
| nvme6n1               | disk  |        | 7.0 TB |             |           | nvme6n1p1             |
| nvme6n1p1             | part  |        | 7.0 TB |             | nvme6n1   | md0                   |
| nvme7n1               | disk  |        | 7.0 TB |             |           | nvme7n1p1             |
| nvme7n1p1             | part  |        | 7.0 TB |             | nvme7n1   | md0                   |
| sda                   | disk  |        | 1.7 TB |             |           | sda1                  |
|                       |       |        |        |             |           | sda2                  |
|                       |       |        |        |             |           | sda3                  |
| sda1                  | part  |        | 1.0 GB |             | sda       |                       |
| sda2                  | part  |        | 2.0 GB |             | sda       |                       |
| sda3                  | part  |        | 1.7 TB |             | sda       | ubuntu--vg-ubuntu--lv |
| sdb                   | disk  |        | 0 B    |             |           |                       |
| ubuntu--vg-ubuntu--lv | lvm   |        | 100 GB |             | sda3      |                       |
+-----------------------+-------+--------+--------+-------------+-----------+-----------------------
```

Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
