### PR TITLE
feat(fault-injector): add kmsg writer to inject nvidia GPU xid/sxid

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -8,6 +8,7 @@ import (
 	cmdcompact "github.com/leptonai/gpud/cmd/gpud/compact"
 	cmdcustomplugins "github.com/leptonai/gpud/cmd/gpud/custom-plugins"
 	cmddown "github.com/leptonai/gpud/cmd/gpud/down"
+	cmdinjectfault "github.com/leptonai/gpud/cmd/gpud/inject-fault"
 	cmdjoin "github.com/leptonai/gpud/cmd/gpud/join"
 	cmdlistplugins "github.com/leptonai/gpud/cmd/gpud/list-plugins"
 	cmdlogin "github.com/leptonai/gpud/cmd/gpud/login"
@@ -218,6 +219,10 @@ sudo rm /etc/systemd/system/gpud.service
 				&cli.BoolFlag{
 					Name:  "enable-plugin-api",
 					Usage: "enable plugin API (default: false)",
+				},
+				&cli.BoolFlag{
+					Name:  "enable-fault-injector",
+					Usage: "enable fault injector (default: false)",
 				},
 			},
 		},
@@ -597,6 +602,26 @@ sudo gpud join
 				&cli.StringFlag{
 					Name:  "log-level,l",
 					Usage: "set the logging level [debug, info, warn, error, fatal, panic, dpanic]",
+				},
+			},
+		},
+		{
+			Name:   "inject-fault",
+			Usage:  "injects a fault such as writing a kernel message to the kernel log",
+			Action: cmdinjectfault.Command,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  "log-level,l",
+					Usage: "set the logging level [debug, info, warn, error, fatal, panic, dpanic]",
+				},
+				&cli.StringFlag{
+					Name:  "kernel-log-level",
+					Usage: "set the kernel log level [KERN_EMERG, KERN_ALERT, KERN_CRIT, KERN_ERR, KERN_WARNING, KERN_NOTICE, KERN_INFO, KERN_DEBUG]",
+					Value: "KERN_INFO",
+				},
+				&cli.StringFlag{
+					Name:  "kernel-message",
+					Usage: "set the kernel message to inject",
 				},
 			},
 		},

