### PR TITLE
feat(fault-injector): use dummy device to simulate xid/sxid/* kernel message

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -20,6 +20,7 @@ import (
 	cmdstatus "github.com/leptonai/gpud/cmd/gpud/status"
 	cmdup "github.com/leptonai/gpud/cmd/gpud/up"
 	cmdupdate "github.com/leptonai/gpud/cmd/gpud/update"
+	cmdwritekmsg "github.com/leptonai/gpud/cmd/gpud/write-kmsg"
 	"github.com/leptonai/gpud/pkg/config"
 	"github.com/leptonai/gpud/version"
 )
@@ -218,6 +219,10 @@ sudo rm /etc/systemd/system/gpud.service
 				&cli.BoolFlag{
 					Name:  "enable-plugin-api",
 					Usage: "enable plugin API (default: false)",
+				},
+				&cli.BoolFlag{
+					Name:  "enable-fault-injector",
+					Usage: "enable fault injector (default: false)",
 				},
 			},
 		},
@@ -597,6 +602,23 @@ sudo gpud join
 				&cli.StringFlag{
 					Name:  "log-level,l",
 					Usage: "set the logging level [debug, info, warn, error, fatal, panic, dpanic]",
+				},
+			},
+		},
+		{
+			Name:      "write-kmsg",
+			Usage:     "write a kernel message to the kernel log",
+			UsageText: "gpud write-kmsg <message>",
+			Action:    cmdwritekmsg.Command,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  "log-level,l",
+					Usage: "set the logging level [debug, info, warn, error, fatal, panic, dpanic]",
+				},
+				&cli.StringFlag{
+					Name:  "kernel-log-level",
+					Usage: "set the kernel log level [KERN_EMERG, KERN_ALERT, KERN_CRIT, KERN_ERR, KERN_WARNING, KERN_NOTICE, KERN_INFO, KERN_DEBUG]",
+					Value: "KERN_INFO",
 				},
 			},
 		},

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -54,6 +54,7 @@ func Command(cliContext *cli.Context) error {
 	ibstatCommand := cliContext.String("ibstat-command")
 	ibstatusCommand := cliContext.String("ibstatus-command")
 	enablePluginAPI := cliContext.Bool("enable-plugin-api")
+	enableFaultInjector := cliContext.Bool("enable-fault-injector")
 	enableComponents := cliContext.String("enable-components")
 
 	configOpts := []config.OpOption{
@@ -85,6 +86,7 @@ func Command(cliContext *cli.Context) error {
 
 	cfg.PluginSpecsFile = pluginSpecsFile
 	cfg.EnablePluginAPI = enablePluginAPI
+	cfg.EnableFaultInjector = enableFaultInjector
 
 	if enableComponents != "" && enableComponents != "*" && enableComponents != "all" {
 		cfg.EnableComponents = strings.Split(enableComponents, ",")

--- a/cmd/gpud/write-kmsg/command.go
+++ b/cmd/gpud/write-kmsg/command.go
@@ -1,0 +1,61 @@
+package customplugins
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	"github.com/urfave/cli"
+
+	pkgkmsgwriter "github.com/leptonai/gpud/pkg/kmsg/writer"
+	"github.com/leptonai/gpud/pkg/log"
+)
+
+func Command(cliContext *cli.Context) error {
+	logLevel := cliContext.String("log-level")
+	zapLvl, err := log.ParseLogLevel(logLevel)
+	if err != nil {
+		return err
+	}
+	log.Logger = log.CreateLogger(zapLvl, "")
+
+	log.Logger.Debugw("starting write-kmsg command")
+
+	if err := pkgkmsgwriter.CheckPermissions(); err != nil {
+		return err
+	}
+
+	msg := cliContext.Args().First()
+	if msg == "" {
+		return errors.New("message is required")
+	}
+
+	workDir, err := os.MkdirTemp(os.TempDir(), "gpud-cmd-write-kmsg-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(workDir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	module := pkgkmsgwriter.NewGPUdKmsgWriterModule(ctx, workDir)
+	if err := module.BuildInstall(ctx); err != nil {
+		return err
+	}
+
+	kernelLogLevel := cliContext.String("kernel-log-level")
+	if err := module.InjectKernelMessage(ctx, &pkgkmsgwriter.KernelMessage{
+		Priority: pkgkmsgwriter.KernelMessagePriority(kernelLogLevel),
+		Message:  msg,
+	}); err != nil {
+		return err
+	}
+
+	if err := module.Uninstall(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/components/accelerator/nvidia/xid/message_to_inject.go
+++ b/components/accelerator/nvidia/xid/message_to_inject.go
@@ -1,0 +1,42 @@
+package xid
+
+import "fmt"
+
+type MessageToInject struct {
+	Priority string
+	Message  string
+}
+
+func GetMessageToInject(xid int) MessageToInject {
+	msg, ok := xidExampleMsgs[xid]
+	if !ok {
+		return MessageToInject{
+			Priority: "KERN_WARNING",
+			Message:  fmt.Sprintf("NVRM: Xid (PCI:0000:04:00): %d, unknown", xid),
+		}
+	}
+	return msg
+}
+
+var xidExampleMsgs = map[int]MessageToInject{
+	63: {
+		Priority: "KERN_WARNING",
+		Message:  "NVRM: Xid (PCI:0000:04:00): 63, Row remapping event: Rows 0x1a and 0x2b have been remapped on GPU 00000000:04:00.0",
+	},
+	64: {
+		Priority: "KERN_WARNING",
+		Message:  "NVRM: Xid (PCI:0000:04:00): 64, Failed to persist row remap table — GPU may require servicing",
+	},
+	69: {
+		Priority: "KERN_WARNING",
+		Message:  "NVRM: Xid (PCI:0000:04:00): 69, pid=34566, name=python3, BAR1 access failure at address 0xffff80001234abcd",
+	},
+	74: {
+		Priority: "KERN_WARNING",
+		Message:  "NVRM: Xid (PCI:0000:04:00): 74, pid=1234, name=python3, Channel 0x23, MMU Fault: ENGINE GRAPHICS GPCCLIENT_T1_0 faulted @ 0x7fc123456000. Fault is of type FAULT_PTE ACCESS_TYPE_VIRT_READ",
+	},
+	79: {
+		Priority: "KERN_ERR",
+		Message:  "NVRM: Xid (PCI:0000:04:00): 79, GPU has fallen off the bus",
+	},
+}

--- a/components/accelerator/nvidia/xid/message_to_inject_test.go
+++ b/components/accelerator/nvidia/xid/message_to_inject_test.go
@@ -1,0 +1,174 @@
+package xid
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetMessageToInject(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		xid           int
+		expectedXid   int
+		expectedPrio  string
+		shouldContain string
+	}{
+		{
+			name:          "known XID 63",
+			xid:           63,
+			expectedXid:   63,
+			expectedPrio:  "KERN_WARNING",
+			shouldContain: "Row remapping event",
+		},
+		{
+			name:          "known XID 64",
+			xid:           64,
+			expectedXid:   64,
+			expectedPrio:  "KERN_WARNING",
+			shouldContain: "Failed to persist row remap table",
+		},
+		{
+			name:          "known XID 69",
+			xid:           69,
+			expectedXid:   69,
+			expectedPrio:  "KERN_WARNING",
+			shouldContain: "BAR1 access failure",
+		},
+		{
+			name:          "known XID 74",
+			xid:           74,
+			expectedXid:   74,
+			expectedPrio:  "KERN_WARNING",
+			shouldContain: "MMU Fault",
+		},
+		{
+			name:          "known XID 79",
+			xid:           79,
+			expectedXid:   79,
+			expectedPrio:  "KERN_ERR",
+			shouldContain: "GPU has fallen off the bus",
+		},
+		{
+			name:          "unknown XID 42",
+			xid:           42,
+			expectedXid:   42,
+			expectedPrio:  "KERN_WARNING",
+			shouldContain: "unknown",
+		},
+		{
+			name:          "unknown XID 999",
+			xid:           999,
+			expectedXid:   999,
+			expectedPrio:  "KERN_WARNING",
+			shouldContain: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetMessageToInject(tt.xid)
+
+			// Check priority
+			require.Equal(t, tt.expectedPrio, result.Priority)
+
+			// Check that message contains expected substring
+			require.NotEmpty(t, result.Message)
+
+			// For this test, we just check that the message contains some expected content
+			// The actual XID extraction test is separate
+			if tt.shouldContain != "" {
+				require.Contains(t, result.Message, tt.shouldContain)
+			}
+		})
+	}
+}
+
+func TestGetMessageToInject_XidExtraction(t *testing.T) {
+	t.Parallel()
+
+	// Test all known XIDs
+	knownXids := []int{63, 64, 69, 74, 79}
+
+	for _, xid := range knownXids {
+		t.Run(fmt.Sprintf("known_xid_%d", xid), func(t *testing.T) {
+			msg := GetMessageToInject(xid)
+			extractedXid := ExtractNVRMXid(msg.Message)
+
+			require.NotZero(t, extractedXid, "ExtractNVRMXid failed to extract XID from message: %s", msg.Message)
+			require.Equal(t, xid, extractedXid)
+		})
+	}
+
+	// Test unknown XIDs
+	unknownXids := []int{1, 25, 42, 100, 999}
+
+	for _, xid := range unknownXids {
+		t.Run(fmt.Sprintf("unknown_xid_%d", xid), func(t *testing.T) {
+			msg := GetMessageToInject(xid)
+			extractedXid := ExtractNVRMXid(msg.Message)
+
+			require.NotZero(t, extractedXid, "ExtractNVRMXid failed to extract XID from message: %s", msg.Message)
+			require.Equal(t, xid, extractedXid)
+		})
+	}
+}
+
+func TestGetMessageToInject_MessageFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		xid  int
+	}{
+		{"known XID 63", 63},
+		{"known XID 79", 79},
+		{"unknown XID 42", 42},
+		{"unknown XID 999", 999},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := GetMessageToInject(tt.xid)
+
+			// All messages should start with "NVRM: Xid"
+			require.True(t, strings.HasPrefix(msg.Message, "NVRM: Xid"), "GetMessageToInject(%d).Message should start with 'NVRM: Xid', got: %s", tt.xid, msg.Message)
+
+			// All messages should contain PCI device information
+			require.Contains(t, msg.Message, "PCI:0000:04:00")
+
+			// Priority should be valid
+			validPriorities := []string{"KERN_WARNING", "KERN_ERR", "KERN_INFO", "KERN_DEBUG"}
+			require.Contains(t, validPriorities, msg.Priority)
+		})
+	}
+}
+
+func TestAllKnownXidsHaveValidMessages(t *testing.T) {
+	t.Parallel()
+
+	// Test every XID in the xidExampleMsgs map
+	for xid := range xidExampleMsgs {
+		t.Run(fmt.Sprintf("xid_%d", xid), func(t *testing.T) {
+			msg := GetMessageToInject(xid)
+			extractedXid := ExtractNVRMXid(msg.Message)
+
+			require.NotZero(t, extractedXid, "XID %d: ExtractNVRMXid failed to extract XID from message: %s", xid, msg.Message)
+			require.Equal(t, xid, extractedXid)
+		})
+	}
+}
+
+func TestExamplesWithExtractNVRMXid(t *testing.T) {
+	t.Parallel()
+	for xid, m := range xidExampleMsgs {
+		t.Run(fmt.Sprintf("xid_%s", m.Message), func(t *testing.T) {
+			extractedXid := ExtractNVRMXid(m.Message)
+			require.Equal(t, xid, extractedXid)
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,6 +48,8 @@ type Config struct {
 
 	// EnablePluginAPI enables the plugin API.
 	EnablePluginAPI bool `json:"enable_plugin_api"`
+	// EnableFaultInjector enables the fault injector.
+	EnableFaultInjector bool `json:"enable_fault_injector"`
 
 	// EnableComponents specifies the components to enable.
 	// Leave empty to enable all components.

--- a/pkg/fault-injector/fault_injector.go
+++ b/pkg/fault-injector/fault_injector.go
@@ -1,0 +1,54 @@
+// Package faultinjector provides a way to inject failures into the system.
+package faultinjector
+
+import (
+	"errors"
+
+	componentsnvidiaxid "github.com/leptonai/gpud/components/accelerator/nvidia/xid"
+	pkgkmsgwriter "github.com/leptonai/gpud/pkg/kmsg/writer"
+)
+
+// Injector defines the interface for injecting failures into the system.
+type Injector interface {
+	pkgkmsgwriter.GPUdKmsgWriterModule
+}
+
+// Request is the request body for the inject-fault endpoint.
+type Request struct {
+	// XidToInject is the XID to inject.
+	Xid *XidToInject `json:"xid,omitempty"`
+
+	// KernelMessage is the kernel message to inject.
+	KernelMessage *pkgkmsgwriter.KernelMessage `json:"kernel_message,omitempty"`
+}
+
+type XidToInject struct {
+	ID int `json:"id"`
+}
+
+var ErrNoFaultFound = errors.New("no fault injection entry found")
+
+func (r *Request) Validate() error {
+	switch {
+	case r.Xid != nil:
+		if r.Xid.ID == 0 {
+			return ErrNoFaultFound
+		}
+
+		msg := componentsnvidiaxid.GetMessageToInject(r.Xid.ID)
+		r.KernelMessage = &pkgkmsgwriter.KernelMessage{
+			Priority: pkgkmsgwriter.ConvertKernelMessagePriority(msg.Priority),
+			Message:  msg.Message,
+		}
+		r.Xid = nil
+
+		// fall through to a subsequent case to call Validate()
+		fallthrough
+
+	case r.KernelMessage != nil:
+		return r.KernelMessage.Validate()
+
+	default:
+		return ErrNoFaultFound
+	}
+}

--- a/pkg/fault-injector/fault_injector_test.go
+++ b/pkg/fault-injector/fault_injector_test.go
@@ -1,0 +1,506 @@
+package faultinjector
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pkgkmsgwriter "github.com/leptonai/gpud/pkg/kmsg/writer"
+)
+
+func TestRequest_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		request     Request
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "nil kernel message should return ErrNoFaultFound",
+			request: Request{
+				KernelMessage: nil,
+			},
+			expectError: true,
+			errorMsg:    "no fault injection entry found",
+		},
+		{
+			name: "valid kernel message should return nil",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "KERN_INFO",
+					Message:  "This is a valid test message",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid kernel message with kern.format priority should return nil",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "kern.err",
+					Message:  "This is a valid error message",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid kernel message with unknown priority should return nil",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "unknown_priority",
+					Message:  "This message has unknown priority but should be normalized",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "empty message should return nil",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "KERN_DEBUG",
+					Message:  "",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "message at maximum length should return nil",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "KERN_INFO",
+					Message:  string(make([]byte, pkgkmsgwriter.MaxPrintkRecordLength)),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "message exceeding maximum length should return error",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "KERN_INFO",
+					Message:  string(make([]byte, pkgkmsgwriter.MaxPrintkRecordLength+1)),
+				},
+			},
+			expectError: true,
+			errorMsg:    "message length exceeds the maximum length of 976",
+		},
+		{
+			name: "message much longer than maximum should return error",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "KERN_ERR",
+					Message:  string(make([]byte, pkgkmsgwriter.MaxPrintkRecordLength*2)),
+				},
+			},
+			expectError: true,
+			errorMsg:    "message length exceeds the maximum length of 976",
+		},
+		{
+			name: "empty priority and message should return nil",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "",
+					Message:  "",
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.request.Validate()
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRequest_Validate_PriorityNormalization(t *testing.T) {
+	// Test that validation correctly normalizes priority through the embedded KernelMessage.Validate()
+	tests := []struct {
+		name             string
+		inputPriority    string
+		expectedPriority string
+	}{
+		{"KERN format", "KERN_ERR", "KERN_ERR"},
+		{"kern format", "kern.warning", "KERN_WARNING"},
+		{"kern.warn format", "kern.warn", "KERN_WARNING"},
+		{"unknown priority", "invalid", "KERN_INFO"},
+		{"empty priority", "", "KERN_INFO"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: pkgkmsgwriter.ConvertKernelMessagePriority(tt.inputPriority),
+					Message:  "test message",
+				},
+			}
+
+			err := request.Validate()
+			require.NoError(t, err)
+
+			// Verify that the priority was normalized by the underlying KernelMessage.Validate()
+			require.Equal(t, tt.expectedPriority, request.KernelMessage.Priority)
+		})
+	}
+}
+
+func TestRequest_Validate_EmptyRequest(t *testing.T) {
+	// Test that an empty request (no fields set) returns ErrNoFaultFound
+	request := Request{}
+	err := request.Validate()
+	require.Error(t, err)
+	require.Equal(t, ErrNoFaultFound, err)
+	require.Contains(t, err.Error(), "no fault injection entry found")
+}
+
+func TestRequest_Validate_LargeValidMessage(t *testing.T) {
+	// Test with a message that's close to but under the limit
+	largeMessage := strings.Repeat("a", pkgkmsgwriter.MaxPrintkRecordLength-10)
+
+	request := Request{
+		KernelMessage: &pkgkmsgwriter.KernelMessage{
+			Priority: "KERN_WARNING",
+			Message:  largeMessage,
+		},
+	}
+
+	err := request.Validate()
+	require.NoError(t, err)
+	require.Equal(t, "KERN_WARNING", request.KernelMessage.Priority)
+	require.Equal(t, largeMessage, request.KernelMessage.Message)
+}
+
+func TestRequest_Validate_ExactMaxLength(t *testing.T) {
+	// Test with a message that's exactly at the maximum length
+	exactMaxMessage := strings.Repeat("x", pkgkmsgwriter.MaxPrintkRecordLength)
+
+	request := Request{
+		KernelMessage: &pkgkmsgwriter.KernelMessage{
+			Priority: "KERN_NOTICE",
+			Message:  exactMaxMessage,
+		},
+	}
+
+	err := request.Validate()
+	require.NoError(t, err)
+	require.Equal(t, "KERN_NOTICE", request.KernelMessage.Priority)
+	require.Equal(t, exactMaxMessage, request.KernelMessage.Message)
+}
+
+func TestErrNoFaultFound(t *testing.T) {
+	// Test that the error variable is properly defined
+	err := ErrNoFaultFound
+	require.NotNil(t, err)
+	require.Equal(t, "no fault injection entry found", err.Error())
+}
+
+func TestRequest_Validate_NilRequestPointer(t *testing.T) {
+	// Test behavior when request itself would be nil (edge case)
+	// This tests the method on a nil KernelMessage field specifically
+	var request *Request = &Request{KernelMessage: nil}
+	err := request.Validate()
+	require.Error(t, err)
+	require.Equal(t, ErrNoFaultFound, err)
+}
+
+func TestRequest_Validate_SwitchCaseLogic(t *testing.T) {
+	// Test the switch statement logic explicitly
+	tests := []struct {
+		name          string
+		kernelMessage *pkgkmsgwriter.KernelMessage
+		expectError   bool
+		expectedError error
+	}{
+		{
+			name:          "nil kernel message triggers default case",
+			kernelMessage: nil,
+			expectError:   true,
+			expectedError: ErrNoFaultFound,
+		},
+		{
+			name: "non-nil kernel message triggers first case",
+			kernelMessage: &pkgkmsgwriter.KernelMessage{
+				Priority: "KERN_INFO",
+				Message:  "test",
+			},
+			expectError:   false,
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := Request{KernelMessage: tt.kernelMessage}
+			err := request.Validate()
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedError, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestRequest_Validate_XidFallthrough tests the specific fallthrough behavior from XID to KernelMessage
+func TestRequest_Validate_XidFallthrough(t *testing.T) {
+	tests := []struct {
+		name                string
+		xidID               int
+		expectError         bool
+		expectKernelMessage bool
+		expectedPriority    string
+		shouldContainMsg    string
+	}{
+		{
+			name:                "valid known XID 63 should fallthrough to kernel message validation",
+			xidID:               63,
+			expectError:         false,
+			expectKernelMessage: true,
+			expectedPriority:    "KERN_WARNING",
+			shouldContainMsg:    "Row remapping event",
+		},
+		{
+			name:                "valid known XID 79 should fallthrough to kernel message validation",
+			xidID:               79,
+			expectError:         false,
+			expectKernelMessage: true,
+			expectedPriority:    "KERN_ERR",
+			shouldContainMsg:    "GPU has fallen off the bus",
+		},
+		{
+			name:                "valid unknown XID 999 should fallthrough to kernel message validation",
+			xidID:               999,
+			expectError:         false,
+			expectKernelMessage: true,
+			expectedPriority:    "KERN_WARNING",
+			shouldContainMsg:    "unknown",
+		},
+		{
+			name:                "XID with ID 0 should return ErrNoFaultFound without fallthrough",
+			xidID:               0,
+			expectError:         true,
+			expectKernelMessage: false,
+			expectedPriority:    "",
+			shouldContainMsg:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create request with XID
+			request := Request{
+				Xid: &XidToInject{
+					ID: tt.xidID,
+				},
+			}
+
+			// Verify initial state
+			require.NotNil(t, request.Xid, "initial Xid should not be nil")
+			require.Nil(t, request.KernelMessage, "initial KernelMessage should be nil")
+
+			// Call Validate
+			err := request.Validate()
+
+			// Check error expectation
+			if tt.expectError {
+				require.Error(t, err)
+				require.Equal(t, ErrNoFaultFound, err)
+				// For error cases, verify no transformation occurred
+				require.NotNil(t, request.Xid, "Xid should still be present when validation fails")
+				require.Nil(t, request.KernelMessage, "KernelMessage should remain nil when validation fails")
+			} else {
+				require.NoError(t, err)
+
+				// For successful cases, verify fallthrough behavior occurred
+				if tt.expectKernelMessage {
+					// Verify that Xid was set to nil after transformation
+					require.Nil(t, request.Xid, "Xid should be nil after successful transformation and fallthrough")
+
+					// Verify that KernelMessage was created from the XID
+					require.NotNil(t, request.KernelMessage, "KernelMessage should be created after XID transformation")
+					require.Equal(t, tt.expectedPriority, request.KernelMessage.Priority)
+					require.Contains(t, request.KernelMessage.Message, tt.shouldContainMsg)
+
+					// Verify the message follows expected XID format
+					require.Contains(t, request.KernelMessage.Message, "NVRM: Xid")
+					require.Contains(t, request.KernelMessage.Message, "PCI:0000:04:00")
+				}
+			}
+		})
+	}
+}
+
+// TestRequest_Validate_XidTransformationDetails tests the specific transformation logic from XID to KernelMessage
+func TestRequest_Validate_XidTransformationDetails(t *testing.T) {
+	// Test with a specific known XID to verify exact transformation
+	request := Request{
+		Xid: &XidToInject{
+			ID: 69, // Known XID with specific message
+		},
+	}
+
+	err := request.Validate()
+	require.NoError(t, err)
+
+	// Verify specific transformation details
+	require.Nil(t, request.Xid, "Xid should be nil after transformation")
+	require.NotNil(t, request.KernelMessage, "KernelMessage should be created")
+
+	// Verify the specific known XID 69 message
+	require.Equal(t, "KERN_WARNING", request.KernelMessage.Priority)
+	require.Contains(t, request.KernelMessage.Message, "BAR1 access failure")
+	require.Contains(t, request.KernelMessage.Message, "NVRM: Xid (PCI:0000:04:00): 69")
+	require.Contains(t, request.KernelMessage.Message, "pid=34566")
+}
+
+// TestRequest_Validate_SwitchCaseFallthrough tests the switch statement logic explicitly
+func TestRequest_Validate_SwitchCaseFallthrough(t *testing.T) {
+	tests := []struct {
+		name              string
+		xid               *XidToInject
+		kernelMessage     *pkgkmsgwriter.KernelMessage
+		expectError       bool
+		expectedError     error
+		expectTransform   bool
+		expectFallthrough bool
+	}{
+		{
+			name: "XID case with valid ID should transform and fallthrough",
+			xid: &XidToInject{
+				ID: 63,
+			},
+			kernelMessage:     nil,
+			expectError:       false,
+			expectedError:     nil,
+			expectTransform:   true,
+			expectFallthrough: true,
+		},
+		{
+			name: "XID case with zero ID should return error without fallthrough",
+			xid: &XidToInject{
+				ID: 0,
+			},
+			kernelMessage:     nil,
+			expectError:       true,
+			expectedError:     ErrNoFaultFound,
+			expectTransform:   false,
+			expectFallthrough: false,
+		},
+		{
+			name: "KernelMessage case only should validate message",
+			xid:  nil,
+			kernelMessage: &pkgkmsgwriter.KernelMessage{
+				Priority: "KERN_INFO",
+				Message:  "direct kernel message test",
+			},
+			expectError:       false,
+			expectedError:     nil,
+			expectTransform:   false,
+			expectFallthrough: false,
+		},
+		{
+			name:              "neither XID nor KernelMessage should trigger default case",
+			xid:               nil,
+			kernelMessage:     nil,
+			expectError:       true,
+			expectedError:     ErrNoFaultFound,
+			expectTransform:   false,
+			expectFallthrough: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := Request{
+				Xid:           tt.xid,
+				KernelMessage: tt.kernelMessage,
+			}
+
+			// Store initial state for verification
+			initialXid := request.Xid
+			initialKernelMessage := request.KernelMessage
+
+			err := request.Validate()
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedError, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tt.expectTransform {
+				// Verify transformation occurred
+				require.Nil(t, request.Xid, "Xid should be nil after transformation")
+				require.NotNil(t, request.KernelMessage, "KernelMessage should be created")
+				require.NotEqual(t, initialKernelMessage, request.KernelMessage, "KernelMessage should be different from initial")
+			}
+
+			if tt.expectFallthrough {
+				// Verify that fallthrough occurred by checking that both:
+				// 1. XID was processed (transformed to nil)
+				// 2. KernelMessage was created and validated (no error)
+				require.Nil(t, request.Xid, "after fallthrough, Xid should be nil")
+				require.NotNil(t, request.KernelMessage, "after fallthrough, KernelMessage should exist")
+				require.NoError(t, err, "fallthrough should result in successful KernelMessage validation")
+			}
+
+			if !tt.expectTransform && !tt.expectFallthrough {
+				// For cases that don't involve XID transformation
+				if initialXid != nil {
+					require.Equal(t, initialXid, request.Xid, "Xid should remain unchanged")
+				}
+				if initialKernelMessage != nil {
+					require.Equal(t, initialKernelMessage.Priority, request.KernelMessage.Priority, "KernelMessage priority should be preserved (possibly normalized)")
+				}
+			}
+		})
+	}
+}
+
+// TestRequest_Validate_FallthroughWithInvalidKernelMessage tests fallthrough to invalid kernel message
+func TestRequest_Validate_FallthroughWithInvalidKernelMessage(t *testing.T) {
+	// This test verifies that when XID transforms to an invalid KernelMessage,
+	// the fallthrough still properly validates and returns the validation error
+
+	// First, let's test with a valid XID that should create a valid message
+	request := Request{
+		Xid: &XidToInject{
+			ID: 63, // Valid XID
+		},
+	}
+
+	err := request.Validate()
+	require.NoError(t, err, "valid XID should create valid KernelMessage and pass validation")
+
+	// Verify the transformation and fallthrough worked
+	require.Nil(t, request.Xid, "Xid should be nil after successful transformation")
+	require.NotNil(t, request.KernelMessage, "KernelMessage should be created")
+
+	// Now manually create a scenario where XID transforms but creates an invalid message
+	// by creating a request that simulates what would happen if GetMessageToInject
+	// returned a message that's too long (though this shouldn't happen in practice)
+
+	// We can't easily test this scenario without mocking GetMessageToInject,
+	// but we can verify that the fallthrough calls the validation correctly
+	// by checking that the priority gets normalized (a sign that validation ran)
+	originalPriority := request.KernelMessage.Priority
+	request.KernelMessage.Priority = "kern.warning" // Use format that gets normalized
+
+	err = request.Validate()
+	require.NoError(t, err)
+	require.Equal(t, "KERN_WARNING", request.KernelMessage.Priority, "priority should be normalized by validation in fallthrough")
+	require.NotEqual(t, originalPriority, "kern.warning", "test setup should use different format")
+}

--- a/pkg/kmsg/writer/doc.go
+++ b/pkg/kmsg/writer/doc.go
@@ -1,0 +1,2 @@
+// Package writer implements the kmsg writer.
+package writer

--- a/pkg/kmsg/writer/gpud_kmsg_writer_module.go
+++ b/pkg/kmsg/writer/gpud_kmsg_writer_module.go
@@ -1,0 +1,391 @@
+package writer
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	pkgkmsg "github.com/leptonai/gpud/pkg/kmsg"
+	"github.com/leptonai/gpud/pkg/log"
+	"github.com/leptonai/gpud/pkg/process"
+)
+
+// CheckPermissions checks if the current user has the necessary permissions to run the gpud_kmsg_writer module.
+func CheckPermissions() error {
+	if runtime.GOOS != "linux" {
+		return errors.New("only supported on Linux")
+	}
+	if os.Geteuid() != 0 {
+		return errors.New("must be run as root")
+	}
+	return nil
+}
+
+// GPUdKmsgWriterModule defines the interface for the gpud_kmsg_writer module.
+type GPUdKmsgWriterModule interface {
+	// BuildInstall builds, installs, loads, and tests the gpud_kmsg_writer module.
+	BuildInstall(context.Context) error
+	// Uninstall uninstalls the gpud_kmsg_writer module.
+	Uninstall(context.Context) error
+	// InjectKernelMessage injects a message into the kernel log.
+	InjectKernelMessage(context.Context, *KernelMessage) error
+}
+
+var _ GPUdKmsgWriterModule = &gpudKmsgWriterModule{}
+
+type gpudKmsgWriterModule struct {
+	ctx context.Context
+
+	kmsgReadFunc  func(context.Context) ([]pkgkmsg.Message, error)
+	processRunner process.Runner
+
+	workDir         string
+	cFile           string
+	cFileContent    string
+	makeFile        string
+	makeFileContent string
+	koFile          string
+	devFile         string
+	devName         string
+	devMajorNum     string
+
+	scriptBuildModule           string
+	scriptReinstallLinuxHeaders string
+	scriptInstallModule         string
+	scriptUninstallModule       string
+
+	createScriptLoadModuleFunc    func(devName string, devMajorNum string) string
+	createScriptInjectMessageFunc func(devName string, msg *KernelMessage) string
+}
+
+var (
+	//go:embed src/gpud_kmsg_writer.c
+	gpudKmsgWriterC string
+
+	//go:embed src/Makefile
+	gpudKmsgWriterMakefile string
+)
+
+func NewGPUdKmsgWriterModule(
+	ctx context.Context,
+	workDir string,
+) GPUdKmsgWriterModule {
+	return &gpudKmsgWriterModule{
+		ctx: ctx,
+
+		kmsgReadFunc: pkgkmsg.ReadAll,
+
+		// one shared runner for all the steps in this plugin
+		// run them in sequence, one by one
+		// this is to avoid running multiple commands in parallel
+		processRunner: process.NewExclusiveRunner(),
+
+		workDir:         workDir,
+		cFile:           filepath.Join(workDir, "gpud_kmsg_writer.c"),
+		cFileContent:    gpudKmsgWriterC,
+		makeFile:        filepath.Join(workDir, "Makefile"),
+		makeFileContent: gpudKmsgWriterMakefile,
+		koFile:          filepath.Join(workDir, "gpud_kmsg_writer.ko"),
+		devFile:         "/dev/gpud_kmsg_writer",
+		devName:         "gpud_kmsg_writer",
+		devMajorNum:     "",
+
+		scriptBuildModule:           defaultScriptBuildModule,
+		scriptReinstallLinuxHeaders: defaultScriptReinstallLinuxHeaders,
+		scriptInstallModule:         "sudo insmod gpud_kmsg_writer.ko",
+		scriptUninstallModule:       "sudo rmmod gpud_kmsg_writer",
+
+		createScriptLoadModuleFunc:    createScriptLoadModule,
+		createScriptInjectMessageFunc: createScriptInjectMessage,
+	}
+}
+
+func (gi *gpudKmsgWriterModule) BuildInstall(ctx context.Context) error {
+	if err := CheckPermissions(); err != nil {
+		return err
+	}
+
+	log.Logger.Infow("building gpud_kmsg_writer module", "os", runtime.GOOS, "euid", os.Geteuid())
+
+	if err := gi.cleanupFiles(); err != nil {
+		return err
+	}
+	if err := gi.writeFiles(); err != nil {
+		return err
+	}
+
+	if err := gi.buildModule(ctx); err != nil {
+		return err
+	}
+	if err := gi.installModule(ctx); err != nil {
+		return err
+	}
+
+	var err error
+	gi.devMajorNum, err = gi.findMajorNum(ctx)
+	if err != nil {
+		return err
+	}
+	if err := gi.loadModule(ctx); err != nil {
+		return err
+	}
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+	}
+
+	if err := gi.injectKmsg(ctx, &KernelMessage{
+		Priority: "KERN_DEBUG",
+		Message:  "GPUd kmsg writer test message",
+	}); err != nil {
+		return err
+	}
+
+	log.Logger.Infow("successfully built and installed gpud_kmsg_writer module")
+	return nil
+}
+
+func (gi *gpudKmsgWriterModule) Uninstall(ctx context.Context) error {
+	if err := gi.uninstallModule(ctx); err != nil {
+		return err
+	}
+
+	if err := gi.cleanupFiles(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (gi *gpudKmsgWriterModule) cleanupFiles() error {
+	if err := os.RemoveAll(gi.cFile); err != nil {
+		return fmt.Errorf("failed to remove %q: %w", gi.cFile, err)
+	}
+
+	if err := os.RemoveAll(gi.koFile); err != nil {
+		return fmt.Errorf("failed to remove %q: %w", gi.koFile, err)
+	}
+
+	if err := os.RemoveAll(gi.devFile); err != nil {
+		return fmt.Errorf("failed to remove %q: %w", gi.devFile, err)
+	}
+
+	log.Logger.Infow("successfully cleaned up files", "cFile", gi.cFile, "koFile", gi.koFile, "devFile", gi.devFile)
+	return nil
+}
+
+func (gi *gpudKmsgWriterModule) writeFiles() error {
+	if err := os.WriteFile(gi.cFile, []byte(gi.cFileContent), 0644); err != nil {
+		return fmt.Errorf("failed to write %q: %w", gi.cFile, err)
+	}
+	if err := os.WriteFile(gi.makeFile, []byte(gi.makeFileContent), 0644); err != nil {
+		return fmt.Errorf("failed to write %q: %w", gi.makeFile, err)
+	}
+
+	log.Logger.Infow("successfully wrote files", "cFile", gi.cFile, "makeFile", gi.makeFile)
+	return nil
+}
+
+const (
+	defaultScriptBuildModule = `make -C /lib/modules/$(uname -r)/build M=$(pwd) modules`
+
+	// some OS requires reinstalling linux headers
+	// otherwise,
+	// "ERROR: Kernel configuration is invalid."
+	// "include/generated/autoconf.h or include/config/auto.conf are missing."
+	defaultScriptReinstallLinuxHeaders = `
+# reinstall Linux Headers
+# ref. https://askubuntu.com/questions/890712/kernel-configuration-is-invalid-error-while-trying-to-install-paragon-ufsd-profe
+sudo apt-get install -y --reinstall linux-headers-$(uname -r)
+sudo apt-get install -y --reinstall -y build-essential dkms linux-generic
+`
+)
+
+func (gi *gpudKmsgWriterModule) buildModule(ctx context.Context) error {
+	log.Logger.Infow("building module", "workDir", gi.workDir)
+
+	if err := os.Chdir(gi.workDir); err != nil {
+		return fmt.Errorf("failed to change directory to %q: %w", gi.workDir, err)
+	}
+
+	execOut, exitCode, err := gi.processRunner.RunUntilCompletion(ctx, gi.scriptBuildModule)
+	if err != nil {
+		log.Logger.Errorw("failed to build module", "output", string(execOut), "exitCode", exitCode, "error", err)
+
+		if strings.Contains(string(execOut), "Kernel configuration is invalid") {
+			log.Logger.Infow("kernel configuration is invalid, reinstalling linux headers", "output", string(execOut), "exitCode", exitCode)
+			execOut, exitCode, err = gi.processRunner.RunUntilCompletion(ctx, gi.scriptReinstallLinuxHeaders)
+			if err != nil {
+				log.Logger.Errorw("failed to reinstall linux headers", "output", string(execOut), "exitCode", exitCode, "error", err)
+				return err
+			}
+
+			log.Logger.Infow("linux header reinstall script output", "output", string(execOut), "exitCode", exitCode)
+
+			execOut, exitCode, err = gi.processRunner.RunUntilCompletion(ctx, gi.scriptBuildModule)
+			if err != nil {
+				log.Logger.Errorw("failed to build module after reinstalling linux headers", "output", string(execOut), "exitCode", exitCode, "error", err)
+				return err
+			}
+
+			log.Logger.Infow("successfully built module after reinstalling linux headers", "output", string(execOut), "exitCode", exitCode)
+		} else {
+			return fmt.Errorf("failed to build module: %w", err)
+		}
+	}
+
+	log.Logger.Infow("successfully built module", "output", string(execOut), "exitCode", exitCode)
+	return nil
+}
+
+func (gi *gpudKmsgWriterModule) installModule(ctx context.Context) error {
+	log.Logger.Infow("installing module", "workDir", gi.workDir)
+
+	if err := os.Chdir(gi.workDir); err != nil {
+		return fmt.Errorf("failed to change directory to %q: %w", gi.workDir, err)
+	}
+
+	execOut, exitCode, err := gi.processRunner.RunUntilCompletion(ctx, gi.scriptInstallModule)
+	if err != nil {
+		// e.g.,
+		// "insmod: ERROR: could not insert module gpud_kmsg_writer.ko: File exists" with "exit status 1"
+		if strings.Contains(string(execOut), "File exists") {
+			log.Logger.Infow("module already installed, skipping", "output", string(execOut), "exitCode", exitCode)
+			return nil
+		}
+
+		log.Logger.Errorw("failed to install module", "output", string(execOut), "exitCode", exitCode, "error", err)
+		return err
+	}
+
+	log.Logger.Infow("successfully installed module", "output", string(execOut), "exitCode", exitCode)
+	return nil
+}
+
+func (gi *gpudKmsgWriterModule) uninstallModule(ctx context.Context) error {
+	log.Logger.Infow("uninstalling module", "workDir", gi.workDir)
+
+	if err := os.Chdir(gi.workDir); err != nil {
+		return fmt.Errorf("failed to change directory to %q: %w", gi.workDir, err)
+	}
+
+	execOut, exitCode, err := gi.processRunner.RunUntilCompletion(ctx, gi.scriptUninstallModule)
+	if err != nil {
+		log.Logger.Errorw("failed to uninstall module", "output", string(execOut), "exitCode", exitCode, "error", err)
+		return err
+	}
+
+	log.Logger.Infow("successfully uninstalled module", "output", string(execOut), "exitCode", exitCode)
+	return nil
+}
+
+func (gi *gpudKmsgWriterModule) findMajorNum(ctx context.Context) (string, error) {
+	log.Logger.Infow("finding device major number")
+
+	log.Logger.Infow("scanning kmsg for device major number")
+	msgs, err := gi.kmsgReadFunc(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to read kmsg: %w", err)
+	}
+	// latest message (biggest timestamp) is the first one in the list
+	sort.Slice(msgs, func(i, j int) bool {
+		return msgs[i].Timestamp.After(msgs[j].Timestamp.Time)
+	})
+
+	majorNum := ""
+	for _, msg := range msgs {
+		if !strings.Contains(msg.Message, "module loaded with device major number") {
+			continue
+		}
+
+		// e.g.,
+		// grep "module loaded with device major number" | awk '{print $NF}'
+		splits := strings.Fields(msg.Message)
+		majorNum = splits[len(splits)-1]
+		break
+	}
+
+	if majorNum == "" {
+		return "", errors.New("failed to find device major number in kmsg")
+	}
+
+	return majorNum, nil
+}
+
+// Utility functions that don't need struct state
+func createScriptLoadModule(devName string, devMajorNum string) string {
+	return fmt.Sprintf("mknod /dev/%s c %s 0", devName, devMajorNum)
+}
+
+func (gi *gpudKmsgWriterModule) loadModule(ctx context.Context) error {
+	log.Logger.Infow("loading module")
+
+	scriptLoadModule := gi.createScriptLoadModuleFunc(gi.devName, gi.devMajorNum)
+	execOut, exitCode, err := gi.processRunner.RunUntilCompletion(ctx, scriptLoadModule)
+	if err != nil {
+		log.Logger.Errorw("failed to load module", "output", string(execOut), "exitCode", exitCode, "error", err)
+		return err
+	}
+
+	log.Logger.Infow("successfully loaded module", "output", string(execOut), "exitCode", exitCode)
+	return nil
+}
+
+func createScriptInjectMessage(devName string, msg *KernelMessage) string {
+	return fmt.Sprintf(`sudo sh -c "echo \"%s,%s\" > /dev/%s"`, msg.Priority, msg.Message, devName)
+}
+
+func (gi *gpudKmsgWriterModule) injectKmsg(ctx context.Context, msg *KernelMessage) error {
+	if msg == nil {
+		return nil
+	}
+
+	if err := msg.Validate(); err != nil {
+		return fmt.Errorf("invalid message: %w", err)
+	}
+	log.Logger.Infow("injecting kernel message via module", "devName", gi.devName, "priority", msg.Priority, "msg", msg.Message)
+
+	scriptInjectMsg := gi.createScriptInjectMessageFunc(gi.devName, msg)
+	execOut, exitCode, err := gi.processRunner.RunUntilCompletion(ctx, scriptInjectMsg)
+	if err != nil {
+		log.Logger.Errorw("failed to test module", "output", string(execOut), "exitCode", exitCode, "error", err)
+		return err
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(3 * time.Second):
+	}
+
+	log.Logger.Infow("scanning kmsg for checking injected message")
+	msgs, err := gi.kmsgReadFunc(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to read kmsg: %w", err)
+	}
+	// latest message (biggest timestamp) is the first one in the list
+	sort.Slice(msgs, func(i, j int) bool {
+		return msgs[i].Timestamp.After(msgs[j].Timestamp.Time)
+	})
+
+	for _, m := range msgs {
+		if strings.Contains(m.Message, msg.Message) {
+			log.Logger.Infow("found message in kmsg", "timestamp", m.Timestamp.Time, "message", m.Message)
+			return nil
+		}
+	}
+
+	return errors.New("failed to find injected message in kmsg")
+}
+
+func (gi *gpudKmsgWriterModule) InjectKernelMessage(ctx context.Context, msg *KernelMessage) error {
+	return gi.injectKmsg(ctx, msg)
+}

--- a/pkg/kmsg/writer/gpud_kmsg_writer_module_test.go
+++ b/pkg/kmsg/writer/gpud_kmsg_writer_module_test.go
@@ -1,0 +1,1334 @@
+package writer
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	pkgkmsg "github.com/leptonai/gpud/pkg/kmsg"
+	"github.com/leptonai/gpud/pkg/process"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEmbed(t *testing.T) {
+	require.NotEmpty(t, gpudKmsgWriterC)
+	require.NotEmpty(t, gpudKmsgWriterMakefile)
+}
+
+func TestNewGPUdKmsgWriterModule(t *testing.T) {
+	tempDir := t.TempDir()
+	ctx := context.Background()
+
+	module := NewGPUdKmsgWriterModule(ctx, tempDir)
+	require.NotNil(t, module)
+
+	// Cast to concrete type to inspect internal state
+	concreteModule := module.(*gpudKmsgWriterModule)
+	require.Equal(t, ctx, concreteModule.ctx)
+	require.Equal(t, tempDir, concreteModule.workDir)
+	require.Equal(t, filepath.Join(tempDir, "gpud_kmsg_writer.c"), concreteModule.cFile)
+	require.Equal(t, filepath.Join(tempDir, "Makefile"), concreteModule.makeFile)
+	require.Equal(t, filepath.Join(tempDir, "gpud_kmsg_writer.ko"), concreteModule.koFile)
+	require.Equal(t, "/dev/gpud_kmsg_writer", concreteModule.devFile)
+	require.Equal(t, "gpud_kmsg_writer", concreteModule.devName)
+	require.NotNil(t, concreteModule.processRunner)
+	require.NotNil(t, concreteModule.kmsgReadFunc)
+}
+
+func TestGPUdKmsgWriterModule_CheckPermissions(t *testing.T) {
+	err := CheckPermissions()
+	if runtime.GOOS != "linux" {
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "only supported on Linux")
+	}
+	// Note: We can't test the root check on Mac since os.Geteuid() will not be 0
+}
+
+func TestGPUdKmsgWriterModule_CleanupFiles(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create test files
+	cFile := filepath.Join(tempDir, "test.c")
+	koFile := filepath.Join(tempDir, "test.ko")
+	devFile := filepath.Join(tempDir, "test_dev")
+
+	require.NoError(t, os.WriteFile(cFile, []byte("test content"), 0644))
+	require.NoError(t, os.WriteFile(koFile, []byte("test content"), 0644))
+	require.NoError(t, os.WriteFile(devFile, []byte("test content"), 0644))
+
+	// Verify files exist
+	require.FileExists(t, cFile)
+	require.FileExists(t, koFile)
+	require.FileExists(t, devFile)
+
+	module := &gpudKmsgWriterModule{
+		cFile:   cFile,
+		koFile:  koFile,
+		devFile: devFile,
+	}
+
+	err := module.cleanupFiles()
+	require.NoError(t, err)
+
+	// Verify files are removed
+	require.NoFileExists(t, cFile)
+	require.NoFileExists(t, koFile)
+	require.NoFileExists(t, devFile)
+}
+
+func TestGPUdKmsgWriterModule_CleanupFiles_NonExistentFiles(t *testing.T) {
+	tempDir := t.TempDir()
+
+	module := &gpudKmsgWriterModule{
+		cFile:   filepath.Join(tempDir, "nonexistent.c"),
+		koFile:  filepath.Join(tempDir, "nonexistent.ko"),
+		devFile: filepath.Join(tempDir, "nonexistent_dev"),
+	}
+
+	err := module.cleanupFiles()
+	require.NoError(t, err)
+}
+
+func TestGPUdKmsgWriterModule_WriteFiles(t *testing.T) {
+	tempDir := t.TempDir()
+
+	module := &gpudKmsgWriterModule{
+		cFile:           filepath.Join(tempDir, "gpud_kmsg_writer.c"),
+		cFileContent:    "test c content",
+		makeFile:        filepath.Join(tempDir, "Makefile"),
+		makeFileContent: "test makefile content",
+	}
+
+	err := module.writeFiles()
+	require.NoError(t, err)
+
+	// Verify files were created with correct content
+	require.FileExists(t, module.cFile)
+	require.FileExists(t, module.makeFile)
+
+	cContent, err := os.ReadFile(module.cFile)
+	require.NoError(t, err)
+	require.Equal(t, "test c content", string(cContent))
+
+	makeContent, err := os.ReadFile(module.makeFile)
+	require.NoError(t, err)
+	require.Equal(t, "test makefile content", string(makeContent))
+}
+
+func TestGPUdKmsgWriterModule_WriteFiles_WriteError(t *testing.T) {
+	invalidPath := "/invalid/path/that/does/not/exist"
+
+	module := &gpudKmsgWriterModule{
+		cFile:           filepath.Join(invalidPath, "gpud_kmsg_writer.c"),
+		cFileContent:    "test content",
+		makeFile:        filepath.Join(invalidPath, "Makefile"),
+		makeFileContent: "test content",
+	}
+
+	err := module.writeFiles()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to write")
+}
+
+func TestGPUdKmsgWriterModule_BuildModule_Success(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			return []byte("build successful"), 0, nil
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		workDir:                     tempDir,
+		scriptBuildModule:           "make modules",
+		scriptReinstallLinuxHeaders: "sudo apt-get install",
+		processRunner:               mockRunner,
+	}
+
+	err := module.buildModule(context.Background())
+	require.NoError(t, err)
+}
+
+func TestGPUdKmsgWriterModule_BuildModule_FailureWithKernelConfig(t *testing.T) {
+	tempDir := t.TempDir()
+
+	callCount := 0
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			callCount++
+			if callCount == 1 {
+				// First call fails with kernel config error
+				return []byte("ERROR: Kernel configuration is invalid"), 1, errors.New("build failed")
+			} else if callCount == 2 {
+				// Second call is the reinstall script
+				return []byte("reinstall successful"), 0, nil
+			} else {
+				// Third call should succeed
+				return []byte("build successful after reinstall"), 0, nil
+			}
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		workDir:                     tempDir,
+		scriptBuildModule:           "make modules",
+		scriptReinstallLinuxHeaders: "sudo apt-get install",
+		processRunner:               mockRunner,
+	}
+
+	err := module.buildModule(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 3, callCount) // Should have made 3 calls
+}
+
+func TestGPUdKmsgWriterModule_BuildModule_FailureWithoutRetry(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			return []byte("some other error"), 1, errors.New("build failed")
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		workDir:                     tempDir,
+		scriptBuildModule:           "make modules",
+		scriptReinstallLinuxHeaders: "sudo apt-get install",
+		processRunner:               mockRunner,
+	}
+
+	err := module.buildModule(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to build module")
+}
+
+func TestGPUdKmsgWriterModule_BuildModule_ReinstallFails(t *testing.T) {
+	tempDir := t.TempDir()
+
+	callCount := 0
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			callCount++
+			if callCount == 1 {
+				// First call fails with kernel config error
+				return []byte("ERROR: Kernel configuration is invalid"), 1, errors.New("build failed")
+			} else {
+				// Reinstall fails
+				return []byte("reinstall failed"), 1, errors.New("reinstall failed")
+			}
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		workDir:                     tempDir,
+		scriptBuildModule:           "make modules",
+		scriptReinstallLinuxHeaders: "sudo apt-get install",
+		processRunner:               mockRunner,
+	}
+
+	err := module.buildModule(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "reinstall failed")
+}
+
+func TestGPUdKmsgWriterModule_InstallModule_Success(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			require.Equal(t, "sudo insmod gpud_kmsg_writer.ko", script)
+			return []byte("module installed"), 0, nil
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		workDir:             tempDir,
+		scriptInstallModule: "sudo insmod gpud_kmsg_writer.ko",
+		processRunner:       mockRunner,
+	}
+
+	err := module.installModule(context.Background())
+	require.NoError(t, err)
+}
+
+func TestGPUdKmsgWriterModule_InstallModule_Failure(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			return []byte("install failed"), 1, errors.New("install failed")
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		workDir:             tempDir,
+		scriptInstallModule: "sudo insmod gpud_kmsg_writer.ko",
+		processRunner:       mockRunner,
+	}
+
+	err := module.installModule(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "install failed")
+}
+
+func TestGPUdKmsgWriterModule_FindMajorNum_SortingLogic(t *testing.T) {
+	baseTime := time.Now()
+
+	tests := []struct {
+		name          string
+		messages      []pkgkmsg.Message
+		expectedMajor string
+		expectedError string
+	}{
+		{
+			name: "finds major number from latest message",
+			messages: []pkgkmsg.Message{
+				{
+					Timestamp: metav1.NewTime(baseTime.Add(-2 * time.Hour)),
+					Message:   "some other message",
+				},
+				{
+					Timestamp: metav1.NewTime(baseTime.Add(-1 * time.Hour)),
+					Message:   "module loaded with device major number 123",
+				},
+				{
+					Timestamp: metav1.NewTime(baseTime), // latest
+					Message:   "module loaded with device major number 456",
+				},
+			},
+			expectedMajor: "456",
+		},
+		{
+			name: "no major number message found",
+			messages: []pkgkmsg.Message{
+				{
+					Timestamp: metav1.NewTime(baseTime),
+					Message:   "some unrelated message",
+				},
+			},
+			expectedError: "failed to find device major number in kmsg",
+		},
+		{
+			name: "sorts correctly - finds latest major number",
+			messages: []pkgkmsg.Message{
+				{
+					Timestamp: metav1.NewTime(baseTime.Add(-3 * time.Hour)),
+					Message:   "module loaded with device major number 111",
+				},
+				{
+					Timestamp: metav1.NewTime(baseTime), // latest
+					Message:   "module loaded with device major number 999",
+				},
+			},
+			expectedMajor: "999",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			module := &gpudKmsgWriterModule{
+				kmsgReadFunc: func(ctx context.Context) ([]pkgkmsg.Message, error) {
+					return tt.messages, nil
+				},
+			}
+
+			major, err := module.findMajorNum(context.Background())
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedMajor, major)
+			}
+		})
+	}
+}
+
+func TestGPUdKmsgWriterModule_FindMajorNum_KmsgReaderError(t *testing.T) {
+	module := &gpudKmsgWriterModule{
+		kmsgReadFunc: func(ctx context.Context) ([]pkgkmsg.Message, error) {
+			return nil, errors.New("failed to read kmsg")
+		},
+	}
+
+	_, err := module.findMajorNum(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to read kmsg")
+}
+
+func TestGPUdKmsgWriterModule_LoadModule_Success(t *testing.T) {
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			require.Equal(t, "mknod /dev/test_device c 123 0", script)
+			return []byte("device created"), 0, nil
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		devName:       "test_device",
+		devMajorNum:   "123",
+		processRunner: mockRunner,
+		createScriptLoadModuleFunc: func(devName string, devMajorNum string) string {
+			return "mknod /dev/" + devName + " c " + devMajorNum + " 0"
+		},
+	}
+
+	err := module.loadModule(context.Background())
+	require.NoError(t, err)
+}
+
+func TestGPUdKmsgWriterModule_LoadModule_Failure(t *testing.T) {
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			return []byte("device creation failed"), 1, errors.New("mknod failed")
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		devName:       "test_device",
+		devMajorNum:   "123",
+		processRunner: mockRunner,
+		createScriptLoadModuleFunc: func(devName string, devMajorNum string) string {
+			return "mknod /dev/" + devName + " c " + devMajorNum + " 0"
+		},
+	}
+
+	err := module.loadModule(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mknod failed")
+}
+
+func TestGPUdKmsgWriterModule_InjectMessage_Success(t *testing.T) {
+	baseTime := time.Now()
+	testMessage := "test message content"
+
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			require.Contains(t, script, testMessage)
+			return []byte("message injected"), 0, nil
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		devName:       "test_device",
+		processRunner: mockRunner,
+		createScriptInjectMessageFunc: func(devName string, msg *KernelMessage) string {
+			return "echo test script with " + msg.Message
+		},
+		kmsgReadFunc: func(ctx context.Context) ([]pkgkmsg.Message, error) {
+			return []pkgkmsg.Message{
+				{
+					Timestamp: metav1.NewTime(baseTime),
+					Message:   "some message with " + testMessage + " in it",
+				},
+			}, nil
+		},
+	}
+
+	msg := &KernelMessage{
+		Priority: "KERN_INFO",
+		Message:  testMessage,
+	}
+
+	err := module.injectKmsg(context.Background(), msg)
+	require.NoError(t, err)
+}
+
+func TestGPUdKmsgWriterModule_InjectMessage_ValidationError(t *testing.T) {
+	module := &gpudKmsgWriterModule{}
+
+	// Create a message that's too long
+	longMessage := make([]byte, MaxPrintkRecordLength+1)
+	for i := range longMessage {
+		longMessage[i] = 'a'
+	}
+
+	msg := &KernelMessage{
+		Priority: "KERN_INFO",
+		Message:  string(longMessage),
+	}
+
+	err := module.injectKmsg(context.Background(), msg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid message")
+}
+
+func TestGPUdKmsgWriterModule_InjectMessage_ProcessRunnerError(t *testing.T) {
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			return []byte("injection failed"), 1, errors.New("process failed")
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		devName:       "test_device",
+		processRunner: mockRunner,
+		createScriptInjectMessageFunc: func(devName string, msg *KernelMessage) string {
+			return "echo test"
+		},
+	}
+
+	msg := &KernelMessage{
+		Priority: "KERN_INFO",
+		Message:  "test message",
+	}
+
+	err := module.injectKmsg(context.Background(), msg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "process failed")
+}
+
+func TestGPUdKmsgWriterModule_InjectMessage_MessageNotFound(t *testing.T) {
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			return []byte("message injected"), 0, nil
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		devName:       "test_device",
+		processRunner: mockRunner,
+		createScriptInjectMessageFunc: func(devName string, msg *KernelMessage) string {
+			return "echo test"
+		},
+		kmsgReadFunc: func(ctx context.Context) ([]pkgkmsg.Message, error) {
+			return []pkgkmsg.Message{
+				{
+					Timestamp: metav1.NewTime(time.Now()),
+					Message:   "some unrelated message",
+				},
+			}, nil
+		},
+	}
+
+	msg := &KernelMessage{
+		Priority: "KERN_INFO",
+		Message:  "test message that won't be found",
+	}
+
+	err := module.injectKmsg(context.Background(), msg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to find injected message in kmsg")
+}
+
+func TestGPUdKmsgWriterModule_InjectMessage_KmsgReaderError(t *testing.T) {
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			return []byte("message injected"), 0, nil
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		devName:       "test_device",
+		processRunner: mockRunner,
+		createScriptInjectMessageFunc: func(devName string, msg *KernelMessage) string {
+			return "echo test"
+		},
+		kmsgReadFunc: func(ctx context.Context) ([]pkgkmsg.Message, error) {
+			return nil, errors.New("kmsg read failed")
+		},
+	}
+
+	msg := &KernelMessage{
+		Priority: "KERN_INFO",
+		Message:  "test message",
+	}
+
+	err := module.injectKmsg(context.Background(), msg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to read kmsg")
+}
+
+func TestGPUdKmsgWriterModule_Inject_InterfaceMethod(t *testing.T) {
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			return []byte("message injected"), 0, nil
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		devName:       "test_device",
+		processRunner: mockRunner,
+		createScriptInjectMessageFunc: func(devName string, msg *KernelMessage) string {
+			return "echo test"
+		},
+		kmsgReadFunc: func(ctx context.Context) ([]pkgkmsg.Message, error) {
+			return []pkgkmsg.Message{
+				{
+					Timestamp: metav1.NewTime(time.Now()),
+					Message:   "some message with test message in it",
+				},
+			}, nil
+		},
+	}
+
+	// Test the interface method
+	var kmsgWriter GPUdKmsgWriterModule = module
+
+	msg := &KernelMessage{
+		Priority: "KERN_INFO",
+		Message:  "test message",
+	}
+
+	err := kmsgWriter.InjectKernelMessage(context.Background(), msg)
+	require.NoError(t, err)
+}
+
+func TestGPUdKmsgWriterModule_BuildInstall_NonLinux(t *testing.T) {
+	tempDir := t.TempDir()
+	module := NewGPUdKmsgWriterModule(context.Background(), tempDir)
+
+	// Should fail on non-Linux platforms
+	if runtime.GOOS != "linux" {
+		err := module.BuildInstall(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "only supported on Linux")
+	}
+}
+
+func TestGPUdKmsgWriterModule_BuildInstall_MockedSuccess(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("Skipping mocked test on Linux platform")
+	}
+
+	tempDir := t.TempDir()
+
+	// Test with mocked components for a full successful flow
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			// Mock all script executions as successful
+			return []byte("success"), 0, nil
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		ctx:                         context.Background(),
+		workDir:                     tempDir,
+		cFile:                       filepath.Join(tempDir, "gpud_kmsg_writer.c"),
+		cFileContent:                "mock c content",
+		makeFile:                    filepath.Join(tempDir, "Makefile"),
+		makeFileContent:             "mock makefile content",
+		koFile:                      filepath.Join(tempDir, "gpud_kmsg_writer.ko"),
+		devFile:                     "/dev/gpud_kmsg_writer",
+		devName:                     "gpud_kmsg_writer",
+		scriptBuildModule:           "make modules",
+		scriptReinstallLinuxHeaders: "sudo apt-get install",
+		scriptInstallModule:         "sudo insmod gpud_kmsg_writer.ko",
+		processRunner:               mockRunner,
+		createScriptLoadModuleFunc: func(devName string, devMajorNum string) string {
+			return "mknod /dev/" + devName + " c " + devMajorNum + " 0"
+		},
+		createScriptInjectMessageFunc: func(devName string, msg *KernelMessage) string {
+			return "echo test"
+		},
+		kmsgReadFunc: func(ctx context.Context) ([]pkgkmsg.Message, error) {
+			// Mock kmsg messages
+			return []pkgkmsg.Message{
+				{
+					Timestamp: metav1.NewTime(time.Now()),
+					Message:   "module loaded with device major number 123",
+				},
+				{
+					Timestamp: metav1.NewTime(time.Now().Add(time.Second)),
+					Message:   "some message with hello world in it",
+				},
+			}, nil
+		},
+	}
+
+	// The BuildInstall should still fail due to platform check, but we're testing the mocked components
+	err := module.BuildInstall(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "only supported on Linux")
+}
+
+func TestCreateScriptLoadModule(t *testing.T) {
+	tests := []struct {
+		name        string
+		devName     string
+		devMajorNum string
+		expected    string
+	}{
+		{
+			name:        "basic case",
+			devName:     "gpud_kmsg_writer",
+			devMajorNum: "123",
+			expected:    "mknod /dev/gpud_kmsg_writer c 123 0",
+		},
+		{
+			name:        "different device name",
+			devName:     "test_device",
+			devMajorNum: "456",
+			expected:    "mknod /dev/test_device c 456 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := createScriptLoadModule(tt.devName, tt.devMajorNum)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCreateScriptInjectMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		devName  string
+		msg      *KernelMessage
+		expected string
+	}{
+		{
+			name:    "basic case",
+			devName: "gpud_kmsg_writer",
+			msg: &KernelMessage{
+				Priority: "KERN_INFO",
+				Message:  "hello world",
+			},
+			expected: `sudo sh -c "echo \"KERN_INFO,hello world\" > /dev/gpud_kmsg_writer"`,
+		},
+		{
+			name:    "different message",
+			devName: "test_device",
+			msg: &KernelMessage{
+				Priority: "KERN_DEBUG",
+				Message:  "test message",
+			},
+			expected: `sudo sh -c "echo \"KERN_DEBUG,test message\" > /dev/test_device"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := createScriptInjectMessage(tt.devName, tt.msg)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Mock runner for testing
+type mockRunner struct {
+	runFunc func(ctx context.Context, script string) ([]byte, int32, error)
+}
+
+func (m *mockRunner) RunUntilCompletion(ctx context.Context, script string) ([]byte, int32, error) {
+	return m.runFunc(ctx, script)
+}
+
+// Ensure mockRunner implements process.Runner interface
+var _ process.Runner = (*mockRunner)(nil)
+
+// Additional tests to increase coverage
+
+func TestNewKmsgWriterWithDummyDevice_NonLinux(t *testing.T) {
+	// Should return noOpKmsgWriter on non-Linux platforms
+	if runtime.GOOS != "linux" {
+		writer := NewKmsgWriterWithDummyDevice()
+		require.NotNil(t, writer)
+
+		// Should be able to write without error
+		msg := &KernelMessage{
+			Priority: "KERN_INFO",
+			Message:  "test message",
+		}
+		err := writer.Write(msg)
+		require.NoError(t, err)
+
+		// Should handle nil message
+		err = writer.Write(nil)
+		require.NoError(t, err)
+	}
+}
+
+func TestNoOpKmsgWriter_Write(t *testing.T) {
+	writer := &noOpKmsgWriter{}
+
+	// Should handle normal message
+	msg := &KernelMessage{
+		Priority: "KERN_INFO",
+		Message:  "test message",
+	}
+	err := writer.Write(msg)
+	require.NoError(t, err)
+
+	// Should handle nil message
+	err = writer.Write(nil)
+	require.NoError(t, err)
+}
+
+func TestKmsgWriterWithDummyDevice_Write_Nil(t *testing.T) {
+	writer := &kmsgWriterWithDummyDevice{}
+
+	// Should handle nil message gracefully
+	err := writer.Write(nil)
+	require.NoError(t, err)
+}
+
+func TestKmsgWriterWithDummyDevice_Write_InvalidMessage(t *testing.T) {
+	writer := &kmsgWriterWithDummyDevice{}
+
+	// Create a message that's too long
+	longMessage := make([]byte, MaxPrintkRecordLength+1)
+	for i := range longMessage {
+		longMessage[i] = 'a'
+	}
+
+	msg := &KernelMessage{
+		Priority: "KERN_INFO",
+		Message:  string(longMessage),
+	}
+
+	err := writer.Write(msg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "message length exceeds")
+}
+
+func TestGPUdKmsgWriterModule_CleanupFiles_PartialFailure(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create one valid file and set up paths where some will fail
+	cFile := filepath.Join(tempDir, "test.c")
+	require.NoError(t, os.WriteFile(cFile, []byte("test content"), 0644))
+
+	module := &gpudKmsgWriterModule{
+		cFile:   cFile,
+		koFile:  filepath.Join(tempDir, "nonexistent.ko"),
+		devFile: "/dev/nonexistent_device", // This will fail to remove but should not error
+	}
+
+	err := module.cleanupFiles()
+	require.NoError(t, err) // Should succeed even if some files don't exist
+
+	// Verify the existing file was removed
+	require.NoFileExists(t, cFile)
+}
+
+func TestGPUdKmsgWriterModule_BuildInstall_ContextCancellation(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("Skipping context cancellation test on Linux")
+	}
+
+	tempDir := t.TempDir()
+
+	// Create a context that's already canceled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	module := NewGPUdKmsgWriterModule(ctx, tempDir)
+
+	// Should fail due to platform check, not context cancellation
+	err := module.BuildInstall(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "only supported on Linux")
+}
+
+func TestGPUdKmsgWriterModule_InjectMessage_ContextCancellation(t *testing.T) {
+	// Create a context that gets canceled during the sleep
+	ctx, cancel := context.WithCancel(context.Background())
+
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			// Cancel the context during execution
+			cancel()
+			return []byte("message injected"), 0, nil
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		devName:       "test_device",
+		processRunner: mockRunner,
+		createScriptInjectMessageFunc: func(devName string, msg *KernelMessage) string {
+			return "echo test"
+		},
+		kmsgReadFunc: func(ctx context.Context) ([]pkgkmsg.Message, error) {
+			// This should not be called due to context cancellation
+			return []pkgkmsg.Message{}, nil
+		},
+	}
+
+	msg := &KernelMessage{
+		Priority: "KERN_INFO",
+		Message:  "test message",
+	}
+
+	err := module.injectKmsg(ctx, msg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "context canceled")
+}
+
+func TestGPUdKmsgWriterModule_FindMajorNum_EmptyMessage(t *testing.T) {
+	module := &gpudKmsgWriterModule{
+		kmsgReadFunc: func(ctx context.Context) ([]pkgkmsg.Message, error) {
+			return []pkgkmsg.Message{
+				{
+					Timestamp: metav1.NewTime(time.Now()),
+					Message:   "", // Empty message
+				},
+			}, nil
+		},
+	}
+
+	_, err := module.findMajorNum(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to find device major number in kmsg")
+}
+
+func TestGPUdKmsgWriterModule_BuildModule_DirectoryChangeError(t *testing.T) {
+	// Test with a directory that doesn't exist to trigger chdir error
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			return []byte("should not be called"), 0, nil
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		workDir:                     "/invalid/nonexistent/directory",
+		scriptBuildModule:           "make modules",
+		scriptReinstallLinuxHeaders: "sudo apt-get install",
+		processRunner:               mockRunner,
+	}
+
+	err := module.buildModule(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to change directory")
+}
+
+func TestGPUdKmsgWriterModule_InstallModule_DirectoryChangeError(t *testing.T) {
+	// Test with a directory that doesn't exist to trigger chdir error
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			return []byte("should not be called"), 0, nil
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		workDir:             "/invalid/nonexistent/directory",
+		scriptInstallModule: "sudo insmod test.ko",
+		processRunner:       mockRunner,
+	}
+
+	err := module.installModule(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to change directory")
+}
+
+// Additional test cases specifically for timestamp-based major number selection
+func TestGPUdKmsgWriterModule_FindMajorNum_TimestampPrecedence(t *testing.T) {
+	baseTime := time.Now()
+
+	tests := []struct {
+		name             string
+		messages         []pkgkmsg.Message
+		expectedMajorNum string
+		description      string
+	}{
+		{
+			name: "picks latest timestamp when multiple major numbers exist",
+			messages: []pkgkmsg.Message{
+				{
+					Timestamp: metav1.NewTime(baseTime.Add(-2 * time.Hour)), // oldest
+					Message:   "module loaded with device major number 111",
+				},
+				{
+					Timestamp: metav1.NewTime(baseTime.Add(-1 * time.Hour)), // middle
+					Message:   "module loaded with device major number 222",
+				},
+				{
+					Timestamp: metav1.NewTime(baseTime), // latest
+					Message:   "module loaded with device major number 333",
+				},
+			},
+			expectedMajorNum: "333",
+			description:      "should pick major number 333 from the latest timestamp",
+		},
+		{
+			name: "picks latest even when older messages appear first in slice",
+			messages: []pkgkmsg.Message{
+				{
+					Timestamp: metav1.NewTime(baseTime), // latest timestamp but first in slice
+					Message:   "module loaded with device major number 999",
+				},
+				{
+					Timestamp: metav1.NewTime(baseTime.Add(-3 * time.Hour)), // oldest
+					Message:   "module loaded with device major number 111",
+				},
+				{
+					Timestamp: metav1.NewTime(baseTime.Add(-1 * time.Hour)), // middle
+					Message:   "module loaded with device major number 555",
+				},
+			},
+			expectedMajorNum: "999",
+			description:      "should pick major number 999 despite slice order",
+		},
+		{
+			name: "picks latest among mixed relevant and irrelevant messages",
+			messages: []pkgkmsg.Message{
+				{
+					Timestamp: metav1.NewTime(baseTime.Add(-3 * time.Hour)),
+					Message:   "some unrelated log message",
+				},
+				{
+					Timestamp: metav1.NewTime(baseTime.Add(-2 * time.Hour)),
+					Message:   "module loaded with device major number 123",
+				},
+				{
+					Timestamp: metav1.NewTime(baseTime.Add(-30 * time.Minute)),
+					Message:   "another unrelated message",
+				},
+				{
+					Timestamp: metav1.NewTime(baseTime.Add(-1 * time.Hour)),
+					Message:   "module loaded with device major number 456",
+				},
+				{
+					Timestamp: metav1.NewTime(baseTime), // latest with major number
+					Message:   "module loaded with device major number 789",
+				},
+				{
+					Timestamp: metav1.NewTime(baseTime.Add(1 * time.Hour)), // even later but no major number
+					Message:   "some future log without major number",
+				},
+			},
+			expectedMajorNum: "789",
+			description:      "should pick major number 789 from latest relevant message",
+		},
+		{
+			name: "handles microsecond precision timestamps",
+			messages: []pkgkmsg.Message{
+				{
+					Timestamp: metav1.NewTime(baseTime.Add(100 * time.Microsecond)),
+					Message:   "module loaded with device major number 100",
+				},
+				{
+					Timestamp: metav1.NewTime(baseTime.Add(200 * time.Microsecond)), // slightly later
+					Message:   "module loaded with device major number 200",
+				},
+				{
+					Timestamp: metav1.NewTime(baseTime.Add(150 * time.Microsecond)),
+					Message:   "module loaded with device major number 150",
+				},
+			},
+			expectedMajorNum: "200",
+			description:      "should pick major number 200 from microsecond-precision latest timestamp",
+		},
+		{
+			name: "handles same timestamp with deterministic ordering",
+			messages: []pkgkmsg.Message{
+				{
+					Timestamp: metav1.NewTime(baseTime), // same timestamp
+					Message:   "module loaded with device major number 111",
+				},
+				{
+					Timestamp: metav1.NewTime(baseTime), // same timestamp
+					Message:   "module loaded with device major number 222",
+				},
+			},
+			expectedMajorNum: "111", // should pick first one found after sorting
+			description:      "should pick first major number when timestamps are identical",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			module := &gpudKmsgWriterModule{
+				kmsgReadFunc: func(ctx context.Context) ([]pkgkmsg.Message, error) {
+					return tt.messages, nil
+				},
+			}
+
+			majorNum, err := module.findMajorNum(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedMajorNum, majorNum, tt.description)
+		})
+	}
+}
+
+func TestGPUdKmsgWriterModule_FindMajorNum_SortingBehaviorEdgeCases(t *testing.T) {
+	baseTime := time.Now()
+
+	t.Run("single message with major number", func(t *testing.T) {
+		module := &gpudKmsgWriterModule{
+			kmsgReadFunc: func(ctx context.Context) ([]pkgkmsg.Message, error) {
+				return []pkgkmsg.Message{
+					{
+						Timestamp: metav1.NewTime(baseTime),
+						Message:   "module loaded with device major number 42",
+					},
+				}, nil
+			},
+		}
+
+		majorNum, err := module.findMajorNum(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "42", majorNum)
+	})
+
+	t.Run("major numbers at beginning, middle, and end of message", func(t *testing.T) {
+		module := &gpudKmsgWriterModule{
+			kmsgReadFunc: func(ctx context.Context) ([]pkgkmsg.Message, error) {
+				return []pkgkmsg.Message{
+					{
+						Timestamp: metav1.NewTime(baseTime.Add(-2 * time.Hour)),
+						Message:   "old module loaded with device major number 456",
+					},
+					{
+						Timestamp: metav1.NewTime(baseTime.Add(-1 * time.Hour)),
+						Message:   "middle module loaded with device major number 789",
+					},
+					{
+						Timestamp: metav1.NewTime(baseTime), // latest
+						Message:   "latest module loaded with device major number 999",
+					},
+				}, nil
+			},
+		}
+
+		majorNum, err := module.findMajorNum(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "999", majorNum) // Should extract major number from latest message
+	})
+
+	t.Run("major number is last field in latest message", func(t *testing.T) {
+		module := &gpudKmsgWriterModule{
+			kmsgReadFunc: func(ctx context.Context) ([]pkgkmsg.Message, error) {
+				return []pkgkmsg.Message{
+					{
+						Timestamp: metav1.NewTime(baseTime.Add(-1 * time.Hour)),
+						Message:   "old module loaded with device major number 111",
+					},
+					{
+						Timestamp: metav1.NewTime(baseTime), // latest
+						Message:   "kernel: module loaded with device major number 777",
+					},
+				}, nil
+			},
+		}
+
+		majorNum, err := module.findMajorNum(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "777", majorNum) // Should extract last field correctly
+	})
+
+	t.Run("verify sorting preserves message order for same timestamps", func(t *testing.T) {
+		module := &gpudKmsgWriterModule{
+			kmsgReadFunc: func(ctx context.Context) ([]pkgkmsg.Message, error) {
+				// All messages have the same timestamp
+				sameTime := metav1.NewTime(baseTime)
+				return []pkgkmsg.Message{
+					{
+						Timestamp: sameTime,
+						Message:   "first module loaded with device major number 111",
+					},
+					{
+						Timestamp: sameTime,
+						Message:   "second module loaded with device major number 222",
+					},
+					{
+						Timestamp: sameTime,
+						Message:   "third module loaded with device major number 333",
+					},
+				}, nil
+			},
+		}
+
+		majorNum, err := module.findMajorNum(context.Background())
+		require.NoError(t, err)
+		// Should be deterministic and pick the first one
+		require.Equal(t, "111", majorNum)
+	})
+
+	t.Run("function extracts last field even with extra text", func(t *testing.T) {
+		module := &gpudKmsgWriterModule{
+			kmsgReadFunc: func(ctx context.Context) ([]pkgkmsg.Message, error) {
+				return []pkgkmsg.Message{
+					{
+						Timestamp: metav1.NewTime(baseTime.Add(-1 * time.Hour)),
+						Message:   "older module loaded with device major number 123",
+					},
+					{
+						Timestamp: metav1.NewTime(baseTime), // latest
+						Message:   "module loaded with device major number 456 extra text here",
+					},
+				}, nil
+			},
+		}
+
+		majorNum, err := module.findMajorNum(context.Background())
+		require.NoError(t, err)
+		// Function extracts last field after splitting by whitespace
+		require.Equal(t, "here", majorNum)
+	})
+}
+
+func TestGPUdKmsgWriterModule_UninstallModule_Success(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			require.Equal(t, "sudo rmmod gpud_kmsg_writer", script)
+			return []byte("module uninstalled"), 0, nil
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		workDir:               tempDir,
+		scriptUninstallModule: "sudo rmmod gpud_kmsg_writer",
+		processRunner:         mockRunner,
+	}
+
+	err := module.uninstallModule(context.Background())
+	require.NoError(t, err)
+}
+
+func TestGPUdKmsgWriterModule_UninstallModule_Failure(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			return []byte("uninstall failed"), 1, errors.New("uninstall failed")
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		workDir:               tempDir,
+		scriptUninstallModule: "sudo rmmod gpud_kmsg_writer",
+		processRunner:         mockRunner,
+	}
+
+	err := module.uninstallModule(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "uninstall failed")
+}
+
+func TestGPUdKmsgWriterModule_UninstallModule_DirectoryChangeError(t *testing.T) {
+	// Test with a directory that doesn't exist to trigger chdir error
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			return []byte("should not be called"), 0, nil
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		workDir:               "/invalid/nonexistent/directory",
+		scriptUninstallModule: "sudo rmmod test.ko",
+		processRunner:         mockRunner,
+	}
+
+	err := module.uninstallModule(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to change directory")
+}
+
+func TestGPUdKmsgWriterModule_Uninstall_Success(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create test files that will be cleaned up
+	cFile := filepath.Join(tempDir, "gpud_kmsg_writer.c")
+	koFile := filepath.Join(tempDir, "gpud_kmsg_writer.ko")
+	devFile := filepath.Join(tempDir, "test_dev")
+
+	require.NoError(t, os.WriteFile(cFile, []byte("test content"), 0644))
+	require.NoError(t, os.WriteFile(koFile, []byte("test content"), 0644))
+	require.NoError(t, os.WriteFile(devFile, []byte("test content"), 0644))
+
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			require.Equal(t, "sudo rmmod gpud_kmsg_writer", script)
+			return []byte("module uninstalled"), 0, nil
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		workDir:               tempDir,
+		cFile:                 cFile,
+		koFile:                koFile,
+		devFile:               devFile,
+		scriptUninstallModule: "sudo rmmod gpud_kmsg_writer",
+		processRunner:         mockRunner,
+	}
+
+	// Verify files exist before uninstall
+	require.FileExists(t, cFile)
+	require.FileExists(t, koFile)
+	require.FileExists(t, devFile)
+
+	err := module.Uninstall(context.Background())
+	require.NoError(t, err)
+
+	// Verify files are cleaned up after uninstall
+	require.NoFileExists(t, cFile)
+	require.NoFileExists(t, koFile)
+	require.NoFileExists(t, devFile)
+}
+
+func TestGPUdKmsgWriterModule_Uninstall_UninstallModuleFailure(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			return []byte("uninstall failed"), 1, errors.New("uninstall failed")
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		workDir:               tempDir,
+		cFile:                 filepath.Join(tempDir, "test.c"),
+		koFile:                filepath.Join(tempDir, "test.ko"),
+		devFile:               filepath.Join(tempDir, "test_dev"),
+		scriptUninstallModule: "sudo rmmod gpud_kmsg_writer",
+		processRunner:         mockRunner,
+	}
+
+	err := module.Uninstall(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "uninstall failed")
+}
+
+func TestGPUdKmsgWriterModule_Uninstall_InterfaceMethod(t *testing.T) {
+	tempDir := t.TempDir()
+
+	mockRunner := &mockRunner{
+		runFunc: func(ctx context.Context, script string) ([]byte, int32, error) {
+			return []byte("module uninstalled"), 0, nil
+		},
+	}
+
+	module := &gpudKmsgWriterModule{
+		workDir:               tempDir,
+		cFile:                 filepath.Join(tempDir, "test.c"),
+		koFile:                filepath.Join(tempDir, "test.ko"),
+		devFile:               filepath.Join(tempDir, "test_dev"),
+		scriptUninstallModule: "sudo rmmod gpud_kmsg_writer",
+		processRunner:         mockRunner,
+	}
+
+	// Test the interface method
+	var kmsgWriter GPUdKmsgWriterModule = module
+
+	err := kmsgWriter.Uninstall(context.Background())
+	require.NoError(t, err)
+}
+
+func TestGPUdKmsgWriterModule_InjectMessage_NilMessage(t *testing.T) {
+	module := &gpudKmsgWriterModule{}
+
+	// Should handle nil message gracefully and return no error
+	err := module.injectKmsg(context.Background(), nil)
+	require.NoError(t, err)
+}
+
+func TestGPUdKmsgWriterModule_InjectKernelMessage_NilMessage(t *testing.T) {
+	module := &gpudKmsgWriterModule{}
+
+	// Test the interface method with nil message
+	var kmsgWriter GPUdKmsgWriterModule = module
+
+	err := kmsgWriter.InjectKernelMessage(context.Background(), nil)
+	require.NoError(t, err)
+}

--- a/pkg/kmsg/writer/kernel_message.go
+++ b/pkg/kmsg/writer/kernel_message.go
@@ -1,0 +1,105 @@
+package writer
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// MaxPrintkRecordLength is the maximum length of a printk record.
+// ref.
+// "PRINTKRB_RECORD_MAX" in https://github.com/torvalds/linux/blob/94305e83eccb3120c921cd3a015cd74731140bac/kernel/printk/internal.h#L52
+// "PRINTK_PREFIX_MAX" in https://github.com/torvalds/linux/blob/94305e83eccb3120c921cd3a015cd74731140bac/kernel/printk/internal.h#L40C9-L40C26
+const MaxPrintkRecordLength = 1024 - 48
+
+// KmsgWriter defines the interface for writing kernel messages.
+type KmsgWriter interface {
+	// Write writes a kernel message to the kernel log.
+	Write(msg *KernelMessage) error
+}
+
+type KernelMessagePriority string
+
+const (
+	KernelMessagePriorityEmerg   KernelMessagePriority = "KERN_EMERG"
+	KernelMessagePriorityAlert   KernelMessagePriority = "KERN_ALERT"
+	KernelMessagePriorityCrit    KernelMessagePriority = "KERN_CRIT"
+	KernelMessagePriorityError   KernelMessagePriority = "KERN_ERR"
+	KernelMessagePriorityWarning KernelMessagePriority = "KERN_WARNING"
+	KernelMessagePriorityNotice  KernelMessagePriority = "KERN_NOTICE"
+	KernelMessagePriorityInfo    KernelMessagePriority = "KERN_INFO"
+	KernelMessagePriorityDebug   KernelMessagePriority = "KERN_DEBUG"
+	KernelMessagePriorityDefault KernelMessagePriority = "KERN_DEFAULT"
+)
+
+// KernelMessage represents a kernel message.
+type KernelMessage struct {
+	// Priority is the priority of the kernel message.
+	// ref. https://github.com/torvalds/linux/blob/master/tools/include/linux/kern_levels.h#L8-L15
+	Priority KernelMessagePriority `json:"priority"`
+	// Message is the message of the kernel message.
+	Message string `json:"message"`
+}
+
+// Validate validates the kernel message.
+func (m *KernelMessage) Validate() error {
+	if len(m.Message) > MaxPrintkRecordLength {
+		return fmt.Errorf("message length exceeds the maximum length of %d", MaxPrintkRecordLength)
+	}
+	m.Priority = ConvertKernelMessagePriority(string(m.Priority))
+	return nil
+}
+
+// ref. https://github.com/torvalds/linux/blob/master/tools/include/linux/kern_levels.h#L8-L15
+func ConvertKernelMessagePriority(s string) KernelMessagePriority {
+	switch s {
+	case "KERN_EMERG", "kern.emerg":
+		return KernelMessagePriorityEmerg
+	case "KERN_ALERT", "kern.alert":
+		return KernelMessagePriorityAlert
+	case "KERN_CRIT", "kern.crit":
+		return KernelMessagePriorityCrit
+	case "KERN_ERR", "kern.err":
+		return KernelMessagePriorityError
+	case "KERN_WARNING", "kern.warning", "kern.warn":
+		return KernelMessagePriorityWarning
+	case "KERN_NOTICE", "kern.notice":
+		return KernelMessagePriorityNotice
+	case "KERN_INFO", "kern.info":
+		return KernelMessagePriorityInfo
+	case "KERN_DEBUG", "kern.debug":
+		return KernelMessagePriorityDebug
+	case "KERN_DEFAULT", "kern.default":
+		return KernelMessagePriorityDefault
+	default: // unknown priority, default to KERN_INFO
+		return KernelMessagePriorityInfo
+	}
+}
+
+func NewKmsgWriterWithDummyDevice() KmsgWriter {
+	if runtime.GOOS != "linux" || os.Geteuid() != 0 {
+		return &noOpKmsgWriter{}
+	}
+
+	return &kmsgWriterWithDummyDevice{}
+}
+
+// kmsgWriterWithDummyDevice is a kernel message writer that writes to a dummy device.
+type kmsgWriterWithDummyDevice struct {
+}
+
+func (w *kmsgWriterWithDummyDevice) Write(msg *KernelMessage) error {
+	if msg == nil {
+		return nil
+	}
+
+	if err := msg.Validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type noOpKmsgWriter struct{}
+
+func (w *noOpKmsgWriter) Write(_ *KernelMessage) error { return nil }

--- a/pkg/kmsg/writer/kernel_message_test.go
+++ b/pkg/kmsg/writer/kernel_message_test.go
@@ -1,0 +1,437 @@
+package writer
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKernelMessage_JSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		msg      KernelMessage
+		expected string
+	}{
+		{
+			name: "basic kernel message",
+			msg: KernelMessage{
+				Priority: KernelMessagePriorityInfo,
+				Message:  "test message",
+			},
+			expected: `{"priority":"KERN_INFO","message":"test message"}`,
+		},
+		{
+			name: "empty message",
+			msg: KernelMessage{
+				Priority: KernelMessagePriorityError,
+				Message:  "",
+			},
+			expected: `{"priority":"KERN_ERR","message":""}`,
+		},
+		{
+			name: "empty priority",
+			msg: KernelMessage{
+				Priority: "",
+				Message:  "test message",
+			},
+			expected: `{"priority":"","message":"test message"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test marshaling
+			data, err := json.Marshal(tt.msg)
+			if err != nil {
+				t.Fatalf("Failed to marshal KernelMessage: %v", err)
+			}
+
+			if string(data) != tt.expected {
+				t.Errorf("Marshal result = %s, want %s", string(data), tt.expected)
+			}
+
+			// Test unmarshaling
+			var unmarshaled KernelMessage
+			err = json.Unmarshal(data, &unmarshaled)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal KernelMessage: %v", err)
+			}
+
+			if unmarshaled.Priority != tt.msg.Priority {
+				t.Errorf("Unmarshaled Priority = %s, want %s", unmarshaled.Priority, tt.msg.Priority)
+			}
+
+			if unmarshaled.Message != tt.msg.Message {
+				t.Errorf("Unmarshaled Message = %s, want %s", unmarshaled.Message, tt.msg.Message)
+			}
+		})
+	}
+}
+
+func TestConvertKernelMessagePriority(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected KernelMessagePriority
+	}{
+		// KERN_ format cases
+		{
+			name:     "KERN_EMERG",
+			input:    "KERN_EMERG",
+			expected: KernelMessagePriorityEmerg,
+		},
+		{
+			name:     "KERN_ALERT",
+			input:    "KERN_ALERT",
+			expected: KernelMessagePriorityAlert,
+		},
+		{
+			name:     "KERN_CRIT",
+			input:    "KERN_CRIT",
+			expected: KernelMessagePriorityCrit,
+		},
+		{
+			name:     "KERN_ERR",
+			input:    "KERN_ERR",
+			expected: KernelMessagePriorityError,
+		},
+		{
+			name:     "KERN_WARNING",
+			input:    "KERN_WARNING",
+			expected: KernelMessagePriorityWarning,
+		},
+		{
+			name:     "KERN_NOTICE",
+			input:    "KERN_NOTICE",
+			expected: KernelMessagePriorityNotice,
+		},
+		{
+			name:     "KERN_INFO",
+			input:    "KERN_INFO",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "KERN_DEBUG",
+			input:    "KERN_DEBUG",
+			expected: KernelMessagePriorityDebug,
+		},
+		{
+			name:     "KERN_DEFAULT",
+			input:    "KERN_DEFAULT",
+			expected: KernelMessagePriorityDefault,
+		},
+		// kern. format cases
+		{
+			name:     "kern.emerg",
+			input:    "kern.emerg",
+			expected: KernelMessagePriorityEmerg,
+		},
+		{
+			name:     "kern.alert",
+			input:    "kern.alert",
+			expected: KernelMessagePriorityAlert,
+		},
+		{
+			name:     "kern.crit",
+			input:    "kern.crit",
+			expected: KernelMessagePriorityCrit,
+		},
+		{
+			name:     "kern.err",
+			input:    "kern.err",
+			expected: KernelMessagePriorityError,
+		},
+		{
+			name:     "kern.warning",
+			input:    "kern.warning",
+			expected: KernelMessagePriorityWarning,
+		},
+		{
+			name:     "kern.warn",
+			input:    "kern.warn",
+			expected: KernelMessagePriorityWarning,
+		},
+		{
+			name:     "kern.notice",
+			input:    "kern.notice",
+			expected: KernelMessagePriorityNotice,
+		},
+		{
+			name:     "kern.info",
+			input:    "kern.info",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "kern.debug",
+			input:    "kern.debug",
+			expected: KernelMessagePriorityDebug,
+		},
+		{
+			name:     "kern.default",
+			input:    "kern.default",
+			expected: KernelMessagePriorityDefault,
+		},
+		// Edge cases
+		{
+			name:     "unknown priority",
+			input:    "unknown",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "case sensitive - lowercase KERN_ERR",
+			input:    "kern_err",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "case sensitive - uppercase kern.err",
+			input:    "KERN.ERR",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "numeric input",
+			input:    "123",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "special characters",
+			input:    "KERN@ERR",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "whitespace",
+			input:    " KERN_ERR ",
+			expected: KernelMessagePriorityInfo,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ConvertKernelMessagePriority(tt.input)
+			if result != tt.expected {
+				t.Errorf("ConvertKernelMessagePriority(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConvertKernelMessagePriority_AllValidCases(t *testing.T) {
+	// Test all valid cases to ensure complete coverage
+	validCases := map[string]KernelMessagePriority{
+		"KERN_EMERG":   KernelMessagePriorityEmerg,
+		"kern.emerg":   KernelMessagePriorityEmerg,
+		"KERN_ALERT":   KernelMessagePriorityAlert,
+		"kern.alert":   KernelMessagePriorityAlert,
+		"KERN_CRIT":    KernelMessagePriorityCrit,
+		"kern.crit":    KernelMessagePriorityCrit,
+		"KERN_ERR":     KernelMessagePriorityError,
+		"kern.err":     KernelMessagePriorityError,
+		"KERN_WARNING": KernelMessagePriorityWarning,
+		"kern.warning": KernelMessagePriorityWarning,
+		"kern.warn":    KernelMessagePriorityWarning,
+		"KERN_NOTICE":  KernelMessagePriorityNotice,
+		"kern.notice":  KernelMessagePriorityNotice,
+		"KERN_INFO":    KernelMessagePriorityInfo,
+		"kern.info":    KernelMessagePriorityInfo,
+		"KERN_DEBUG":   KernelMessagePriorityDebug,
+		"kern.debug":   KernelMessagePriorityDebug,
+		"KERN_DEFAULT": KernelMessagePriorityDefault,
+		"kern.default": KernelMessagePriorityDefault,
+	}
+
+	for input, expected := range validCases {
+		result := ConvertKernelMessagePriority(input)
+		if result != expected {
+			t.Errorf("ConvertKernelMessagePriority(%q) = %q, want %q", input, result, expected)
+		}
+	}
+}
+
+func TestConvertKernelMessagePriority_DefaultBehavior(t *testing.T) {
+	// Test that unknown inputs default to KERN_INFO
+	unknownInputs := []string{
+		"random",
+		"invalid",
+		"KERN_UNKNOWN",
+		"kern.unknown",
+		"123",
+		"!@#$%",
+		"KERN_ERR_TYPO",
+		"kern.info.extra",
+	}
+
+	for _, input := range unknownInputs {
+		result := ConvertKernelMessagePriority(input)
+		if result != KernelMessagePriorityInfo {
+			t.Errorf("ConvertKernelMessagePriority(%q) = %q, want %q (default)", input, result, KernelMessagePriorityInfo)
+		}
+	}
+}
+
+func TestKernelMessage_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		msg         KernelMessage
+		expectedErr bool
+		expectedMsg string
+	}{
+		{
+			name: "valid message with correct priority",
+			msg: KernelMessage{
+				Priority: KernelMessagePriorityInfo,
+				Message:  "This is a valid message",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "valid message with kern.format priority",
+			msg: KernelMessage{
+				Priority: "kern.err",
+				Message:  "This is a valid message",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "valid message with unknown priority (should be normalized)",
+			msg: KernelMessage{
+				Priority: "unknown_priority",
+				Message:  "This is a valid message",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "valid message at maximum length",
+			msg: KernelMessage{
+				Priority: KernelMessagePriorityInfo,
+				Message:  string(make([]byte, MaxPrintkRecordLength)),
+			},
+			expectedErr: false,
+		},
+		{
+			name: "invalid message exceeding maximum length",
+			msg: KernelMessage{
+				Priority: KernelMessagePriorityInfo,
+				Message:  string(make([]byte, MaxPrintkRecordLength+1)),
+			},
+			expectedErr: true,
+			expectedMsg: "message length exceeds the maximum length of 976",
+		},
+		{
+			name: "invalid message much longer than maximum",
+			msg: KernelMessage{
+				Priority: KernelMessagePriorityError,
+				Message:  string(make([]byte, MaxPrintkRecordLength*2)),
+			},
+			expectedErr: true,
+			expectedMsg: "message length exceeds the maximum length of 976",
+		},
+		{
+			name: "empty message",
+			msg: KernelMessage{
+				Priority: KernelMessagePriorityDebug,
+				Message:  "",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "empty priority and message",
+			msg: KernelMessage{
+				Priority: "",
+				Message:  "",
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalPriority := tt.msg.Priority
+			err := tt.msg.Validate()
+
+			if tt.expectedErr {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+					return
+				}
+				if err.Error() != tt.expectedMsg {
+					t.Errorf("Expected error message %q, got %q", tt.expectedMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+					return
+				}
+
+				// Check that priority was normalized correctly
+				expectedPriority := ConvertKernelMessagePriority(string(originalPriority))
+				if tt.msg.Priority != expectedPriority {
+					t.Errorf("Priority not normalized correctly: got %q, want %q", tt.msg.Priority, expectedPriority)
+				}
+			}
+		})
+	}
+}
+
+func TestMaxPrintkRecordLength(t *testing.T) {
+	// Test that the constant has the expected value
+	expected := 1024 - 48
+	if MaxPrintkRecordLength != expected {
+		t.Errorf("MaxPrintkRecordLength = %d, want %d", MaxPrintkRecordLength, expected)
+	}
+
+	// Test that the constant value is 976
+	if MaxPrintkRecordLength != 976 {
+		t.Errorf("MaxPrintkRecordLength = %d, want 976", MaxPrintkRecordLength)
+	}
+}
+
+func TestKernelMessage_Validate_PriorityNormalization(t *testing.T) {
+	// Test that Validate correctly normalizes various priority formats
+	tests := []struct {
+		name             string
+		inputPriority    KernelMessagePriority
+		expectedPriority KernelMessagePriority
+	}{
+		{"KERN format", KernelMessagePriorityError, KernelMessagePriorityError},
+		{"kern format", "kern.warning", KernelMessagePriorityWarning},
+		{"kern.warn format", "kern.warn", KernelMessagePriorityWarning},
+		{"unknown priority", "invalid", KernelMessagePriorityInfo},
+		{"empty priority", "", KernelMessagePriorityInfo},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := KernelMessage{
+				Priority: tt.inputPriority,
+				Message:  "test message",
+			}
+
+			err := msg.Validate()
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if msg.Priority != tt.expectedPriority {
+				t.Errorf("Priority normalization failed: got %q, want %q", msg.Priority, tt.expectedPriority)
+			}
+		})
+	}
+}
+
+func Test_kmsgWriterWithDummyDevice_UpdateKernelMessage(t *testing.T) {
+	writer := &kmsgWriterWithDummyDevice{}
+
+	msg := KernelMessage{
+		Priority: "kern.info",
+		Message:  "test message",
+	}
+
+	_ = writer.Write(&msg)
+
+	require.Equal(t, msg.Priority, KernelMessagePriorityInfo)
+}

--- a/pkg/kmsg/writer/src/Makefile
+++ b/pkg/kmsg/writer/src/Makefile
@@ -1,0 +1,17 @@
+obj-m += gpud_kmsg_writer.o
+
+
+build:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+
+
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+
+
+install:
+	sudo insmod gpud_kmsg_writer.ko
+
+
+uninstall:
+	sudo rmmod gpud_kmsg_writer

--- a/pkg/kmsg/writer/src/gpud_kmsg_writer.c
+++ b/pkg/kmsg/writer/src/gpud_kmsg_writer.c
@@ -1,0 +1,141 @@
+#include <linux/fs.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/spinlock.h>
+#include <linux/string.h>
+#include <linux/uaccess.h>
+
+#define DEVICE_NAME "gpud-kmsg-writer"
+#define BUF_LEN 1000
+
+static int major;
+static char msg[BUF_LEN];
+static DEFINE_MUTEX(msg_mutex);
+
+// Function to parse log level from input and return the appropriate KERN_*
+// level.
+// Both of the following commands are valid:
+// e.g.,
+// sh -c "echo \"KERN_EMERG, System critical error!\" > /dev/gpud_kmsg_writer"
+// sh -c "echo \"kern.emerg, System critical error!\" > /dev/gpud_kmsg_writer"
+static const char *parse_log_level(const char *input, char *remaining_msg) {
+  const char *comma_pos;
+  char level_str[32];
+  int level_len;
+
+  // Find the first comma
+  comma_pos = strchr(input, ',');
+  if (!comma_pos) {
+    // No comma found, use default level and copy entire message
+    strncpy(remaining_msg, input, BUF_LEN - 1);
+    remaining_msg[BUF_LEN - 1] = '\0';
+    return KERN_INFO; // default level
+  }
+
+  // Extract the level part (before comma)
+  level_len = comma_pos - input;
+  if (level_len >= sizeof(level_str)) {
+    level_len = sizeof(level_str) - 1;
+  }
+  strncpy(level_str, input, level_len);
+  level_str[level_len] = '\0';
+
+  // Copy the remaining message (after comma, skipping leading spaces)
+  comma_pos++; // skip the comma
+  while (*comma_pos == ' ' || *comma_pos == '\t') {
+    comma_pos++; // skip leading whitespace
+  }
+  strncpy(remaining_msg, comma_pos, BUF_LEN - 1);
+  remaining_msg[BUF_LEN - 1] = '\0';
+
+  // Map level string to KERN_* constants
+  // ref.
+  // https://github.com/torvalds/linux/blob/master/tools/include/linux/kern_levels.h#L8-L15
+  if (strcmp(level_str, "kern.emerg") == 0 ||
+      strcmp(level_str, "KERN_EMERG") == 0) {
+    return KERN_EMERG;
+  } else if (strcmp(level_str, "kern.alert") == 0 ||
+             strcmp(level_str, "KERN_ALERT") == 0) {
+    return KERN_ALERT;
+  } else if (strcmp(level_str, "kern.crit") == 0 ||
+             strcmp(level_str, "KERN_CRIT") == 0) {
+    return KERN_CRIT;
+  } else if (strcmp(level_str, "kern.err") == 0 ||
+             strcmp(level_str, "KERN_ERR") == 0) {
+    return KERN_ERR;
+  } else if (strcmp(level_str, "kern.warning") == 0 ||
+             strcmp(level_str, "KERN_WARNING") == 0) {
+    return KERN_WARNING;
+  } else if (strcmp(level_str, "kern.notice") == 0 ||
+             strcmp(level_str, "KERN_NOTICE") == 0) {
+    return KERN_NOTICE;
+  } else if (strcmp(level_str, "kern.info") == 0 ||
+             strcmp(level_str, "KERN_INFO") == 0) {
+    return KERN_INFO;
+  } else if (strcmp(level_str, "kern.debug") == 0 ||
+             strcmp(level_str, "KERN_DEBUG") == 0) {
+    return KERN_DEBUG;
+  } else {
+    // Unknown level, use default
+    return KERN_INFO;
+  }
+}
+
+static ssize_t dev_write(struct file *file, const char __user *buf, size_t len,
+                         loff_t *offset) {
+  ssize_t ret;
+  const char *log_level;
+  char parsed_msg[BUF_LEN];
+
+  if (len > BUF_LEN - 1)
+    len = BUF_LEN - 1;
+
+  if (!mutex_trylock(&msg_mutex)) {
+    return -EBUSY;
+  }
+
+  if (copy_from_user(msg, buf, len)) {
+    mutex_unlock(&msg_mutex);
+    return -EFAULT;
+  }
+
+  msg[len] = '\0';
+
+  // Parse the log level and extract the message
+  log_level = parse_log_level(msg, parsed_msg);
+
+  // Use the parsed log level in printk
+  printk("%s%s\n", log_level, parsed_msg);
+
+  ret = len;
+  mutex_unlock(&msg_mutex);
+
+  return ret;
+}
+
+static struct file_operations fops = {
+    .owner = THIS_MODULE,
+    .write = dev_write,
+};
+
+static int __init gpud_kmsg_writer_device_init(void) {
+  major = register_chrdev(0, DEVICE_NAME, &fops);
+  if (major < 0) {
+    printk(KERN_ALERT "Registering dummy device failed with %d\n", major);
+    return major;
+  }
+  printk(KERN_INFO "module loaded with device major number %d\n", major);
+  return 0;
+}
+
+static void __exit gpud_kmsg_writer_device_exit(void) {
+  unregister_chrdev(major, DEVICE_NAME);
+  printk(KERN_INFO "char_device module unloaded\n");
+}
+
+module_init(gpud_kmsg_writer_device_init);
+module_exit(gpud_kmsg_writer_device_exit);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Hitoshi Mitake, Gyuho Lee");
+MODULE_DESCRIPTION("char device for injecting messages to kernel log");

--- a/pkg/process/runner_exclusive.go
+++ b/pkg/process/runner_exclusive.go
@@ -64,7 +64,7 @@ func (er *exclusiveRunner) RunUntilCompletion(ctx context.Context, script string
 		er.running = nil
 		er.mu.Unlock()
 	}()
-	log.Logger.Infow("started running script", "pid", p.PID())
+	log.Logger.Debugw("started running script", "pid", p.PID())
 
 	er.mu.Lock()
 	er.running = p

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/leptonai/gpud/components"
 	gpudconfig "github.com/leptonai/gpud/pkg/config"
 	"github.com/leptonai/gpud/pkg/errdefs"
+	pkgfaultinjector "github.com/leptonai/gpud/pkg/fault-injector"
 	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
 )
 
@@ -32,9 +33,11 @@ type globalHandler struct {
 	metricsStore pkgmetrics.Store
 
 	gpudInstance *components.GPUdInstance
+
+	faultInjector pkgfaultinjector.Injector
 }
 
-func newGlobalHandler(cfg *gpudconfig.Config, componentsRegistry components.Registry, metricsStore pkgmetrics.Store, gpudInstance *components.GPUdInstance) *globalHandler {
+func newGlobalHandler(cfg *gpudconfig.Config, componentsRegistry components.Registry, metricsStore pkgmetrics.Store, gpudInstance *components.GPUdInstance, faultInjector pkgfaultinjector.Injector) *globalHandler {
 	var componentNames []string
 	for _, c := range componentsRegistry.All() {
 		componentNames = append(componentNames, c.Name())
@@ -47,6 +50,7 @@ func newGlobalHandler(cfg *gpudconfig.Config, componentsRegistry components.Regi
 		componentNames:     componentNames,
 		metricsStore:       metricsStore,
 		gpudInstance:       gpudInstance,
+		faultInjector:      faultInjector,
 	}
 }
 

--- a/pkg/server/handlers_components_test.go
+++ b/pkg/server/handlers_components_test.go
@@ -229,7 +229,7 @@ func TestGetComponents(t *testing.T) {
 	cfg := &config.Config{}
 	store := &mockMetricsStore{}
 
-	handler := newGlobalHandler(cfg, registry, store, nil)
+	handler := newGlobalHandler(cfg, registry, store, nil, nil)
 	_, c, w := setupTestRouter()
 
 	// Test with default JSON content type
@@ -259,7 +259,7 @@ func TestGetComponentsYAML(t *testing.T) {
 	cfg := &config.Config{}
 	store := &mockMetricsStore{}
 
-	handler := newGlobalHandler(cfg, registry, store, nil)
+	handler := newGlobalHandler(cfg, registry, store, nil, nil)
 	_, c, w := setupTestRouter()
 
 	// Set up a new request with YAML content type
@@ -607,7 +607,7 @@ func TestGetInfo(t *testing.T) {
 	cfg := &config.Config{}
 	store := &mockMetricsStore{metrics: metricsData}
 
-	handler := newGlobalHandler(cfg, registry, store, nil)
+	handler := newGlobalHandler(cfg, registry, store, nil, nil)
 	_, c, w := setupTestRouter()
 
 	// Test getting info for a specific component
@@ -678,7 +678,7 @@ func TestGetMetrics(t *testing.T) {
 	cfg := &config.Config{}
 	store := &mockMetricsStore{metrics: metricsData}
 
-	handler := newGlobalHandler(cfg, registry, store, nil)
+	handler := newGlobalHandler(cfg, registry, store, nil, nil)
 	_, c, w := setupTestRouter()
 
 	// Test getting metrics for a specific component

--- a/pkg/server/handlers_inject_fault.go
+++ b/pkg/server/handlers_inject_fault.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/leptonai/gpud/pkg/errdefs"
+	pkgfaultinjector "github.com/leptonai/gpud/pkg/fault-injector"
+)
+
+const URLPathInjectFault = "/inject-fault"
+
+func (g *globalHandler) handleInjectFault(c *gin.Context) {
+	if g.faultInjector == nil {
+		c.JSON(http.StatusNotFound, gin.H{"code": errdefs.ErrNotFound, "message": "fault injector not set up"})
+		return
+	}
+
+	// read the request body
+	request := new(pkgfaultinjector.Request)
+	if err := json.NewDecoder(c.Request.Body).Decode(request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"code": errdefs.ErrInvalidArgument, "message": "failed to decode request body: " + err.Error()})
+		return
+	}
+	if err := request.Validate(); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"code": errdefs.ErrInvalidArgument, "message": "invalid request: " + err.Error()})
+		return
+	}
+
+	switch {
+	case request.KernelMessage != nil:
+		if err := g.faultInjector.InjectKernelMessage(c.Request.Context(), request.KernelMessage); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"code": errdefs.ErrUnknown, "message": "failed to inject kernel message: " + err.Error()})
+			return
+		}
+
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"code": errdefs.ErrInvalidArgument, "message": "kernel message is required"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "fault injected"})
+}

--- a/pkg/server/handlers_inject_fault_test.go
+++ b/pkg/server/handlers_inject_fault_test.go
@@ -1,0 +1,569 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	pkgfaultinjector "github.com/leptonai/gpud/pkg/fault-injector"
+	pkgkmsgwriter "github.com/leptonai/gpud/pkg/kmsg/writer"
+)
+
+// Mock fault injector for testing
+type mockFaultInjector struct {
+	mock.Mock
+}
+
+func (m *mockFaultInjector) InjectKernelMessage(ctx context.Context, kernelMessage *pkgkmsgwriter.KernelMessage) error {
+	args := m.Called(ctx, kernelMessage)
+	return args.Error(0)
+}
+
+func (m *mockFaultInjector) BuildInstall(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockFaultInjector) Uninstall(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+// Helper function to setup test context
+func setupInjectFaultTest() (*gin.Engine, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	recorder := httptest.NewRecorder()
+	return router, recorder
+}
+
+func TestHandleInjectFault_NilFaultInjector(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create handler with nil fault injector
+	handler := &globalHandler{
+		faultInjector: nil,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create request with valid JSON
+	request := pkgfaultinjector.Request{
+		KernelMessage: &pkgkmsgwriter.KernelMessage{
+			Priority: "KERN_INFO",
+			Message:  "test message",
+		},
+	}
+	requestBody, _ := json.Marshal(request)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// The error object serializes as an empty map in JSON
+	assert.Equal(t, map[string]interface{}{}, response["code"])
+	assert.Equal(t, "fault injector not set up", response["message"])
+}
+
+func TestHandleInjectFault_InvalidJSON(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create handler with mock fault injector
+	mockInjector := new(mockFaultInjector)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create HTTP request with invalid JSON
+	invalidJSON := `{"invalid": json}`
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBufferString(invalidJSON))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// The error object serializes as an empty map in JSON
+	assert.Equal(t, map[string]interface{}{}, response["code"])
+	assert.Contains(t, response["message"], "failed to decode request body")
+
+	// Assert no calls were made to the fault injector
+	mockInjector.AssertNotCalled(t, "InjectKernelMessage")
+}
+
+func TestHandleInjectFault_SuccessfulKernelMessageInjection(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create mock fault injector
+	mockInjector := new(mockFaultInjector)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create valid request
+	kernelMessage := &pkgkmsgwriter.KernelMessage{
+		Priority: "KERN_INFO",
+		Message:  "test kernel message",
+	}
+	request := pkgfaultinjector.Request{
+		KernelMessage: kernelMessage,
+	}
+	requestBody, _ := json.Marshal(request)
+
+	// Mock successful injection
+	mockInjector.On("InjectKernelMessage", mock.Anything, kernelMessage).Return(nil)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "fault injected", response["message"])
+
+	// Verify mock was called
+	mockInjector.AssertExpectations(t)
+}
+
+func TestHandleInjectFault_FailedKernelMessageInjection(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create mock fault injector
+	mockInjector := new(mockFaultInjector)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create valid request
+	kernelMessage := &pkgkmsgwriter.KernelMessage{
+		Priority: "KERN_ERR",
+		Message:  "test error message",
+	}
+	request := pkgfaultinjector.Request{
+		KernelMessage: kernelMessage,
+	}
+	requestBody, _ := json.Marshal(request)
+
+	// Mock failed injection
+	injectionError := errors.New("injection failed")
+	mockInjector.On("InjectKernelMessage", mock.Anything, kernelMessage).Return(injectionError)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// The error object serializes as an empty map in JSON
+	assert.Equal(t, map[string]interface{}{}, response["code"])
+	assert.Equal(t, "failed to inject kernel message: injection failed", response["message"])
+
+	// Verify mock was called
+	mockInjector.AssertExpectations(t)
+}
+
+func TestHandleInjectFault_NilKernelMessage_DefaultCase(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create mock fault injector
+	mockInjector := new(mockFaultInjector)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create request with nil KernelMessage (validation fails before reaching switch)
+	request := pkgfaultinjector.Request{
+		KernelMessage: nil,
+	}
+	requestBody, _ := json.Marshal(request)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// The error object serializes as an empty map in JSON
+	assert.Equal(t, map[string]interface{}{}, response["code"])
+	assert.Equal(t, "invalid request: no fault injection entry found", response["message"])
+
+	// Verify no injection was attempted
+	mockInjector.AssertNotCalled(t, "InjectKernelMessage")
+}
+
+func TestHandleInjectFault_EmptyRequest_DefaultCase(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create mock fault injector
+	mockInjector := new(mockFaultInjector)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create empty request (no fields set, validation fails before reaching switch)
+	request := pkgfaultinjector.Request{}
+	requestBody, _ := json.Marshal(request)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// The error object serializes as an empty map in JSON
+	assert.Equal(t, map[string]interface{}{}, response["code"])
+	assert.Equal(t, "invalid request: no fault injection entry found", response["message"])
+
+	// Verify no injection was attempted
+	mockInjector.AssertNotCalled(t, "InjectKernelMessage")
+}
+
+func TestHandleInjectFault_ContextPropagation(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create mock fault injector
+	mockInjector := new(mockFaultInjector)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create valid request
+	kernelMessage := &pkgkmsgwriter.KernelMessage{
+		Priority: "KERN_DEBUG",
+		Message:  "test context propagation",
+	}
+	request := pkgfaultinjector.Request{
+		KernelMessage: kernelMessage,
+	}
+	requestBody, _ := json.Marshal(request)
+
+	// Mock the injector to verify context is passed correctly
+	// Note: c.Request.Context() returns the underlying HTTP request context, not the gin context
+	mockInjector.On("InjectKernelMessage", mock.Anything, kernelMessage).Return(nil)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	// Verify mock was called with correct context type
+	mockInjector.AssertExpectations(t)
+}
+
+// Validation-specific tests for request.Validate() call
+func TestHandleInjectFault_Validation(t *testing.T) {
+	t.Run("valid request passes validation", func(t *testing.T) {
+		// Setup
+		router, recorder := setupInjectFaultTest()
+
+		// Create mock fault injector
+		mockInjector := new(mockFaultInjector)
+		handler := &globalHandler{
+			faultInjector: mockInjector,
+		}
+
+		// Register the handler
+		router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+		// Create request with valid kernel message
+		kernelMessage := &pkgkmsgwriter.KernelMessage{
+			Priority: "KERN_INFO",
+			Message:  "valid message for validation test",
+		}
+		request := pkgfaultinjector.Request{
+			KernelMessage: kernelMessage,
+		}
+		requestBody, _ := json.Marshal(request)
+
+		// Mock successful injection since validation will pass
+		mockInjector.On("InjectKernelMessage", mock.Anything, kernelMessage).Return(nil)
+
+		// Create HTTP request
+		req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		// Send request
+		router.ServeHTTP(recorder, req)
+
+		// Assert validation passed (status is OK, not BadRequest)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(recorder.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, "fault injected", response["message"])
+
+		// Verify mock was called (proves validation passed)
+		mockInjector.AssertExpectations(t)
+	})
+
+	t.Run("invalid request fails validation - message too long", func(t *testing.T) {
+		// Setup
+		router, recorder := setupInjectFaultTest()
+
+		// Create mock fault injector
+		mockInjector := new(mockFaultInjector)
+		handler := &globalHandler{
+			faultInjector: mockInjector,
+		}
+
+		// Register the handler
+		router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+		// Create request with message exceeding MaxPrintkRecordLength (976 characters)
+		maxLength := 976
+		longMessage := make([]byte, maxLength+100) // Exceeds the limit
+		for i := range longMessage {
+			longMessage[i] = 'A'
+		}
+
+		kernelMessage := &pkgkmsgwriter.KernelMessage{
+			Priority: "KERN_ERR",
+			Message:  string(longMessage),
+		}
+		request := pkgfaultinjector.Request{
+			KernelMessage: kernelMessage,
+		}
+		requestBody, _ := json.Marshal(request)
+
+		// Create HTTP request
+		req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		// Send request
+		router.ServeHTTP(recorder, req)
+
+		// Assert validation failed
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(recorder.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		// The error object serializes as an empty map in JSON
+		assert.Equal(t, map[string]interface{}{}, response["code"])
+		assert.Contains(t, response["message"], "invalid request:")
+		assert.Contains(t, response["message"], "message length exceeds the maximum length")
+		assert.Contains(t, response["message"], "976")
+
+		// Verify no injection was attempted (proves validation stopped execution)
+		mockInjector.AssertNotCalled(t, "InjectKernelMessage")
+	})
+
+	t.Run("request with nil kernel message fails validation", func(t *testing.T) {
+		// Setup
+		router, recorder := setupInjectFaultTest()
+
+		// Create mock fault injector
+		mockInjector := new(mockFaultInjector)
+		handler := &globalHandler{
+			faultInjector: mockInjector,
+		}
+
+		// Register the handler
+		router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+		// Create request with nil KernelMessage (validation fails before reaching switch)
+		request := pkgfaultinjector.Request{
+			KernelMessage: nil,
+		}
+		requestBody, _ := json.Marshal(request)
+
+		// Create HTTP request
+		req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		// Send request
+		router.ServeHTTP(recorder, req)
+
+		// Assert validation failed
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(recorder.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		// This should be the validation error, not switch case error
+		assert.Equal(t, "invalid request: no fault injection entry found", response["message"])
+
+		// Verify no injection was attempted
+		mockInjector.AssertNotCalled(t, "InjectKernelMessage")
+	})
+}
+
+func TestHandleInjectFault_XidToKernelMessageTransformation(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create mock fault injector
+	mockInjector := new(mockFaultInjector)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create request with XID (will be transformed to KernelMessage during validation)
+	request := pkgfaultinjector.Request{
+		Xid: &pkgfaultinjector.XidToInject{
+			ID: 79, // Valid XID that should be transformed
+		},
+	}
+	requestBody, _ := json.Marshal(request)
+
+	// Mock successful injection - the XID will be transformed to KernelMessage
+	// We need to match any parameters since the transformation happens during validation
+	mockInjector.On("InjectKernelMessage", mock.Anything, mock.Anything).Return(nil)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "fault injected", response["message"])
+
+	// Verify mock was called (proves XID was transformed and injection was attempted)
+	mockInjector.AssertExpectations(t)
+}
+
+func TestHandleInjectFault_InvalidXid(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create mock fault injector
+	mockInjector := new(mockFaultInjector)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create request with invalid XID (ID = 0, should fail validation)
+	request := pkgfaultinjector.Request{
+		Xid: &pkgfaultinjector.XidToInject{
+			ID: 0, // Invalid XID, should fail validation
+		},
+	}
+	requestBody, _ := json.Marshal(request)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// The error object serializes as an empty map in JSON
+	assert.Equal(t, map[string]interface{}{}, response["code"])
+	assert.Equal(t, "invalid request: no fault injection entry found", response["message"])
+
+	// Verify no injection was attempted
+	mockInjector.AssertNotCalled(t, "InjectKernelMessage")
+}

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestNewGlobalHandler(t *testing.T) {
 	var metricStore metrics.Store
-	ghler := newGlobalHandler(nil, components.NewRegistry(nil), metricStore, nil)
+	ghler := newGlobalHandler(nil, components.NewRegistry(nil), metricStore, nil, nil)
 	assert.NotNil(t, ghler)
 }
 

--- a/pkg/server/handlers_testutils_test.go
+++ b/pkg/server/handlers_testutils_test.go
@@ -17,7 +17,7 @@ func setupTestHandler(comps []components.Component) (*globalHandler, *mockRegist
 	cfg := &config.Config{}
 	store := &mockMetricsStore{}
 
-	handler := newGlobalHandler(cfg, registry, store, nil)
+	handler := newGlobalHandler(cfg, registry, store, nil, nil)
 	return handler, registry, store
 }
 
@@ -33,7 +33,7 @@ func setupTestHandlerWithPluginAPI(comps []components.Component) (*globalHandler
 	}
 	store := &mockMetricsStore{}
 
-	handler := newGlobalHandler(cfg, registry, store, nil)
+	handler := newGlobalHandler(cfg, registry, store, nil, nil)
 	return handler, registry, store
 }
 

--- a/pkg/session/serve.go
+++ b/pkg/session/serve.go
@@ -19,6 +19,7 @@ import (
 	"github.com/leptonai/gpud/pkg/config"
 	pkgcustomplugins "github.com/leptonai/gpud/pkg/custom-plugins"
 	"github.com/leptonai/gpud/pkg/errdefs"
+	pkgfaultinjector "github.com/leptonai/gpud/pkg/fault-injector"
 	gpudmanager "github.com/leptonai/gpud/pkg/gpud-manager"
 	pkdsystemd "github.com/leptonai/gpud/pkg/gpud-manager/systemd"
 	pkghost "github.com/leptonai/gpud/pkg/host"
@@ -45,7 +46,8 @@ type Request struct {
 	UpdateVersion string            `json:"update_version,omitempty"`
 	UpdateConfig  map[string]string `json:"update_config,omitempty"`
 
-	Bootstrap *BootstrapRequest `json:"bootstrap,omitempty"`
+	Bootstrap          *BootstrapRequest         `json:"bootstrap,omitempty"`
+	InjectFaultRequest *pkgfaultinjector.Request `json:"inject_fault_request,omitempty"`
 
 	// ComponentName is the name of the component to query or deregister.
 	ComponentName string `json:"component_name,omitempty"`
@@ -297,6 +299,35 @@ func (s *Session) serve() {
 				if err != nil {
 					response.Error = err.Error()
 				}
+			}
+
+		case "injectFault":
+			if payload.InjectFaultRequest != nil {
+				if s.faultInjector == nil {
+					response.Error = "fault injector is not initialized"
+					break
+				}
+
+				if err := payload.InjectFaultRequest.Validate(); err != nil {
+					response.Error = err.Error()
+					log.Logger.Errorw("invalid fault inject request", "error", err)
+					break
+				}
+
+				switch {
+				case payload.InjectFaultRequest.KernelMessage != nil:
+					if err := s.faultInjector.InjectKernelMessage(ctx, payload.InjectFaultRequest.KernelMessage); err != nil {
+						response.Error = err.Error()
+						log.Logger.Errorw("failed to inject kernel message", "message", payload.InjectFaultRequest.KernelMessage.Message, "error", err)
+					} else {
+						log.Logger.Infow("successfully injected kernel message", "message", payload.InjectFaultRequest.KernelMessage.Message)
+					}
+
+				default:
+					log.Logger.Warnw("fault inject request is nil or kernel message is nil")
+				}
+			} else {
+				log.Logger.Warnw("fault inject request is nil")
 			}
 
 		case "triggerComponentCheck":


### PR DESCRIPTION

<img width="668" alt="Screenshot 2025-05-24 at 4 01 38 PM" src="https://github.com/user-attachments/assets/09231529-c66c-4bae-82f7-ec293c1cabc2" />

e.g.,

```
sudo /tmp/gpud run --enable-auto-update=false --enable-fault-injector

curl -kX POST https://localhost:15132/inject-fault \
-H "Content-Type: application/json" \
-d '{
    "kernel_message": {
        "priority": "KERN_DEBUG",
        "message": "Debug fault injection test"
    }
}'

curl -kX POST https://localhost:15132/inject-fault \
-H "Content-Type: application/json" \
-d '{
    "kernel_message": {
        "priority": "kern.warn",
        "message": "NVRM: Xid (PCI:0000:04:00): 74, pid=1234, name=python3, Channel 0x23, MMU Fault: ENGINE GRAPHICS GPCCLIENT_T1_0 faulted @ 0x7fc123456000. Fault is of type FAULT_PTE ACCESS_TYPE_VIRT_READ"
    }
}'

curl -kX POST https://localhost:15132/inject-fault \
-H "Content-Type: application/json" \
-d '{
    "kernel_message": {
        "priority": "kern.err",
        "message":  "NVRM: Xid (PCI:0000:04:00): 79, GPU has fallen off the bus"
    }
}'

curl -kX POST https://localhost:15132/inject-fault \
-H "Content-Type: application/json" \
-d '{"xid": {"id": 79}}'
```
