### PR TITLE
feat(server): retain only 24 hours of metrics/events data (retain xid/sxid/reboot as exceptions)

### DIFF
--- a/components/accelerator/nvidia/sxid/component.go
+++ b/components/accelerator/nvidia/sxid/component.go
@@ -77,7 +77,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 
 	if gpudInstance.EventStore != nil {
 		var err error
-		c.eventBucket, err = gpudInstance.EventStore.Bucket(Name)
+		c.eventBucket, err = gpudInstance.EventStore.Bucket(Name, eventstore.WithDisablePurge())
 		if err != nil {
 			ccancel()
 			return nil, err

--- a/components/accelerator/nvidia/xid/component.go
+++ b/components/accelerator/nvidia/xid/component.go
@@ -77,7 +77,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 
 	if gpudInstance.EventStore != nil {
 		var err error
-		c.eventBucket, err = gpudInstance.EventStore.Bucket(Name)
+		c.eventBucket, err = gpudInstance.EventStore.Bucket(Name, eventstore.WithDisablePurge())
 		if err != nil {
 			ccancel()
 			return nil, err

--- a/pkg/eventstore/database.go
+++ b/pkg/eventstore/database.go
@@ -57,7 +57,11 @@ type table struct {
 	rootCtx    context.Context
 	rootCancel context.CancelFunc
 
-	retention     time.Duration
+	// retention is the duration to keep the events
+	// set to 0 to disable periodic purge
+	retention time.Duration
+	// purgeInterval is the interval to purge the events
+	// set to 0 to disable periodic purge
 	purgeInterval time.Duration
 
 	table string
@@ -91,10 +95,6 @@ func (d *database) Bucket(name string, opts ...OpOption) (Bucket, error) {
 	}
 
 	return newTable(d.dbRW, d.dbRO, name, d.retention, purgeInterval)
-}
-
-func (d *database) LoadBucketWithNoPurge(name string) (Bucket, error) {
-	return newTable(d.dbRW, d.dbRO, name, 0, 0)
 }
 
 func newTable(dbRW *sql.DB, dbRO *sql.DB, name string, retention time.Duration, purgeInterval time.Duration) (*table, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -127,7 +127,7 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *lepconfig.Con
 		return nil, fmt.Errorf("failed to create metadata table: %w", err)
 	}
 
-	eventStore, err := eventstore.New(dbRW, dbRO, 0)
+	eventStore, err := eventstore.New(dbRW, dbRO, 24*time.Hour)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open events database: %w", err)
 	}
@@ -150,7 +150,7 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *lepconfig.Con
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metrics store: %w", err)
 	}
-	syncer := pkgmetricssyncer.NewSyncer(ctx, promScraper, metricsSQLiteStore, time.Minute, time.Minute, 3*24*time.Hour)
+	syncer := pkgmetricssyncer.NewSyncer(ctx, promScraper, metricsSQLiteStore, time.Minute, time.Minute, 24*time.Hour)
 	syncer.Start()
 
 	promRecorder := pkgmetricsrecorder.NewPrometheusRecorder(ctx, 15*time.Minute, dbRO)


### PR DESCRIPTION
Signed-off-by: Gyuho Lee <gyuhol@nvidia.com>
