### PR TITLE
feat(components): add "IsSupported" method to skip GPU components in CPU machines

### DIFF
--- a/components/accelerator/nvidia/bad-envs/component.go
+++ b/components/accelerator/nvidia/bad-envs/component.go
@@ -70,6 +70,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/clock-speed/component.go
+++ b/components/accelerator/nvidia/clock-speed/component.go
@@ -67,6 +67,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/ecc/component.go
+++ b/components/accelerator/nvidia/ecc/component.go
@@ -69,6 +69,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/fabric-manager/component.go
+++ b/components/accelerator/nvidia/fabric-manager/component.go
@@ -93,6 +93,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/gpm/component.go
+++ b/components/accelerator/nvidia/gpm/component.go
@@ -112,6 +112,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/gsp-firmware-mode/component.go
+++ b/components/accelerator/nvidia/gsp-firmware-mode/component.go
@@ -65,6 +65,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/hw-slowdown/component.go
+++ b/components/accelerator/nvidia/hw-slowdown/component.go
@@ -112,6 +112,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/infiniband/component.go
+++ b/components/accelerator/nvidia/infiniband/component.go
@@ -100,6 +100,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/info/component.go
+++ b/components/accelerator/nvidia/info/component.go
@@ -74,6 +74,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/memory/component.go
+++ b/components/accelerator/nvidia/memory/component.go
@@ -67,6 +67,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/nccl/component.go
+++ b/components/accelerator/nvidia/nccl/component.go
@@ -78,6 +78,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	return apiv1.HealthStates{
 		{

--- a/components/accelerator/nvidia/nvlink/component.go
+++ b/components/accelerator/nvidia/nvlink/component.go
@@ -67,6 +67,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/peermem/component.go
+++ b/components/accelerator/nvidia/peermem/component.go
@@ -92,6 +92,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/persistence-mode/component.go
+++ b/components/accelerator/nvidia/persistence-mode/component.go
@@ -65,6 +65,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/power/component.go
+++ b/components/accelerator/nvidia/power/component.go
@@ -67,6 +67,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/processes/component.go
+++ b/components/accelerator/nvidia/processes/component.go
@@ -67,6 +67,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/remapped-rows/component.go
+++ b/components/accelerator/nvidia/remapped-rows/component.go
@@ -84,6 +84,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/sxid/component.go
+++ b/components/accelerator/nvidia/sxid/component.go
@@ -132,6 +132,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/components/accelerator/nvidia/temperature/component.go
+++ b/components/accelerator/nvidia/temperature/component.go
@@ -68,6 +68,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/temperature/component_test.go
+++ b/components/accelerator/nvidia/temperature/component_test.go
@@ -23,11 +23,22 @@ import (
 
 // mockNVMLInstance is a simple mock implementation of nvidianvml.Instance
 type mockNVMLInstance struct {
-	devices map[string]device.Device
+	devices  map[string]device.Device
+	exists   bool
+	prodName string
+}
+
+// NewMockNVMLInstance creates a new mockNVMLInstance with default settings
+func NewMockNVMLInstance(devices map[string]device.Device) *mockNVMLInstance {
+	return &mockNVMLInstance{
+		devices:  devices,
+		exists:   true,       // default to true
+		prodName: "Test GPU", // default to non-empty
+	}
 }
 
 func (m *mockNVMLInstance) NVMLExists() bool {
-	return true
+	return m.exists
 }
 
 func (m *mockNVMLInstance) Library() nvml_lib.Library {
@@ -40,7 +51,7 @@ func (m *mockNVMLInstance) Devices() map[string]device.Device {
 }
 
 func (m *mockNVMLInstance) ProductName() string {
-	return "Test GPU"
+	return m.prodName
 }
 
 func (m *mockNVMLInstance) Architecture() string {
@@ -97,7 +108,11 @@ func MockTemperatureComponent(
 
 func TestNew(t *testing.T) {
 	ctx := context.Background()
-	mockNVML := &mockNVMLInstance{devices: map[string]device.Device{}}
+	mockNVML := &mockNVMLInstance{
+		devices:  map[string]device.Device{},
+		exists:   true,
+		prodName: "Test GPU",
+	}
 
 	// Create a GPUdInstance with the mock NVML
 	gpudInstance := &components.GPUdInstance{
@@ -123,7 +138,11 @@ func TestNew(t *testing.T) {
 
 func TestName(t *testing.T) {
 	ctx := context.Background()
-	mockNVML := &mockNVMLInstance{devices: map[string]device.Device{}}
+	mockNVML := &mockNVMLInstance{
+		devices:  map[string]device.Device{},
+		exists:   true,
+		prodName: "Test GPU",
+	}
 	c := MockTemperatureComponent(ctx, mockNVML, nil)
 	assert.Equal(t, Name, c.Name(), "Component name should match")
 }
@@ -143,7 +162,11 @@ func TestCheck_Success(t *testing.T) {
 		uuid: mockDev,
 	}
 
-	mockNVML := &mockNVMLInstance{devices: devs}
+	mockNVML := &mockNVMLInstance{
+		devices:  devs,
+		exists:   true,
+		prodName: "Test GPU",
+	}
 
 	temperature := nvidianvml.Temperature{
 		UUID:                     uuid,
@@ -191,7 +214,11 @@ func TestCheck_TemperatureError(t *testing.T) {
 		uuid: mockDev,
 	}
 
-	mockNVML := &mockNVMLInstance{devices: devs}
+	mockNVML := &mockNVMLInstance{
+		devices:  devs,
+		exists:   true,
+		prodName: "Test GPU",
+	}
 
 	errExpected := errors.New("temperature error")
 	getTemperatureFunc := func(uuid string, dev device.Device) (nvidianvml.Temperature, error) {
@@ -214,7 +241,11 @@ func TestCheck_TemperatureError(t *testing.T) {
 func TestCheck_NoDevices(t *testing.T) {
 	ctx := context.Background()
 
-	mockNVML := &mockNVMLInstance{devices: map[string]device.Device{}}
+	mockNVML := &mockNVMLInstance{
+		devices:  map[string]device.Device{},
+		exists:   true,
+		prodName: "Test GPU",
+	}
 
 	component := MockTemperatureComponent(ctx, mockNVML, nil).(*component)
 	result := component.Check()
@@ -244,7 +275,11 @@ func TestCheck_GetUsedPercentSlowdownError(t *testing.T) {
 		uuid: mockDev,
 	}
 
-	mockNVML := &mockNVMLInstance{devices: devs}
+	mockNVML := &mockNVMLInstance{
+		devices:  devs,
+		exists:   true,
+		prodName: "Test GPU",
+	}
 
 	// Create temperature data with invalid UsedPercentSlowdown format
 	invalidTemperature := nvidianvml.Temperature{
@@ -279,7 +314,11 @@ func TestCheck_GetUsedPercentSlowdownError(t *testing.T) {
 
 func TestLastHealthStates_WithData(t *testing.T) {
 	ctx := context.Background()
-	mockNVML := &mockNVMLInstance{devices: map[string]device.Device{}}
+	mockNVML := &mockNVMLInstance{
+		devices:  map[string]device.Device{},
+		exists:   true,
+		prodName: "Test GPU",
+	}
 	component := MockTemperatureComponent(ctx, mockNVML, nil).(*component)
 
 	// Set test data
@@ -317,7 +356,11 @@ func TestLastHealthStates_WithData(t *testing.T) {
 
 func TestLastHealthStates_WithError(t *testing.T) {
 	ctx := context.Background()
-	mockNVML := &mockNVMLInstance{devices: map[string]device.Device{}}
+	mockNVML := &mockNVMLInstance{
+		devices:  map[string]device.Device{},
+		exists:   true,
+		prodName: "Test GPU",
+	}
 	component := MockTemperatureComponent(ctx, mockNVML, nil).(*component)
 
 	// Set test data with error
@@ -342,7 +385,11 @@ func TestLastHealthStates_WithError(t *testing.T) {
 
 func TestLastHealthStates_NoData(t *testing.T) {
 	ctx := context.Background()
-	mockNVML := &mockNVMLInstance{devices: map[string]device.Device{}}
+	mockNVML := &mockNVMLInstance{
+		devices:  map[string]device.Device{},
+		exists:   true,
+		prodName: "Test GPU",
+	}
 	component := MockTemperatureComponent(ctx, mockNVML, nil).(*component)
 
 	// Don't set any data
@@ -359,7 +406,11 @@ func TestLastHealthStates_NoData(t *testing.T) {
 
 func TestEvents(t *testing.T) {
 	ctx := context.Background()
-	mockNVML := &mockNVMLInstance{devices: map[string]device.Device{}}
+	mockNVML := &mockNVMLInstance{
+		devices:  map[string]device.Device{},
+		exists:   true,
+		prodName: "Test GPU",
+	}
 	component := MockTemperatureComponent(ctx, mockNVML, nil)
 
 	events, err := component.Events(ctx, time.Now())
@@ -384,7 +435,11 @@ func TestStart(t *testing.T) {
 	}
 
 	callCount := &atomic.Int32{}
-	mockNVML := &mockNVMLInstance{devices: devs}
+	mockNVML := &mockNVMLInstance{
+		devices:  devs,
+		exists:   true,
+		prodName: "Test GPU",
+	}
 
 	getTemperatureFunc := func(uuid string, dev device.Device) (nvidianvml.Temperature, error) {
 		callCount.Add(1)
@@ -407,7 +462,11 @@ func TestStart(t *testing.T) {
 
 func TestClose(t *testing.T) {
 	ctx := context.Background()
-	mockNVML := &mockNVMLInstance{devices: map[string]device.Device{}}
+	mockNVML := &mockNVMLInstance{
+		devices:  map[string]device.Device{},
+		exists:   true,
+		prodName: "Test GPU",
+	}
 	component := MockTemperatureComponent(ctx, mockNVML, nil).(*component)
 
 	err := component.Close()
@@ -512,7 +571,11 @@ func TestCheck_MemoryTemperatureThreshold(t *testing.T) {
 				uuid: mockDev,
 			}
 
-			mockNVML := &mockNVMLInstance{devices: devs}
+			mockNVML := &mockNVMLInstance{
+				devices:  devs,
+				exists:   true,
+				prodName: "Test GPU",
+			}
 
 			temperature := nvidianvml.Temperature{
 				UUID:                     uuid,
@@ -544,4 +607,42 @@ func TestCheck_MemoryTemperatureThreshold(t *testing.T) {
 			assert.Len(t, data.Temperatures, 1)
 		})
 	}
+}
+
+func TestIsSupported(t *testing.T) {
+	ctx := context.Background()
+	cctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Test with nil NVML instance
+	comp := &component{
+		ctx:          cctx,
+		cancel:       cancel,
+		nvmlInstance: nil, // Explicitly nil
+	}
+	assert.False(t, comp.IsSupported())
+
+	// Test with NVML instance that doesn't exist
+	mockNVML := &mockNVMLInstance{
+		exists:   false,
+		prodName: "Tesla V100",
+	}
+	comp.nvmlInstance = mockNVML
+	assert.False(t, comp.IsSupported())
+
+	// Test with NVML that exists but has empty product name
+	mockNVML = &mockNVMLInstance{
+		exists:   true,
+		prodName: "",
+	}
+	comp.nvmlInstance = mockNVML
+	assert.False(t, comp.IsSupported())
+
+	// Test with NVML that exists and has a product name
+	mockNVML = &mockNVMLInstance{
+		exists:   true,
+		prodName: "Tesla V100",
+	}
+	comp.nvmlInstance = mockNVML
+	assert.True(t, comp.IsSupported())
 }

--- a/components/accelerator/nvidia/utilization/component.go
+++ b/components/accelerator/nvidia/utilization/component.go
@@ -67,6 +67,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/accelerator/nvidia/xid/component.go
+++ b/components/accelerator/nvidia/xid/component.go
@@ -132,6 +132,13 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	if c.nvmlInstance == nil {
+		return false
+	}
+	return c.nvmlInstance.NVMLExists() && c.nvmlInstance.ProductName() != ""
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/components/containerd/pod/component.go
+++ b/components/containerd/pod/component.go
@@ -79,6 +79,10 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/cpu/component.go
+++ b/components/cpu/component.go
@@ -103,6 +103,10 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/disk/component.go
+++ b/components/disk/component.go
@@ -108,6 +108,10 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/docker/container/component.go
+++ b/components/docker/container/component.go
@@ -79,6 +79,10 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/fd/component.go
+++ b/components/fd/component.go
@@ -124,6 +124,10 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/fuse/component.go
+++ b/components/fuse/component.go
@@ -100,6 +100,10 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/info/component.go
+++ b/components/info/component.go
@@ -78,6 +78,10 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/kernel-module/component.go
+++ b/components/kernel-module/component.go
@@ -65,6 +65,10 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/kubelet/pod/component.go
+++ b/components/kubelet/pod/component.go
@@ -81,6 +81,10 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/library/component.go
+++ b/components/library/component.go
@@ -121,6 +121,10 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/memory/component.go
+++ b/components/memory/component.go
@@ -93,6 +93,10 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/network/latency/component.go
+++ b/components/network/latency/component.go
@@ -79,6 +79,10 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/os/component.go
+++ b/components/os/component.go
@@ -71,6 +71,10 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/pci/component.go
+++ b/components/pci/component.go
@@ -99,6 +99,10 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/registry_test.go
+++ b/components/registry_test.go
@@ -30,6 +30,10 @@ func (m *mockComponent) Start() error {
 	return nil
 }
 
+func (m *mockComponent) IsSupported() bool {
+	return true
+}
+
 func (m *mockComponent) Check() CheckResult {
 	return &mockCheckResult{}
 }

--- a/components/tailscale/component.go
+++ b/components/tailscale/component.go
@@ -65,6 +65,10 @@ func (c *component) Start() error {
 	return nil
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/components/types.go
+++ b/components/types.go
@@ -27,6 +27,11 @@ type Component interface {
 	// Implements component-specific poller start logic.
 	Start() error
 
+	// IsSupported returns true if the component is supported on the current machine.
+	// For example, this returns "false" if a component requires NVIDIA GPUs,
+	// but the machine does not have NVIDIA GPUs.
+	IsSupported() bool
+
 	// Check triggers the component check once, and returns the latest health check result.
 	// This is used for one-time checks, such as "gpud scan".
 	// It is up to the component to decide the check timeouts.

--- a/pkg/custom-plugins/component.go
+++ b/pkg/custom-plugins/component.go
@@ -197,6 +197,10 @@ func (c *component) Check() components.CheckResult {
 	return cr
 }
 
+func (c *component) IsSupported() bool {
+	return true
+}
+
 func (c *component) LastHealthStates() apiv1.HealthStates {
 	c.lastMu.RLock()
 	lastCheckResult := c.lastCheckResult

--- a/pkg/custom-plugins/component_test.go
+++ b/pkg/custom-plugins/component_test.go
@@ -37,6 +37,7 @@ func TestNewInitFunc(t *testing.T) {
 	comp, err := initFunc(gpudInstance)
 	assert.NoError(t, err)
 	assert.NotNil(t, comp)
+	assert.True(t, comp.IsSupported())
 
 	customPluginRegisteree, ok := comp.(CustomPluginRegisteree)
 	assert.True(t, ok)

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -157,6 +157,9 @@ func Scan(ctx context.Context, opts ...OpOption) error {
 		if err != nil {
 			return err
 		}
+		if !c.IsSupported() {
+			continue
+		}
 		printSummary(c.Check())
 	}
 

--- a/pkg/server/handlers_components.go
+++ b/pkg/server/handlers_components.go
@@ -305,8 +305,9 @@ func (g *globalHandler) getHealthStates(c *gin.Context) {
 		currState := apiv1.ComponentHealthStates{
 			Component: componentName,
 		}
-		component := g.componentsRegistry.Get(componentName)
-		if component == nil {
+
+		comp := g.componentsRegistry.Get(componentName)
+		if comp == nil {
 			log.Logger.Errorw("failed to get component",
 				"operation", "GetStates",
 				"component", componentName,
@@ -315,9 +316,13 @@ func (g *globalHandler) getHealthStates(c *gin.Context) {
 			states = append(states, currState)
 			continue
 		}
+		if !comp.IsSupported() {
+			log.Logger.Debugw("component not supported", "component", componentName)
+			continue
+		}
 
 		log.Logger.Debugw("getting states", "component", componentName)
-		state := component.LastHealthStates()
+		state := comp.LastHealthStates()
 
 		log.Logger.Debugw("successfully got states", "component", componentName)
 		currState.States = state
@@ -380,8 +385,9 @@ func (g *globalHandler) getEvents(c *gin.Context) {
 			StartTime: startTime,
 			EndTime:   endTime,
 		}
-		component := g.componentsRegistry.Get(componentName)
-		if component == nil {
+
+		comp := g.componentsRegistry.Get(componentName)
+		if comp == nil {
 			log.Logger.Errorw("failed to get component",
 				"operation", "GetEvents",
 				"component", componentName,
@@ -390,7 +396,12 @@ func (g *globalHandler) getEvents(c *gin.Context) {
 			events = append(events, currEvent)
 			continue
 		}
-		event, err := component.Events(c, startTime)
+		if !comp.IsSupported() {
+			log.Logger.Debugw("component not supported", "component", componentName)
+			continue
+		}
+
+		event, err := comp.Events(c, startTime)
 		if err != nil {
 			log.Logger.Errorw("failed to invoke component events",
 				"operation", "GetEvents",
@@ -496,8 +507,9 @@ func (g *globalHandler) getInfo(c *gin.Context) {
 			EndTime:   endTime,
 			Info:      apiv1.Info{},
 		}
-		component := g.componentsRegistry.Get(componentName)
-		if component == nil {
+
+		comp := g.componentsRegistry.Get(componentName)
+		if comp == nil {
 			log.Logger.Errorw("failed to get component",
 				"operation", "GetInfo",
 				"component", componentName,
@@ -506,7 +518,12 @@ func (g *globalHandler) getInfo(c *gin.Context) {
 			infos = append(infos, currInfo)
 			continue
 		}
-		events, err := component.Events(c, startTime)
+		if !comp.IsSupported() {
+			log.Logger.Debugw("component not supported", "component", componentName)
+			continue
+		}
+
+		events, err := comp.Events(c, startTime)
 		if err != nil {
 			log.Logger.Errorw("failed to invoke component events",
 				"operation", "GetInfo",
@@ -517,7 +534,7 @@ func (g *globalHandler) getInfo(c *gin.Context) {
 			currInfo.Info.Events = events
 		}
 
-		state := component.LastHealthStates()
+		state := comp.LastHealthStates()
 		currInfo.Info.States = state
 
 		currInfo.Info.Metrics = componentsToMetrics[componentName]


### PR DESCRIPTION
If GPUd runs on CPU-only machines, we shouldn't report nvidia/accelerator components.