### PR TITLE
fix(nvidia/nccl, peermem): add missing cancel calls

### DIFF
--- a/components/accelerator/nvidia/nccl/component.go
+++ b/components/accelerator/nvidia/nccl/component.go
@@ -118,6 +118,8 @@ func (c *component) Events(ctx context.Context, since time.Time) (apiv1.Events, 
 func (c *component) Close() error {
 	log.Logger.Debugw("closing component")
 
+	c.cancel()
+
 	if c.kmsgSyncer != nil {
 		c.kmsgSyncer.Close()
 	}

--- a/components/accelerator/nvidia/nccl/component_test.go
+++ b/components/accelerator/nvidia/nccl/component_test.go
@@ -414,7 +414,11 @@ func TestComponentClose(t *testing.T) {
 	mockEventBucket := new(mockEventBucket)
 	mockEventBucket.On("Close").Return()
 
+	cancelCalled := false
 	comp := &component{
+		cancel: func() {
+			cancelCalled = true
+		},
 		eventBucket: mockEventBucket,
 	}
 
@@ -422,6 +426,7 @@ func TestComponentClose(t *testing.T) {
 	assert.NoError(t, err)
 
 	mockEventBucket.AssertCalled(t, "Close")
+	assert.True(t, cancelCalled)
 }
 
 func TestEventsWithNilBucket(t *testing.T) {

--- a/components/accelerator/nvidia/peermem/component.go
+++ b/components/accelerator/nvidia/peermem/component.go
@@ -128,6 +128,8 @@ func (c *component) Events(ctx context.Context, since time.Time) (apiv1.Events, 
 func (c *component) Close() error {
 	log.Logger.Debugw("closing component")
 
+	c.cancel()
+
 	if c.kmsgSyncer != nil {
 		c.kmsgSyncer.Close()
 	}


### PR DESCRIPTION
Signed-off-by: Gyuho Lee <gyuhol@nvidia.com>
