### PR TITLE
feat(custom-plugins): register health state metrics for custom plugins

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -275,21 +275,33 @@ func (i *MachineInfo) RenderTable(wr io.Writer) {
 	table := tablewriter.NewWriter(wr)
 	table.SetAlignment(tablewriter.ALIGN_CENTER)
 	table.Append([]string{"GPUd Version", i.GPUdVersion})
-	table.Append([]string{"CUDA Version", i.CUDAVersion})
 	table.Append([]string{"Container Runtime Version", i.ContainerRuntimeVersion})
-	table.Append([]string{"Kernel Version", i.KernelVersion})
 	table.Append([]string{"OS Image", i.OSImage})
+	table.Append([]string{"Kernel Version", i.KernelVersion})
 
-	if i.DiskInfo != nil {
-		table.Append([]string{"Container Root Disk", i.DiskInfo.ContainerRootDisk})
+	if i.CPUInfo != nil {
+		table.Append([]string{"CPU Type", i.CPUInfo.Type})
+		table.Append([]string{"CPU Manufacturer", i.CPUInfo.Manufacturer})
+		table.Append([]string{"CPU Architecture", i.CPUInfo.Architecture})
 	}
 
+	table.Append([]string{"CUDA Version", i.CUDAVersion})
 	if i.GPUInfo != nil {
 		table.Append([]string{"GPU Driver Version", i.GPUDriverVersion})
 		table.Append([]string{"GPU Product", i.GPUInfo.Product})
 		table.Append([]string{"GPU Manufacturer", i.GPUInfo.Manufacturer})
 		table.Append([]string{"GPU Architecture", i.GPUInfo.Architecture})
 		table.Append([]string{"GPU Memory", i.GPUInfo.Memory})
+	}
+
+	if i.NICInfo != nil {
+		for idx, nic := range i.NICInfo.PrivateIPInterfaces {
+			table.Append([]string{fmt.Sprintf("Private IP Interface %d", idx+1), fmt.Sprintf("%s (%s, %s)", nic.Interface, nic.MAC, nic.IP)})
+		}
+	}
+
+	if i.DiskInfo != nil {
+		table.Append([]string{"Container Root Disk", i.DiskInfo.ContainerRootDisk})
 	}
 
 	table.Render()

--- a/pkg/custom-plugins/component_health_test.go
+++ b/pkg/custom-plugins/component_health_test.go
@@ -1,0 +1,98 @@
+package customplugins
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/leptonai/gpud/components"
+	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
+)
+
+// TestHealthStateSetterInitialization tests the initialization of the healthStateSetter in NewInitFunc
+func TestHealthStateSetterInitialization(t *testing.T) {
+	spec := &Spec{
+		PluginName: "test-plugin",
+		Timeout: metav1.Duration{
+			Duration: time.Second * 10,
+		},
+	}
+
+	initFunc := spec.NewInitFunc()
+	require.NotNil(t, initFunc)
+
+	rootCtx := context.Background()
+	gpudInstance := &components.GPUdInstance{
+		RootCtx: rootCtx,
+	}
+
+	// Call the init function to create a component
+	comp, err := initFunc(gpudInstance)
+	require.NoError(t, err)
+	require.NotNil(t, comp)
+
+	// Assert the component is of the expected type
+	c, ok := comp.(*component)
+	require.True(t, ok)
+
+	// Verify the healthStateSetter was initialized
+	assert.NotNil(t, c.healthStateSetter)
+}
+
+// TestComponentCheck_ValidHealthStateMetrics tests that valid health state metrics are passed to RegisterHealthStateMetrics
+func TestComponentCheck_ValidHealthStateMetrics(t *testing.T) {
+	// This test is a more realistic test using the actual pkgmetrics package,
+	// rather than mocks
+
+	// Create a spec and register health state metrics
+	spec := &Spec{
+		PluginName: "test-plugin",
+	}
+
+	// Register metrics with a custom registry
+	registry := prometheus.NewRegistry()
+	healthStateSetter, err := pkgmetrics.RegisterHealthStateMetricsWithRegisterer(registry, spec.ComponentName())
+	require.NoError(t, err)
+	require.NotNil(t, healthStateSetter)
+
+	// Create a component with the real healthStateSetter
+	c := &component{
+		ctx:               context.Background(),
+		spec:              spec,
+		healthStateSetter: healthStateSetter,
+	}
+
+	// Run a check which should set some health metrics
+	result := c.Check()
+	require.NotNil(t, result)
+
+	// Verify metrics were registered by gathering them from the registry
+	metrics, err := registry.Gather()
+	require.NoError(t, err)
+
+	// There should be three metrics for healthy, unhealthy, and degraded
+	foundMetrics := 0
+	for _, m := range metrics {
+		if m.GetName() == pkgmetrics.NormalizeComponentNameToMetricSubsystem(spec.ComponentName())+"_health_state_healthy" {
+			foundMetrics++
+			// Since the component should be healthy, the value should be 1
+			require.Equal(t, float64(1), m.GetMetric()[0].GetGauge().GetValue())
+		}
+		if m.GetName() == pkgmetrics.NormalizeComponentNameToMetricSubsystem(spec.ComponentName())+"_health_state_unhealthy" {
+			foundMetrics++
+			// Since the component should not be unhealthy, the value should be 0
+			require.Equal(t, float64(0), m.GetMetric()[0].GetGauge().GetValue())
+		}
+		if m.GetName() == pkgmetrics.NormalizeComponentNameToMetricSubsystem(spec.ComponentName())+"_health_state_degraded" {
+			foundMetrics++
+			// Since the component should not be degraded, the value should be 0
+			require.Equal(t, float64(0), m.GetMetric()[0].GetGauge().GetValue())
+		}
+	}
+	require.Equal(t, 3, foundMetrics, "Expected to find three health state metrics")
+}

--- a/pkg/custom-plugins/component_test.go
+++ b/pkg/custom-plugins/component_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv1 "github.com/leptonai/gpud/api/v1"
 	"github.com/leptonai/gpud/components"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewInitFunc(t *testing.T) {

--- a/pkg/metrics/utils.go
+++ b/pkg/metrics/utils.go
@@ -2,6 +2,10 @@ package metrics
 
 import (
 	"sort"
+	"strings"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
 
 	apiv1 "github.com/leptonai/gpud/api/v1"
 )
@@ -37,4 +41,135 @@ func ConvertToLeptonMetrics(ms Metrics) apiv1.GPUdComponentMetrics {
 		})
 	}
 	return converted