--- a/cmd/gpud/inject-fault/command.go
+++ b/cmd/gpud/inject-fault/command.go
@@ -1,0 +1,33 @@
+// Package injectfault provides a command to inject faults into the system.
+package injectfault
+
+import (
+	"github.com/urfave/cli"
+
+	pkgkmsgwriter "github.com/leptonai/gpud/pkg/kmsg/writer"
+	"github.com/leptonai/gpud/pkg/log"
+)
+
+func Command(cliContext *cli.Context) error {
+	logLevel := cliContext.String("log-level")
+	zapLvl, err := log.ParseLogLevel(logLevel)
+	if err != nil {
+		return err
+	}
+	log.Logger = log.CreateLogger(zapLvl, "")
+
+	log.Logger.Debugw("starting inject-fault command")
+
+	kernelLogLevel := cliContext.String("kernel-log-level")
+	kernelMsg := cliContext.String("kernel-message")
+
+	wr := pkgkmsgwriter.NewWriter(pkgkmsgwriter.DefaultDevKmsg)
+	if err := wr.Write(&pkgkmsgwriter.KernelMessage{
+		Priority: pkgkmsgwriter.KernelMessagePriority(kernelLogLevel),
+		Message:  kernelMsg,
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -54,6 +54,7 @@ func Command(cliContext *cli.Context) error {
 	ibstatCommand := cliContext.String("ibstat-command")
 	ibstatusCommand := cliContext.String("ibstatus-command")
 	enablePluginAPI := cliContext.Bool("enable-plugin-api")
+	enableFaultInjector := cliContext.Bool("enable-fault-injector")
 	enableComponents := cliContext.String("enable-components")
 
 	configOpts := []config.OpOption{
@@ -85,6 +86,7 @@ func Command(cliContext *cli.Context) error {
 
 	cfg.PluginSpecsFile = pluginSpecsFile
 	cfg.EnablePluginAPI = enablePluginAPI
+	cfg.EnableFaultInjector = enableFaultInjector
 
 	if enableComponents != "" && enableComponents != "*" && enableComponents != "all" {
 		cfg.EnableComponents = strings.Split(enableComponents, ",")

--- a/components/accelerator/nvidia/xid/message_to_inject.go
+++ b/components/accelerator/nvidia/xid/message_to_inject.go
@@ -1,0 +1,42 @@
+package xid
+
+import "fmt"
+
+type MessageToInject struct {
+	Priority string
+	Message  string
+}
+
+func GetMessageToInject(xid int) MessageToInject {
+	msg, ok := xidExampleMsgs[xid]
+	if !ok {
+		return MessageToInject{
+			Priority: "KERN_WARNING",
+			Message:  fmt.Sprintf("NVRM: Xid (PCI:0000:04:00): %d, unknown", xid),
+		}
+	}
+	return msg
+}
+
+var xidExampleMsgs = map[int]MessageToInject{
+	63: {
+		Priority: "KERN_WARNING",
+		Message:  "NVRM: Xid (PCI:0000:04:00): 63, Row remapping event: Rows 0x1a and 0x2b have been remapped on GPU 00000000:04:00.0",
+	},
+	64: {
+		Priority: "KERN_WARNING",
+		Message:  "NVRM: Xid (PCI:0000:04:00): 64, Failed to persist row remap table — GPU may require servicing",
+	},
+	69: {
+		Priority: "KERN_WARNING",
+		Message:  "NVRM: Xid (PCI:0000:04:00): 69, pid=34566, name=python3, BAR1 access failure at address 0xffff80001234abcd",
+	},
+	74: {
+		Priority: "KERN_WARNING",
+		Message:  "NVRM: Xid (PCI:0000:04:00): 74, pid=1234, name=python3, Channel 0x23, MMU Fault: ENGINE GRAPHICS GPCCLIENT_T1_0 faulted @ 0x7fc123456000. Fault is of type FAULT_PTE ACCESS_TYPE_VIRT_READ",
+	},
+	79: {
+		Priority: "KERN_ERR",
+		Message:  "NVRM: Xid (PCI:0000:04:00): 79, GPU has fallen off the bus",
+	},
+}

--- a/components/accelerator/nvidia/xid/message_to_inject_test.go
+++ b/components/accelerator/nvidia/xid/message_to_inject_test.go
@@ -1,0 +1,174 @@
+package xid
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetMessageToInject(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		xid           int
+		expectedXid   int
+		expectedPrio  string
+		shouldContain string
+	}{
+		{
+			name:          "known XID 63",
+			xid:           63,
+			expectedXid:   63,
+			expectedPrio:  "KERN_WARNING",
+			shouldContain: "Row remapping event",
+		},
+		{
+			name:          "known XID 64",
+			xid:           64,
+			expectedXid:   64,
+			expectedPrio:  "KERN_WARNING",
+			shouldContain: "Failed to persist row remap table",
+		},
+		{
+			name:          "known XID 69",
+			xid:           69,
+			expectedXid:   69,
+			expectedPrio:  "KERN_WARNING",
+			shouldContain: "BAR1 access failure",
+		},
+		{
+			name:          "known XID 74",
+			xid:           74,
+			expectedXid:   74,
+			expectedPrio:  "KERN_WARNING",
+			shouldContain: "MMU Fault",
+		},
+		{
+			name:          "known XID 79",
+			xid:           79,
+			expectedXid:   79,
+			expectedPrio:  "KERN_ERR",
+			shouldContain: "GPU has fallen off the bus",
+		},
+		{
+			name:          "unknown XID 42",
+			xid:           42,
+			expectedXid:   42,
+			expectedPrio:  "KERN_WARNING",
+			shouldContain: "unknown",
+		},
+		{
+			name:          "unknown XID 999",
+			xid:           999,
+			expectedXid:   999,
+			expectedPrio:  "KERN_WARNING",
+			shouldContain: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetMessageToInject(tt.xid)
+
+			// Check priority
+			require.Equal(t, tt.expectedPrio, result.Priority)
+
+			// Check that message contains expected substring
+			require.NotEmpty(t, result.Message)
+
+			// For this test, we just check that the message contains some expected content
+			// The actual XID extraction test is separate
+			if tt.shouldContain != "" {
+				require.Contains(t, result.Message, tt.shouldContain)
+			}
+		})
+	}
+}
+
+func TestGetMessageToInject_XidExtraction(t *testing.T) {
+	t.Parallel()
+
+	// Test all known XIDs
+	knownXids := []int{63, 64, 69, 74, 79}
+
+	for _, xid := range knownXids {
+		t.Run(fmt.Sprintf("known_xid_%d", xid), func(t *testing.T) {
+			msg := GetMessageToInject(xid)
+			extractedXid := ExtractNVRMXid(msg.Message)
+
+			require.NotZero(t, extractedXid, "ExtractNVRMXid failed to extract XID from message: %s", msg.Message)
+			require.Equal(t, xid, extractedXid)
+		})
+	}
+
+	// Test unknown XIDs
+	unknownXids := []int{1, 25, 42, 100, 999}
+
+	for _, xid := range unknownXids {
+		t.Run(fmt.Sprintf("unknown_xid_%d", xid), func(t *testing.T) {
+			msg := GetMessageToInject(xid)
+			extractedXid := ExtractNVRMXid(msg.Message)
+
+			require.NotZero(t, extractedXid, "ExtractNVRMXid failed to extract XID from message: %s", msg.Message)
+			require.Equal(t, xid, extractedXid)
+		})
+	}
+}
+
+func TestGetMessageToInject_MessageFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		xid  int
+	}{
+		{"known XID 63", 63},
+		{"known XID 79", 79},
+		{"unknown XID 42", 42},
+		{"unknown XID 999", 999},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := GetMessageToInject(tt.xid)
+
+			// All messages should start with "NVRM: Xid"
+			require.True(t, strings.HasPrefix(msg.Message, "NVRM: Xid"), "GetMessageToInject(%d).Message should start with 'NVRM: Xid', got: %s", tt.xid, msg.Message)
+
+			// All messages should contain PCI device information
+			require.Contains(t, msg.Message, "PCI:0000:04:00")
+
+			// Priority should be valid
+			validPriorities := []string{"KERN_WARNING", "KERN_ERR", "KERN_INFO", "KERN_DEBUG"}
+			require.Contains(t, validPriorities, msg.Priority)
+		})
+	}
+}
+
+func TestAllKnownXidsHaveValidMessages(t *testing.T) {
+	t.Parallel()
+
+	// Test every XID in the xidExampleMsgs map
+	for xid := range xidExampleMsgs {
+		t.Run(fmt.Sprintf("xid_%d", xid), func(t *testing.T) {
+			msg := GetMessageToInject(xid)
+			extractedXid := ExtractNVRMXid(msg.Message)
+
+			require.NotZero(t, extractedXid, "XID %d: ExtractNVRMXid failed to extract XID from message: %s", xid, msg.Message)
+			require.Equal(t, xid, extractedXid)
+		})
+	}
+}
+
+func TestExamplesWithExtractNVRMXid(t *testing.T) {
+	t.Parallel()
+	for xid, m := range xidExampleMsgs {
+		t.Run(fmt.Sprintf("xid_%s", m.Message), func(t *testing.T) {
+			extractedXid := ExtractNVRMXid(m.Message)
+			require.Equal(t, xid, extractedXid)
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,6 +48,8 @@ type Config struct {
 
 	// EnablePluginAPI enables the plugin API.
 	EnablePluginAPI bool `json:"enable_plugin_api"`
+	// EnableFaultInjector enables the fault injector.
+	EnableFaultInjector bool `json:"enable_fault_injector"`
 
 	// EnableComponents specifies the components to enable.
 	// Leave empty to enable all components.

--- a/pkg/fault-injector/fault_injector.go
+++ b/pkg/fault-injector/fault_injector.go
@@ -1,0 +1,68 @@
+// Package faultinjector provides a way to inject failures into the system.
+package faultinjector
+
+import (
+	"errors"
+
+	componentsnvidiaxid "github.com/leptonai/gpud/components/accelerator/nvidia/xid"
+	pkgkmsgwriter "github.com/leptonai/gpud/pkg/kmsg/writer"
+)
+
+// Injector defines the interface for injecting failures into the system.
+type Injector interface {
+	KmsgWriter() pkgkmsgwriter.KmsgWriter
+}
+
+func NewInjector(kmsgWriter pkgkmsgwriter.KmsgWriter) Injector {
+	return &injector{
+		kmsgWriter: kmsgWriter,
+	}
+}
+
+type injector struct {
+	kmsgWriter pkgkmsgwriter.KmsgWriter
+}
+
+func (i *injector) KmsgWriter() pkgkmsgwriter.KmsgWriter {
+	return i.kmsgWriter
+}
+
+// Request is the request body for the inject-fault endpoint.
+type Request struct {
+	// XID is the XID to inject.
+	XID *XIDToInject `json:"xid,omitempty"`
+
+	// KernelMessage is the kernel message to inject.
+	KernelMessage *pkgkmsgwriter.KernelMessage `json:"kernel_message,omitempty"`
+}
+
+type XIDToInject struct {
+	ID int `json:"id"`
+}
+
+var ErrNoFaultFound = errors.New("no fault injection entry found")
+
+func (r *Request) Validate() error {
+	switch {
+	case r.XID != nil:
+		if r.XID.ID == 0 {
+			return ErrNoFaultFound
+		}
+
+		msg := componentsnvidiaxid.GetMessageToInject(r.XID.ID)
+		r.KernelMessage = &pkgkmsgwriter.KernelMessage{
+			Priority: pkgkmsgwriter.ConvertKernelMessagePriority(msg.Priority),
+			Message:  msg.Message,
+		}
+		r.XID = nil
+
+		// fall through to a subsequent case to call Validate()
+		fallthrough
+
+	case r.KernelMessage != nil:
+		return r.KernelMessage.Validate()
+
+	default:
+		return ErrNoFaultFound
+	}
+}

--- a/pkg/fault-injector/fault_injector_test.go
+++ b/pkg/fault-injector/fault_injector_test.go
@@ -1,0 +1,506 @@
+package faultinjector
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pkgkmsgwriter "github.com/leptonai/gpud/pkg/kmsg/writer"
+)
+
+func TestRequest_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		request     Request
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "nil kernel message should return ErrNoFaultFound",
+			request: Request{
+				KernelMessage: nil,
+			},
+			expectError: true,
+			errorMsg:    "no fault injection entry found",
+		},
+		{
+			name: "valid kernel message should return nil",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "KERN_INFO",
+					Message:  "This is a valid test message",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid kernel message with kern.format priority should return nil",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "kern.err",
+					Message:  "This is a valid error message",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid kernel message with unknown priority should return nil",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "unknown_priority",
+					Message:  "This message has unknown priority but should be normalized",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "empty message should return nil",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "KERN_DEBUG",
+					Message:  "",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "message at maximum length should return nil",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "KERN_INFO",
+					Message:  string(make([]byte, pkgkmsgwriter.MaxPrintkRecordLength)),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "message exceeding maximum length should return error",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "KERN_INFO",
+					Message:  string(make([]byte, pkgkmsgwriter.MaxPrintkRecordLength+1)),
+				},
+			},
+			expectError: true,
+			errorMsg:    "message length exceeds the maximum length of 976",
+		},
+		{
+			name: "message much longer than maximum should return error",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "KERN_ERR",
+					Message:  string(make([]byte, pkgkmsgwriter.MaxPrintkRecordLength*2)),
+				},
+			},
+			expectError: true,
+			errorMsg:    "message length exceeds the maximum length of 976",
+		},
+		{
+			name: "empty priority and message should return nil",
+			request: Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: "",
+					Message:  "",
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.request.Validate()
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRequest_Validate_PriorityNormalization(t *testing.T) {
+	// Test that validation correctly normalizes priority through the embedded KernelMessage.Validate()
+	tests := []struct {
+		name             string
+		inputPriority    string
+		expectedPriority pkgkmsgwriter.KernelMessagePriority
+	}{
+		{"KERN format", "KERN_ERR", pkgkmsgwriter.KernelMessagePriorityError},
+		{"kern format", "kern.warning", pkgkmsgwriter.KernelMessagePriorityWarning},
+		{"kern.warn format", "kern.warn", pkgkmsgwriter.KernelMessagePriorityWarning},
+		{"unknown priority", "invalid", pkgkmsgwriter.KernelMessagePriorityInfo},
+		{"empty priority", "", pkgkmsgwriter.KernelMessagePriorityInfo},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := Request{
+				KernelMessage: &pkgkmsgwriter.KernelMessage{
+					Priority: pkgkmsgwriter.ConvertKernelMessagePriority(tt.inputPriority),
+					Message:  "test message",
+				},
+			}
+
+			err := request.Validate()
+			require.NoError(t, err)
+
+			// Verify that the priority was normalized by the underlying KernelMessage.Validate()
+			require.Equal(t, tt.expectedPriority, request.KernelMessage.Priority)
+		})
+	}
+}
+
+func TestRequest_Validate_EmptyRequest(t *testing.T) {
+	// Test that an empty request (no fields set) returns ErrNoFaultFound
+	request := Request{}
+	err := request.Validate()
+	require.Error(t, err)
+	require.Equal(t, ErrNoFaultFound, err)
+	require.Contains(t, err.Error(), "no fault injection entry found")
+}
+
+func TestRequest_Validate_LargeValidMessage(t *testing.T) {
+	// Test with a message that's close to but under the limit
+	largeMessage := strings.Repeat("a", pkgkmsgwriter.MaxPrintkRecordLength-10)
+
+	request := Request{
+		KernelMessage: &pkgkmsgwriter.KernelMessage{
+			Priority: "KERN_WARNING",
+			Message:  largeMessage,
+		},
+	}
+
+	err := request.Validate()
+	require.NoError(t, err)
+	require.Equal(t, pkgkmsgwriter.KernelMessagePriorityWarning, request.KernelMessage.Priority)
+	require.Equal(t, largeMessage, request.KernelMessage.Message)
+}
+
+func TestRequest_Validate_ExactMaxLength(t *testing.T) {
+	// Test with a message that's exactly at the maximum length
+	exactMaxMessage := strings.Repeat("x", pkgkmsgwriter.MaxPrintkRecordLength)
+
+	request := Request{
+		KernelMessage: &pkgkmsgwriter.KernelMessage{
+			Priority: "KERN_NOTICE",
+			Message:  exactMaxMessage,
+		},
+	}
+
+	err := request.Validate()
+	require.NoError(t, err)
+	require.Equal(t, pkgkmsgwriter.KernelMessagePriorityNotice, request.KernelMessage.Priority)
+	require.Equal(t, exactMaxMessage, request.KernelMessage.Message)
+}
+
+func TestErrNoFaultFound(t *testing.T) {
+	// Test that the error variable is properly defined
+	err := ErrNoFaultFound
+	require.NotNil(t, err)
+	require.Equal(t, "no fault injection entry found", err.Error())
+}
+
+func TestRequest_Validate_NilRequestPointer(t *testing.T) {
+	// Test behavior when request itself would be nil (edge case)
+	// This tests the method on a nil KernelMessage field specifically
+	var request *Request = &Request{KernelMessage: nil}
+	err := request.Validate()
+	require.Error(t, err)
+	require.Equal(t, ErrNoFaultFound, err)
+}
+
+func TestRequest_Validate_SwitchCaseLogic(t *testing.T) {
+	// Test the switch statement logic explicitly
+	tests := []struct {
+		name          string
+		kernelMessage *pkgkmsgwriter.KernelMessage
+		expectError   bool
+		expectedError error
+	}{
+		{
+			name:          "nil kernel message triggers default case",
+			kernelMessage: nil,
+			expectError:   true,
+			expectedError: ErrNoFaultFound,
+		},
+		{
+			name: "non-nil kernel message triggers first case",
+			kernelMessage: &pkgkmsgwriter.KernelMessage{
+				Priority: "KERN_INFO",
+				Message:  "test",
+			},
+			expectError:   false,
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := Request{KernelMessage: tt.kernelMessage}
+			err := request.Validate()
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedError, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestRequest_Validate_XidFallthrough tests the specific fallthrough behavior from XID to KernelMessage
+func TestRequest_Validate_XidFallthrough(t *testing.T) {
+	tests := []struct {
+		name                string
+		xidID               int
+		expectError         bool
+		expectKernelMessage bool
+		expectedPriority    pkgkmsgwriter.KernelMessagePriority
+		shouldContainMsg    string
+	}{
+		{
+			name:                "valid known XID 63 should fallthrough to kernel message validation",
+			xidID:               63,
+			expectError:         false,
+			expectKernelMessage: true,
+			expectedPriority:    pkgkmsgwriter.KernelMessagePriorityWarning,
+			shouldContainMsg:    "Row remapping event",
+		},
+		{
+			name:                "valid known XID 79 should fallthrough to kernel message validation",
+			xidID:               79,
+			expectError:         false,
+			expectKernelMessage: true,
+			expectedPriority:    pkgkmsgwriter.KernelMessagePriorityError,
+			shouldContainMsg:    "GPU has fallen off the bus",
+		},
+		{
+			name:                "valid unknown XID 999 should fallthrough to kernel message validation",
+			xidID:               999,
+			expectError:         false,
+			expectKernelMessage: true,
+			expectedPriority:    pkgkmsgwriter.KernelMessagePriorityWarning,
+			shouldContainMsg:    "unknown",
+		},
+		{
+			name:                "XID with ID 0 should return ErrNoFaultFound without fallthrough",
+			xidID:               0,
+			expectError:         true,
+			expectKernelMessage: false,
+			expectedPriority:    "",
+			shouldContainMsg:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create request with XID
+			request := Request{
+				XID: &XIDToInject{
+					ID: tt.xidID,
+				},
+			}
+
+			// Verify initial state
+			require.NotNil(t, request.XID, "initial Xid should not be nil")
+			require.Nil(t, request.KernelMessage, "initial KernelMessage should be nil")
+
+			// Call Validate
+			err := request.Validate()
+
+			// Check error expectation
+			if tt.expectError {
+				require.Error(t, err)
+				require.Equal(t, ErrNoFaultFound, err)
+				// For error cases, verify no transformation occurred
+				require.NotNil(t, request.XID, "Xid should still be present when validation fails")
+				require.Nil(t, request.KernelMessage, "KernelMessage should remain nil when validation fails")
+			} else {
+				require.NoError(t, err)
+
+				// For successful cases, verify fallthrough behavior occurred
+				if tt.expectKernelMessage {
+					// Verify that Xid was set to nil after transformation
+					require.Nil(t, request.XID, "Xid should be nil after successful transformation and fallthrough")
+
+					// Verify that KernelMessage was created from the XID
+					require.NotNil(t, request.KernelMessage, "KernelMessage should be created after XID transformation")
+					require.Equal(t, tt.expectedPriority, request.KernelMessage.Priority)
+					require.Contains(t, request.KernelMessage.Message, tt.shouldContainMsg)
+
+					// Verify the message follows expected XID format
+					require.Contains(t, request.KernelMessage.Message, "NVRM: Xid")
+					require.Contains(t, request.KernelMessage.Message, "PCI:0000:04:00")
+				}
+			}
+		})
+	}
+}
+
+// TestRequest_Validate_XidTransformationDetails tests the specific transformation logic from XID to KernelMessage
+func TestRequest_Validate_XidTransformationDetails(t *testing.T) {
+	// Test with a specific known XID to verify exact transformation
+	request := Request{
+		XID: &XIDToInject{
+			ID: 69, // Known XID with specific message
+		},
+	}
+
+	err := request.Validate()
+	require.NoError(t, err)
+
+	// Verify specific transformation details
+	require.Nil(t, request.XID, "Xid should be nil after transformation")
+	require.NotNil(t, request.KernelMessage, "KernelMessage should be created")
+
+	// Verify the specific known XID 69 message
+	require.Equal(t, pkgkmsgwriter.KernelMessagePriorityWarning, request.KernelMessage.Priority)
+	require.Contains(t, request.KernelMessage.Message, "BAR1 access failure")
+	require.Contains(t, request.KernelMessage.Message, "NVRM: Xid (PCI:0000:04:00): 69")
+	require.Contains(t, request.KernelMessage.Message, "pid=34566")
+}
+
+// TestRequest_Validate_SwitchCaseFallthrough tests the switch statement logic explicitly
+func TestRequest_Validate_SwitchCaseFallthrough(t *testing.T) {
+	tests := []struct {
+		name              string
+		xid               *XIDToInject
+		kernelMessage     *pkgkmsgwriter.KernelMessage
+		expectError       bool
+		expectedError     error
+		expectTransform   bool
+		expectFallthrough bool
+	}{
+		{
+			name: "XID case with valid ID should transform and fallthrough",
+			xid: &XIDToInject{
+				ID: 63,
+			},
+			kernelMessage:     nil,
+			expectError:       false,
+			expectedError:     nil,
+			expectTransform:   true,
+			expectFallthrough: true,
+		},
+		{
+			name: "XID case with zero ID should return error without fallthrough",
+			xid: &XIDToInject{
+				ID: 0,
+			},
+			kernelMessage:     nil,
+			expectError:       true,
+			expectedError:     ErrNoFaultFound,
+			expectTransform:   false,
+			expectFallthrough: false,
+		},
+		{
+			name: "KernelMessage case only should validate message",
+			xid:  nil,
+			kernelMessage: &pkgkmsgwriter.KernelMessage{
+				Priority: "KERN_INFO",
+				Message:  "direct kernel message test",
+			},
+			expectError:       false,
+			expectedError:     nil,
+			expectTransform:   false,
+			expectFallthrough: false,
+		},
+		{
+			name:              "neither XID nor KernelMessage should trigger default case",
+			xid:               nil,
+			kernelMessage:     nil,
+			expectError:       true,
+			expectedError:     ErrNoFaultFound,
+			expectTransform:   false,
+			expectFallthrough: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := Request{
+				XID:           tt.xid,
+				KernelMessage: tt.kernelMessage,
+			}
+
+			// Store initial state for verification
+			initialXid := request.XID
+			initialKernelMessage := request.KernelMessage
+
+			err := request.Validate()
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedError, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tt.expectTransform {
+				// Verify transformation occurred
+				require.Nil(t, request.XID, "Xid should be nil after transformation")
+				require.NotNil(t, request.KernelMessage, "KernelMessage should be created")
+				require.NotEqual(t, initialKernelMessage, request.KernelMessage, "KernelMessage should be different from initial")
+			}
+
+			if tt.expectFallthrough {
+				// Verify that fallthrough occurred by checking that both:
+				// 1. XID was processed (transformed to nil)
+				// 2. KernelMessage was created and validated (no error)
+				require.Nil(t, request.XID, "after fallthrough, Xid should be nil")
+				require.NotNil(t, request.KernelMessage, "after fallthrough, KernelMessage should exist")
+				require.NoError(t, err, "fallthrough should result in successful KernelMessage validation")
+			}
+
+			if !tt.expectTransform && !tt.expectFallthrough {
+				// For cases that don't involve XID transformation
+				if initialXid != nil {
+					require.Equal(t, initialXid, request.XID, "Xid should remain unchanged")
+				}
+				if initialKernelMessage != nil {
+					require.Equal(t, initialKernelMessage.Priority, request.KernelMessage.Priority, "KernelMessage priority should be preserved (possibly normalized)")
+				}
+			}
+		})
+	}
+}
+
+// TestRequest_Validate_FallthroughWithInvalidKernelMessage tests fallthrough to invalid kernel message
+func TestRequest_Validate_FallthroughWithInvalidKernelMessage(t *testing.T) {
+	// This test verifies that when XID transforms to an invalid KernelMessage,
+	// the fallthrough still properly validates and returns the validation error
+
+	// First, let's test with a valid XID that should create a valid message
+	request := Request{
+		XID: &XIDToInject{
+			ID: 63, // Valid XID
+		},
+	}
+
+	err := request.Validate()
+	require.NoError(t, err, "valid XID should create valid KernelMessage and pass validation")
+
+	// Verify the transformation and fallthrough worked
+	require.Nil(t, request.XID, "Xid should be nil after successful transformation")
+	require.NotNil(t, request.KernelMessage, "KernelMessage should be created")
+
+	// Now manually create a scenario where XID transforms but creates an invalid message
+	// by creating a request that simulates what would happen if GetMessageToInject
+	// returned a message that's too long (though this shouldn't happen in practice)
+
+	// We can't easily test this scenario without mocking GetMessageToInject,
+	// but we can verify that the fallthrough calls the validation correctly
+	// by checking that the priority gets normalized (a sign that validation ran)
+	originalPriority := request.KernelMessage.Priority
+	request.KernelMessage.Priority = "kern.warning" // Use format that gets normalized
+
+	err = request.Validate()
+	require.NoError(t, err)
+	require.Equal(t, pkgkmsgwriter.KernelMessagePriorityWarning, request.KernelMessage.Priority, "priority should be normalized by validation in fallthrough")
+	require.NotEqual(t, originalPriority, pkgkmsgwriter.KernelMessagePriority("kern.warning"), "test setup should use different format")
+}

--- a/pkg/kmsg/writer/doc.go
+++ b/pkg/kmsg/writer/doc.go
@@ -1,0 +1,2 @@
+// Package writer implements the kmsg writer.
+package writer

--- a/pkg/kmsg/writer/kmsg.go
+++ b/pkg/kmsg/writer/kmsg.go
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package writer
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/leptonai/gpud/pkg/log"
+)
+
+const DefaultDevKmsg = "/dev/kmsg"
+
+func openKmsgForWrite(devFile string) (io.Writer, error) {
+	kmsg, err := os.OpenFile(devFile, os.O_RDWR|unix.O_CLOEXEC|unix.O_NONBLOCK|unix.O_NOCTTY, 0o666)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open %q: %w", devFile, err)
+	}
+	return kmsg, nil
+}
+
+// KmsgWriter defines the interface for writing kernel messages.
+type KmsgWriter interface {
+	// Write writes a kernel message to the kernel log.
+	Write(msg *KernelMessage) error
+}
+
+func NewWriter(devFile string) KmsgWriter {
+	if runtime.GOOS != "linux" || os.Geteuid() != 0 {
+		return &noOpWriter{}
+	}
+
+	if devFile == "" {
+		devFile = DefaultDevKmsg
+	}
+
+	wr, err := openKmsgForWrite(devFile)
+	if err != nil {
+		log.Logger.Errorw("failed to open kmsg for write", "error", err)
+		return &noOpWriter{}
+	}
+	return &kmsgWriter{wr: wr}
+}
+
+var _ KmsgWriter = &noOpWriter{}
+
+type noOpWriter struct{}
+
+func (w *noOpWriter) Write(_ *KernelMessage) error {
+	return nil
+}
+
+var _ KmsgWriter = &kmsgWriter{}
+
+type kmsgWriter struct {
+	wr io.Writer
+}
+
+// Write implements io.Writer interface with priority support.
+// https://www.kernel.org/doc/Documentation/ABI/testing/dev-kmsg
+// Copied from https://github.com/siderolabs/go-kmsg/blob/main/writer.go.
+func (w *kmsgWriter) Write(msg *KernelMessage) error {
+	priority := msg.Priority.SyslogPriority()
+
+	p := []byte(msg.Message)
+	for len(p) > 0 { // split writes by `\n`, and limit each line to MaxPrintkRecordLength
+		i := bytes.IndexByte(p, '\n')
+		if i == -1 {
+			i = len(p) - 1
+		}
+
+		line := p[:i+1]
+
+		prioritizedLine := buildKmsgLine(priority, line)
+		if len(prioritizedLine) > MaxPrintkRecordLength {
+			prioritizedLine = append(prioritizedLine[:MaxPrintkRecordLength-4], []byte("...\n")...)
+		}
+
+		if _, err := w.wr.Write(prioritizedLine); err != nil {
+			return err
+		}
+
+		p = p[i+1:]
+	}
+
+	return nil
+}
+
+func buildKmsgLine(priority int, line []byte) []byte {
+	// remove trailing newline to add priority prefix, we'll add it back later
+	trimmed := bytes.TrimSuffix(line, []byte{'\n'})
+
+	// replace tab characters from multierror library error messages with spaces,
+	// as tabs are not visible in the console
+	trimmed = bytes.ReplaceAll(trimmed, []byte{'\t'}, []byte{' '})
+
+	// format message with syslog priority: "<priority>message"
+	msg := fmt.Sprintf("<%d>%s\n", priority, string(trimmed))
+	return []byte(msg)
+}

