### PR TITLE
fix(gpud.service): simplify systemd dependency

### DIFF
--- a/pkg/gpud-manager/systemd/gpud.service
+++ b/pkg/gpud-manager/systemd/gpud.service
@@ -2,8 +2,7 @@
 Description=gpud
 
 # https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#
-Wants=network-pre.target
-After=network-pre.target NetworkManager.service systemd-resolved.service
+After=network.target local-fs.target
 
 [Service]
 Slice=runtime.slice


### PR DESCRIPTION
Make this similar to containerd.service

And in many OS,

```
sudo systemctl status NetworkManager.service
Unit NetworkManager.service could not be found.
```