+}
+
+type HealthStateSetter interface {
+	Set(healthState apiv1.HealthStateType)
+}
+
+var _ HealthStateSetter = &healthStateSetter{}
+
+type healthStateSetter struct {
+	setHealthy   func(healthy bool)
+	setUnhealthy func(unhealthy bool)
+	setDegraded  func(degraded bool)
+}
+
+func (s *healthStateSetter) Set(healthState apiv1.HealthStateType) {
+	s.setHealthy(healthState == apiv1.HealthStateTypeHealthy)
+	s.setUnhealthy(healthState == apiv1.HealthStateTypeUnhealthy)
+	s.setDegraded(healthState == apiv1.HealthStateTypeDegraded)
+}
+
+// to prevent duplicate metrics registration
+var (
+	registeredHealthStateMetricsMu sync.Mutex
+	registeredHealthStateMetrics   = make(map[string]HealthStateSetter)
+)
+
+func RegisterHealthStateMetrics(componentName string) (HealthStateSetter, error) {
+	registeredHealthStateMetricsMu.Lock()
+	defer registeredHealthStateMetricsMu.Unlock()
+
+	if v, ok := registeredHealthStateMetrics[componentName]; ok {
+		return v, nil
+	}
+
+	setter, err := RegisterHealthStateMetricsWithRegisterer(defaultRegisterer, componentName)
+	if err != nil {
+		return nil, err
+	}
+
+	registeredHealthStateMetrics[componentName] = setter
+	return setter, nil
+}
+
+// RegisterHealthStateMetricsWithRegisterer registers the health state metrics for the given component.
+// Returns the function to update the health state metrics.
+func RegisterHealthStateMetricsWithRegisterer(reg prometheus.Registerer, componentName string) (HealthStateSetter, error) {
+	metricStateHealthy := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: NormalizeComponentNameToMetricSubsystem(componentName),
+			Name:      "health_state_healthy",
+			Help:      "last known healthy state of the component (set to 1 if healthy)",
+		},
+		[]string{MetricComponentLabelKey},
+	).MustCurryWith(
+		prometheus.Labels{
+			MetricComponentLabelKey: componentName,
+		},
+	)
+	if err := reg.Register(metricStateHealthy); err != nil {
+		return nil, err
+	}
+	setHealthy := func(healthy bool) {
+		if healthy {
+			metricStateHealthy.With(prometheus.Labels{}).Set(1)
+		} else {
+			metricStateHealthy.With(prometheus.Labels{}).Set(0)
+		}
+	}
+
+	metricStateUnhealthy := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: NormalizeComponentNameToMetricSubsystem(componentName),
+			Name:      "health_state_unhealthy",
+			Help:      "last known unhealthy state of the component (set to 1 if unhealthy)",
+		},
+		[]string{MetricComponentLabelKey},
+	).MustCurryWith(
+		prometheus.Labels{
+			MetricComponentLabelKey: componentName,
+		},
+	)
+	if err := reg.Register(metricStateUnhealthy); err != nil {
+		return nil, err
+	}
+	setUnhealthy := func(unhealthy bool) {
+		if unhealthy {
+			metricStateUnhealthy.With(prometheus.Labels{}).Set(1)
+		} else {
+			metricStateUnhealthy.With(prometheus.Labels{}).Set(0)
+		}
+	}
+
+	metricStateDegraded := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: NormalizeComponentNameToMetricSubsystem(componentName),
+			Name:      "health_state_degraded",
+			Help:      "last known degraded state of the component (set to 1 if degraded)",
+		},
+		[]string{MetricComponentLabelKey},
+	).MustCurryWith(
+		prometheus.Labels{
+			MetricComponentLabelKey: componentName,
+		},
+	)
+	if err := reg.Register(metricStateDegraded); err != nil {
+		return nil, err
+	}
+	setDegraded := func(degraded bool) {
+		if degraded {
+			metricStateDegraded.With(prometheus.Labels{}).Set(1)
+		} else {
+			metricStateDegraded.With(prometheus.Labels{}).Set(0)
+		}
+	}
+
+	return &healthStateSetter{
+		setHealthy:   setHealthy,
+		setUnhealthy: setUnhealthy,
+		setDegraded:  setDegraded,
+	}, nil
+}
+
+func NormalizeComponentNameToMetricSubsystem(componentName string) string {
+	s := strings.ToLower(componentName)
+	s = strings.ReplaceAll(s, "-", "_")
+	s = strings.ReplaceAll(s, ".", "_")
+	s = strings.ReplaceAll(s, "/", "_")
+	return s
 }

