### PR TITLE
fix(goreleaser): use correct compiler triplet for Amazon Linux 2023

### DIFF
--- a/.goreleaser_linux_arm64_amzn2.yaml
+++ b/.goreleaser_linux_arm64_amzn2.yaml
@@ -7,7 +7,7 @@ builds:
     main: ./cmd/gpud
     env:
       - CGO_ENABLED=1
-      - CC=aarch64-linux-gnu-gcc
+      - CC=gcc
     flags:
       - -v
 

--- a/.goreleaser_linux_arm64_amzn2023.yaml
+++ b/.goreleaser_linux_arm64_amzn2023.yaml
@@ -7,7 +7,8 @@ builds:
     main: ./cmd/gpud
     env:
       - CGO_ENABLED=1
-      - CC=aarch64-linux-gnu-gcc
+      # ref. https://docs.aws.amazon.com/linux/al2023/ug/compare-with-al2.html#compiler-triplet
+      - CC=aarch64-amazon-linux-gcc
     flags:
       - -v
 


### PR DESCRIPTION
Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
