### PR TITLE
feat(pkg/session, process): reduce log noise for non-critical logs

### DIFF
--- a/pkg/process/runner_exclusive.go
+++ b/pkg/process/runner_exclusive.go
@@ -59,7 +59,7 @@ func (er *exclusiveRunner) RunUntilCompletion(ctx context.Context, script string
 		if err := p.Close(ctx); err != nil {
 			log.Logger.Errorw("failed to close process", "pid", p.PID(), "error", err)
 		}
-		log.Logger.Infow("closed running script", "pid", p.PID())
+		log.Logger.Debugw("closed running script", "pid", p.PID())
 		er.mu.Lock()
 		er.running = nil
 		er.mu.Unlock()
@@ -90,7 +90,7 @@ func (er *exclusiveRunner) RunUntilCompletion(ctx context.Context, script string
 
 			return output, p.ExitCode(), err
 		}
-		log.Logger.Infow("process exited", "pid", p.PID(), "exitCode", p.ExitCode())
+		log.Logger.Debugw("process exited", "pid", p.PID(), "exitCode", p.ExitCode())
 	}
 
 	output, err := os.ReadFile(tmpFile.Name())

--- a/pkg/session/serve.go
+++ b/pkg/session/serve.go
@@ -430,7 +430,7 @@ func (s *Session) serve() {
 					break
 				}
 
-				log.Logger.Infow("registered and started custom plugin", "name", comp.Name())
+				log.Logger.Infow("updated and started custom plugin", "name", comp.Name())
 			}
 		}
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -197,7 +197,7 @@ func (s *Session) keepAlive() {
 			ctx, cancel := context.WithCancel(context.Background()) // create local context for each session
 			jar, _ := cookiejar.New(nil)
 
-			log.Logger.Infow("session keep alive: checking server health")
+			log.Logger.Debugw("session keep alive: checking server health")
 			if err := s.checkServerHealth(ctx, jar); err != nil {
 				log.Logger.Errorf("session keep alive: error checking server health: %v", err)
 				cancel()


### PR DESCRIPTION
No need to see these logs

```
{"level":"info","ts":"2025-05-22T14:57:50Z","msg":"process exited","pid":3855,"exitCode":0}
{"level":"info","ts":"2025-05-22T14:57:50Z","msg":"closed running script","pid":3855}
{"level":"info","ts":"2025-05-22T14:57:50Z","msg":"process exited","pid":3948,"exitCode":0}
{"level":"info","ts":"2025-05-22T14:57:50Z","msg":"process exited","pid":3846,"exitCode":0}
{"level":"info","ts":"2025-05-22T14:57:50Z","msg":"closed running script","pid":3846}
{"level":"info","ts":"2025-05-22T14:57:50Z","msg":"process exited","pid":3873,"exitCode":0}
{"level":"info","ts":"2025-05-22T14:57:50Z","msg":"closed running script","pid":3873}
{"level":"info","ts":"2025-05-22T14:57:50Z","msg":"closed running script","pid":3948}
{"level":"info","ts":"2025-05-22T14:57:50Z","msg":"process exited","pid":3856,"exitCode":0}
{"level":"info","ts":"2025-05-22T14:57:50Z","msg":"closed running script","pid":3856}
{"level":"info","ts":"2025-05-22T14:57:50Z","msg":"process exited","pid":3920,"exitCode":0}
{"level":"info","ts":"2025-05-22T14:57:50Z","msg":"closed running script","pid":3920}
{"level":"info","ts":"2025-05-22T14:57:50Z","msg":"process exited","pid":3847,"exitCode":0}
```

Split from https://github.com/leptonai/gpud/pull/864.