### PR TITLE
nits(httputil): move common header constants to httputil package

### DIFF
--- a/client/v1/options.go
+++ b/client/v1/options.go
@@ -1,9 +1,7 @@
 // Package v1 provides the gpud v1 client for the server.
 package v1
 
-import (
-	"github.com/leptonai/gpud/pkg/server"
-)
+import "github.com/leptonai/gpud/pkg/httputil"
 
 type Op struct {
 	requestContentType    string
@@ -24,21 +22,21 @@ func (op *Op) applyOpts(opts []OpOption) error {
 // WithRequestContentTypeYAML sets the request content type to YAML.
 func WithRequestContentTypeYAML() OpOption {
 	return func(op *Op) {
-		op.requestContentType = server.RequestHeaderYAML
+		op.requestContentType = httputil.RequestHeaderYAML
 	}
 }
 
 // WithRequestContentTypeJSON sets the request content type to JSON.
 func WithRequestContentTypeJSON() OpOption {
 	return func(op *Op) {
-		op.requestContentType = server.RequestHeaderJSON
+		op.requestContentType = httputil.RequestHeaderJSON
 	}
 }
 
 // WithAcceptEncodingGzip requests gzip encoding for the response.
 func WithAcceptEncodingGzip() OpOption {
 	return func(op *Op) {
-		op.requestAcceptEncoding = server.RequestHeaderEncodingGzip
+		op.requestAcceptEncoding = httputil.RequestHeaderEncodingGzip
 	}
 }
 

--- a/client/v1/v1.go
+++ b/client/v1/v1.go
@@ -18,8 +18,8 @@ import (
 	v1 "github.com/leptonai/gpud/api/v1"
 	pkgcustomplugins "github.com/leptonai/gpud/pkg/custom-plugins"
 	"github.com/leptonai/gpud/pkg/errdefs"
+	"github.com/leptonai/gpud/pkg/httputil"
 	"github.com/leptonai/gpud/pkg/log"
-	"github.com/leptonai/gpud/pkg/server"
 )
 
 func GetComponents(ctx context.Context, addr string, opts ...OpOption) ([]string, error) {
@@ -33,10 +33,10 @@ func GetComponents(ctx context.Context, addr string, opts ...OpOption) ([]string
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	if op.requestContentType != "" {
-		req.Header.Set(server.RequestHeaderContentType, op.requestContentType)
+		req.Header.Set(httputil.RequestHeaderContentType, op.requestContentType)
 	}
 	if op.requestAcceptEncoding != "" {
-		req.Header.Set(server.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
+		req.Header.Set(httputil.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
 	}
 
 	resp, err := createDefaultHTTPClient().Do(req)
@@ -59,7 +59,7 @@ func ReadComponents(rd io.Reader, opts ...OpOption) ([]string, error) {
 
 	var components []string
 	switch op.requestAcceptEncoding {
-	case server.RequestHeaderEncodingGzip:
+	case httputil.RequestHeaderEncodingGzip:
 		gr, err := gzip.NewReader(rd)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
@@ -67,11 +67,11 @@ func ReadComponents(rd io.Reader, opts ...OpOption) ([]string, error) {
 		defer gr.Close()
 
 		switch op.requestContentType {
-		case server.RequestHeaderJSON, "":
+		case httputil.RequestHeaderJSON, "":
 			if err := json.NewDecoder(gr).Decode(&components); err != nil {
 				return nil, fmt.Errorf("failed to decode json: %w", err)
 			}
-		case server.RequestHeaderYAML:
+		case httputil.RequestHeaderYAML:
 			b, err := io.ReadAll(gr)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read yaml: %w", err)
@@ -85,11 +85,11 @@ func ReadComponents(rd io.Reader, opts ...OpOption) ([]string, error) {
 
 	default:
 		switch op.requestContentType {
-		case server.RequestHeaderJSON, "":
+		case httputil.RequestHeaderJSON, "":
 			if err := json.NewDecoder(rd).Decode(&components); err != nil {
 				return nil, fmt.Errorf("failed to decode json: %w", err)
 			}
-		case server.RequestHeaderYAML:
+		case httputil.RequestHeaderYAML:
 			b, err := io.ReadAll(rd)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read yaml: %w", err)
@@ -132,10 +132,10 @@ func DeregisterComponent(ctx context.Context, addr string, componentName string,
 	}
 
 	if op.requestContentType != "" {
-		req.Header.Set(server.RequestHeaderContentType, op.requestContentType)
+		req.Header.Set(httputil.RequestHeaderContentType, op.requestContentType)
 	}
 	if op.requestAcceptEncoding != "" {
-		req.Header.Set(server.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
+		req.Header.Set(httputil.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
 	}
 
 	resp, err := createDefaultHTTPClient().Do(req)
@@ -184,10 +184,10 @@ func TriggerComponentCheck(ctx context.Context, addr string, componentName strin
 	}
 
 	if op.requestContentType != "" {
-		req.Header.Set(server.RequestHeaderContentType, op.requestContentType)
+		req.Header.Set(httputil.RequestHeaderContentType, op.requestContentType)
 	}
 	if op.requestAcceptEncoding != "" {
-		req.Header.Set(server.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
+		req.Header.Set(httputil.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
 	}
 
 	resp, err := createDefaultHTTPClient().Do(req)
@@ -235,10 +235,10 @@ func TriggerComponentCheckByTag(ctx context.Context, addr string, tagName string
 	}
 
 	if op.requestContentType != "" {
-		req.Header.Set(server.RequestHeaderContentType, op.requestContentType)
+		req.Header.Set(httputil.RequestHeaderContentType, op.requestContentType)
 	}
 	if op.requestAcceptEncoding != "" {
-		req.Header.Set(server.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
+		req.Header.Set(httputil.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
 	}
 
 	resp, err := createDefaultHTTPClient().Do(req)
@@ -320,10 +320,10 @@ func GetInfo(ctx context.Context, addr string, opts ...OpOption) (v1.GPUdCompone
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	if op.requestContentType != "" {
-		req.Header.Set(server.RequestHeaderContentType, op.requestContentType)
+		req.Header.Set(httputil.RequestHeaderContentType, op.requestContentType)
 	}
 	if op.requestAcceptEncoding != "" {
-		req.Header.Set(server.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
+		req.Header.Set(httputil.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
 	}
 
 	resp, err := createDefaultHTTPClient().Do(req)
@@ -346,7 +346,7 @@ func ReadInfo(rd io.Reader, opts ...OpOption) (v1.GPUdComponentInfos, error) {
 
 	var info v1.GPUdComponentInfos
 	switch op.requestAcceptEncoding {
-	case server.RequestHeaderEncodingGzip:
+	case httputil.RequestHeaderEncodingGzip:
 		gr, err := gzip.NewReader(rd)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
@@ -354,11 +354,11 @@ func ReadInfo(rd io.Reader, opts ...OpOption) (v1.GPUdComponentInfos, error) {
 		defer gr.Close()
 
 		switch op.requestContentType {
-		case server.RequestHeaderJSON, "":
+		case httputil.RequestHeaderJSON, "":
 			if err := json.NewDecoder(gr).Decode(&info); err != nil {
 				return nil, fmt.Errorf("failed to decode json: %w", err)
 			}
-		case server.RequestHeaderYAML:
+		case httputil.RequestHeaderYAML:
 			b, err := io.ReadAll(gr)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read yaml: %w", err)
@@ -372,11 +372,11 @@ func ReadInfo(rd io.Reader, opts ...OpOption) (v1.GPUdComponentInfos, error) {
 
 	default:
 		switch op.requestContentType {
-		case server.RequestHeaderJSON, "":
+		case httputil.RequestHeaderJSON, "":
 			if err := json.NewDecoder(rd).Decode(&info); err != nil {
 				return nil, fmt.Errorf("failed to decode json: %w", err)
 			}
-		case server.RequestHeaderYAML:
+		case httputil.RequestHeaderYAML:
 			b, err := io.ReadAll(rd)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read yaml: %w", err)
@@ -443,10 +443,10 @@ func GetHealthStates(ctx context.Context, addr string, opts ...OpOption) (v1.GPU
 	}
 
 	if op.requestContentType != "" {
-		req.Header.Set(server.RequestHeaderContentType, op.requestContentType)
+		req.Header.Set(httputil.RequestHeaderContentType, op.requestContentType)
 	}
 	if op.requestAcceptEncoding != "" {
-		req.Header.Set(server.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
+		req.Header.Set(httputil.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
 	}
 
 	resp, err := createDefaultHTTPClient().Do(req)
@@ -473,7 +473,7 @@ func ReadHealthStates(rd io.Reader, opts ...OpOption) (v1.GPUdComponentHealthSta
 
 	var states v1.GPUdComponentHealthStates
 	switch op.requestAcceptEncoding {
-	case server.RequestHeaderEncodingGzip:
+	case httputil.RequestHeaderEncodingGzip:
 		gr, err := gzip.NewReader(rd)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
@@ -481,11 +481,11 @@ func ReadHealthStates(rd io.Reader, opts ...OpOption) (v1.GPUdComponentHealthSta
 		defer gr.Close()
 
 		switch op.requestContentType {
-		case server.RequestHeaderJSON, "":
+		case httputil.RequestHeaderJSON, "":
 			if err := json.NewDecoder(gr).Decode(&states); err != nil {
 				return nil, fmt.Errorf("failed to decode json: %w", err)
 			}
-		case server.RequestHeaderYAML:
+		case httputil.RequestHeaderYAML:
 			b, err := io.ReadAll(gr)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read yaml: %w", err)
@@ -499,11 +499,11 @@ func ReadHealthStates(rd io.Reader, opts ...OpOption) (v1.GPUdComponentHealthSta
 
 	default:
 		switch op.requestContentType {
-		case server.RequestHeaderJSON, "":
+		case httputil.RequestHeaderJSON, "":
 			if err := json.NewDecoder(rd).Decode(&states); err != nil {
 				return nil, fmt.Errorf("failed to decode json: %w", err)
 			}
-		case server.RequestHeaderYAML:
+		case httputil.RequestHeaderYAML:
 			b, err := io.ReadAll(rd)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read yaml: %w", err)
@@ -530,10 +530,10 @@ func GetEvents(ctx context.Context, addr string, opts ...OpOption) (v1.GPUdCompo
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	if op.requestContentType != "" {
-		req.Header.Set(server.RequestHeaderContentType, op.requestContentType)
+		req.Header.Set(httputil.RequestHeaderContentType, op.requestContentType)
 	}
 	if op.requestAcceptEncoding != "" {
-		req.Header.Set(server.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
+		req.Header.Set(httputil.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
 	}
 
 	resp, err := createDefaultHTTPClient().Do(req)
@@ -556,7 +556,7 @@ func ReadEvents(rd io.Reader, opts ...OpOption) (v1.GPUdComponentEvents, error) 
 
 	var evs v1.GPUdComponentEvents
 	switch op.requestAcceptEncoding {
-	case server.RequestHeaderEncodingGzip:
+	case httputil.RequestHeaderEncodingGzip:
 		gr, err := gzip.NewReader(rd)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
@@ -564,11 +564,11 @@ func ReadEvents(rd io.Reader, opts ...OpOption) (v1.GPUdComponentEvents, error) 
 		defer gr.Close()
 
 		switch op.requestContentType {
-		case server.RequestHeaderJSON, "":
+		case httputil.RequestHeaderJSON, "":
 			if err := json.NewDecoder(gr).Decode(&evs); err != nil {
 				return nil, fmt.Errorf("failed to decode json: %w", err)
 			}
-		case server.RequestHeaderYAML:
+		case httputil.RequestHeaderYAML:
 			b, err := io.ReadAll(gr)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read yaml: %w", err)
@@ -582,11 +582,11 @@ func ReadEvents(rd io.Reader, opts ...OpOption) (v1.GPUdComponentEvents, error) 
 
 	default:
 		switch op.requestContentType {
-		case server.RequestHeaderJSON, "":
+		case httputil.RequestHeaderJSON, "":
 			if err := json.NewDecoder(rd).Decode(&evs); err != nil {
 				return nil, fmt.Errorf("failed to decode json: %w", err)
 			}
-		case server.RequestHeaderYAML:
+		case httputil.RequestHeaderYAML:
 			b, err := io.ReadAll(rd)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read yaml: %w", err)
@@ -613,10 +613,10 @@ func GetMetrics(ctx context.Context, addr string, opts ...OpOption) (v1.GPUdComp
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	if op.requestContentType != "" {
-		req.Header.Set(server.RequestHeaderContentType, op.requestContentType)
+		req.Header.Set(httputil.RequestHeaderContentType, op.requestContentType)
 	}
 	if op.requestAcceptEncoding != "" {
-		req.Header.Set(server.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
+		req.Header.Set(httputil.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
 	}
 
 	resp, err := createDefaultHTTPClient().Do(req)
@@ -639,7 +639,7 @@ func ReadMetrics(rd io.Reader, opts ...OpOption) (v1.GPUdComponentMetrics, error
 
 	var metrics v1.GPUdComponentMetrics
 	switch op.requestAcceptEncoding {
-	case server.RequestHeaderEncodingGzip:
+	case httputil.RequestHeaderEncodingGzip:
 		gr, err := gzip.NewReader(rd)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
@@ -647,11 +647,11 @@ func ReadMetrics(rd io.Reader, opts ...OpOption) (v1.GPUdComponentMetrics, error
 		defer gr.Close()
 
 		switch op.requestContentType {
-		case server.RequestHeaderJSON, "":
+		case httputil.RequestHeaderJSON, "":
 			if err := json.NewDecoder(gr).Decode(&metrics); err != nil {
 				return nil, fmt.Errorf("failed to decode json: %w", err)
 			}
-		case server.RequestHeaderYAML:
+		case httputil.RequestHeaderYAML:
 			b, err := io.ReadAll(gr)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read yaml: %w", err)
@@ -665,11 +665,11 @@ func ReadMetrics(rd io.Reader, opts ...OpOption) (v1.GPUdComponentMetrics, error
 
 	default:
 		switch op.requestContentType {
-		case server.RequestHeaderJSON, "":
+		case httputil.RequestHeaderJSON, "":
 			if err := json.NewDecoder(rd).Decode(&metrics); err != nil {
 				return nil, fmt.Errorf("failed to decode json: %w", err)
 			}
-		case server.RequestHeaderYAML:
+		case httputil.RequestHeaderYAML:
 			b, err := io.ReadAll(rd)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read yaml: %w", err)
@@ -703,10 +703,10 @@ func GetCustomPlugins(ctx context.Context, addr string, opts ...OpOption) (map[s
 	}
 
 	if op.requestContentType != "" {
-		req.Header.Set(server.RequestHeaderContentType, op.requestContentType)
+		req.Header.Set(httputil.RequestHeaderContentType, op.requestContentType)
 	}
 	if op.requestAcceptEncoding != "" {
-		req.Header.Set(server.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
+		req.Header.Set(httputil.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
 	}
 
 	resp, err := createDefaultHTTPClient().Do(req)
@@ -734,7 +734,7 @@ func ReadCustomPluginSpecs(rd io.Reader, opts ...OpOption) (map[string]pkgcustom
 
 	var csPlugins map[string]pkgcustomplugins.Spec
 	switch op.requestAcceptEncoding {
-	case server.RequestHeaderEncodingGzip:
+	case httputil.RequestHeaderEncodingGzip:
 		gr, err := gzip.NewReader(rd)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
@@ -742,11 +742,11 @@ func ReadCustomPluginSpecs(rd io.Reader, opts ...OpOption) (map[string]pkgcustom
 		defer gr.Close()
 
 		switch op.requestContentType {
-		case server.RequestHeaderJSON, "":
+		case httputil.RequestHeaderJSON, "":
 			if err := json.NewDecoder(gr).Decode(&csPlugins); err != nil {
 				return nil, fmt.Errorf("failed to decode json: %w", err)
 			}
-		case server.RequestHeaderYAML:
+		case httputil.RequestHeaderYAML:
 			b, err := io.ReadAll(gr)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read yaml: %w", err)
@@ -760,11 +760,11 @@ func ReadCustomPluginSpecs(rd io.Reader, opts ...OpOption) (map[string]pkgcustom
 
 	default:
 		switch op.requestContentType {
-		case server.RequestHeaderJSON, "":
+		case httputil.RequestHeaderJSON, "":
 			if err := json.NewDecoder(rd).Decode(&csPlugins); err != nil {
 				return nil, fmt.Errorf("failed to decode json: %w", err)
 			}
-		case server.RequestHeaderYAML:
+		case httputil.RequestHeaderYAML:
 			b, err := io.ReadAll(rd)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read yaml: %w", err)
@@ -819,10 +819,10 @@ func registerOrUpdateCustomPlugin(ctx context.Context, addr string, spec pkgcust
 	}
 
 	if op.requestContentType != "" {
-		req.Header.Set(server.RequestHeaderContentType, op.requestContentType)
+		req.Header.Set(httputil.RequestHeaderContentType, op.requestContentType)
 	}
 	if op.requestAcceptEncoding != "" {
-		req.Header.Set(server.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
+		req.Header.Set(httputil.RequestHeaderAcceptEncoding, op.requestAcceptEncoding)
 	}
 
 	switch method {

--- a/client/v1/v1_plugin_test.go
+++ b/client/v1/v1_plugin_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	pkgcustomplugins "github.com/leptonai/gpud/pkg/custom-plugins"
-	"github.com/leptonai/gpud/pkg/server"
+	"github.com/leptonai/gpud/pkg/httputil"
 )
 
 func TestReadCustomPluginSpecs_Comprehensive(t *testing.T) {
@@ -71,46 +71,46 @@ func TestReadCustomPluginSpecs_Comprehensive(t *testing.T) {
 		{
 			name:           "read JSON explicitly",
 			input:          bytes.NewReader(jsonData),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			expectedResult: testPlugins,
 		},
 		{
 			name:           "read YAML",
 			input:          bytes.NewReader(yamlData),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			expectedResult: testPlugins,
 		},
 		{
 			name:           "read gzipped JSON",
 			input:          bytes.NewReader(gzipJSON),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testPlugins,
 		},
 		{
 			name:           "read gzipped YAML",
 			input:          bytes.NewReader(gzipYAML),
-			contentType:    server.RequestHeaderYAML,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderYAML,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testPlugins,
 		},
 		{
 			name:          "invalid JSON data",
 			input:         bytes.NewReader([]byte(`{"invalid": JSON`)),
-			contentType:   server.RequestHeaderJSON,
+			contentType:   httputil.RequestHeaderJSON,
 			expectedError: "failed to decode json",
 		},
 		{
 			name:          "invalid YAML data",
 			input:         bytes.NewReader([]byte(`invalid: YAML:`)),
-			contentType:   server.RequestHeaderYAML,
+			contentType:   httputil.RequestHeaderYAML,
 			expectedError: "failed to unmarshal yaml",
 		},
 		{
 			name:           "invalid gzip data with JSON content type",
 			input:          bytes.NewReader([]byte(`not a gzip`)),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedError:  "failed to create gzip reader",
 		},
 		{
@@ -125,9 +125,9 @@ func TestReadCustomPluginSpecs_Comprehensive(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := []OpOption{}
 			if tt.contentType != "" {
-				if tt.contentType == server.RequestHeaderYAML {
+				if tt.contentType == httputil.RequestHeaderYAML {
 					opts = append(opts, WithRequestContentTypeYAML())
-				} else if tt.contentType == server.RequestHeaderJSON {
+				} else if tt.contentType == httputil.RequestHeaderJSON {
 					opts = append(opts, WithRequestContentTypeJSON())
 				} else {
 					opts = append(opts, func(op *Op) {

--- a/client/v1/v1_read_helpers_test.go
+++ b/client/v1/v1_read_helpers_test.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/leptonai/gpud/api/v1"
-	"github.com/leptonai/gpud/pkg/server"
+	"github.com/leptonai/gpud/pkg/httputil"
 )
 
 func TestReadComponents_Comprehensive(t *testing.T) {
@@ -35,46 +35,46 @@ func TestReadComponents_Comprehensive(t *testing.T) {
 		{
 			name:           "read JSON explicitly",
 			input:          bytes.NewReader(jsonData),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			expectedResult: testComponents,
 		},
 		{
 			name:           "read YAML",
 			input:          bytes.NewReader(yamlData),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			expectedResult: testComponents,
 		},
 		{
 			name:           "read gzipped JSON",
 			input:          bytes.NewReader(gzipContent(t, jsonData)),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testComponents,
 		},
 		{
 			name:           "read gzipped YAML",
 			input:          bytes.NewReader(gzipContent(t, yamlData)),
-			contentType:    server.RequestHeaderYAML,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderYAML,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testComponents,
 		},
 		{
 			name:          "invalid JSON data",
 			input:         bytes.NewReader([]byte(`{"invalid": JSON`)),
-			contentType:   server.RequestHeaderJSON,
+			contentType:   httputil.RequestHeaderJSON,
 			expectedError: "failed to decode json",
 		},
 		{
 			name:          "invalid YAML data",
 			input:         bytes.NewReader([]byte(`invalid: YAML:`)),
-			contentType:   server.RequestHeaderYAML,
+			contentType:   httputil.RequestHeaderYAML,
 			expectedError: "failed to unmarshal yaml",
 		},
 		{
 			name:           "invalid gzip data with JSON content type",
 			input:          bytes.NewReader([]byte(`not a gzip`)),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedError:  "failed to create gzip reader",
 		},
 		{
@@ -89,9 +89,9 @@ func TestReadComponents_Comprehensive(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := []OpOption{}
 			if tt.contentType != "" {
-				if tt.contentType == server.RequestHeaderYAML {
+				if tt.contentType == httputil.RequestHeaderYAML {
 					opts = append(opts, WithRequestContentTypeYAML())
-				} else if tt.contentType == server.RequestHeaderJSON {
+				} else if tt.contentType == httputil.RequestHeaderJSON {
 					opts = append(opts, WithRequestContentTypeJSON())
 				} else {
 					opts = append(opts, func(op *Op) {
@@ -151,46 +151,46 @@ func TestReadEvents_Comprehensive(t *testing.T) {
 		{
 			name:           "read JSON explicitly",
 			input:          bytes.NewReader(jsonData),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			expectedResult: testEvents,
 		},
 		{
 			name:           "read YAML",
 			input:          bytes.NewReader(yamlData),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			expectedResult: testEvents,
 		},
 		{
 			name:           "read gzipped JSON",
 			input:          bytes.NewReader(gzipContent(t, jsonData)),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testEvents,
 		},
 		{
 			name:           "read gzipped YAML",
 			input:          bytes.NewReader(gzipContent(t, yamlData)),
-			contentType:    server.RequestHeaderYAML,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderYAML,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testEvents,
 		},
 		{
 			name:          "invalid JSON data",
 			input:         bytes.NewReader([]byte(`{"invalid": JSON`)),
-			contentType:   server.RequestHeaderJSON,
+			contentType:   httputil.RequestHeaderJSON,
 			expectedError: "failed to decode json",
 		},
 		{
 			name:          "invalid YAML data",
 			input:         bytes.NewReader([]byte(`invalid: YAML:`)),
-			contentType:   server.RequestHeaderYAML,
+			contentType:   httputil.RequestHeaderYAML,
 			expectedError: "failed to unmarshal yaml",
 		},
 		{
 			name:           "invalid gzip data with JSON content type",
 			input:          bytes.NewReader([]byte(`not a gzip`)),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedError:  "failed to create gzip reader",
 		},
 		{
@@ -205,9 +205,9 @@ func TestReadEvents_Comprehensive(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := []OpOption{}
 			if tt.contentType != "" {
-				if tt.contentType == server.RequestHeaderYAML {
+				if tt.contentType == httputil.RequestHeaderYAML {
 					opts = append(opts, WithRequestContentTypeYAML())
-				} else if tt.contentType == server.RequestHeaderJSON {
+				} else if tt.contentType == httputil.RequestHeaderJSON {
 					opts = append(opts, WithRequestContentTypeJSON())
 				} else {
 					opts = append(opts, func(op *Op) {
@@ -277,46 +277,46 @@ func TestReadMetrics_Comprehensive(t *testing.T) {
 		{
 			name:           "read JSON explicitly",
 			input:          bytes.NewReader(jsonData),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			expectedResult: testMetrics,
 		},
 		{
 			name:           "read YAML",
 			input:          bytes.NewReader(yamlData),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			expectedResult: testMetrics,
 		},
 		{
 			name:           "read gzipped JSON",
 			input:          bytes.NewReader(gzipContent(t, jsonData)),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testMetrics,
 		},
 		{
 			name:           "read gzipped YAML",
 			input:          bytes.NewReader(gzipContent(t, yamlData)),
-			contentType:    server.RequestHeaderYAML,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderYAML,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testMetrics,
 		},
 		{
 			name:          "invalid JSON data",
 			input:         bytes.NewReader([]byte(`{"invalid": JSON`)),
-			contentType:   server.RequestHeaderJSON,
+			contentType:   httputil.RequestHeaderJSON,
 			expectedError: "failed to decode json",
 		},
 		{
 			name:          "invalid YAML data",
 			input:         bytes.NewReader([]byte(`invalid: YAML:`)),
-			contentType:   server.RequestHeaderYAML,
+			contentType:   httputil.RequestHeaderYAML,
 			expectedError: "failed to unmarshal yaml",
 		},
 		{
 			name:           "invalid gzip data with JSON content type",
 			input:          bytes.NewReader([]byte(`not a gzip`)),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedError:  "failed to create gzip reader",
 		},
 		{
@@ -331,9 +331,9 @@ func TestReadMetrics_Comprehensive(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := []OpOption{}
 			if tt.contentType != "" {
-				if tt.contentType == server.RequestHeaderYAML {
+				if tt.contentType == httputil.RequestHeaderYAML {
 					opts = append(opts, WithRequestContentTypeYAML())
-				} else if tt.contentType == server.RequestHeaderJSON {
+				} else if tt.contentType == httputil.RequestHeaderJSON {
 					opts = append(opts, WithRequestContentTypeJSON())
 				} else {
 					opts = append(opts, func(op *Op) {

--- a/client/v1/v1_read_test.go
+++ b/client/v1/v1_read_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	v1 "github.com/leptonai/gpud/api/v1"
-	"github.com/leptonai/gpud/pkg/server"
+	"github.com/leptonai/gpud/pkg/httputil"
 )
 
 func TestReadHealthStates_Comprehensive(t *testing.T) {
@@ -63,46 +63,46 @@ func TestReadHealthStates_Comprehensive(t *testing.T) {
 		{
 			name:           "read JSON explicitly",
 			input:          bytes.NewReader(jsonData),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			expectedResult: testStates,
 		},
 		{
 			name:           "read YAML",
 			input:          bytes.NewReader(yamlData),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			expectedResult: testStates,
 		},
 		{
 			name:           "read gzipped JSON",
 			input:          bytes.NewReader(gzipJSON),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testStates,
 		},
 		{
 			name:           "read gzipped YAML",
 			input:          bytes.NewReader(gzipYAML),
-			contentType:    server.RequestHeaderYAML,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderYAML,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testStates,
 		},
 		{
 			name:          "invalid JSON data",
 			input:         bytes.NewReader([]byte(`{"invalid": JSON`)),
-			contentType:   server.RequestHeaderJSON,
+			contentType:   httputil.RequestHeaderJSON,
 			expectedError: "failed to decode json",
 		},
 		{
 			name:          "invalid YAML data",
 			input:         bytes.NewReader([]byte(`invalid: YAML:`)),
-			contentType:   server.RequestHeaderYAML,
+			contentType:   httputil.RequestHeaderYAML,
 			expectedError: "failed to unmarshal yaml",
 		},
 		{
 			name:           "invalid gzip data with JSON content type",
 			input:          bytes.NewReader([]byte(`not a gzip`)),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedError:  "failed to create gzip reader",
 		},
 		{
@@ -117,9 +117,9 @@ func TestReadHealthStates_Comprehensive(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := []OpOption{}
 			if tt.contentType != "" {
-				if tt.contentType == server.RequestHeaderYAML {
+				if tt.contentType == httputil.RequestHeaderYAML {
 					opts = append(opts, WithRequestContentTypeYAML())
-				} else if tt.contentType == server.RequestHeaderJSON {
+				} else if tt.contentType == httputil.RequestHeaderJSON {
 					opts = append(opts, WithRequestContentTypeJSON())
 				} else {
 					opts = append(opts, func(op *Op) {
@@ -198,46 +198,46 @@ func TestReadInfo_Comprehensive(t *testing.T) {
 		{
 			name:           "read JSON explicitly",
 			input:          bytes.NewReader(jsonData),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			expectedResult: testInfo,
 		},
 		{
 			name:           "read YAML",
 			input:          bytes.NewReader(yamlData),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			expectedResult: testInfo,
 		},
 		{
 			name:           "read gzipped JSON",
 			input:          bytes.NewReader(gzipJSON),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testInfo,
 		},
 		{
 			name:           "read gzipped YAML",
 			input:          bytes.NewReader(gzipYAML),
-			contentType:    server.RequestHeaderYAML,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderYAML,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testInfo,
 		},
 		{
 			name:          "invalid JSON data",
 			input:         bytes.NewReader([]byte(`{"invalid": JSON`)),
-			contentType:   server.RequestHeaderJSON,
+			contentType:   httputil.RequestHeaderJSON,
 			expectedError: "failed to decode json",
 		},
 		{
 			name:          "invalid YAML data",
 			input:         bytes.NewReader([]byte(`invalid: YAML:`)),
-			contentType:   server.RequestHeaderYAML,
+			contentType:   httputil.RequestHeaderYAML,
 			expectedError: "failed to unmarshal yaml",
 		},
 		{
 			name:           "invalid gzip data with JSON content type",
 			input:          bytes.NewReader([]byte(`not a gzip`)),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedError:  "failed to create gzip reader",
 		},
 		{
@@ -252,9 +252,9 @@ func TestReadInfo_Comprehensive(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := []OpOption{}
 			if tt.contentType != "" {
-				if tt.contentType == server.RequestHeaderYAML {
+				if tt.contentType == httputil.RequestHeaderYAML {
 					opts = append(opts, WithRequestContentTypeYAML())
-				} else if tt.contentType == server.RequestHeaderJSON {
+				} else if tt.contentType == httputil.RequestHeaderJSON {
 					opts = append(opts, WithRequestContentTypeJSON())
 				} else {
 					opts = append(opts, func(op *Op) {

--- a/client/v1/v1_register_test.go
+++ b/client/v1/v1_register_test.go
@@ -14,7 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	pkgcustomplugins "github.com/leptonai/gpud/pkg/custom-plugins"
-	"github.com/leptonai/gpud/pkg/server"
+	"github.com/leptonai/gpud/pkg/httputil"
 )
 
 func TestRegisterOrUpdateCustomPlugin(t *testing.T) {
@@ -50,7 +50,7 @@ func TestRegisterOrUpdateCustomPlugin(t *testing.T) {
 			name:        "register with POST method",
 			method:      http.MethodPost,
 			spec:        validSpec,
-			contentType: server.RequestHeaderJSON,
+			contentType: httputil.RequestHeaderJSON,
 			serverResp:  "ok",
 			statusCode:  http.StatusOK,
 		},
@@ -58,7 +58,7 @@ func TestRegisterOrUpdateCustomPlugin(t *testing.T) {
 			name:        "update with PUT method",
 			method:      http.MethodPut,
 			spec:        validSpec,
-			contentType: server.RequestHeaderJSON,
+			contentType: httputil.RequestHeaderJSON,
 			serverResp:  "ok",
 			statusCode:  http.StatusOK,
 		},
@@ -66,8 +66,8 @@ func TestRegisterOrUpdateCustomPlugin(t *testing.T) {
 			name:           "with YAML content type",
 			method:         http.MethodPost,
 			spec:           validSpec,
-			contentType:    server.RequestHeaderYAML,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderYAML,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			serverResp:     "ok",
 			statusCode:     http.StatusOK,
 		},
@@ -82,7 +82,7 @@ func TestRegisterOrUpdateCustomPlugin(t *testing.T) {
 			name:          "server error",
 			method:        http.MethodPost,
 			spec:          validSpec,
-			contentType:   server.RequestHeaderJSON,
+			contentType:   httputil.RequestHeaderJSON,
 			statusCode:    http.StatusInternalServerError,
 			expectedError: "server not ready, response not 200",
 		},
@@ -90,7 +90,7 @@ func TestRegisterOrUpdateCustomPlugin(t *testing.T) {
 			name:          "unsupported method",
 			method:        http.MethodDelete,
 			spec:          validSpec,
-			contentType:   server.RequestHeaderJSON,
+			contentType:   httputil.RequestHeaderJSON,
 			expectedError: "unsupported method",
 			validateOnly:  true,
 		},
@@ -112,10 +112,10 @@ func TestRegisterOrUpdateCustomPlugin(t *testing.T) {
 
 				// Verify request headers
 				if tt.contentType != "" {
-					assert.Equal(t, tt.contentType, r.Header.Get(server.RequestHeaderContentType))
+					assert.Equal(t, tt.contentType, r.Header.Get(httputil.RequestHeaderContentType))
 				}
 				if tt.acceptEncoding != "" {
-					assert.Equal(t, tt.acceptEncoding, r.Header.Get(server.RequestHeaderAcceptEncoding))
+					assert.Equal(t, tt.acceptEncoding, r.Header.Get(httputil.RequestHeaderAcceptEncoding))
 				}
 
 				// Verify the request body contains the correct spec
@@ -135,9 +135,9 @@ func TestRegisterOrUpdateCustomPlugin(t *testing.T) {
 			defer srv.Close()
 
 			opts := []OpOption{}
-			if tt.contentType == server.RequestHeaderYAML {
+			if tt.contentType == httputil.RequestHeaderYAML {
 				opts = append(opts, WithRequestContentTypeYAML())
-			} else if tt.contentType == server.RequestHeaderJSON {
+			} else if tt.contentType == httputil.RequestHeaderJSON {
 				opts = append(opts, WithRequestContentTypeJSON())
 			}
 			if tt.acceptEncoding != "" {

--- a/client/v1/v1_test.go
+++ b/client/v1/v1_test.go
@@ -19,7 +19,7 @@ import (
 	apiv1 "github.com/leptonai/gpud/api/v1"
 	pkgcustomplugins "github.com/leptonai/gpud/pkg/custom-plugins"
 	"github.com/leptonai/gpud/pkg/errdefs"
-	"github.com/leptonai/gpud/pkg/server"
+	"github.com/leptonai/gpud/pkg/httputil"
 )
 
 func gzipContent(t *testing.T, data []byte) []byte {
@@ -47,22 +47,22 @@ func TestGetComponents(t *testing.T) {
 		{
 			name:           "successful JSON response",
 			serverResponse: []byte(`["comp1","comp2","comp3"]`),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			statusCode:     http.StatusOK,
 			expectedResult: testComponents,
 		},
 		{
 			name:           "successful YAML response",
 			serverResponse: []byte("- comp1\n- comp2\n- comp3\n"),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			statusCode:     http.StatusOK,
 			expectedResult: testComponents,
 		},
 		{
 			name:           "successful gzipped JSON response",
 			serverResponse: []byte(`["comp1","comp2","comp3"]`),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			statusCode:     http.StatusOK,
 			expectedResult: testComponents,
 			useGzip:        true,
@@ -76,14 +76,14 @@ func TestGetComponents(t *testing.T) {
 		{
 			name:           "invalid JSON response",
 			serverResponse: []byte(`invalid json`),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			statusCode:     http.StatusOK,
 			expectedError:  "failed to decode json",
 		},
 		{
 			name:           "invalid YAML response",
 			serverResponse: []byte(`invalid yaml:`),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			statusCode:     http.StatusOK,
 			expectedError:  "failed to unmarshal yaml",
 		},
@@ -102,17 +102,17 @@ func TestGetComponents(t *testing.T) {
 				assert.Equal(t, "/v1/components", r.URL.Path)
 				assert.Equal(t, http.MethodGet, r.Method)
 
-				contentType := r.Header.Get(server.RequestHeaderContentType)
+				contentType := r.Header.Get(httputil.RequestHeaderContentType)
 				if tt.contentType != "" {
 					assert.Equal(t, tt.contentType, contentType)
 				}
 				if tt.acceptEncoding != "" {
-					assert.Equal(t, tt.acceptEncoding, r.Header.Get(server.RequestHeaderAcceptEncoding))
+					assert.Equal(t, tt.acceptEncoding, r.Header.Get(httputil.RequestHeaderAcceptEncoding))
 				}
 
 				// Set response content type
 				if tt.contentType != "" {
-					w.Header().Set(server.RequestHeaderContentType, tt.contentType)
+					w.Header().Set(httputil.RequestHeaderContentType, tt.contentType)
 				}
 
 				w.WriteHeader(tt.statusCode)
@@ -127,16 +127,16 @@ func TestGetComponents(t *testing.T) {
 			defer srv.Close()
 
 			opts := []OpOption{}
-			if tt.contentType == server.RequestHeaderYAML {
+			if tt.contentType == httputil.RequestHeaderYAML {
 				opts = append(opts, WithRequestContentTypeYAML())
-			} else if tt.contentType == server.RequestHeaderJSON {
+			} else if tt.contentType == httputil.RequestHeaderJSON {
 				opts = append(opts, WithRequestContentTypeJSON())
 			} else if tt.contentType != "" {
 				opts = append(opts, func(op *Op) {
 					op.requestContentType = tt.contentType
 				})
 			}
-			if tt.acceptEncoding == server.RequestHeaderEncodingGzip {
+			if tt.acceptEncoding == httputil.RequestHeaderEncodingGzip {
 				opts = append(opts, WithAcceptEncodingGzip())
 			}
 
@@ -185,14 +185,14 @@ func TestGetInfo(t *testing.T) {
 		{
 			name:           "successful JSON response",
 			serverResponse: mustMarshalJSON(t, testInfo),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			statusCode:     http.StatusOK,
 			expectedResult: testInfo,
 		},
 		{
 			name:           "successful YAML response",
 			serverResponse: mustMarshalYAML(t, testInfo),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			statusCode:     http.StatusOK,
 			expectedResult: testInfo,
 		},
@@ -200,7 +200,7 @@ func TestGetInfo(t *testing.T) {
 			name:           "with components filter",
 			components:     []string{"comp1", "comp2"},
 			serverResponse: mustMarshalJSON(t, testInfo),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			statusCode:     http.StatusOK,
 			expectedResult: testInfo,
 		},
@@ -223,11 +223,11 @@ func TestGetInfo(t *testing.T) {
 				}
 
 				if tt.contentType != "" {
-					assert.Equal(t, tt.contentType, r.Header.Get(server.RequestHeaderContentType))
-					w.Header().Set(server.RequestHeaderContentType, tt.contentType)
+					assert.Equal(t, tt.contentType, r.Header.Get(httputil.RequestHeaderContentType))
+					w.Header().Set(httputil.RequestHeaderContentType, tt.contentType)
 				}
 				if tt.acceptEncoding != "" {
-					assert.Equal(t, tt.acceptEncoding, r.Header.Get(server.RequestHeaderAcceptEncoding))
+					assert.Equal(t, tt.acceptEncoding, r.Header.Get(httputil.RequestHeaderAcceptEncoding))
 				}
 
 				w.WriteHeader(tt.statusCode)
@@ -242,12 +242,12 @@ func TestGetInfo(t *testing.T) {
 			defer srv.Close()
 
 			opts := []OpOption{}
-			if tt.contentType == server.RequestHeaderYAML {
+			if tt.contentType == httputil.RequestHeaderYAML {
 				opts = append(opts, WithRequestContentTypeYAML())
-			} else if tt.contentType == server.RequestHeaderJSON {
+			} else if tt.contentType == httputil.RequestHeaderJSON {
 				opts = append(opts, WithRequestContentTypeJSON())
 			}
-			if tt.acceptEncoding == server.RequestHeaderEncodingGzip {
+			if tt.acceptEncoding == httputil.RequestHeaderEncodingGzip {
 				opts = append(opts, WithAcceptEncodingGzip())
 			}
 			for _, comp := range tt.components {
@@ -301,7 +301,7 @@ func TestGetStates(t *testing.T) {
 		{
 			name:           "successful JSON response",
 			serverResponse: mustMarshalJSON(t, testStates),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			statusCode:     http.StatusOK,
 			expectedResult: testStates,
 		},
@@ -324,11 +324,11 @@ func TestGetStates(t *testing.T) {
 				}
 
 				if tt.contentType != "" {
-					assert.Equal(t, tt.contentType, r.Header.Get(server.RequestHeaderContentType))
-					w.Header().Set(server.RequestHeaderContentType, tt.contentType)
+					assert.Equal(t, tt.contentType, r.Header.Get(httputil.RequestHeaderContentType))
+					w.Header().Set(httputil.RequestHeaderContentType, tt.contentType)
 				}
 				if tt.acceptEncoding != "" {
-					assert.Equal(t, tt.acceptEncoding, r.Header.Get(server.RequestHeaderAcceptEncoding))
+					assert.Equal(t, tt.acceptEncoding, r.Header.Get(httputil.RequestHeaderAcceptEncoding))
 				}
 
 				w.WriteHeader(tt.statusCode)
@@ -343,12 +343,12 @@ func TestGetStates(t *testing.T) {
 			defer srv.Close()
 
 			opts := []OpOption{}
-			if tt.contentType == server.RequestHeaderYAML {
+			if tt.contentType == httputil.RequestHeaderYAML {
 				opts = append(opts, WithRequestContentTypeYAML())
-			} else if tt.contentType == server.RequestHeaderJSON {
+			} else if tt.contentType == httputil.RequestHeaderJSON {
 				opts = append(opts, WithRequestContentTypeJSON())
 			}
-			if tt.acceptEncoding == server.RequestHeaderEncodingGzip {
+			if tt.acceptEncoding == httputil.RequestHeaderEncodingGzip {
 				opts = append(opts, WithAcceptEncodingGzip())
 			}
 			for _, comp := range tt.components {
@@ -384,20 +384,20 @@ func TestReadComponents(t *testing.T) {
 		{
 			name:           "read JSON",
 			input:          bytes.NewReader(jsonData),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			expectedResult: testComponents,
 		},
 		{
 			name:           "read YAML",
 			input:          bytes.NewReader(yamlData),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			expectedResult: testComponents,
 		},
 		{
 			name:           "read gzipped JSON",
 			input:          bytes.NewReader(gzipContent(t, jsonData)),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testComponents,
 		},
 		{
@@ -412,9 +412,9 @@ func TestReadComponents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := []OpOption{}
 			if tt.contentType != "" {
-				if tt.contentType == server.RequestHeaderYAML {
+				if tt.contentType == httputil.RequestHeaderYAML {
 					opts = append(opts, WithRequestContentTypeYAML())
-				} else if tt.contentType == server.RequestHeaderJSON {
+				} else if tt.contentType == httputil.RequestHeaderJSON {
 					opts = append(opts, WithRequestContentTypeJSON())
 				} else {
 					opts = append(opts, func(op *Op) {
@@ -465,7 +465,7 @@ func TestDeregisterComponent(t *testing.T) {
 			name:          "successful deregistration",
 			componentName: "test-component",
 			statusCode:    http.StatusOK,
-			contentType:   server.RequestHeaderJSON,
+			contentType:   httputil.RequestHeaderJSON,
 		},
 		{
 			name:          "empty component name",
@@ -496,10 +496,10 @@ func TestDeregisterComponent(t *testing.T) {
 				assert.Equal(t, tt.componentName, r.URL.Query().Get("componentName"))
 
 				if tt.contentType != "" {
-					assert.Equal(t, tt.contentType, r.Header.Get(server.RequestHeaderContentType))
+					assert.Equal(t, tt.contentType, r.Header.Get(httputil.RequestHeaderContentType))
 				}
 				if tt.acceptEncoding != "" {
-					assert.Equal(t, tt.acceptEncoding, r.Header.Get(server.RequestHeaderAcceptEncoding))
+					assert.Equal(t, tt.acceptEncoding, r.Header.Get(httputil.RequestHeaderAcceptEncoding))
 				}
 
 				w.WriteHeader(tt.statusCode)
@@ -509,12 +509,12 @@ func TestDeregisterComponent(t *testing.T) {
 			defer srv.Close()
 
 			opts := []OpOption{}
-			if tt.contentType == server.RequestHeaderYAML {
+			if tt.contentType == httputil.RequestHeaderYAML {
 				opts = append(opts, WithRequestContentTypeYAML())
-			} else if tt.contentType == server.RequestHeaderJSON {
+			} else if tt.contentType == httputil.RequestHeaderJSON {
 				opts = append(opts, WithRequestContentTypeJSON())
 			}
-			if tt.acceptEncoding == server.RequestHeaderEncodingGzip {
+			if tt.acceptEncoding == httputil.RequestHeaderEncodingGzip {
 				opts = append(opts, WithAcceptEncodingGzip())
 			}
 
@@ -559,22 +559,22 @@ func TestGetCustomPlugins(t *testing.T) {
 		{
 			name:           "successful JSON response",
 			serverResponse: mustMarshalJSON(t, testPlugins),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			statusCode:     http.StatusOK,
 			expectedResult: testPlugins,
 		},
 		{
 			name:           "successful YAML response",
 			serverResponse: mustMarshalYAML(t, testPlugins),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			statusCode:     http.StatusOK,
 			expectedResult: testPlugins,
 		},
 		{
 			name:           "successful gzipped JSON response",
 			serverResponse: mustMarshalJSON(t, testPlugins),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			statusCode:     http.StatusOK,
 			expectedResult: testPlugins,
 			useGzip:        true,
@@ -594,14 +594,14 @@ func TestGetCustomPlugins(t *testing.T) {
 		{
 			name:           "empty response",
 			serverResponse: []byte(`{}`),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			statusCode:     http.StatusOK,
 			expectedResult: map[string]pkgcustomplugins.Spec{},
 		},
 		{
 			name:           "invalid JSON response",
 			serverResponse: []byte(`invalid json`),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			statusCode:     http.StatusOK,
 			expectedError:  "failed to decode json",
 		},
@@ -614,11 +614,11 @@ func TestGetCustomPlugins(t *testing.T) {
 				assert.Equal(t, http.MethodGet, r.Method)
 
 				if tt.contentType != "" {
-					assert.Equal(t, tt.contentType, r.Header.Get(server.RequestHeaderContentType))
-					w.Header().Set(server.RequestHeaderContentType, tt.contentType)
+					assert.Equal(t, tt.contentType, r.Header.Get(httputil.RequestHeaderContentType))
+					w.Header().Set(httputil.RequestHeaderContentType, tt.contentType)
 				}
 				if tt.acceptEncoding != "" {
-					assert.Equal(t, tt.acceptEncoding, r.Header.Get(server.RequestHeaderAcceptEncoding))
+					assert.Equal(t, tt.acceptEncoding, r.Header.Get(httputil.RequestHeaderAcceptEncoding))
 				}
 
 				w.WriteHeader(tt.statusCode)
@@ -633,12 +633,12 @@ func TestGetCustomPlugins(t *testing.T) {
 			defer srv.Close()
 
 			opts := []OpOption{}
-			if tt.contentType == server.RequestHeaderYAML {
+			if tt.contentType == httputil.RequestHeaderYAML {
 				opts = append(opts, WithRequestContentTypeYAML())
-			} else if tt.contentType == server.RequestHeaderJSON {
+			} else if tt.contentType == httputil.RequestHeaderJSON {
 				opts = append(opts, WithRequestContentTypeJSON())
 			}
-			if tt.acceptEncoding == server.RequestHeaderEncodingGzip {
+			if tt.acceptEncoding == httputil.RequestHeaderEncodingGzip {
 				opts = append(opts, WithAcceptEncodingGzip())
 			}
 
@@ -684,20 +684,20 @@ func TestReadCustomPluginSpecs(t *testing.T) {
 		{
 			name:           "read JSON",
 			input:          bytes.NewReader(jsonData),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			expectedResult: testPlugins,
 		},
 		{
 			name:           "read YAML",
 			input:          bytes.NewReader(yamlData),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			expectedResult: testPlugins,
 		},
 		{
 			name:           "read gzipped JSON",
 			input:          bytes.NewReader(gzipContent(t, jsonData)),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testPlugins,
 		},
 		{
@@ -712,9 +712,9 @@ func TestReadCustomPluginSpecs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := []OpOption{}
 			if tt.contentType != "" {
-				if tt.contentType == server.RequestHeaderYAML {
+				if tt.contentType == httputil.RequestHeaderYAML {
 					opts = append(opts, WithRequestContentTypeYAML())
-				} else if tt.contentType == server.RequestHeaderJSON {
+				} else if tt.contentType == httputil.RequestHeaderJSON {
 					opts = append(opts, WithRequestContentTypeJSON())
 				} else {
 					opts = append(opts, func(op *Op) {
@@ -773,7 +773,7 @@ func TestRegisterCustomPlugin(t *testing.T) {
 			spec:        createValidPluginSpec(),
 			method:      http.MethodPost,
 			statusCode:  http.StatusOK,
-			contentType: server.RequestHeaderJSON,
+			contentType: httputil.RequestHeaderJSON,
 		},
 		{
 			name:          "invalid spec",
@@ -787,7 +787,7 @@ func TestRegisterCustomPlugin(t *testing.T) {
 			spec:          createValidPluginSpec(),
 			method:        http.MethodPost,
 			statusCode:    http.StatusInternalServerError,
-			contentType:   server.RequestHeaderJSON,
+			contentType:   httputil.RequestHeaderJSON,
 			expectedError: "server not ready, response not 200",
 		},
 	}
@@ -807,7 +807,7 @@ func TestRegisterCustomPlugin(t *testing.T) {
 				assert.Equal(t, tt.method, r.Method)
 
 				if tt.contentType != "" {
-					assert.Equal(t, tt.contentType, r.Header.Get(server.RequestHeaderContentType))
+					assert.Equal(t, tt.contentType, r.Header.Get(httputil.RequestHeaderContentType))
 				}
 
 				// Verify the request body contains the correct spec
@@ -823,9 +823,9 @@ func TestRegisterCustomPlugin(t *testing.T) {
 			defer srv.Close()
 
 			opts := []OpOption{}
-			if tt.contentType == server.RequestHeaderYAML {
+			if tt.contentType == httputil.RequestHeaderYAML {
 				opts = append(opts, WithRequestContentTypeYAML())
-			} else if tt.contentType == server.RequestHeaderJSON {
+			} else if tt.contentType == httputil.RequestHeaderJSON {
 				opts = append(opts, WithRequestContentTypeJSON())
 			}
 
@@ -856,7 +856,7 @@ func TestUpdateCustomPlugin(t *testing.T) {
 			spec:        createValidPluginSpec(),
 			method:      http.MethodPut,
 			statusCode:  http.StatusOK,
-			contentType: server.RequestHeaderJSON,
+			contentType: httputil.RequestHeaderJSON,
 		},
 		{
 			name:          "invalid spec",
@@ -870,7 +870,7 @@ func TestUpdateCustomPlugin(t *testing.T) {
 			spec:          createValidPluginSpec(),
 			method:        http.MethodPut,
 			statusCode:    http.StatusInternalServerError,
-			contentType:   server.RequestHeaderJSON,
+			contentType:   httputil.RequestHeaderJSON,
 			expectedError: "server not ready, response not 200",
 		},
 	}
@@ -890,7 +890,7 @@ func TestUpdateCustomPlugin(t *testing.T) {
 				assert.Equal(t, tt.method, r.Method)
 
 				if tt.contentType != "" {
-					assert.Equal(t, tt.contentType, r.Header.Get(server.RequestHeaderContentType))
+					assert.Equal(t, tt.contentType, r.Header.Get(httputil.RequestHeaderContentType))
 				}
 
 				// Verify the request body contains the correct spec
@@ -906,9 +906,9 @@ func TestUpdateCustomPlugin(t *testing.T) {
 			defer srv.Close()
 
 			opts := []OpOption{}
-			if tt.contentType == server.RequestHeaderYAML {
+			if tt.contentType == httputil.RequestHeaderYAML {
 				opts = append(opts, WithRequestContentTypeYAML())
-			} else if tt.contentType == server.RequestHeaderJSON {
+			} else if tt.contentType == httputil.RequestHeaderJSON {
 				opts = append(opts, WithRequestContentTypeJSON())
 			}
 
@@ -954,22 +954,22 @@ func TestGetEvents(t *testing.T) {
 		{
 			name:           "successful JSON response",
 			serverResponse: mustMarshalJSON(t, testEvents),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			statusCode:     http.StatusOK,
 			expectedResult: testEvents,
 		},
 		{
 			name:           "successful YAML response",
 			serverResponse: mustMarshalYAML(t, testEvents),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			statusCode:     http.StatusOK,
 			expectedResult: testEvents,
 		},
 		{
 			name:           "successful gzipped JSON response",
 			serverResponse: mustMarshalJSON(t, testEvents),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			statusCode:     http.StatusOK,
 			expectedResult: testEvents,
 			useGzip:        true,
@@ -983,14 +983,14 @@ func TestGetEvents(t *testing.T) {
 		{
 			name:           "invalid JSON response",
 			serverResponse: []byte(`invalid json`),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			statusCode:     http.StatusOK,
 			expectedError:  "failed to decode json",
 		},
 		{
 			name:           "invalid YAML response",
 			serverResponse: []byte(`invalid yaml:`),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			statusCode:     http.StatusOK,
 			expectedError:  "failed to unmarshal yaml",
 		},
@@ -1003,11 +1003,11 @@ func TestGetEvents(t *testing.T) {
 				assert.Equal(t, http.MethodGet, r.Method)
 
 				if tt.contentType != "" {
-					assert.Equal(t, tt.contentType, r.Header.Get(server.RequestHeaderContentType))
-					w.Header().Set(server.RequestHeaderContentType, tt.contentType)
+					assert.Equal(t, tt.contentType, r.Header.Get(httputil.RequestHeaderContentType))
+					w.Header().Set(httputil.RequestHeaderContentType, tt.contentType)
 				}
 				if tt.acceptEncoding != "" {
-					assert.Equal(t, tt.acceptEncoding, r.Header.Get(server.RequestHeaderAcceptEncoding))
+					assert.Equal(t, tt.acceptEncoding, r.Header.Get(httputil.RequestHeaderAcceptEncoding))
 				}
 
 				w.WriteHeader(tt.statusCode)
@@ -1022,12 +1022,12 @@ func TestGetEvents(t *testing.T) {
 			defer srv.Close()
 
 			opts := []OpOption{}
-			if tt.contentType == server.RequestHeaderYAML {
+			if tt.contentType == httputil.RequestHeaderYAML {
 				opts = append(opts, WithRequestContentTypeYAML())
-			} else if tt.contentType == server.RequestHeaderJSON {
+			} else if tt.contentType == httputil.RequestHeaderJSON {
 				opts = append(opts, WithRequestContentTypeJSON())
 			}
-			if tt.acceptEncoding == server.RequestHeaderEncodingGzip {
+			if tt.acceptEncoding == httputil.RequestHeaderEncodingGzip {
 				opts = append(opts, WithAcceptEncodingGzip())
 			}
 
@@ -1060,7 +1060,7 @@ func TestGetEvents(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "/v1/events", r.URL.Path)
 			assert.Equal(t, http.MethodGet, r.Method)
-			w.Header().Set(server.RequestHeaderContentType, "application/xml")
+			w.Header().Set(httputil.RequestHeaderContentType, "application/xml")
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte(`<events></events>`))
 			require.NoError(t, err)
@@ -1109,20 +1109,20 @@ func TestReadEvents(t *testing.T) {
 		{
 			name:           "read JSON",
 			input:          bytes.NewReader(jsonData),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			expectedResult: testEvents,
 		},
 		{
 			name:           "read YAML",
 			input:          bytes.NewReader(yamlData),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			expectedResult: testEvents,
 		},
 		{
 			name:           "read gzipped JSON",
 			input:          bytes.NewReader(gzipContent(t, jsonData)),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testEvents,
 		},
 		{
@@ -1137,9 +1137,9 @@ func TestReadEvents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := []OpOption{}
 			if tt.contentType != "" {
-				if tt.contentType == server.RequestHeaderYAML {
+				if tt.contentType == httputil.RequestHeaderYAML {
 					opts = append(opts, WithRequestContentTypeYAML())
-				} else if tt.contentType == server.RequestHeaderJSON {
+				} else if tt.contentType == httputil.RequestHeaderJSON {
 					opts = append(opts, WithRequestContentTypeJSON())
 				} else {
 					opts = append(opts, func(op *Op) {
@@ -1204,22 +1204,22 @@ func TestGetMetrics(t *testing.T) {
 		{
 			name:           "successful JSON response",
 			serverResponse: mustMarshalJSON(t, testMetrics),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			statusCode:     http.StatusOK,
 			expectedResult: testMetrics,
 		},
 		{
 			name:           "successful YAML response",
 			serverResponse: mustMarshalYAML(t, testMetrics),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			statusCode:     http.StatusOK,
 			expectedResult: testMetrics,
 		},
 		{
 			name:           "successful gzipped JSON response",
 			serverResponse: mustMarshalJSON(t, testMetrics),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			statusCode:     http.StatusOK,
 			expectedResult: testMetrics,
 			useGzip:        true,
@@ -1233,14 +1233,14 @@ func TestGetMetrics(t *testing.T) {
 		{
 			name:           "invalid JSON response",
 			serverResponse: []byte(`invalid json`),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			statusCode:     http.StatusOK,
 			expectedError:  "failed to decode json",
 		},
 		{
 			name:           "invalid YAML response",
 			serverResponse: []byte(`invalid yaml:`),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			statusCode:     http.StatusOK,
 			expectedError:  "failed to unmarshal yaml",
 		},
@@ -1253,11 +1253,11 @@ func TestGetMetrics(t *testing.T) {
 				assert.Equal(t, http.MethodGet, r.Method)
 
 				if tt.contentType != "" {
-					assert.Equal(t, tt.contentType, r.Header.Get(server.RequestHeaderContentType))
-					w.Header().Set(server.RequestHeaderContentType, tt.contentType)
+					assert.Equal(t, tt.contentType, r.Header.Get(httputil.RequestHeaderContentType))
+					w.Header().Set(httputil.RequestHeaderContentType, tt.contentType)
 				}
 				if tt.acceptEncoding != "" {
-					assert.Equal(t, tt.acceptEncoding, r.Header.Get(server.RequestHeaderAcceptEncoding))
+					assert.Equal(t, tt.acceptEncoding, r.Header.Get(httputil.RequestHeaderAcceptEncoding))
 				}
 
 				w.WriteHeader(tt.statusCode)
@@ -1272,12 +1272,12 @@ func TestGetMetrics(t *testing.T) {
 			defer srv.Close()
 
 			opts := []OpOption{}
-			if tt.contentType == server.RequestHeaderYAML {
+			if tt.contentType == httputil.RequestHeaderYAML {
 				opts = append(opts, WithRequestContentTypeYAML())
-			} else if tt.contentType == server.RequestHeaderJSON {
+			} else if tt.contentType == httputil.RequestHeaderJSON {
 				opts = append(opts, WithRequestContentTypeJSON())
 			}
-			if tt.acceptEncoding == server.RequestHeaderEncodingGzip {
+			if tt.acceptEncoding == httputil.RequestHeaderEncodingGzip {
 				opts = append(opts, WithAcceptEncodingGzip())
 			}
 
@@ -1310,10 +1310,10 @@ func TestGetMetrics(t *testing.T) {
 			assert.Equal(t, http.MethodGet, r.Method)
 
 			// Verify that the XML content type is sent
-			contentType := r.Header.Get(server.RequestHeaderContentType)
+			contentType := r.Header.Get(httputil.RequestHeaderContentType)
 			assert.Equal(t, "application/xml", contentType)
 
-			w.Header().Set(server.RequestHeaderContentType, "application/xml")
+			w.Header().Set(httputil.RequestHeaderContentType, "application/xml")
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte(`<metrics></metrics>`))
 			require.NoError(t, err)
@@ -1360,20 +1360,20 @@ func TestReadMetrics(t *testing.T) {
 		{
 			name:           "read JSON",
 			input:          bytes.NewReader(jsonData),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			expectedResult: testMetrics,
 		},
 		{
 			name:           "read YAML",
 			input:          bytes.NewReader(yamlData),
-			contentType:    server.RequestHeaderYAML,
+			contentType:    httputil.RequestHeaderYAML,
 			expectedResult: testMetrics,
 		},
 		{
 			name:           "read gzipped JSON",
 			input:          bytes.NewReader(gzipContent(t, jsonData)),
-			contentType:    server.RequestHeaderJSON,
-			acceptEncoding: server.RequestHeaderEncodingGzip,
+			contentType:    httputil.RequestHeaderJSON,
+			acceptEncoding: httputil.RequestHeaderEncodingGzip,
 			expectedResult: testMetrics,
 		},
 		{
@@ -1388,9 +1388,9 @@ func TestReadMetrics(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := []OpOption{}
 			if tt.contentType != "" {
-				if tt.contentType == server.RequestHeaderYAML {
+				if tt.contentType == httputil.RequestHeaderYAML {
 					opts = append(opts, WithRequestContentTypeYAML())
-				} else if tt.contentType == server.RequestHeaderJSON {
+				} else if tt.contentType == httputil.RequestHeaderJSON {
 					opts = append(opts, WithRequestContentTypeJSON())
 				} else {
 					opts = append(opts, func(op *Op) {

--- a/client/v1/v1_trigger_test.go
+++ b/client/v1/v1_trigger_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	v1 "github.com/leptonai/gpud/api/v1"
-	"github.com/leptonai/gpud/pkg/server"
+	"github.com/leptonai/gpud/pkg/httputil"
 )
 
 func TestTriggerComponentCheck(t *testing.T) {
@@ -37,7 +37,7 @@ func TestTriggerComponentCheck(t *testing.T) {
 			name:           "successful trigger check",
 			componentName:  "test-component",
 			serverResponse: mustMarshalJSON(t, testHealthStates),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			statusCode:     http.StatusOK,
 			expectedResult: testHealthStates,
 		},
@@ -56,7 +56,7 @@ func TestTriggerComponentCheck(t *testing.T) {
 			name:           "invalid JSON response",
 			componentName:  "test-component",
 			serverResponse: []byte(`invalid json`),
-			contentType:    server.RequestHeaderJSON,
+			contentType:    httputil.RequestHeaderJSON,
 			statusCode:     http.StatusOK,
 			expectedError:  "failed to decode json",
 		},
@@ -79,10 +79,10 @@ func TestTriggerComponentCheck(t *testing.T) {
 				assert.Equal(t, tt.componentName, r.URL.Query().Get("componentName"))
 
 				if tt.contentType != "" {
-					assert.Equal(t, tt.contentType, r.Header.Get(server.RequestHeaderContentType))
+					assert.Equal(t, tt.contentType, r.Header.Get(httputil.RequestHeaderContentType))
 				}
 				if tt.acceptEncoding != "" {
-					assert.Equal(t, tt.acceptEncoding, r.Header.Get(server.RequestHeaderAcceptEncoding))
+					assert.Equal(t, tt.acceptEncoding, r.Header.Get(httputil.RequestHeaderAcceptEncoding))
 				}
 
 				w.WriteHeader(tt.statusCode)
@@ -94,12 +94,12 @@ func TestTriggerComponentCheck(t *testing.T) {
 			defer srv.Close()
 
 			opts := []OpOption{}
-			if tt.contentType == server.RequestHeaderYAML {
+			if tt.contentType == httputil.RequestHeaderYAML {
 				opts = append(opts, WithRequestContentTypeYAML())
-			} else if tt.contentType == server.RequestHeaderJSON {
+			} else if tt.contentType == httputil.RequestHeaderJSON {
 				opts = append(opts, WithRequestContentTypeJSON())
 			}
-			if tt.acceptEncoding == server.RequestHeaderEncodingGzip {
+			if tt.acceptEncoding == httputil.RequestHeaderEncodingGzip {
 				opts = append(opts, WithAcceptEncodingGzip())
 			}
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -29,8 +29,8 @@ import (
 	mocklspci "github.com/leptonai/gpud/e2e/mock/lspci"
 	pkgcustomplugins "github.com/leptonai/gpud/pkg/custom-plugins"
 	"github.com/leptonai/gpud/pkg/errdefs"
+	"github.com/leptonai/gpud/pkg/httputil"
 	nvmllib "github.com/leptonai/gpud/pkg/nvidia-query/nvml/lib"
-	"github.com/leptonai/gpud/pkg/server"
 )
 
 func TestE2E(t *testing.T) {
@@ -244,8 +244,8 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 			req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/v1/states", ep), nil)
 			Expect(err).NotTo(HaveOccurred(), "failed to create request")
 
-			req.Header.Set(server.RequestHeaderContentType, server.RequestHeaderJSON)
-			req.Header.Set(server.RequestHeaderAcceptEncoding, server.RequestHeaderEncodingGzip)
+			req.Header.Set(httputil.RequestHeaderContentType, httputil.RequestHeaderJSON)
+			req.Header.Set(httputil.RequestHeaderAcceptEncoding, httputil.RequestHeaderEncodingGzip)
 
 			resp, err := client.Do(req)
 			Expect(err).NotTo(HaveOccurred(), "failed to make request")

--- a/pkg/httputil/header.go
+++ b/pkg/httputil/header.go
@@ -1,0 +1,11 @@
+package httputil
+
+const (
+	RequestHeaderContentType = "Content-Type"
+	RequestHeaderJSON        = "application/json"
+	RequestHeaderYAML        = "application/yaml"
+	RequestHeaderJSONIndent  = "json-indent"
+
+	RequestHeaderAcceptEncoding = "Accept-Encoding"
+	RequestHeaderEncodingGzip   = "gzip"
+)

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -21,16 +21,6 @@ const (
 	URLPathSwaggerDesc = "Swagger endpoint for docs"
 )
 
-const (
-	RequestHeaderContentType = "Content-Type"
-	RequestHeaderJSON        = "application/json"
-	RequestHeaderYAML        = "application/yaml"
-	RequestHeaderJSONIndent  = "json-indent"
-
-	RequestHeaderAcceptEncoding = "Accept-Encoding"
-	RequestHeaderEncodingGzip   = "gzip"
-)
-
 type globalHandler struct {
 	cfg *gpudconfig.Config
 

--- a/pkg/server/handlers_components.go
+++ b/pkg/server/handlers_components.go
@@ -12,6 +12,7 @@ import (
 	"github.com/leptonai/gpud/components"
 	pkgcustomplugins "github.com/leptonai/gpud/pkg/custom-plugins"
 	"github.com/leptonai/gpud/pkg/errdefs"
+	"github.com/leptonai/gpud/pkg/httputil"
 	"github.com/leptonai/gpud/pkg/log"
 	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
 )
@@ -52,8 +53,8 @@ func (g *globalHandler) getComponents(c *gin.Context) {
 	}
 	sort.Strings(components)
 
-	switch c.GetHeader(RequestHeaderContentType) {
-	case RequestHeaderYAML:
+	switch c.GetHeader(httputil.RequestHeaderContentType) {
+	case httputil.RequestHeaderYAML:
 		yb, err := yaml.Marshal(components)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"code": http.StatusInternalServerError, "message": "failed to marshal components " + err.Error()})
@@ -61,8 +62,8 @@ func (g *globalHandler) getComponents(c *gin.Context) {
 		}
 		c.String(http.StatusOK, string(yb))
 
-	case RequestHeaderJSON, "":
-		if c.GetHeader(RequestHeaderJSONIndent) == "true" {
+	case httputil.RequestHeaderJSON, "":
+		if c.GetHeader(httputil.RequestHeaderJSONIndent) == "true" {
 			c.IndentedJSON(http.StatusOK, components)
 			return
 		}
@@ -160,8 +161,8 @@ func (g *globalHandler) getComponentsCustomPlugins(c *gin.Context) {
 		}
 	}
 
-	switch c.GetHeader(RequestHeaderContentType) {
-	case RequestHeaderYAML:
+	switch c.GetHeader(httputil.RequestHeaderContentType) {
+	case httputil.RequestHeaderYAML:
 		yb, err := yaml.Marshal(cs)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"code": http.StatusInternalServerError, "message": "failed to marshal custom plugins " + err.Error()})
@@ -169,8 +170,8 @@ func (g *globalHandler) getComponentsCustomPlugins(c *gin.Context) {
 		}
 		c.String(http.StatusOK, string(yb))
 
-	case RequestHeaderJSON, "":
-		if c.GetHeader(RequestHeaderJSONIndent) == "true" {
+	case httputil.RequestHeaderJSON, "":
+		if c.GetHeader(httputil.RequestHeaderJSONIndent) == "true" {
 			c.IndentedJSON(http.StatusOK, cs)
 			return
 		}
@@ -321,8 +322,8 @@ func (g *globalHandler) getHealthStates(c *gin.Context) {
 		states = append(states, currState)
 	}
 
-	switch c.GetHeader(RequestHeaderContentType) {
-	case RequestHeaderYAML:
+	switch c.GetHeader(httputil.RequestHeaderContentType) {
+	case httputil.RequestHeaderYAML:
 		yb, err := yaml.Marshal(states)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"code": http.StatusInternalServerError, "message": "failed to marshal states " + err.Error()})
@@ -330,8 +331,8 @@ func (g *globalHandler) getHealthStates(c *gin.Context) {
 		}
 		c.String(http.StatusOK, string(yb))
 
-	case RequestHeaderJSON, "":
-		if c.GetHeader(RequestHeaderJSONIndent) == "true" {
+	case httputil.RequestHeaderJSON, "":
+		if c.GetHeader(httputil.RequestHeaderJSONIndent) == "true" {
 			c.IndentedJSON(http.StatusOK, states)
 			return
 		}
@@ -405,8 +406,8 @@ func (g *globalHandler) getEvents(c *gin.Context) {
 		events = append(events, currEvent)
 	}
 
-	switch c.GetHeader(RequestHeaderContentType) {
-	case RequestHeaderYAML:
+	switch c.GetHeader(httputil.RequestHeaderContentType) {
+	case httputil.RequestHeaderYAML:
 		yb, err := yaml.Marshal(events)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"code": http.StatusInternalServerError, "message": "failed to marshal events " + err.Error()})
@@ -414,8 +415,8 @@ func (g *globalHandler) getEvents(c *gin.Context) {
 		}
 		c.String(http.StatusOK, string(yb))
 
-	case RequestHeaderJSON, "":
-		if c.GetHeader(RequestHeaderJSONIndent) == "true" {
+	case httputil.RequestHeaderJSON, "":
+		if c.GetHeader(httputil.RequestHeaderJSONIndent) == "true" {
 			c.IndentedJSON(http.StatusOK, events)
 			return
 		}
@@ -533,8 +534,8 @@ func (g *globalHandler) getInfo(c *gin.Context) {
 		infos = append(infos, currInfo)
 	}
 
-	switch c.GetHeader(RequestHeaderContentType) {
-	case RequestHeaderYAML:
+	switch c.GetHeader(httputil.RequestHeaderContentType) {
+	case httputil.RequestHeaderYAML:
 		yb, err := yaml.Marshal(infos)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"code": http.StatusInternalServerError, "message": "failed to marshal infos " + err.Error()})
@@ -542,8 +543,8 @@ func (g *globalHandler) getInfo(c *gin.Context) {
 		}
 		c.String(http.StatusOK, string(yb))
 
-	case RequestHeaderJSON, "":
-		if c.GetHeader(RequestHeaderJSONIndent) == "true" {
+	case httputil.RequestHeaderJSON, "":
+		if c.GetHeader(httputil.RequestHeaderJSONIndent) == "true" {
 			c.IndentedJSON(http.StatusOK, infos)
 			return
 		}
@@ -595,8 +596,8 @@ func (g *globalHandler) getMetrics(c *gin.Context) {
 	}
 
 	metrics := pkgmetrics.ConvertToLeptonMetrics(metricsData)
-	switch c.GetHeader(RequestHeaderContentType) {
-	case RequestHeaderYAML:
+	switch c.GetHeader(httputil.RequestHeaderContentType) {
+	case httputil.RequestHeaderYAML:
 		yb, err := yaml.Marshal(metrics)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"code": http.StatusInternalServerError, "message": "failed to marshal metrics " + err.Error()})
@@ -604,8 +605,8 @@ func (g *globalHandler) getMetrics(c *gin.Context) {
 		}
 		c.String(http.StatusOK, string(yb))
 
-	case RequestHeaderJSON, "":
-		if c.GetHeader(RequestHeaderJSONIndent) == "true" {
+	case httputil.RequestHeaderJSON, "":
+		if c.GetHeader(httputil.RequestHeaderJSONIndent) == "true" {
 			c.IndentedJSON(http.StatusOK, metrics)
 			return
 		}

--- a/pkg/server/handlers_components_test.go
+++ b/pkg/server/handlers_components_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/leptonai/gpud/components"
 	"github.com/leptonai/gpud/pkg/config"
 	pkgcustomplugins "github.com/leptonai/gpud/pkg/custom-plugins"
+	"github.com/leptonai/gpud/pkg/httputil"
 	"github.com/leptonai/gpud/pkg/metrics"
 )
 
@@ -263,7 +264,7 @@ func TestGetComponentsYAML(t *testing.T) {
 
 	// Set up a new request with YAML content type
 	c.Request = httptest.NewRequest("GET", "/v1/components", nil)
-	c.Request.Header.Set(RequestHeaderContentType, RequestHeaderYAML)
+	c.Request.Header.Set(httputil.RequestHeaderContentType, httputil.RequestHeaderYAML)
 
 	handler.getComponents(c)
 


### PR DESCRIPTION
to avoid client/v1 package to import server package

Signed-off-by: Gyuho Lee <gyuhox@gmail.com>