--- a/pkg/kmsg/writer/kmsg_test.go
+++ b/pkg/kmsg/writer/kmsg_test.go
@@ -1,0 +1,449 @@
+package writer
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultDevKmsg(t *testing.T) {
+	assert.Equal(t, "/dev/kmsg", DefaultDevKmsg)
+}
+
+func TestOpenKmsgForWrite(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Skipping test on non-Linux platform")
+	}
+
+	// Test with non-existent file
+	_, err := openKmsgForWrite("/non/existent/file")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open")
+
+	// Test with /dev/kmsg (may fail if not running as root)
+	if os.Geteuid() == 0 {
+		writer, err := openKmsgForWrite(DefaultDevKmsg)
+		if err == nil {
+			defer writer.(*os.File).Close()
+			assert.NotNil(t, writer)
+		}
+	}
+}
+
+func TestOpenKmsgForWrite_WithTempFile(t *testing.T) {
+	// Create a temporary file to simulate kmsg device
+	tmpFile, err := os.CreateTemp("", "test-kmsg-*")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	// Test opening the temporary file
+	writer, err := openKmsgForWrite(tmpFile.Name())
+	if err == nil {
+		defer writer.(*os.File).Close()
+		assert.NotNil(t, writer)
+
+		// Test writing to the file
+		_, writeErr := writer.Write([]byte("test"))
+		assert.NoError(t, writeErr)
+	}
+}
+
+func TestNewWriter(t *testing.T) {
+	tests := []struct {
+		name     string
+		devFile  string
+		setup    func()
+		teardown func()
+		check    func(t *testing.T, writer KmsgWriter)
+	}{
+		{
+			name:    "non-Linux returns noOpWriter",
+			devFile: "",
+			setup: func() {
+				// No need to skip - the test will verify behavior on current platform
+			},
+			teardown: func() {},
+			check: func(t *testing.T, writer KmsgWriter) {
+				if runtime.GOOS != "linux" {
+					_, ok := writer.(*noOpWriter)
+					assert.True(t, ok, "Expected noOpWriter on non-Linux platform")
+				}
+			},
+		},
+		{
+			name:    "non-root returns noOpWriter",
+			devFile: "",
+			setup: func() {
+				// No need to skip - the test will verify behavior on current platform
+			},
+			teardown: func() {},
+			check: func(t *testing.T, writer KmsgWriter) {
+				if runtime.GOOS == "linux" && os.Geteuid() != 0 {
+					_, ok := writer.(*noOpWriter)
+					assert.True(t, ok, "Expected noOpWriter when not running as root")
+				}
+			},
+		},
+		{
+			name:    "empty devFile uses default",
+			devFile: "",
+			setup: func() {
+				// This test will return noOpWriter on non-Linux or non-root
+			},
+			teardown: func() {},
+			check: func(t *testing.T, writer KmsgWriter) {
+				assert.NotNil(t, writer)
+			},
+		},
+		{
+			name:    "invalid devFile returns noOpWriter",
+			devFile: "/invalid/path/to/kmsg",
+			setup: func() {
+				// No need to skip - the test will verify behavior on current platform
+			},
+			teardown: func() {},
+			check: func(t *testing.T, writer KmsgWriter) {
+				// On any platform, invalid device file should return noOpWriter
+				_, ok := writer.(*noOpWriter)
+				assert.True(t, ok, "Expected noOpWriter for invalid device file")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			defer tt.teardown()
+
+			writer := NewWriter(tt.devFile)
+			tt.check(t, writer)
+		})
+	}
+}
+
+func TestNoOpWriter_Write(t *testing.T) {
+	writer := &noOpWriter{}
+
+	msg := &KernelMessage{
+		Priority: KernelMessagePriorityInfo,
+		Message:  "test message",
+	}
+
+	err := writer.Write(msg)
+	assert.NoError(t, err)
+
+	// Test with nil message
+	err = writer.Write(nil)
+	assert.NoError(t, err)
+}
+
+// mockWriter is a mock implementation of io.Writer for testing
+type mockWriter struct {
+	written []byte
+	err     error
+}
+
+func (m *mockWriter) Write(p []byte) (n int, err error) {
+	if m.err != nil {
+		return 0, m.err
+	}
+	m.written = append(m.written, p...)
+	return len(p), nil
+}
+
+func TestKmsgWriter_Write(t *testing.T) {
+	tests := []struct {
+		name        string
+		msg         *KernelMessage
+		expectedErr error
+		checkOutput func(t *testing.T, output string)
+	}{
+		{
+			name: "simple message",
+			msg: &KernelMessage{
+				Priority: KernelMessagePriorityInfo,
+				Message:  "test message",
+			},
+			expectedErr: nil,
+			checkOutput: func(t *testing.T, output string) {
+				assert.Contains(t, output, "<46>test message\n")
+			},
+		},
+		{
+			name: "message with newline",
+			msg: &KernelMessage{
+				Priority: KernelMessagePriorityError,
+				Message:  "line1\nline2\n",
+			},
+			expectedErr: nil,
+			checkOutput: func(t *testing.T, output string) {
+				assert.Contains(t, output, "<43>line1\n")
+				assert.Contains(t, output, "<43>line2\n")
+			},
+		},
+		{
+			name: "message with tabs",
+			msg: &KernelMessage{
+				Priority: KernelMessagePriorityWarning,
+				Message:  "message\twith\ttabs",
+			},
+			expectedErr: nil,
+			checkOutput: func(t *testing.T, output string) {
+				assert.Contains(t, output, "<44>message with tabs\n")
+			},
+		},
+		{
+			name: "empty message",
+			msg: &KernelMessage{
+				Priority: KernelMessagePriorityDebug,
+				Message:  "",
+			},
+			expectedErr: nil,
+			checkOutput: func(t *testing.T, output string) {
+				assert.Equal(t, "", output)
+			},
+		},
+		{
+			name: "very long message",
+			msg: &KernelMessage{
+				Priority: KernelMessagePriorityInfo,
+				Message:  strings.Repeat("a", MaxPrintkRecordLength+100),
+			},
+			expectedErr: nil,
+			checkOutput: func(t *testing.T, output string) {
+				// Should be truncated with "..." at the end
+				assert.Contains(t, output, "...\n")
+				assert.LessOrEqual(t, len(output), MaxPrintkRecordLength)
+			},
+		},
+		{
+			name: "message with multiple lines and tabs",
+			msg: &KernelMessage{
+				Priority: KernelMessagePriorityCrit,
+				Message:  "error:\n\tdetail1\n\tdetail2\n",
+			},
+			expectedErr: nil,
+			checkOutput: func(t *testing.T, output string) {
+				lines := strings.Split(output, "\n")
+				assert.Contains(t, lines[0], "<42>error:")
+				assert.Contains(t, lines[1], "<42> detail1")
+				assert.Contains(t, lines[2], "<42> detail2")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockWriter{}
+			writer := &kmsgWriter{wr: mock}
+
+			err := writer.Write(tt.msg)
+			if tt.expectedErr != nil {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+				tt.checkOutput(t, string(mock.written))
+			}
+		})
+	}
+}
+
+func TestKmsgWriter_WriteError(t *testing.T) {
+	expectedErr := errors.New("write error")
+	mock := &mockWriter{err: expectedErr}
+	writer := &kmsgWriter{wr: mock}
+
+	msg := &KernelMessage{
+		Priority: KernelMessagePriorityInfo,
+		Message:  "test message",
+	}
+
+	err := writer.Write(msg)
+	assert.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestBuildKmsgLine(t *testing.T) {
+	tests := []struct {
+		name     string
+		priority int
+		line     []byte
+		expected string
+	}{
+		{
+			name:     "simple line without newline",
+			priority: 46, // LOG_SYSLOG + INFO
+			line:     []byte("test message"),
+			expected: "<46>test message\n",
+		},
+		{
+			name:     "line with newline",
+			priority: 43, // LOG_SYSLOG + ERR
+			line:     []byte("test message\n"),
+			expected: "<43>test message\n",
+		},
+		{
+			name:     "line with tabs",
+			priority: 44, // LOG_SYSLOG + WARNING
+			line:     []byte("message\twith\ttabs"),
+			expected: "<44>message with tabs\n",
+		},
+		{
+			name:     "empty line",
+			priority: 46,
+			line:     []byte(""),
+			expected: "<46>\n",
+		},
+		{
+			name:     "line with multiple tabs",
+			priority: 42, // LOG_SYSLOG + CRIT
+			line:     []byte("\terror:\t\tdetails\t"),
+			expected: "<42> error:  details \n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildKmsgLine(tt.priority, tt.line)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
+func TestKmsgWriter_InterfaceCompliance(t *testing.T) {
+	// Ensure both implementations satisfy the interface
+	var _ KmsgWriter = &noOpWriter{}
+	var _ KmsgWriter = &kmsgWriter{}
+}
+
+func TestKmsgWriter_MultilineMessageSplitting(t *testing.T) {
+	mock := &mockWriter{}
+	writer := &kmsgWriter{wr: mock}
+
+	// Test message with multiple newlines
+	msg := &KernelMessage{
+		Priority: KernelMessagePriorityInfo,
+		Message:  "line1\nline2\nline3",
+	}
+
+	err := writer.Write(msg)
+	require.NoError(t, err)
+
+	output := string(mock.written)
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+
+	assert.Len(t, lines, 3)
+	assert.Contains(t, lines[0], "<46>line1")
+	assert.Contains(t, lines[1], "<46>line2")
+	assert.Contains(t, lines[2], "<46>line3")
+}
+
+func TestKmsgWriter_MessageWithOnlyNewlines(t *testing.T) {
+	mock := &mockWriter{}
+	writer := &kmsgWriter{wr: mock}
+
+	msg := &KernelMessage{
+		Priority: KernelMessagePriorityInfo,
+		Message:  "\n\n\n",
+	}
+
+	err := writer.Write(msg)
+	require.NoError(t, err)
+
+	output := string(mock.written)
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+
+	// Each newline should produce an empty message line
+	for _, line := range lines {
+		if line != "" {
+			assert.Equal(t, "<46>", line)
+		}
+	}
+}
+
+func TestKmsgWriter_LongLineTruncation(t *testing.T) {
+	mock := &mockWriter{}
+	writer := &kmsgWriter{wr: mock}
+
+	// Create a message that will exceed MaxPrintkRecordLength after adding priority
+	longMessage := strings.Repeat("a", MaxPrintkRecordLength)
+	msg := &KernelMessage{
+		Priority: KernelMessagePriorityInfo,
+		Message:  longMessage,
+	}
+
+	err := writer.Write(msg)
+	require.NoError(t, err)
+
+	output := string(mock.written)
+
+	// Verify the output was truncated
+	assert.LessOrEqual(t, len(output), MaxPrintkRecordLength)
+	assert.Contains(t, output, "...")
+	assert.True(t, strings.HasSuffix(output, "...\n"), "Expected output to end with '...\\n'")
+}
+
+// Benchmark tests
+func BenchmarkBuildKmsgLine(b *testing.B) {
+	line := []byte("This is a test kernel message with some content")
+	priority := 46 // LOG_SYSLOG + INFO
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = buildKmsgLine(priority, line)
+	}
+}
+
+func BenchmarkKmsgWriter_Write(b *testing.B) {
+	writer := &kmsgWriter{wr: io.Discard}
+	msg := &KernelMessage{
+		Priority: KernelMessagePriorityInfo,
+		Message:  "This is a test kernel message\nWith multiple lines\nAnd some tabs\there",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = writer.Write(msg)
+	}
+}
+
+// Example test
+func ExampleNewWriter() {
+	// Create a new writer (will be noOpWriter on non-Linux or non-root)
+	writer := NewWriter("")
+
+	// Write a kernel message
+	msg := &KernelMessage{
+		Priority: KernelMessagePriorityInfo,
+		Message:  "System initialized successfully",
+	}
+
+	_ = writer.Write(msg)
+	// Output:
+}
+
+func ExampleKernelMessage() {
+	msg := &KernelMessage{
+		Priority: KernelMessagePriorityWarning,
+		Message:  "Temperature threshold exceeded",
+	}
+
+	// Validate the message
+	if err := msg.Validate(); err != nil {
+		fmt.Printf("Invalid message: %v\n", err)
+	}
+
+	// Get syslog priority
+	priority := msg.Priority.SyslogPriority()
+	fmt.Printf("Syslog priority: %d\n", priority)
+	// Output: Syslog priority: 44
+}

--- a/pkg/kmsg/writer/type_kernel_message.go
+++ b/pkg/kmsg/writer/type_kernel_message.go
@@ -1,0 +1,109 @@
+package writer
+
+import (
+	"fmt"
+	"log/syslog"
+)
+
+// MaxPrintkRecordLength is the maximum length of a printk record.
+// ref.
+// "PRINTKRB_RECORD_MAX" in https://github.com/torvalds/linux/blob/94305e83eccb3120c921cd3a015cd74731140bac/kernel/printk/internal.h#L52
+// "PRINTK_PREFIX_MAX" in https://github.com/torvalds/linux/blob/94305e83eccb3120c921cd3a015cd74731140bac/kernel/printk/internal.h#L40C9-L40C26
+const MaxPrintkRecordLength = 1024 - 48
+
+type KernelMessagePriority string
+
+const (
+	KernelMessagePriorityEmerg   KernelMessagePriority = "KERN_EMERG"
+	KernelMessagePriorityAlert   KernelMessagePriority = "KERN_ALERT"
+	KernelMessagePriorityCrit    KernelMessagePriority = "KERN_CRIT"
+	KernelMessagePriorityError   KernelMessagePriority = "KERN_ERR"
+	KernelMessagePriorityWarning KernelMessagePriority = "KERN_WARNING"
+	KernelMessagePriorityNotice  KernelMessagePriority = "KERN_NOTICE"
+	KernelMessagePriorityInfo    KernelMessagePriority = "KERN_INFO"
+	KernelMessagePriorityDebug   KernelMessagePriority = "KERN_DEBUG"
+	KernelMessagePriorityDefault KernelMessagePriority = "KERN_DEFAULT"
+)
+
+// KernelMessage represents a kernel message.
+type KernelMessage struct {
+	// Priority is the priority of the kernel message.
+	// ref. https://github.com/torvalds/linux/blob/master/tools/include/linux/kern_levels.h#L8-L15
+	Priority KernelMessagePriority `json:"priority"`
+	// Message is the message of the kernel message.
+	Message string `json:"message"`
+}
+
+// Validate validates the kernel message.
+func (m *KernelMessage) Validate() error {
+	if len(m.Message) > MaxPrintkRecordLength {
+		return fmt.Errorf("message length exceeds the maximum length of %d", MaxPrintkRecordLength)
+	}
+	m.Priority = ConvertKernelMessagePriority(string(m.Priority))
+	return nil
+}
+
+// ref. https://github.com/torvalds/linux/blob/master/tools/include/linux/kern_levels.h#L8-L15
+func ConvertKernelMessagePriority(s string) KernelMessagePriority {
+	switch s {
+	case "KERN_EMERG", "kern.emerg":
+		return KernelMessagePriorityEmerg
+	case "KERN_ALERT", "kern.alert":
+		return KernelMessagePriorityAlert
+	case "KERN_CRIT", "kern.crit":
+		return KernelMessagePriorityCrit
+	case "KERN_ERR", "kern.err":
+		return KernelMessagePriorityError
+	case "KERN_WARNING", "kern.warning", "kern.warn":
+		return KernelMessagePriorityWarning
+	case "KERN_NOTICE", "kern.notice":
+		return KernelMessagePriorityNotice
+	case "KERN_INFO", "kern.info":
+		return KernelMessagePriorityInfo
+	case "KERN_DEBUG", "kern.debug":
+		return KernelMessagePriorityDebug
+	case "KERN_DEFAULT", "kern.default":
+		return KernelMessagePriorityDefault
+	default: // unknown priority, default to KERN_INFO
+		return KernelMessagePriorityInfo
+	}
+}
+
+// SyslogPriority converts KernelMessagePriority to syslog priority value.
+// Default facility is LOG_USER, severity mapping follows standard syslog levels.
+// ref. https://www.kernel.org/doc/Documentation/ABI/testing/dev-kmsg
+func (priority KernelMessagePriority) SyslogPriority() int {
+	normalizedPriority := ConvertKernelMessagePriority(string(priority))
+
+	// Map kernel message priorities to syslog severity levels
+	var severity int
+	switch normalizedPriority {
+	case KernelMessagePriorityEmerg:
+		severity = 0 // Emergency: system is unusable
+	case KernelMessagePriorityAlert:
+		severity = 1 // Alert: action must be taken immediately
+	case KernelMessagePriorityCrit:
+		severity = 2 // Critical: critical conditions
+	case KernelMessagePriorityError:
+		severity = 3 // Error: error conditions
+	case KernelMessagePriorityWarning:
+		severity = 4 // Warning: warning conditions
+	case KernelMessagePriorityNotice:
+		severity = 5 // Notice: normal but significant condition
+	case KernelMessagePriorityInfo:
+		severity = 6 // Informational: informational messages
+	case KernelMessagePriorityDebug:
+		severity = 7 // Debug: debug-level messages
+	default:
+		severity = 6 // Default to INFO
+	}
+
+	// "default kernel log priority and the facility number is set to DEFAULT_LOG_USER (1)"
+	// "not possible to inject messages from userspace with the facility number LOG_KERN (0),
+	// "to make sure that the origin of the messages can always be reliably determined."
+	// ref. https://www.kernel.org/doc/Documentation/ABI/testing/dev-kmsg
+	//
+	// See https://github.com/leptonai/gpud/pull/864 on how to inject messages
+	// using a kernel module.
+	return int(syslog.LOG_SYSLOG) + severity
+}

--- a/pkg/kmsg/writer/type_kernel_message_test.go
+++ b/pkg/kmsg/writer/type_kernel_message_test.go
@@ -1,0 +1,601 @@
+package writer
+
+import (
+	"encoding/json"
+	"log/syslog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKernelMessage_JSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		msg      KernelMessage
+		expected string
+	}{
+		{
+			name: "basic kernel message",
+			msg: KernelMessage{
+				Priority: KernelMessagePriorityInfo,
+				Message:  "test message",
+			},
+			expected: `{"priority":"KERN_INFO","message":"test message"}`,
+		},
+		{
+			name: "empty message",
+			msg: KernelMessage{
+				Priority: KernelMessagePriorityError,
+				Message:  "",
+			},
+			expected: `{"priority":"KERN_ERR","message":""}`,
+		},
+		{
+			name: "empty priority",
+			msg: KernelMessage{
+				Priority: "",
+				Message:  "test message",
+			},
+			expected: `{"priority":"","message":"test message"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test marshaling
+			data, err := json.Marshal(tt.msg)
+			if err != nil {
+				t.Fatalf("Failed to marshal KernelMessage: %v", err)
+			}
+
+			if string(data) != tt.expected {
+				t.Errorf("Marshal result = %s, want %s", string(data), tt.expected)
+			}
+
+			// Test unmarshaling
+			var unmarshaled KernelMessage
+			err = json.Unmarshal(data, &unmarshaled)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal KernelMessage: %v", err)
+			}
+
+			if unmarshaled.Priority != tt.msg.Priority {
+				t.Errorf("Unmarshaled Priority = %s, want %s", unmarshaled.Priority, tt.msg.Priority)
+			}
+
+			if unmarshaled.Message != tt.msg.Message {
+				t.Errorf("Unmarshaled Message = %s, want %s", unmarshaled.Message, tt.msg.Message)
+			}
+		})
+	}
+}
+
+func TestConvertKernelMessagePriority(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected KernelMessagePriority
+	}{
+		// KERN_ format cases
+		{
+			name:     "KERN_EMERG",
+			input:    "KERN_EMERG",
+			expected: KernelMessagePriorityEmerg,
+		},
+		{
+			name:     "KERN_ALERT",
+			input:    "KERN_ALERT",
+			expected: KernelMessagePriorityAlert,
+		},
+		{
+			name:     "KERN_CRIT",
+			input:    "KERN_CRIT",
+			expected: KernelMessagePriorityCrit,
+		},
+		{
+			name:     "KERN_ERR",
+			input:    "KERN_ERR",
+			expected: KernelMessagePriorityError,
+		},
+		{
+			name:     "KERN_WARNING",
+			input:    "KERN_WARNING",
+			expected: KernelMessagePriorityWarning,
+		},
+		{
+			name:     "KERN_NOTICE",
+			input:    "KERN_NOTICE",
+			expected: KernelMessagePriorityNotice,
+		},
+		{
+			name:     "KERN_INFO",
+			input:    "KERN_INFO",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "KERN_DEBUG",
+			input:    "KERN_DEBUG",
+			expected: KernelMessagePriorityDebug,
+		},
+		{
+			name:     "KERN_DEFAULT",
+			input:    "KERN_DEFAULT",
+			expected: KernelMessagePriorityDefault,
+		},
+		// kern. format cases
+		{
+			name:     "kern.emerg",
+			input:    "kern.emerg",
+			expected: KernelMessagePriorityEmerg,
+		},
+		{
+			name:     "kern.alert",
+			input:    "kern.alert",
+			expected: KernelMessagePriorityAlert,
+		},
+		{
+			name:     "kern.crit",
+			input:    "kern.crit",
+			expected: KernelMessagePriorityCrit,
+		},
+		{
+			name:     "kern.err",
+			input:    "kern.err",
+			expected: KernelMessagePriorityError,
+		},
+		{
+			name:     "kern.warning",
+			input:    "kern.warning",
+			expected: KernelMessagePriorityWarning,
+		},
+		{
+			name:     "kern.warn",
+			input:    "kern.warn",
+			expected: KernelMessagePriorityWarning,
+		},
+		{
+			name:     "kern.notice",
+			input:    "kern.notice",
+			expected: KernelMessagePriorityNotice,
+		},
+		{
+			name:     "kern.info",
+			input:    "kern.info",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "kern.debug",
+			input:    "kern.debug",
+			expected: KernelMessagePriorityDebug,
+		},
+		{
+			name:     "kern.default",
+			input:    "kern.default",
+			expected: KernelMessagePriorityDefault,
+		},
+		// Edge cases
+		{
+			name:     "unknown priority",
+			input:    "unknown",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "case sensitive - lowercase KERN_ERR",
+			input:    "kern_err",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "case sensitive - uppercase kern.err",
+			input:    "KERN.ERR",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "numeric input",
+			input:    "123",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "special characters",
+			input:    "KERN@ERR",
+			expected: KernelMessagePriorityInfo,
+		},
+		{
+			name:     "whitespace",
+			input:    " KERN_ERR ",
+			expected: KernelMessagePriorityInfo,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ConvertKernelMessagePriority(tt.input)
+			if result != tt.expected {
+				t.Errorf("ConvertKernelMessagePriority(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConvertKernelMessagePriority_AllValidCases(t *testing.T) {
+	// Test all valid cases to ensure complete coverage
+	validCases := map[string]KernelMessagePriority{
+		"KERN_EMERG":   KernelMessagePriorityEmerg,
+		"kern.emerg":   KernelMessagePriorityEmerg,
+		"KERN_ALERT":   KernelMessagePriorityAlert,
+		"kern.alert":   KernelMessagePriorityAlert,
+		"KERN_CRIT":    KernelMessagePriorityCrit,
+		"kern.crit":    KernelMessagePriorityCrit,
+		"KERN_ERR":     KernelMessagePriorityError,
+		"kern.err":     KernelMessagePriorityError,
+		"KERN_WARNING": KernelMessagePriorityWarning,
+		"kern.warning": KernelMessagePriorityWarning,
+		"kern.warn":    KernelMessagePriorityWarning,
+		"KERN_NOTICE":  KernelMessagePriorityNotice,
+		"kern.notice":  KernelMessagePriorityNotice,
+		"KERN_INFO":    KernelMessagePriorityInfo,
+		"kern.info":    KernelMessagePriorityInfo,
+		"KERN_DEBUG":   KernelMessagePriorityDebug,
+		"kern.debug":   KernelMessagePriorityDebug,
+		"KERN_DEFAULT": KernelMessagePriorityDefault,
+		"kern.default": KernelMessagePriorityDefault,
+	}
+
+	for input, expected := range validCases {
+		result := ConvertKernelMessagePriority(input)
+		if result != expected {
+			t.Errorf("ConvertKernelMessagePriority(%q) = %q, want %q", input, result, expected)
+		}
+	}
+}
+
+func TestConvertKernelMessagePriority_DefaultBehavior(t *testing.T) {
+	// Test that unknown inputs default to KERN_INFO
+	unknownInputs := []string{
+		"random",
+		"invalid",
+		"KERN_UNKNOWN",
+		"kern.unknown",
+		"123",
+		"!@#$%",
+		"KERN_ERR_TYPO",
+		"kern.info.extra",
+	}
+
+	for _, input := range unknownInputs {
+		result := ConvertKernelMessagePriority(input)
+		if result != KernelMessagePriorityInfo {
+			t.Errorf("ConvertKernelMessagePriority(%q) = %q, want %q (default)", input, result, KernelMessagePriorityInfo)
+		}
+	}
+}
+
+func TestKernelMessage_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		msg         KernelMessage
+		expectedErr bool
+		expectedMsg string
+	}{
+		{
+			name: "valid message with correct priority",
+			msg: KernelMessage{
+				Priority: KernelMessagePriorityInfo,
+				Message:  "This is a valid message",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "valid message with kern.format priority",
+			msg: KernelMessage{
+				Priority: "kern.err",
+				Message:  "This is a valid message",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "valid message with unknown priority (should be normalized)",
+			msg: KernelMessage{
+				Priority: "unknown_priority",
+				Message:  "This is a valid message",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "valid message at maximum length",
+			msg: KernelMessage{
+				Priority: KernelMessagePriorityInfo,
+				Message:  string(make([]byte, MaxPrintkRecordLength)),
+			},
+			expectedErr: false,
+		},
+		{
+			name: "invalid message exceeding maximum length",
+			msg: KernelMessage{
+				Priority: KernelMessagePriorityInfo,
+				Message:  string(make([]byte, MaxPrintkRecordLength+1)),
+			},
+			expectedErr: true,
+			expectedMsg: "message length exceeds the maximum length of 976",
+		},
+		{
+			name: "invalid message much longer than maximum",
+			msg: KernelMessage{
+				Priority: KernelMessagePriorityError,
+				Message:  string(make([]byte, MaxPrintkRecordLength*2)),
+			},
+			expectedErr: true,
+			expectedMsg: "message length exceeds the maximum length of 976",
+		},
+		{
+			name: "empty message",
+			msg: KernelMessage{
+				Priority: KernelMessagePriorityDebug,
+				Message:  "",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "empty priority and message",
+			msg: KernelMessage{
+				Priority: "",
+				Message:  "",
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalPriority := tt.msg.Priority
+			err := tt.msg.Validate()
+
+			if tt.expectedErr {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+					return
+				}
+				if err.Error() != tt.expectedMsg {
+					t.Errorf("Expected error message %q, got %q", tt.expectedMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+					return
+				}
+
+				// Check that priority was normalized correctly
+				expectedPriority := ConvertKernelMessagePriority(string(originalPriority))
+				if tt.msg.Priority != expectedPriority {
+					t.Errorf("Priority not normalized correctly: got %q, want %q", tt.msg.Priority, expectedPriority)
+				}
+			}
+		})
+	}
+}
+
+func TestMaxPrintkRecordLength(t *testing.T) {
+	// Test that the constant has the expected value
+	expected := 1024 - 48
+	if MaxPrintkRecordLength != expected {
+		t.Errorf("MaxPrintkRecordLength = %d, want %d", MaxPrintkRecordLength, expected)
+	}
+
+	// Test that the constant value is 976
+	if MaxPrintkRecordLength != 976 {
+		t.Errorf("MaxPrintkRecordLength = %d, want 976", MaxPrintkRecordLength)
+	}
+}
+
+func TestKernelMessage_Validate_PriorityNormalization(t *testing.T) {
+	// Test that Validate correctly normalizes various priority formats
+	tests := []struct {
+		name             string
+		inputPriority    KernelMessagePriority
+		expectedPriority KernelMessagePriority
+	}{
+		{"KERN format", KernelMessagePriorityError, KernelMessagePriorityError},
+		{"kern format", "kern.warning", KernelMessagePriorityWarning},
+		{"kern.warn format", "kern.warn", KernelMessagePriorityWarning},
+		{"unknown priority", "invalid", KernelMessagePriorityInfo},
+		{"empty priority", "", KernelMessagePriorityInfo},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := KernelMessage{
+				Priority: tt.inputPriority,
+				Message:  "test message",
+			}
+
+			err := msg.Validate()
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if msg.Priority != tt.expectedPriority {
+				t.Errorf("Priority normalization failed: got %q, want %q", msg.Priority, tt.expectedPriority)
+			}
+		})
+	}
+}
+
+func Test_kmsgWriterWithDummyDevice_UpdateKernelMessage(t *testing.T) {
+	writer := &noOpWriter{}
+
+	msg := KernelMessage{
+		Priority: "kern.info",
+		Message:  "test message",
+	}
+
+	// The noOpWriter doesn't modify the message
+	_ = writer.Write(&msg)
+
+	// The priority should remain unchanged after writing with noOpWriter
+	require.Equal(t, KernelMessagePriority("kern.info"), msg.Priority)
+}
+
+func TestKernelMessagePriority_SyslogPriority(t *testing.T) {
+	tests := []struct {
+		name     string
+		priority KernelMessagePriority
+		expected int
+	}{
+		// Standard KERN_ format priorities
+		{
+			name:     "KERN_EMERG",
+			priority: KernelMessagePriorityEmerg,
+			expected: int(syslog.LOG_SYSLOG) + 0,
+		},
+		{
+			name:     "KERN_ALERT",
+			priority: KernelMessagePriorityAlert,
+			expected: int(syslog.LOG_SYSLOG) + 1,
+		},
+		{
+			name:     "KERN_CRIT",
+			priority: KernelMessagePriorityCrit,
+			expected: int(syslog.LOG_SYSLOG) + 2,
+		},
+		{
+			name:     "KERN_ERR",
+			priority: KernelMessagePriorityError,
+			expected: int(syslog.LOG_SYSLOG) + 3,
+		},
+		{
+			name:     "KERN_WARNING",
+			priority: KernelMessagePriorityWarning,
+			expected: int(syslog.LOG_SYSLOG) + 4,
+		},
+		{
+			name:     "KERN_NOTICE",
+			priority: KernelMessagePriorityNotice,
+			expected: int(syslog.LOG_SYSLOG) + 5,
+		},
+		{
+			name:     "KERN_INFO",
+			priority: KernelMessagePriorityInfo,
+			expected: int(syslog.LOG_SYSLOG) + 6,
+		},
+		{
+			name:     "KERN_DEBUG",
+			priority: KernelMessagePriorityDebug,
+			expected: int(syslog.LOG_SYSLOG) + 7,
+		},
+		{
+			name:     "KERN_DEFAULT",
+			priority: KernelMessagePriorityDefault,
+			expected: int(syslog.LOG_SYSLOG) + 6, // Default maps to INFO
+		},
+		// kern. format priorities (should be normalized)
+		{
+			name:     "kern.emerg",
+			priority: "kern.emerg",
+			expected: int(syslog.LOG_SYSLOG) + 0,
+		},
+		{
+			name:     "kern.alert",
+			priority: "kern.alert",
+			expected: int(syslog.LOG_SYSLOG) + 1,
+		},
+		{
+			name:     "kern.crit",
+			priority: "kern.crit",
+			expected: int(syslog.LOG_SYSLOG) + 2,
+		},
+		{
+			name:     "kern.err",
+			priority: "kern.err",
+			expected: int(syslog.LOG_SYSLOG) + 3,
+		},
+		{
+			name:     "kern.warning",
+			priority: "kern.warning",
+			expected: int(syslog.LOG_SYSLOG) + 4,
+		},
+		{
+			name:     "kern.warn",
+			priority: "kern.warn",
+			expected: int(syslog.LOG_SYSLOG) + 4,
+		},
+		{
+			name:     "kern.notice",
+			priority: "kern.notice",
+			expected: int(syslog.LOG_SYSLOG) + 5,
+		},
+		{
+			name:     "kern.info",
+			priority: "kern.info",
+			expected: int(syslog.LOG_SYSLOG) + 6,
+		},
+		{
+			name:     "kern.debug",
+			priority: "kern.debug",
+			expected: int(syslog.LOG_SYSLOG) + 7,
+		},
+		{
+			name:     "kern.default",
+			priority: "kern.default",
+			expected: int(syslog.LOG_SYSLOG) + 6, // Default maps to INFO
+		},
+		// Invalid priorities (should default to INFO)
+		{
+			name:     "unknown priority",
+			priority: "unknown",
+			expected: int(syslog.LOG_SYSLOG) + 6,
+		},
+		{
+			name:     "empty priority",
+			priority: "",
+			expected: int(syslog.LOG_SYSLOG) + 6,
+		},
+		{
+			name:     "invalid format",
+			priority: "KERN_INVALID",
+			expected: int(syslog.LOG_SYSLOG) + 6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.priority.SyslogPriority()
+			if result != tt.expected {
+				t.Errorf("SyslogPriority() = %d, want %d", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSyslogPriority_VerifyFacility(t *testing.T) {
+	// Verify that all priorities use LOG_SYSLOG facility (40)
+	// LOG_SYSLOG = 5 << 3 = 40
+	expectedFacility := int(syslog.LOG_SYSLOG)
+	if expectedFacility != 40 {
+		t.Errorf("Expected LOG_SYSLOG to be 40, got %d", expectedFacility)
+	}
+
+	// Test that all priorities have the correct facility
+	priorities := []KernelMessagePriority{
+		KernelMessagePriorityEmerg,
+		KernelMessagePriorityAlert,
+		KernelMessagePriorityCrit,
+		KernelMessagePriorityError,
+		KernelMessagePriorityWarning,
+		KernelMessagePriorityNotice,
+		KernelMessagePriorityInfo,
+		KernelMessagePriorityDebug,
+		KernelMessagePriorityDefault,
+	}
+
+	for _, priority := range priorities {
+		result := priority.SyslogPriority()
+		facility := result & 0xF8 // Extract facility bits
+		if facility != expectedFacility {
+			t.Errorf("Priority %s has facility %d, expected %d", priority, facility, expectedFacility)
+		}
+	}
+}

--- a/pkg/process/runner_exclusive.go
+++ b/pkg/process/runner_exclusive.go
@@ -64,7 +64,7 @@ func (er *exclusiveRunner) RunUntilCompletion(ctx context.Context, script string
 		er.running = nil
 		er.mu.Unlock()
 	}()
-	log.Logger.Infow("started running script", "pid", p.PID())
+	log.Logger.Debugw("started running script", "pid", p.PID())
 
 	er.mu.Lock()
 	er.running = p

--- a/pkg/server/handlers.go
+++ b/pkg/server/handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/leptonai/gpud/components"
 	gpudconfig "github.com/leptonai/gpud/pkg/config"
 	"github.com/leptonai/gpud/pkg/errdefs"
+	pkgfaultinjector "github.com/leptonai/gpud/pkg/fault-injector"
 	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
 )
 
@@ -32,9 +33,11 @@ type globalHandler struct {
 	metricsStore pkgmetrics.Store
 
 	gpudInstance *components.GPUdInstance
+
+	faultInjector pkgfaultinjector.Injector
 }
 
-func newGlobalHandler(cfg *gpudconfig.Config, componentsRegistry components.Registry, metricsStore pkgmetrics.Store, gpudInstance *components.GPUdInstance) *globalHandler {
+func newGlobalHandler(cfg *gpudconfig.Config, componentsRegistry components.Registry, metricsStore pkgmetrics.Store, gpudInstance *components.GPUdInstance, faultInjector pkgfaultinjector.Injector) *globalHandler {
 	var componentNames []string
 	for _, c := range componentsRegistry.All() {
 		componentNames = append(componentNames, c.Name())
@@ -47,6 +50,7 @@ func newGlobalHandler(cfg *gpudconfig.Config, componentsRegistry components.Regi
 		componentNames:     componentNames,
 		metricsStore:       metricsStore,
 		gpudInstance:       gpudInstance,
+		faultInjector:      faultInjector,
 	}
 }
 

--- a/pkg/server/handlers_components_test.go
+++ b/pkg/server/handlers_components_test.go
@@ -229,7 +229,7 @@ func TestGetComponents(t *testing.T) {
 	cfg := &config.Config{}
 	store := &mockMetricsStore{}
 
-	handler := newGlobalHandler(cfg, registry, store, nil)
+	handler := newGlobalHandler(cfg, registry, store, nil, nil)
 	_, c, w := setupTestRouter()
 
 	// Test with default JSON content type
@@ -259,7 +259,7 @@ func TestGetComponentsYAML(t *testing.T) {
 	cfg := &config.Config{}
 	store := &mockMetricsStore{}
 
-	handler := newGlobalHandler(cfg, registry, store, nil)
+	handler := newGlobalHandler(cfg, registry, store, nil, nil)
 	_, c, w := setupTestRouter()
 
 	// Set up a new request with YAML content type
@@ -607,7 +607,7 @@ func TestGetInfo(t *testing.T) {
 	cfg := &config.Config{}
 	store := &mockMetricsStore{metrics: metricsData}
 
-	handler := newGlobalHandler(cfg, registry, store, nil)
+	handler := newGlobalHandler(cfg, registry, store, nil, nil)
 	_, c, w := setupTestRouter()
 
 	// Test getting info for a specific component
@@ -678,7 +678,7 @@ func TestGetMetrics(t *testing.T) {
 	cfg := &config.Config{}
 	store := &mockMetricsStore{metrics: metricsData}
 
-	handler := newGlobalHandler(cfg, registry, store, nil)
+	handler := newGlobalHandler(cfg, registry, store, nil, nil)
 	_, c, w := setupTestRouter()
 
 	// Test getting metrics for a specific component

--- a/pkg/server/handlers_inject_fault.go
+++ b/pkg/server/handlers_inject_fault.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/leptonai/gpud/pkg/errdefs"
+	pkgfaultinjector "github.com/leptonai/gpud/pkg/fault-injector"
+)
+
+const URLPathInjectFault = "/inject-fault"
+
+func (g *globalHandler) handleInjectFault(c *gin.Context) {
+	if g.faultInjector == nil {
+		c.JSON(http.StatusNotFound, gin.H{"code": errdefs.ErrNotFound, "message": "fault injector not set up"})
+		return
+	}
+
+	// read the request body
+	request := new(pkgfaultinjector.Request)
+	if err := json.NewDecoder(c.Request.Body).Decode(request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"code": errdefs.ErrInvalidArgument, "message": "failed to decode request body: " + err.Error()})
+		return
+	}
+	if err := request.Validate(); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"code": errdefs.ErrInvalidArgument, "message": "invalid request: " + err.Error()})
+		return
+	}
+
+	switch {
+	case request.KernelMessage != nil:
+		if err := g.faultInjector.KmsgWriter().Write(request.KernelMessage); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"code": errdefs.ErrUnknown, "message": "failed to inject kernel message: " + err.Error()})
+			return
+		}
+
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"code": errdefs.ErrInvalidArgument, "message": "kernel message is required"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "fault injected"})
+}

--- a/pkg/server/handlers_inject_fault_test.go
+++ b/pkg/server/handlers_inject_fault_test.go
@@ -1,0 +1,585 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	pkgfaultinjector "github.com/leptonai/gpud/pkg/fault-injector"
+	pkgkmsgwriter "github.com/leptonai/gpud/pkg/kmsg/writer"
+)
+
+// Mock kmsg writer for testing
+type mockKmsgWriter struct {
+	mock.Mock
+}
+
+func (m *mockKmsgWriter) Write(msg *pkgkmsgwriter.KernelMessage) error {
+	args := m.Called(msg)
+	return args.Error(0)
+}
+
+// Mock fault injector for testing
+type mockFaultInjector struct {
+	mock.Mock
+}
+
+func (m *mockFaultInjector) KmsgWriter() pkgkmsgwriter.KmsgWriter {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(pkgkmsgwriter.KmsgWriter)
+}
+
+// Helper function to setup test context
+func setupInjectFaultTest() (*gin.Engine, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	recorder := httptest.NewRecorder()
+	return router, recorder
+}
+
+func TestHandleInjectFault_NilFaultInjector(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create handler with nil fault injector
+	handler := &globalHandler{
+		faultInjector: nil,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create request with valid JSON
+	request := pkgfaultinjector.Request{
+		KernelMessage: &pkgkmsgwriter.KernelMessage{
+			Priority: "KERN_INFO",
+			Message:  "test message",
+		},
+	}
+	requestBody, _ := json.Marshal(request)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusNotFound, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// The error object serializes as an empty map in JSON
+	assert.Equal(t, map[string]interface{}{}, response["code"])
+	assert.Equal(t, "fault injector not set up", response["message"])
+}
+
+func TestHandleInjectFault_InvalidJSON(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create handler with mock fault injector
+	mockInjector := new(mockFaultInjector)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create HTTP request with invalid JSON
+	invalidJSON := `{"invalid": json}`
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBufferString(invalidJSON))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// The error object serializes as an empty map in JSON
+	assert.Equal(t, map[string]interface{}{}, response["code"])
+	assert.Contains(t, response["message"], "failed to decode request body")
+
+	// Assert no calls were made to the fault injector
+	mockInjector.AssertNotCalled(t, "KmsgWriter")
+}
+
+func TestHandleInjectFault_SuccessfulKernelMessageInjection(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create mock fault injector and kmsg writer
+	mockInjector := new(mockFaultInjector)
+	mockWriter := new(mockKmsgWriter)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create valid request
+	kernelMessage := &pkgkmsgwriter.KernelMessage{
+		Priority: "KERN_INFO",
+		Message:  "test kernel message",
+	}
+	request := pkgfaultinjector.Request{
+		KernelMessage: kernelMessage,
+	}
+	requestBody, _ := json.Marshal(request)
+
+	// Mock successful injection
+	mockInjector.On("KmsgWriter").Return(mockWriter)
+	mockWriter.On("Write", kernelMessage).Return(nil)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "fault injected", response["message"])
+
+	// Verify mock was called
+	mockInjector.AssertExpectations(t)
+	mockWriter.AssertExpectations(t)
+}
+
+func TestHandleInjectFault_FailedKernelMessageInjection(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create mock fault injector and kmsg writer
+	mockInjector := new(mockFaultInjector)
+	mockWriter := new(mockKmsgWriter)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create valid request
+	kernelMessage := &pkgkmsgwriter.KernelMessage{
+		Priority: "KERN_ERR",
+		Message:  "test error message",
+	}
+	request := pkgfaultinjector.Request{
+		KernelMessage: kernelMessage,
+	}
+	requestBody, _ := json.Marshal(request)
+
+	// Mock failed injection
+	injectionError := errors.New("injection failed")
+	mockInjector.On("KmsgWriter").Return(mockWriter)
+	mockWriter.On("Write", kernelMessage).Return(injectionError)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// The error object serializes as an empty map in JSON
+	assert.Equal(t, map[string]interface{}{}, response["code"])
+	assert.Equal(t, "failed to inject kernel message: injection failed", response["message"])
+
+	// Verify mock was called
+	mockInjector.AssertExpectations(t)
+	mockWriter.AssertExpectations(t)
+}
+
+func TestHandleInjectFault_NilKernelMessage_DefaultCase(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create mock fault injector
+	mockInjector := new(mockFaultInjector)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create request with nil KernelMessage (validation fails before reaching switch)
+	request := pkgfaultinjector.Request{
+		KernelMessage: nil,
+	}
+	requestBody, _ := json.Marshal(request)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// The error object serializes as an empty map in JSON
+	assert.Equal(t, map[string]interface{}{}, response["code"])
+	assert.Equal(t, "invalid request: no fault injection entry found", response["message"])
+
+	// Verify no injection was attempted
+	mockInjector.AssertNotCalled(t, "KmsgWriter")
+}
+
+func TestHandleInjectFault_EmptyRequest_DefaultCase(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create mock fault injector
+	mockInjector := new(mockFaultInjector)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create empty request (no fields set, validation fails before reaching switch)
+	request := pkgfaultinjector.Request{}
+	requestBody, _ := json.Marshal(request)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// The error object serializes as an empty map in JSON
+	assert.Equal(t, map[string]interface{}{}, response["code"])
+	assert.Equal(t, "invalid request: no fault injection entry found", response["message"])
+
+	// Verify no injection was attempted
+	mockInjector.AssertNotCalled(t, "KmsgWriter")
+}
+
+func TestHandleInjectFault_ContextPropagation(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create mock fault injector and kmsg writer
+	mockInjector := new(mockFaultInjector)
+	mockWriter := new(mockKmsgWriter)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create valid request
+	kernelMessage := &pkgkmsgwriter.KernelMessage{
+		Priority: "KERN_DEBUG",
+		Message:  "test context propagation",
+	}
+	request := pkgfaultinjector.Request{
+		KernelMessage: kernelMessage,
+	}
+	requestBody, _ := json.Marshal(request)
+
+	// Mock the injector to verify context is passed correctly
+	mockInjector.On("KmsgWriter").Return(mockWriter)
+	mockWriter.On("Write", kernelMessage).Return(nil)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	// Verify mock was called with correct context type
+	mockInjector.AssertExpectations(t)
+	mockWriter.AssertExpectations(t)
+}
+
+// Validation-specific tests for request.Validate() call
+func TestHandleInjectFault_Validation(t *testing.T) {
+	t.Run("valid request passes validation", func(t *testing.T) {
+		// Setup
+		router, recorder := setupInjectFaultTest()
+
+		// Create mock fault injector and kmsg writer
+		mockInjector := new(mockFaultInjector)
+		mockWriter := new(mockKmsgWriter)
+		handler := &globalHandler{
+			faultInjector: mockInjector,
+		}
+
+		// Register the handler
+		router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+		// Create request with valid kernel message
+		kernelMessage := &pkgkmsgwriter.KernelMessage{
+			Priority: "KERN_INFO",
+			Message:  "valid message for validation test",
+		}
+		request := pkgfaultinjector.Request{
+			KernelMessage: kernelMessage,
+		}
+		requestBody, _ := json.Marshal(request)
+
+		// Mock successful injection since validation will pass
+		mockInjector.On("KmsgWriter").Return(mockWriter)
+		mockWriter.On("Write", kernelMessage).Return(nil)
+
+		// Create HTTP request
+		req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		// Send request
+		router.ServeHTTP(recorder, req)
+
+		// Assert validation passed (status is OK, not BadRequest)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(recorder.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, "fault injected", response["message"])
+
+		// Verify mock was called (proves validation passed)
+		mockInjector.AssertExpectations(t)
+		mockWriter.AssertExpectations(t)
+	})
+
+	t.Run("invalid request fails validation - message too long", func(t *testing.T) {
+		// Setup
+		router, recorder := setupInjectFaultTest()
+
+		// Create mock fault injector
+		mockInjector := new(mockFaultInjector)
+		handler := &globalHandler{
+			faultInjector: mockInjector,
+		}
+
+		// Register the handler
+		router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+		// Create request with message exceeding MaxPrintkRecordLength (976 characters)
+		maxLength := 976
+		longMessage := make([]byte, maxLength+100) // Exceeds the limit
+		for i := range longMessage {
+			longMessage[i] = 'A'
+		}
+
+		kernelMessage := &pkgkmsgwriter.KernelMessage{
+			Priority: "KERN_ERR",
+			Message:  string(longMessage),
+		}
+		request := pkgfaultinjector.Request{
+			KernelMessage: kernelMessage,
+		}
+		requestBody, _ := json.Marshal(request)
+
+		// Create HTTP request
+		req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		// Send request
+		router.ServeHTTP(recorder, req)
+
+		// Assert validation failed
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(recorder.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		// The error object serializes as an empty map in JSON
+		assert.Equal(t, map[string]interface{}{}, response["code"])
+		assert.Contains(t, response["message"], "invalid request:")
+		assert.Contains(t, response["message"], "message length exceeds the maximum length")
+		assert.Contains(t, response["message"], "976")
+
+		// Verify no injection was attempted (proves validation stopped execution)
+		mockInjector.AssertNotCalled(t, "KmsgWriter")
+	})
+
+	t.Run("request with nil kernel message fails validation", func(t *testing.T) {
+		// Setup
+		router, recorder := setupInjectFaultTest()
+
+		// Create mock fault injector
+		mockInjector := new(mockFaultInjector)
+		handler := &globalHandler{
+			faultInjector: mockInjector,
+		}
+
+		// Register the handler
+		router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+		// Create request with nil KernelMessage (validation fails before reaching switch)
+		request := pkgfaultinjector.Request{
+			KernelMessage: nil,
+		}
+		requestBody, _ := json.Marshal(request)
+
+		// Create HTTP request
+		req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		// Send request
+		router.ServeHTTP(recorder, req)
+
+		// Assert validation failed
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(recorder.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		// This should be the validation error, not switch case error
+		assert.Equal(t, "invalid request: no fault injection entry found", response["message"])
+
+		// Verify no injection was attempted
+		mockInjector.AssertNotCalled(t, "KmsgWriter")
+	})
+}
+
+func TestHandleInjectFault_XidToKernelMessageTransformation(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create mock fault injector and kmsg writer
+	mockInjector := new(mockFaultInjector)
+	mockWriter := new(mockKmsgWriter)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create request with XID (will be transformed to KernelMessage during validation)
+	request := pkgfaultinjector.Request{
+		XID: &pkgfaultinjector.XIDToInject{
+			ID: 79, // Valid XID that should be transformed
+		},
+	}
+	requestBody, _ := json.Marshal(request)
+
+	// Mock successful injection - the XID will be transformed to KernelMessage
+	// We need to match any parameters since the transformation happens during validation
+	mockInjector.On("KmsgWriter").Return(mockWriter)
+	mockWriter.On("Write", mock.Anything).Return(nil)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	assert.Equal(t, "fault injected", response["message"])
+
+	// Verify mock was called (proves XID was transformed and injection was attempted)
+	mockInjector.AssertExpectations(t)
+	mockWriter.AssertExpectations(t)
+}
+
+func TestHandleInjectFault_InvalidXid(t *testing.T) {
+	// Setup
+	router, recorder := setupInjectFaultTest()
+
+	// Create mock fault injector
+	mockInjector := new(mockFaultInjector)
+	handler := &globalHandler{
+		faultInjector: mockInjector,
+	}
+
+	// Register the handler
+	router.POST(URLPathInjectFault, handler.handleInjectFault)
+
+	// Create request with invalid XID (ID = 0, should fail validation)
+	request := pkgfaultinjector.Request{
+		XID: &pkgfaultinjector.XIDToInject{
+			ID: 0, // Invalid XID, should fail validation
+		},
+	}
+	requestBody, _ := json.Marshal(request)
+
+	// Create HTTP request
+	req := httptest.NewRequest(http.MethodPost, URLPathInjectFault, bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	router.ServeHTTP(recorder, req)
+
+	// Assert response
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+
+	var response map[string]interface{}
+	err := json.Unmarshal(recorder.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// The error object serializes as an empty map in JSON
+	assert.Equal(t, map[string]interface{}{}, response["code"])
+	assert.Equal(t, "invalid request: no fault injection entry found", response["message"])
+
+	// Verify no injection was attempted
+	mockInjector.AssertNotCalled(t, "KmsgWriter")
+}

--- a/pkg/server/handlers_test.go
+++ b/pkg/server/handlers_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestNewGlobalHandler(t *testing.T) {
 	var metricStore metrics.Store
-	ghler := newGlobalHandler(nil, components.NewRegistry(nil), metricStore, nil)
+	ghler := newGlobalHandler(nil, components.NewRegistry(nil), metricStore, nil, nil)
 	assert.NotNil(t, ghler)
 }
 

--- a/pkg/server/handlers_testutils_test.go
+++ b/pkg/server/handlers_testutils_test.go
@@ -17,7 +17,7 @@ func setupTestHandler(comps []components.Component) (*globalHandler, *mockRegist
 	cfg := &config.Config{}
 	store := &mockMetricsStore{}
 
-	handler := newGlobalHandler(cfg, registry, store, nil)
+	handler := newGlobalHandler(cfg, registry, store, nil, nil)
 	return handler, registry, store
 }
 
@@ -33,7 +33,7 @@ func setupTestHandlerWithPluginAPI(comps []components.Component) (*globalHandler
 	}
 	store := &mockMetricsStore{}
 
-	handler := newGlobalHandler(cfg, registry, store, nil)
+	handler := newGlobalHandler(cfg, registry, store, nil, nil)
 	return handler, registry, store
 }
 

--- a/pkg/session/serve_test.go
+++ b/pkg/session/serve_test.go
@@ -17,6 +17,8 @@ import (
 
 	apiv1 "github.com/leptonai/gpud/api/v1"
 	"github.com/leptonai/gpud/components"
+	pkgfaultinjector "github.com/leptonai/gpud/pkg/fault-injector"
+	pkgkmsgwriter "github.com/leptonai/gpud/pkg/kmsg/writer"
 	"github.com/leptonai/gpud/pkg/metrics"
 )
 
@@ -168,13 +170,40 @@ func (m *mockProcessRunner) RunUntilCompletion(ctx context.Context, command stri
 	return args.Get(0).([]byte), int32(args.Int(1)), args.Error(2)
 }
 
+type mockFaultInjector struct {
+	mock.Mock
+}
+
+func (m *mockFaultInjector) Write(kernelMessage *pkgkmsgwriter.KernelMessage) error {
+	args := m.Called(kernelMessage)
+	return args.Error(0)
+}
+
+func (m *mockFaultInjector) KmsgWriter() pkgkmsgwriter.KmsgWriter {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(pkgkmsgwriter.KmsgWriter)
+}
+
+type mockKmsgWriter struct {
+	mock.Mock
+}
+
+func (m *mockKmsgWriter) Write(msg *pkgkmsgwriter.KernelMessage) error {
+	args := m.Called(msg)
+	return args.Error(0)
+}
+
 // Helper functions for testing
-func setupTestSession() (*Session, *mockComponentRegistry, *mockMetricsStore, *mockProcessRunner, chan Body, chan Body) {
+func setupTestSession() (*Session, *mockComponentRegistry, *mockMetricsStore, *mockProcessRunner, *mockFaultInjector, chan Body, chan Body) {
 	reader := make(chan Body, 10)
 	writer := make(chan Body, 10)
 	componentsRegistry := new(mockComponentRegistry)
 	metricsStore := new(mockMetricsStore)
 	processRunner := new(mockProcessRunner)
+	faultInjector := new(mockFaultInjector)
 
 	session := &Session{
 		reader:             reader,
@@ -182,13 +211,19 @@ func setupTestSession() (*Session, *mockComponentRegistry, *mockMetricsStore, *m
 		componentsRegistry: componentsRegistry,
 		metricsStore:       metricsStore,
 		processRunner:      processRunner,
+		faultInjector:      faultInjector,
 		components:         []string{"component1", "component2"},
 		ctx:                context.Background(),
 		enableAutoUpdate:   false,
 		autoUpdateExitCode: -1,
 	}
 
-	return session, componentsRegistry, metricsStore, processRunner, reader, writer
+	return session, componentsRegistry, metricsStore, processRunner, faultInjector, reader, writer
+}
+
+func setupTestSessionWithoutFaultInjector() (*Session, *mockComponentRegistry, *mockMetricsStore, *mockProcessRunner, chan Body, chan Body) {
+	session, registry, store, runner, _, reader, writer := setupTestSession()
+	return session, registry, store, runner, reader, writer
 }
 
 func createMockSession(registry *mockComponentRegistry) *Session {
@@ -212,7 +247,7 @@ func createMockSession(registry *mockComponentRegistry) *Session {
 
 // Tests for getStatesFromComponent
 func TestGetStatesFromComponent(t *testing.T) {
-	session, registry, _, _, _, _ := setupTestSession()
+	session, registry, _, _, _, _ := setupTestSessionWithoutFaultInjector()
 
 	t.Run("component not found", func(t *testing.T) {
 		registry.On("Get", "nonexistent").Return(nil)
@@ -399,7 +434,7 @@ func TestCreateNeedDeleteFiles(t *testing.T) {
 
 // Test getHealthStates
 func TestGetHealthStates(t *testing.T) {
-	session, registry, _, _, _, _ := setupTestSession()
+	session, registry, _, _, _, _ := setupTestSessionWithoutFaultInjector()
 
 	t.Run("with specific components", func(t *testing.T) {
 		// Use a simpler implementation to avoid goroutine race conditions
@@ -440,7 +475,7 @@ func TestGetHealthStates(t *testing.T) {
 
 // Test handling bootstrap request
 func TestHandleBootstrapRequest(t *testing.T) {
-	session, _, _, processRunner, reader, writer := setupTestSession()
+	session, _, _, processRunner, reader, writer := setupTestSessionWithoutFaultInjector()
 
 	// Start the session in a separate goroutine
 	go session.serve()
@@ -495,7 +530,7 @@ func TestHandleBootstrapRequest(t *testing.T) {
 
 // Test triggerComponentCheck
 func TestTriggerComponentCheck(t *testing.T) {
-	session, registry, _, _, reader, writer := setupTestSession()
+	session, registry, _, _, reader, writer := setupTestSessionWithoutFaultInjector()
 
 	// Start the session in a separate goroutine
 	go session.serve()
@@ -554,7 +589,7 @@ func TestTriggerComponentCheck(t *testing.T) {
 
 // Test triggerComponentCheckByTag with non-empty TagName
 func TestTriggerComponentCheckByTag(t *testing.T) {
-	session, registry, _, _, reader, writer := setupTestSession()
+	session, registry, _, _, reader, writer := setupTestSessionWithoutFaultInjector()
 
 	// Start the session in a separate goroutine
 	go session.serve()
@@ -626,7 +661,7 @@ func TestTriggerComponentCheckByTag(t *testing.T) {
 
 // Test deregisterComponent
 func TestDeregisterComponent(t *testing.T) {
-	session, registry, _, _, reader, writer := setupTestSession()
+	session, registry, _, _, reader, writer := setupTestSessionWithoutFaultInjector()
 
 	// Start the session in a separate goroutine
 	go session.serve()
@@ -721,7 +756,7 @@ func TestDeregisterComponent(t *testing.T) {
 
 // Test for handling malformed requests
 func TestMalformedRequest(t *testing.T) {
-	session, _, _, _, reader, _ := setupTestSession()
+	session, _, _, _, reader, _ := setupTestSessionWithoutFaultInjector()
 
 	// Use a channel with buffer to ensure we don't block
 	done := make(chan bool, 1)
@@ -745,4 +780,583 @@ func TestMalformedRequest(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for serve to exit")
 	}
+}
+
+// Test handling injectFault request
+func TestHandleInjectFaultRequest(t *testing.T) {
+	t.Run("successful kernel message injection", func(t *testing.T) {
+		session, _, _, _, faultInjector, reader, writer := setupTestSession()
+
+		// Start the session in a separate goroutine
+		go session.serve()
+		defer close(reader) // Ensure the goroutine exits
+
+		// Create an inject fault request
+		kernelMessage := &pkgkmsgwriter.KernelMessage{
+			Priority: "KERN_INFO",
+			Message:  "test kernel message",
+		}
+
+		req := Request{
+			Method: "injectFault",
+			InjectFaultRequest: &pkgfaultinjector.Request{
+				KernelMessage: kernelMessage,
+			},
+		}
+
+		reqData, _ := json.Marshal(req)
+
+		// Mock the fault injector to succeed
+		mockWriter := new(mockKmsgWriter)
+		mockWriter.On("Write", kernelMessage).Return(nil)
+		faultInjector.On("KmsgWriter").Return(mockWriter)
+
+		// Send the request
+		reader <- Body{
+			Data:  reqData,
+			ReqID: "test-inject-fault-success",
+		}
+
+		// Read the response
+		var resp Body
+		select {
+		case resp = <-writer:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for response")
+		}
+
+		// Parse the response
+		var response Response
+		err := json.Unmarshal(resp.Data, &response)
+		require.NoError(t, err)
+
+		// Check the response
+		assert.Equal(t, "test-inject-fault-success", resp.ReqID)
+		assert.Empty(t, response.Error)
+
+		faultInjector.AssertExpectations(t)
+		mockWriter.AssertExpectations(t)
+	})
+
+	t.Run("failed kernel message injection", func(t *testing.T) {
+		session, _, _, _, faultInjector, reader, writer := setupTestSession()
+
+		// Start the session in a separate goroutine
+		go session.serve()
+		defer close(reader) // Ensure the goroutine exits
+
+		// Create an inject fault request
+		kernelMessage := &pkgkmsgwriter.KernelMessage{
+			Priority: "KERN_ERR",
+			Message:  "test error message",
+		}
+
+		req := Request{
+			Method: "injectFault",
+			InjectFaultRequest: &pkgfaultinjector.Request{
+				KernelMessage: kernelMessage,
+			},
+		}
+
+		reqData, _ := json.Marshal(req)
+
+		// Mock the fault injector to fail
+		expectedError := errors.New("fault injection failed")
+		mockWriter := new(mockKmsgWriter)
+		mockWriter.On("Write", kernelMessage).Return(expectedError)
+		faultInjector.On("KmsgWriter").Return(mockWriter)
+
+		// Send the request
+		reader <- Body{
+			Data:  reqData,
+			ReqID: "test-inject-fault-error",
+		}
+
+		// Read the response
+		var resp Body
+		select {
+		case resp = <-writer:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for response")
+		}
+
+		// Parse the response
+		var response Response
+		err := json.Unmarshal(resp.Data, &response)
+		require.NoError(t, err)
+
+		// Check the response
+		assert.Equal(t, "test-inject-fault-error", resp.ReqID)
+		assert.Equal(t, expectedError.Error(), response.Error)
+
+		faultInjector.AssertExpectations(t)
+		mockWriter.AssertExpectations(t)
+	})
+
+	t.Run("nil fault inject request", func(t *testing.T) {
+		session, _, _, _, _, reader, writer := setupTestSession()
+
+		// Start the session in a separate goroutine
+		go session.serve()
+		defer close(reader) // Ensure the goroutine exits
+
+		// Create an inject fault request with nil FaultInjectRequest
+		req := Request{
+			Method:             "injectFault",
+			InjectFaultRequest: nil,
+		}
+
+		reqData, _ := json.Marshal(req)
+
+		// Send the request
+		reader <- Body{
+			Data:  reqData,
+			ReqID: "test-inject-fault-nil-request",
+		}
+
+		// Read the response
+		var resp Body
+		select {
+		case resp = <-writer:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for response")
+		}
+
+		// Parse the response
+		var response Response
+		err := json.Unmarshal(resp.Data, &response)
+		require.NoError(t, err)
+
+		// Check the response - nil request doesn't trigger validation or injection
+		assert.Equal(t, "test-inject-fault-nil-request", resp.ReqID)
+		assert.Empty(t, response.Error) // Should not set error for nil request
+	})
+
+	t.Run("nil kernel message validation failure", func(t *testing.T) {
+		session, _, _, _, _, reader, writer := setupTestSession()
+
+		// Start the session in a separate goroutine
+		go session.serve()
+		defer close(reader) // Ensure the goroutine exits
+
+		// Create an inject fault request with nil KernelMessage
+		// According to fault-injector validation logic, this should fail validation
+		req := Request{
+			Method: "injectFault",
+			InjectFaultRequest: &pkgfaultinjector.Request{
+				KernelMessage: nil,
+			},
+		}
+
+		reqData, _ := json.Marshal(req)
+
+		// Send the request
+		reader <- Body{
+			Data:  reqData,
+			ReqID: "test-inject-fault-nil-kernel-message",
+		}
+
+		// Read the response
+		var resp Body
+		select {
+		case resp = <-writer:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for response")
+		}
+
+		// Parse the response
+		var response Response
+		err := json.Unmarshal(resp.Data, &response)
+		require.NoError(t, err)
+
+		// Check the response - should fail validation
+		assert.Equal(t, "test-inject-fault-nil-kernel-message", resp.ReqID)
+		assert.Equal(t, "no fault injection entry found", response.Error)
+	})
+
+	t.Run("empty fault request validation failure", func(t *testing.T) {
+		session, _, _, _, _, reader, writer := setupTestSession()
+
+		// Start the session in a separate goroutine
+		go session.serve()
+		defer close(reader) // Ensure the goroutine exits
+
+		// Create an inject fault request with empty struct (no fields set)
+		// This should fail validation with "no fault injection entry found"
+		req := Request{
+			Method:             "injectFault",
+			InjectFaultRequest: &pkgfaultinjector.Request{
+				// No fields set - should hit default case in validation
+			},
+		}
+
+		reqData, _ := json.Marshal(req)
+
+		// Send the request
+		reader <- Body{
+			Data:  reqData,
+			ReqID: "test-inject-fault-empty-request",
+		}
+
+		// Read the response
+		var resp Body
+		select {
+		case resp = <-writer:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for response")
+		}
+
+		// Parse the response
+		var response Response
+		err := json.Unmarshal(resp.Data, &response)
+		require.NoError(t, err)
+
+		// Check the response - should fail validation
+		assert.Equal(t, "test-inject-fault-empty-request", resp.ReqID)
+		assert.Equal(t, "no fault injection entry found", response.Error)
+	})
+}
+
+// Test handling injectFault request validation
+func TestHandleInjectFaultRequestValidation(t *testing.T) {
+	t.Run("valid fault inject request with valid kernel message", func(t *testing.T) {
+		session, _, _, _, faultInjector, reader, writer := setupTestSession()
+
+		// Start the session in a separate goroutine
+		go session.serve()
+		defer close(reader) // Ensure the goroutine exits
+
+		// Create a valid inject fault request
+		kernelMessage := &pkgkmsgwriter.KernelMessage{
+			Priority: "KERN_INFO",
+			Message:  "valid test kernel message",
+		}
+
+		req := Request{
+			Method: "injectFault",
+			InjectFaultRequest: &pkgfaultinjector.Request{
+				KernelMessage: kernelMessage,
+			},
+		}
+
+		reqData, _ := json.Marshal(req)
+
+		// Mock the fault injector to succeed (since validation passes, injection will be attempted)
+		mockWriter := new(mockKmsgWriter)
+		mockWriter.On("Write", kernelMessage).Return(nil)
+		faultInjector.On("KmsgWriter").Return(mockWriter)
+
+		// Send the request
+		reader <- Body{
+			Data:  reqData,
+			ReqID: "test-validate-success",
+		}
+
+		// Read the response
+		var resp Body
+		select {
+		case resp = <-writer:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for response")
+		}
+
+		// Parse the response
+		var response Response
+		err := json.Unmarshal(resp.Data, &response)
+		require.NoError(t, err)
+
+		// Check the response - validation should pass, no error should be set
+		assert.Equal(t, "test-validate-success", resp.ReqID)
+		assert.Empty(t, response.Error, "validation should pass for valid kernel message")
+
+		faultInjector.AssertExpectations(t)
+		mockWriter.AssertExpectations(t)
+	})
+
+	t.Run("invalid fault inject request with message too long", func(t *testing.T) {
+		session, _, _, _, _, reader, writer := setupTestSession()
+
+		// Start the session in a separate goroutine
+		go session.serve()
+		defer close(reader) // Ensure the goroutine exits
+
+		// MaxPrintkRecordLength is 1024 - 48 = 976 characters
+		maxLength := 976
+		// Create a kernel message with message exceeding MaxPrintkRecordLength
+		longMessage := make([]byte, maxLength+100) // Exceeds the limit
+		for i := range longMessage {
+			longMessage[i] = 'A'
+		}
+
+		kernelMessage := &pkgkmsgwriter.KernelMessage{
+			Priority: "KERN_ERR",
+			Message:  string(longMessage),
+		}
+
+		req := Request{
+			Method: "injectFault",
+			InjectFaultRequest: &pkgfaultinjector.Request{
+				KernelMessage: kernelMessage,
+			},
+		}
+
+		reqData, _ := json.Marshal(req)
+
+		// Send the request
+		reader <- Body{
+			Data:  reqData,
+			ReqID: "test-validate-error",
+		}
+
+		// Read the response
+		var resp Body
+		select {
+		case resp = <-writer:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for response")
+		}
+
+		// Parse the response
+		var response Response
+		err := json.Unmarshal(resp.Data, &response)
+		require.NoError(t, err)
+
+		// Check the response - validation should fail
+		assert.Equal(t, "test-validate-error", resp.ReqID)
+		assert.NotEmpty(t, response.Error, "validation should fail for message too long")
+		assert.Contains(t, response.Error, "message length exceeds the maximum length", "error should mention message length limit")
+		assert.Contains(t, response.Error, "976", "error should mention the specific limit")
+	})
+
+	t.Run("invalid fault inject request with nil kernel message", func(t *testing.T) {
+		session, _, _, _, _, reader, writer := setupTestSession()
+
+		// Start the session in a separate goroutine
+		go session.serve()
+		defer close(reader) // Ensure the goroutine exits
+
+		// Create a fault inject request with nil KernelMessage (should fail validation)
+		req := Request{
+			Method: "injectFault",
+			InjectFaultRequest: &pkgfaultinjector.Request{
+				KernelMessage: nil,
+			},
+		}
+
+		reqData, _ := json.Marshal(req)
+
+		// Send the request
+		reader <- Body{
+			Data:  reqData,
+			ReqID: "test-validate-nil-failure",
+		}
+
+		// Read the response
+		var resp Body
+		select {
+		case resp = <-writer:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for response")
+		}
+
+		// Parse the response
+		var response Response
+		err := json.Unmarshal(resp.Data, &response)
+		require.NoError(t, err)
+
+		// Check the response - validation should fail for nil kernel message
+		assert.Equal(t, "test-validate-nil-failure", resp.ReqID)
+		assert.Equal(t, "no fault injection entry found", response.Error, "validation should fail for nil kernel message")
+	})
+
+	t.Run("nil fault inject request", func(t *testing.T) {
+		session, _, _, _, _, reader, writer := setupTestSession()
+
+		// Start the session in a separate goroutine
+		go session.serve()
+		defer close(reader) // Ensure the goroutine exits
+
+		// Create a request with nil FaultInjectRequest (should not call Validate)
+		req := Request{
+			Method:             "injectFault",
+			InjectFaultRequest: nil,
+		}
+
+		reqData, _ := json.Marshal(req)
+
+		// Send the request
+		reader <- Body{
+			Data:  reqData,
+			ReqID: "test-validate-nil-request",
+		}
+
+		// Read the response
+		var resp Body
+		select {
+		case resp = <-writer:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for response")
+		}
+
+		// Parse the response
+		var response Response
+		err := json.Unmarshal(resp.Data, &response)
+		require.NoError(t, err)
+
+		// Check the response - should not error since Validate is not called for nil request
+		assert.Equal(t, "test-validate-nil-request", resp.ReqID)
+		assert.Empty(t, response.Error, "nil fault inject request should not cause validation error")
+	})
+
+	t.Run("valid XID converts to kernel message", func(t *testing.T) {
+		session, _, _, _, faultInjector, reader, writer := setupTestSession()
+
+		// Start the session in a separate goroutine
+		go session.serve()
+		defer close(reader) // Ensure the goroutine exits
+
+		// Create a fault inject request with valid XID (should transform to kernel message)
+		req := Request{
+			Method: "injectFault",
+			InjectFaultRequest: &pkgfaultinjector.Request{
+				XID: &pkgfaultinjector.XIDToInject{
+					ID: 63, // Valid XID that should convert to kernel message
+				},
+			},
+		}
+
+		reqData, _ := json.Marshal(req)
+
+		// Mock the fault injector - after XID validation, it converts to KernelMessage
+		// We need to mock with mock.Anything since we don't know the exact converted message
+		mockWriter := new(mockKmsgWriter)
+		mockWriter.On("Write", mock.AnythingOfType("*writer.KernelMessage")).Return(nil)
+		faultInjector.On("KmsgWriter").Return(mockWriter)
+
+		// Send the request
+		reader <- Body{
+			Data:  reqData,
+			ReqID: "test-validate-xid-success",
+		}
+
+		// Read the response
+		var resp Body
+		select {
+		case resp = <-writer:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for response")
+		}
+
+		// Parse the response
+		var response Response
+		err := json.Unmarshal(resp.Data, &response)
+		require.NoError(t, err)
+
+		// Check the response - validation should pass and XID should be converted
+		assert.Equal(t, "test-validate-xid-success", resp.ReqID)
+		assert.Empty(t, response.Error, "validation should pass for valid XID")
+
+		faultInjector.AssertExpectations(t)
+		mockWriter.AssertExpectations(t)
+	})
+
+	t.Run("invalid XID with zero ID", func(t *testing.T) {
+		session, _, _, _, _, reader, writer := setupTestSession()
+
+		// Start the session in a separate goroutine
+		go session.serve()
+		defer close(reader) // Ensure the goroutine exits
+
+		// Create a fault inject request with invalid XID (ID = 0)
+		req := Request{
+			Method: "injectFault",
+			InjectFaultRequest: &pkgfaultinjector.Request{
+				XID: &pkgfaultinjector.XIDToInject{
+					ID: 0, // Invalid XID, should fail validation
+				},
+			},
+		}
+
+		reqData, _ := json.Marshal(req)
+
+		// Send the request
+		reader <- Body{
+			Data:  reqData,
+			ReqID: "test-validate-xid-failure",
+		}
+
+		// Read the response
+		var resp Body
+		select {
+		case resp = <-writer:
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for response")
+		}
+
+		// Parse the response
+		var response Response
+		err := json.Unmarshal(resp.Data, &response)
+		require.NoError(t, err)
+
+		// Check the response - validation should fail for invalid XID
+		assert.Equal(t, "test-validate-xid-failure", resp.ReqID)
+		assert.Equal(t, "no fault injection entry found", response.Error, "validation should fail for XID with ID 0")
+	})
+}
+
+// Test handling injectFault request with nil faultInjector
+func TestHandleInjectFaultRequest_NilFaultInjector(t *testing.T) {
+	// Create a session with nil faultInjector using createMockSession
+	registry := new(mockComponentRegistry)
+	session := createMockSession(registry)
+	// Ensure faultInjector is nil (it should be by default from createMockSession)
+	session.faultInjector = nil
+
+	reader := make(chan Body, 10)
+	writer := make(chan Body, 10)
+	session.reader = reader
+	session.writer = writer
+
+	// Start the session in a separate goroutine
+	go session.serve()
+	defer close(reader) // Ensure the goroutine exits
+
+	// Create an inject fault request with valid InjectFaultRequest
+	kernelMessage := &pkgkmsgwriter.KernelMessage{
+		Priority: "KERN_INFO",
+		Message:  "test kernel message",
+	}
+
+	req := Request{
+		Method: "injectFault",
+		InjectFaultRequest: &pkgfaultinjector.Request{
+			KernelMessage: kernelMessage,
+		},
+	}
+
+	reqData, _ := json.Marshal(req)
+
+	// Send the request
+	reader <- Body{
+		Data:  reqData,
+		ReqID: "test-nil-fault-injector",
+	}
+
+	// Read the response
+	var resp Body
+	select {
+	case resp = <-writer:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for response")
+	}
+
+	// Parse the response
+	var response Response
+	err := json.Unmarshal(resp.Data, &response)
+	require.NoError(t, err)
+
+	// Check the response - should contain the expected error message
+	assert.Equal(t, "test-nil-fault-injector", resp.ReqID)
+	assert.Equal(t, "fault injector is not initialized", response.Error)
+	assert.Equal(t, int32(0), response.ErrorCode) // Should be 0 as no specific error code is set
 }


### PR DESCRIPTION
Replace https://github.com/leptonai/gpud/pull/864.


> sudo /tmp/gpud inject-fault --kernel-log-level KERN_EMERG --kernel-message "hello"
sudo /tmp/gpud inject-fault --kernel-log-level kern.err --kernel-message "NVRM: Xid (PCI:0000:04:00): 79, GPU has fallen off the bus"

```
syslog:emerg : 2025-05-27T04:18:33,211323+00:00 hello
syslog:err   : 2025-05-27T04:18:56,089671+00:00 NVRM: Xid (PCI:0000:04:00): 79, GPU has fallen off the bus
```

```
  {
    "component": "accelerator-nvidia-error-xid",
    "states": [
      {
        "time": null,
        "name": "error_xid",
        "health": "Unhealthy",
        "reason": "XID 79 (GPU has fallen off the bus) detected on PCI:0000:04:00",
        "suggested_actions": {
          "description": "",
          "repair_actions": [
            "HARDWARE_INSPECTION"
          ]
        }
      }
```