--- a/pkg/server/handlers_components.go
+++ b/pkg/server/handlers_components.go
@@ -217,6 +217,19 @@ func (g *globalHandler) registerComponentsCustomPlugin(c *gin.Context) {
 		return
 	}
 
+	g.componentNamesMu.Lock()
+	defer g.componentNamesMu.Unlock()
+	found := false
+	for _, name := range g.componentNames {
+		if name == comp.Name() {
+			found = true
+			break
+		}
+	}
+	if !found {
+		g.componentNames = append(g.componentNames, comp.Name())
+	}
+
 	c.JSON(http.StatusOK, gin.H{"code": http.StatusOK, "message": "component registered and started", "component": comp.Name()})
 }
 


### PR DESCRIPTION
```
# HELP init_plugin_health_state_degraded last known degraded state of the component (set to 1 if degraded)
# TYPE init_plugin_health_state_degraded gauge
init_plugin_health_state_degraded{gpud_component="init-plugin"} 0
# HELP init_plugin_health_state_healthy last known healthy state of the component (set to 1 if healthy)
# TYPE init_plugin_health_state_healthy gauge
init_plugin_health_state_healthy{gpud_component="init-plugin"} 1
# HELP init_plugin_health_state_unhealthy last known unhealthy state of the component (set to 1 if unhealthy)
# TYPE init_plugin_health_state_unhealthy gauge
init_plugin_health_state_unhealthy{gpud_component="init-plugin"} 0

...

# HELP y9w0v16wbm_health_state_degraded last known degraded state of the component (set to 1 if degraded)
# TYPE y9w0v16wbm_health_state_degraded gauge
y9w0v16wbm_health_state_degraded{gpud_component="y9w0v16wbm"} 0
# HELP y9w0v16wbm_health_state_healthy last known healthy state of the component (set to 1 if healthy)
# TYPE y9w0v16wbm_health_state_healthy gauge
y9w0v16wbm_health_state_healthy{gpud_component="y9w0v16wbm"} 1
# HELP y9w0v16wbm_health_state_unhealthy last known unhealthy state of the component (set to 1 if unhealthy)
# TYPE y9w0v16wbm_health_state_unhealthy gauge
y9w0v16wbm_health_state_unhealthy{gpud_component="y9w0v16wbm"} 0
```