### PR TITLE
fix(machine-info): skip infiniband link for private ip listing

### DIFF
--- a/pkg/machine-info/machine_info.go
+++ b/pkg/machine-info/machine_info.go
@@ -151,6 +151,7 @@ func GetMachineNICInfo() *apiv1.MachineNICInfo {
 			"docker",
 			"lepton",
 			"tailscale",
+			"ib", // e.g., "ibp24s0" infiniband links
 		),
 		netutil.WithSuffixesToSkip(".calico"),
 	)


### PR DESCRIPTION
Signed-off-by: Gyuho Lee <gyuhol@nvidia.com>
