### PR TITLE
fix(session): health check with correct endpoint

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,6 +18,7 @@ import (
 	"net/http/pprof"
 	"net/url"
 	stdos "os"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -291,8 +292,12 @@ func New(ctx context.Context, config *lepconfig.Config, packageManager *gpudmana
 		return nil, fmt.Errorf("failed to read endpoint: %w", err)
 	}
 	s.epControlPlane = createURL(epControlPlane)
-	s.epLocalGPUdServer = fmt.Sprintf("https://%s", config.Address)
 
+	if strings.HasPrefix(config.Address, ":") { // e.g., ":12345"
+		s.epLocalGPUdServer = fmt.Sprintf("https://localhost%s", config.Address)
+	} else { // e.g., "0.0.0.0:12345"
+		s.epLocalGPUdServer = fmt.Sprintf("https://%s", config.Address)
+	}
 	userToken := &UserToken{}
 	go s.updateToken(ctx, metricsSQLiteStore, userToken)
 	go s.sendGossip(ctx, nvmlInstance, userToken)


### PR DESCRIPTION
Split from https://github.com/leptonai/gpud/pull/819.

> {"level":"info","ts":"2025-05-16T10:10:04Z","msg":"session keep alive: checking server health"}
{"level":"info","ts":"2025-05-16T10:10:04Z","msg":"/healthz","status":200,"method":"GET","path":"/healthz","query":"","ip":"127.0.0.1","user-agent":"Go-http-client/1.1","latency":0.000024397,"time":"2025-05-16T10:10:04Z"}
[GIN] 2025/05/16 - 10:10:04 | 200 |      64.628µs |       127.0.0.1 | GET      "/healthz"