### PR TITLE
feat(machine-info): GPU count fallback to pci device list if nvml/nvidia driver has not been loaded

### DIFF
--- a/pkg/nvidia-query/detect_test.go
+++ b/pkg/nvidia-query/detect_test.go
@@ -1,0 +1,20 @@
+package query
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_listNVIDIAPCIs(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	command := "cat ./testdata/lspci.gb200"
+	lines, err := listNVIDIAPCIs(ctx, command)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(lines))
+	require.Contains(t, lines[0], "NVIDIA")
+}

--- a/pkg/nvidia-query/testdata/lspci.gb200
+++ b/pkg/nvidia-query/testdata/lspci.gb200
@@ -1,0 +1,87 @@
+0000:00:00.0 PCI bridge: NVIDIA Corporation Device 22b2
+0000:01:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0000:02:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0000:02:01.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0000:03:00.0 Infiniband controller: Mellanox Technologies MT2910 Family [ConnectX-7]
+0000:04:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0000:05:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0000:05:08.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0002:00:00.0 PCI bridge: NVIDIA Corporation Device 22b2
+0002:01:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0002:02:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0002:02:01.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0002:03:00.0 Infiniband controller: Mellanox Technologies MT2910 Family [ConnectX-7]
+0002:04:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0002:05:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0002:05:08.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0005:00:00.0 PCI bridge: NVIDIA Corporation Device 22b8
+0005:01:00.0 PCI bridge: Pericom Semiconductor Device c008 (rev 0f)
+0005:02:01.0 PCI bridge: Pericom Semiconductor Device c008 (rev 06)
+0005:02:02.0 PCI bridge: Pericom Semiconductor Device c008 (rev 06)
+0005:02:03.0 PCI bridge: Pericom Semiconductor Device c008 (rev 06)
+0005:02:04.0 PCI bridge: Pericom Semiconductor Device c008 (rev 06)
+0005:02:05.0 PCI bridge: Pericom Semiconductor Device c008 (rev 06)
+0005:02:06.0 PCI bridge: Pericom Semiconductor Device c008 (rev 06)
+0005:02:07.0 PCI bridge: Pericom Semiconductor Device c008 (rev 06)
+0005:06:00.0 PCI bridge: ASPEED Technology, Inc. AST1150 PCI-to-PCI Bridge (rev 06)
+0005:07:00.0 VGA compatible controller: ASPEED Technology, Inc. ASPEED Graphics Family (rev 52)
+0005:08:00.0 USB controller: Renesas Technology Corp. uPD720201 USB 3.0 Host Controller (rev 03)
+0005:09:00.0 Ethernet controller: Intel Corporation I210 Gigabit Network Connection (rev 03)
+0006:00:00.0 PCI bridge: NVIDIA Corporation Device 22b2
+0006:01:00.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0006:02:00.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0006:02:02.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0006:03:00.0 Ethernet controller: Mellanox Technologies MT43244 BlueField-3 integrated ConnectX-7 network controller (rev 01)
+0006:03:00.1 Ethernet controller: Mellanox Technologies MT43244 BlueField-3 integrated ConnectX-7 network controller (rev 01)
+0006:03:00.2 DMA controller: Mellanox Technologies MT43244 BlueField-3 SoC Management Interface (rev 01)
+0006:04:00.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0006:05:00.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0006:05:04.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0006:05:08.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0006:05:0c.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0006:06:00.0 Non-Volatile memory controller: Samsung Electronics Co Ltd NVMe SSD Controller PM9A1/PM9A3/980PRO
+0006:07:00.0 Non-Volatile memory controller: Samsung Electronics Co Ltd NVMe SSD Controller PM9A1/PM9A3/980PRO
+0006:08:00.0 Non-Volatile memory controller: Samsung Electronics Co Ltd NVMe SSD Controller PM9A1/PM9A3/980PRO
+0006:09:00.0 Non-Volatile memory controller: Samsung Electronics Co Ltd NVMe SSD Controller PM9A1/PM9A3/980PRO
+0008:00:00.0 PCI bridge: NVIDIA Corporation Device 22b1
+0008:01:00.0 3D controller: NVIDIA Corporation Device 2941 (rev a1)
+0009:00:00.0 PCI bridge: NVIDIA Corporation Device 22b1
+0009:01:00.0 3D controller: NVIDIA Corporation Device 2941 (rev a1)
+0010:00:00.0 PCI bridge: NVIDIA Corporation Device 22b2
+0010:01:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0010:02:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0010:02:01.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0010:03:00.0 Infiniband controller: Mellanox Technologies MT2910 Family [ConnectX-7]
+0010:04:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0010:05:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0010:05:08.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0012:00:00.0 PCI bridge: NVIDIA Corporation Device 22b2
+0012:01:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0012:02:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0012:02:01.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0012:03:00.0 Infiniband controller: Mellanox Technologies MT2910 Family [ConnectX-7]
+0012:04:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0012:05:00.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0012:05:08.0 PCI bridge: Mellanox Technologies MT2910 Family [ConnectX-7 PCIe Bridge]
+0015:00:00.0 PCI bridge: NVIDIA Corporation Device 22b8
+0015:01:00.0 Non-Volatile memory controller: Samsung Electronics Co Ltd NVMe SSD Controller PM9A1/PM9A3/980PRO
+0016:00:00.0 PCI bridge: NVIDIA Corporation Device 22b2
+0016:01:00.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0016:02:00.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0016:02:02.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0016:03:00.0 Ethernet controller: Mellanox Technologies MT43244 BlueField-3 integrated ConnectX-7 network controller (rev 01)
+0016:03:00.1 Ethernet controller: Mellanox Technologies MT43244 BlueField-3 integrated ConnectX-7 network controller (rev 01)
+0016:03:00.2 DMA controller: Mellanox Technologies MT43244 BlueField-3 SoC Management Interface (rev 01)
+0016:04:00.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0016:05:00.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0016:05:04.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0016:05:08.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0016:05:0c.0 PCI bridge: Mellanox Technologies MT43244 Family [BlueField-3 SoC PCIe Bridge] (rev 01)
+0016:06:00.0 Non-Volatile memory controller: Samsung Electronics Co Ltd NVMe SSD Controller PM9A1/PM9A3/980PRO
+0016:07:00.0 Non-Volatile memory controller: Samsung Electronics Co Ltd NVMe SSD Controller PM9A1/PM9A3/980PRO
+0016:08:00.0 Non-Volatile memory controller: Samsung Electronics Co Ltd NVMe SSD Controller PM9A1/PM9A3/980PRO
+0016:09:00.0 Non-Volatile memory controller: Samsung Electronics Co Ltd NVMe SSD Controller PM9A1/PM9A3/980PRO
+0018:00:00.0 PCI bridge: NVIDIA Corporation Device 22b1
+0018:01:00.0 3D controller: NVIDIA Corporation Device 2941 (rev a1)
+0019:00:00.0 PCI bridge: NVIDIA Corporation Device 22b1
+0019:01:00.0 3D controller: NVIDIA Corporation Device 2941 (rev a1)


### PR DESCRIPTION
Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
