### PR TITLE
feat(nfs): check mount fs type, degraded if not nfs

### DIFF
--- a/components/nfs/default_test.go
+++ b/components/nfs/default_test.go
@@ -23,7 +23,7 @@ func TestDefaultConfig(t *testing.T) {
 		tempDir := t.TempDir()
 
 		expectedConfig := pkgnfschecker.Config{
-			Dir:              tempDir,
+			VolumePath:       tempDir,
 			FileContents:     "test-content",
 			TTLToDelete:      metav1.Duration{Duration: time.Minute},
 			NumExpectedFiles: 5,
@@ -34,7 +34,7 @@ func TestDefaultConfig(t *testing.T) {
 
 		assert.Len(t, actualConfigs, 1)
 		actualConfig := actualConfigs[0]
-		assert.Equal(t, expectedConfig.Dir, actualConfig.Dir)
+		assert.Equal(t, expectedConfig.VolumePath, actualConfig.VolumePath)
 		assert.Equal(t, expectedConfig.FileContents, actualConfig.FileContents)
 		assert.Equal(t, expectedConfig.TTLToDelete.Duration, actualConfig.TTLToDelete.Duration)
 		assert.Equal(t, expectedConfig.NumExpectedFiles, actualConfig.NumExpectedFiles)
@@ -46,7 +46,7 @@ func TestDefaultConfig(t *testing.T) {
 
 		// Set first config
 		config1 := pkgnfschecker.Config{
-			Dir:              tempDir1,
+			VolumePath:       tempDir1,
 			FileContents:     "content-1",
 			TTLToDelete:      metav1.Duration{Duration: time.Minute},
 			NumExpectedFiles: 1,
@@ -55,12 +55,12 @@ func TestDefaultConfig(t *testing.T) {
 
 		retrieved1 := GetDefaultConfigs()
 		assert.Len(t, retrieved1, 1)
-		assert.Equal(t, config1.Dir, retrieved1[0].Dir)
+		assert.Equal(t, config1.VolumePath, retrieved1[0].VolumePath)
 		assert.Equal(t, config1.FileContents, retrieved1[0].FileContents)
 
 		// Set second config (should overwrite)
 		config2 := pkgnfschecker.Config{
-			Dir:              tempDir2,
+			VolumePath:       tempDir2,
 			FileContents:     "content-2",
 			TTLToDelete:      metav1.Duration{Duration: 2 * time.Minute},
 			NumExpectedFiles: 2,
@@ -69,13 +69,13 @@ func TestDefaultConfig(t *testing.T) {
 
 		retrieved2 := GetDefaultConfigs()
 		assert.Len(t, retrieved2, 1)
-		assert.Equal(t, config2.Dir, retrieved2[0].Dir)
+		assert.Equal(t, config2.VolumePath, retrieved2[0].VolumePath)
 		assert.Equal(t, config2.FileContents, retrieved2[0].FileContents)
 		assert.Equal(t, config2.TTLToDelete.Duration, retrieved2[0].TTLToDelete.Duration)
 		assert.Equal(t, config2.NumExpectedFiles, retrieved2[0].NumExpectedFiles)
 
 		// Should not match the first config anymore
-		assert.NotEqual(t, config1.Dir, retrieved2[0].Dir)
+		assert.NotEqual(t, config1.VolumePath, retrieved2[0].VolumePath)
 		assert.NotEqual(t, config1.FileContents, retrieved2[0].FileContents)
 	})
 
@@ -83,7 +83,7 @@ func TestDefaultConfig(t *testing.T) {
 		tempDir := t.TempDir()
 
 		config := pkgnfschecker.Config{
-			Dir:              tempDir,
+			VolumePath:       tempDir,
 			FileContents:     "concurrent-test",
 			TTLToDelete:      metav1.Duration{Duration: time.Minute},
 			NumExpectedFiles: 10,
@@ -107,7 +107,7 @@ func TestDefaultConfig(t *testing.T) {
 			result := <-results
 			assert.Len(t, result, 1)
 			resultConfig := result[0]
-			assert.Equal(t, config.Dir, resultConfig.Dir)
+			assert.Equal(t, config.VolumePath, resultConfig.VolumePath)
 			assert.Equal(t, config.FileContents, resultConfig.FileContents)
 			assert.Equal(t, config.TTLToDelete.Duration, resultConfig.TTLToDelete.Duration)
 			assert.Equal(t, config.NumExpectedFiles, resultConfig.NumExpectedFiles)
@@ -119,14 +119,14 @@ func TestDefaultConfig(t *testing.T) {
 		tempDir2 := t.TempDir()
 
 		config1 := pkgnfschecker.Config{
-			Dir:              tempDir1,
+			VolumePath:       tempDir1,
 			FileContents:     "content-1",
 			TTLToDelete:      metav1.Duration{Duration: time.Minute},
 			NumExpectedFiles: 1,
 		}
 
 		config2 := pkgnfschecker.Config{
-			Dir:              tempDir2,
+			VolumePath:       tempDir2,
 			FileContents:     "content-2",
 			TTLToDelete:      metav1.Duration{Duration: 2 * time.Minute},
 			NumExpectedFiles: 2,
@@ -139,13 +139,13 @@ func TestDefaultConfig(t *testing.T) {
 		assert.Len(t, retrieved, 2)
 
 		// Check first config
-		assert.Equal(t, config1.Dir, retrieved[0].Dir)
+		assert.Equal(t, config1.VolumePath, retrieved[0].VolumePath)
 		assert.Equal(t, config1.FileContents, retrieved[0].FileContents)
 		assert.Equal(t, config1.TTLToDelete.Duration, retrieved[0].TTLToDelete.Duration)
 		assert.Equal(t, config1.NumExpectedFiles, retrieved[0].NumExpectedFiles)
 
 		// Check second config
-		assert.Equal(t, config2.Dir, retrieved[1].Dir)
+		assert.Equal(t, config2.VolumePath, retrieved[1].VolumePath)
 		assert.Equal(t, config2.FileContents, retrieved[1].FileContents)
 		assert.Equal(t, config2.TTLToDelete.Duration, retrieved[1].TTLToDelete.Duration)
 		assert.Equal(t, config2.NumExpectedFiles, retrieved[1].NumExpectedFiles)

--- a/pkg/disk/mount_test.go
+++ b/pkg/disk/mount_test.go
@@ -15,12 +15,15 @@ func Test_findMntTargetDevice(t *testing.T) {
 
 	buf := bufio.NewScanner(f)
 
-	mountPoint, err := findMntTargetDevice(buf, "/var/lib/kubelet")
+	mountPoint, fsType, err := findMntTargetDevice(buf, "/var/lib/kubelet")
 	if err != nil {
 		t.Fatalf("failed to find mount point: %v", err)
 	}
 	if mountPoint != "/dev/mapper/vgroot-lvroot" {
 		t.Fatalf("expected mount point: %s, got: %s", "/dev/mapper/vgroot-lvroot", mountPoint)
+	}
+	if fsType != "ext4" {
+		t.Fatalf("expected fsType ext4, got: %s", fsType)
 	}
 }
 

--- a/pkg/nfs-checker/group_config_test.go
+++ b/pkg/nfs-checker/group_config_test.go
@@ -23,7 +23,7 @@ func TestGroupConfig_Validate(t *testing.T) {
 		{
 			name: "valid config",
 			config: Config{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
 				FileContents:     "test-content",
 				TTLToDelete:      metav1.Duration{Duration: time.Minute},
 				NumExpectedFiles: 1,
@@ -33,37 +33,37 @@ func TestGroupConfig_Validate(t *testing.T) {
 		{
 			name: "empty directory",
 			config: Config{
-				Dir:              "",
+				VolumePath:       "",
 				FileContents:     "test-content",
 				TTLToDelete:      metav1.Duration{Duration: time.Minute},
 				NumExpectedFiles: 1,
 			},
-			wantErr: ErrDirEmpty,
+			wantErr: ErrVolumePathEmpty,
 		},
 		{
 			name: "relative directory path",
 			config: Config{
-				Dir:              "relative/path",
+				VolumePath:       "relative/path",
 				FileContents:     "test-content",
 				TTLToDelete:      metav1.Duration{Duration: time.Minute},
 				NumExpectedFiles: 1,
 			},
-			wantErr: ErrAbsDir,
+			wantErr: ErrVolumePathNotAbs,
 		},
 		{
 			name: "directory does not exist",
 			config: Config{
-				Dir:              "/non/existent/dir",
+				VolumePath:       "/non/existent/dir",
 				FileContents:     "test-content",
 				TTLToDelete:      metav1.Duration{Duration: time.Minute},
 				NumExpectedFiles: 1,
 			},
-			wantErr: ErrDirNotExists,
+			wantErr: ErrVolumePathNotExists,
 		},
 		{
 			name: "empty file contents",
 			config: Config{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
 				FileContents:     "",
 				TTLToDelete:      metav1.Duration{Duration: time.Minute},
 				NumExpectedFiles: 1,
@@ -73,7 +73,7 @@ func TestGroupConfig_Validate(t *testing.T) {
 		{
 			name: "zero TTL",
 			config: Config{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
 				FileContents:     "test-content",
 				TTLToDelete:      metav1.Duration{Duration: 0},
 				NumExpectedFiles: 1,
@@ -83,7 +83,7 @@ func TestGroupConfig_Validate(t *testing.T) {
 		{
 			name: "zero expected files",
 			config: Config{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
 				FileContents:     "test-content",
 				TTLToDelete:      metav1.Duration{Duration: time.Minute},
 				NumExpectedFiles: 0,
@@ -122,7 +122,7 @@ func TestGroupConfig_ValidateStatError(t *testing.T) {
 		}()
 
 		config := Config{
-			Dir:              restrictedDir,
+			VolumePath:       restrictedDir,
 			FileContents:     "test-content",
 			TTLToDelete:      metav1.Duration{Duration: time.Minute},
 			NumExpectedFiles: 1,
@@ -131,8 +131,8 @@ func TestGroupConfig_ValidateStatError(t *testing.T) {
 		err = config.ValidateAndMkdir()
 		// Should return the os.Stat error (not ErrDirNotExists)
 		assert.Error(t, err)
-		assert.NotErrorIs(t, err, ErrDirNotExists)
-		assert.NotErrorIs(t, err, ErrDirEmpty)
+		assert.NotErrorIs(t, err, ErrVolumePathNotExists)
+		assert.NotErrorIs(t, err, ErrVolumePathEmpty)
 	})
 }
 
@@ -142,7 +142,7 @@ func TestGroupConfig_ValidateEdgeCases(t *testing.T) {
 		longContent := string(make([]byte, 100000)) // 100KB of null bytes
 
 		config := Config{
-			Dir:              tempDir,
+			VolumePath:       tempDir,
 			FileContents:     longContent,
 			TTLToDelete:      metav1.Duration{Duration: time.Minute},
 			NumExpectedFiles: 1,
@@ -156,7 +156,7 @@ func TestGroupConfig_ValidateEdgeCases(t *testing.T) {
 		tempDir := t.TempDir()
 
 		config := Config{
-			Dir:              tempDir,
+			VolumePath:       tempDir,
 			FileContents:     "test-content",
 			TTLToDelete:      metav1.Duration{Duration: time.Minute},
 			NumExpectedFiles: 10000, // Very large number
@@ -170,7 +170,7 @@ func TestGroupConfig_ValidateEdgeCases(t *testing.T) {
 		tempDir := t.TempDir()
 
 		config := Config{
-			Dir:              tempDir,
+			VolumePath:       tempDir,
 			FileContents:     "test-content",
 			TTLToDelete:      metav1.Duration{Duration: time.Nanosecond}, // Very short TTL
 			NumExpectedFiles: 1,
@@ -184,7 +184,7 @@ func TestGroupConfig_ValidateEdgeCases(t *testing.T) {
 		tempDir := t.TempDir()
 
 		config := Config{
-			Dir:              tempDir,
+			VolumePath:       tempDir,
 			FileContents:     "test-content",
 			TTLToDelete:      metav1.Duration{Duration: 24 * time.Hour}, // Very long TTL
 			NumExpectedFiles: 1,
@@ -201,7 +201,7 @@ func TestGroupConfig_ValidateEdgeCases(t *testing.T) {
 		require.NoError(t, err)
 
 		config := Config{
-			Dir:              spacedDir,
+			VolumePath:       spacedDir,
 			FileContents:     "test-content",
 			TTLToDelete:      metav1.Duration{Duration: time.Minute},
 			NumExpectedFiles: 1,
@@ -218,7 +218,7 @@ func TestGroupConfig_ValidateEdgeCases(t *testing.T) {
 		require.NoError(t, err)
 
 		config := Config{
-			Dir:              specialDir,
+			VolumePath:       specialDir,
 			FileContents:     "test-content",
 			TTLToDelete:      metav1.Duration{Duration: time.Minute},
 			NumExpectedFiles: 1,
@@ -236,7 +236,7 @@ func TestGroupConfig_ValidateSpecialCharacters(t *testing.T) {
 		specialContent := "test-content with special chars: !@#$%^&*()_+-=[]{}|;':\",./<>?"
 
 		config := Config{
-			Dir:              tempDir,
+			VolumePath:       tempDir,
 			FileContents:     specialContent,
 			TTLToDelete:      metav1.Duration{Duration: time.Minute},
 			NumExpectedFiles: 1,
@@ -250,7 +250,7 @@ func TestGroupConfig_ValidateSpecialCharacters(t *testing.T) {
 		unicodeContent := "test-content with unicode: 你好世界 🌍 🚀 ñáéíóú"
 
 		config := Config{
-			Dir:              tempDir,
+			VolumePath:       tempDir,
 			FileContents:     unicodeContent,
 			TTLToDelete:      metav1.Duration{Duration: time.Minute},
 			NumExpectedFiles: 1,
@@ -264,7 +264,7 @@ func TestGroupConfig_ValidateSpecialCharacters(t *testing.T) {
 		multilineContent := "line1\nline2\tindented\r\nwindows-style"
 
 		config := Config{
-			Dir:              tempDir,
+			VolumePath:       tempDir,
 			FileContents:     multilineContent,
 			TTLToDelete:      metav1.Duration{Duration: time.Minute},
 			NumExpectedFiles: 1,
@@ -277,16 +277,16 @@ func TestGroupConfig_ValidateSpecialCharacters(t *testing.T) {
 
 func TestGroupConfig_ErrorConstants(t *testing.T) {
 	t.Run("error constants are defined", func(t *testing.T) {
-		assert.NotNil(t, ErrDirEmpty)
-		assert.NotNil(t, ErrDirNotExists)
+		assert.NotNil(t, ErrVolumePathEmpty)
+		assert.NotNil(t, ErrVolumePathNotExists)
 		assert.NotNil(t, ErrFileContentsEmpty)
 		assert.NotNil(t, ErrTTLZero)
 		assert.NotNil(t, ErrExpectedFilesZero)
 	})
 
 	t.Run("error messages are meaningful", func(t *testing.T) {
-		assert.Contains(t, ErrDirEmpty.Error(), "directory")
-		assert.Contains(t, ErrDirNotExists.Error(), "directory")
+		assert.Contains(t, ErrVolumePathEmpty.Error(), "volume path")
+		assert.Contains(t, ErrVolumePathNotExists.Error(), "volume path")
 		assert.Contains(t, ErrFileContentsEmpty.Error(), "file content")
 		assert.Contains(t, ErrTTLZero.Error(), "TTL")
 		assert.Contains(t, ErrExpectedFilesZero.Error(), "expected files")
@@ -300,7 +300,8 @@ func TestGroupConfig_JSONTags(t *testing.T) {
 		tempDir := t.TempDir()
 
 		config := Config{
-			Dir:              tempDir,
+			VolumePath:       tempDir,
+			DirName:          "test-dir",
 			FileContents:     "test-content",
 			TTLToDelete:      metav1.Duration{Duration: time.Minute},
 			NumExpectedFiles: 1,
@@ -311,7 +312,7 @@ func TestGroupConfig_JSONTags(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Check that all fields are accessible (this would fail if JSON tags were wrong)
-		assert.NotEmpty(t, config.Dir)
+		assert.NotEmpty(t, config.VolumePath)
 		assert.NotEmpty(t, config.FileContents)
 		assert.NotZero(t, config.TTLToDelete.Duration)
 		assert.NotZero(t, config.NumExpectedFiles)
@@ -330,7 +331,8 @@ func TestGroupConfig_JSONEncoding(t *testing.T) {
 		{
 			name: "1 minute TTL",
 			config: Config{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
+				DirName:          "test-dir-1",
 				FileContents:     "test-content",
 				TTLToDelete:      metav1.Duration{Duration: time.Minute},
 				NumExpectedFiles: 1,
@@ -341,7 +343,8 @@ func TestGroupConfig_JSONEncoding(t *testing.T) {
 		{
 			name: "30 seconds TTL",
 			config: Config{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
+				DirName:          "test-dir-2",
 				FileContents:     "test-content",
 				TTLToDelete:      metav1.Duration{Duration: 30 * time.Second},
 				NumExpectedFiles: 2,
@@ -352,7 +355,8 @@ func TestGroupConfig_JSONEncoding(t *testing.T) {
 		{
 			name: "1 hour TTL",
 			config: Config{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
+				DirName:          "test-dir-3",
 				FileContents:     "test-content",
 				TTLToDelete:      metav1.Duration{Duration: time.Hour},
 				NumExpectedFiles: 3,
@@ -397,7 +401,8 @@ func TestGroupConfig_JSONDecoding(t *testing.T) {
 		{
 			name: "decode 1m TTL",
 			jsonInput: `{
-				"dir": "` + tempDir + `",
+				"volume_path": "` + tempDir + `",
+				"dir_name": "test-dir",
 				"file_contents": "test-content",
 				"ttl_to_delete": "1m",
 				"num_expected_files": 1
@@ -408,7 +413,8 @@ func TestGroupConfig_JSONDecoding(t *testing.T) {
 		{
 			name: "decode 30s TTL",
 			jsonInput: `{
-				"dir": "` + tempDir + `",
+				"volume_path": "` + tempDir + `",
+				"dir_name": "test-dir",
 				"file_contents": "test-content",
 				"ttl_to_delete": "30s",
 				"num_expected_files": 2
@@ -419,7 +425,8 @@ func TestGroupConfig_JSONDecoding(t *testing.T) {
 		{
 			name: "decode 1h TTL",
 			jsonInput: `{
-				"dir": "` + tempDir + `",
+				"volume_path": "` + tempDir + `",
+				"dir_name": "test-dir",
 				"file_contents": "test-content",
 				"ttl_to_delete": "1h",
 				"num_expected_files": 3
@@ -430,7 +437,8 @@ func TestGroupConfig_JSONDecoding(t *testing.T) {
 		{
 			name: "decode 2h30m TTL",
 			jsonInput: `{
-				"dir": "` + tempDir + `",
+				"volume_path": "` + tempDir + `",
+				"dir_name": "test-dir",
 				"file_contents": "test-content",
 				"ttl_to_delete": "2h30m",
 				"num_expected_files": 1
@@ -441,7 +449,8 @@ func TestGroupConfig_JSONDecoding(t *testing.T) {
 		{
 			name: "decode 500ms TTL",
 			jsonInput: `{
-				"dir": "` + tempDir + `",
+				"volume_path": "` + tempDir + `",
+				"dir_name": "test-dir",
 				"file_contents": "test-content",
 				"ttl_to_delete": "500ms",
 				"num_expected_files": 1
@@ -452,7 +461,8 @@ func TestGroupConfig_JSONDecoding(t *testing.T) {
 		{
 			name: "decode nanosecond duration",
 			jsonInput: `{
-				"dir": "` + tempDir + `",
+				"volume_path": "` + tempDir + `",
+				"dir_name": "test-dir",
 				"file_contents": "test-content",
 				"ttl_to_delete": "60000000000ns",
 				"num_expected_files": 1
@@ -463,7 +473,8 @@ func TestGroupConfig_JSONDecoding(t *testing.T) {
 		{
 			name: "decode invalid TTL format",
 			jsonInput: `{
-				"dir": "` + tempDir + `",
+				"volume_path": "` + tempDir + `",
+				"dir_name": "test-dir",
 				"file_contents": "test-content",
 				"ttl_to_delete": "invalid-duration",
 				"num_expected_files": 1
@@ -484,7 +495,7 @@ func TestGroupConfig_JSONDecoding(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedTTL, config.TTLToDelete.Duration)
-			assert.Equal(t, tempDir, config.Dir)
+			assert.Equal(t, tempDir, config.VolumePath)
 			assert.Equal(t, "test-content", config.FileContents)
 		})
 	}
@@ -530,7 +541,8 @@ func TestGroupConfig_JSONRoundTrip(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			original := Config{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
+				DirName:          "test-dir",
 				FileContents:     "test-content",
 				TTLToDelete:      metav1.Duration{Duration: tt.ttlDuration},
 				NumExpectedFiles: 1,
@@ -546,7 +558,7 @@ func TestGroupConfig_JSONRoundTrip(t *testing.T) {
 			require.NoError(t, err)
 
 			// Verify all fields are preserved
-			assert.Equal(t, original.Dir, decoded.Dir)
+			assert.Equal(t, original.VolumePath, decoded.VolumePath)
 			assert.Equal(t, original.FileContents, decoded.FileContents)
 			assert.Equal(t, original.TTLToDelete.Duration, decoded.TTLToDelete.Duration)
 			assert.Equal(t, original.NumExpectedFiles, decoded.NumExpectedFiles)
@@ -562,7 +574,8 @@ func TestGroupConfig_JSONWithStringDuration(t *testing.T) {
 
 	t.Run("decode string duration 1m", func(t *testing.T) {
 		jsonInput := `{
-			"dir": "` + tempDir + `",
+			"volume_path": "` + tempDir + `",
+			"dir_name": "test-dir",
 			"file_contents": "test-content",
 			"ttl_to_delete": "1m",
 			"num_expected_files": 1
@@ -575,7 +588,8 @@ func TestGroupConfig_JSONWithStringDuration(t *testing.T) {
 
 	t.Run("decode string duration 5m30s", func(t *testing.T) {
 		jsonInput := `{
-			"dir": "` + tempDir + `",
+			"volume_path": "` + tempDir + `",
+			"dir_name": "test-dir",
 			"file_contents": "test-content",
 			"ttl_to_delete": "5m30s",
 			"num_expected_files": 1
@@ -588,7 +602,8 @@ func TestGroupConfig_JSONWithStringDuration(t *testing.T) {
 
 	t.Run("decode string duration with quotes", func(t *testing.T) {
 		jsonInput := `{
-			"dir": "` + tempDir + `",
+			"volume_path": "` + tempDir + `",
+			"dir_name": "test-dir",
 			"file_contents": "test-content",
 			"ttl_to_delete": "10m15s",
 			"num_expected_files": 1
@@ -601,7 +616,8 @@ func TestGroupConfig_JSONWithStringDuration(t *testing.T) {
 
 	t.Run("validate decoded config with string duration", func(t *testing.T) {
 		jsonInput := `{
-			"dir": "` + tempDir + `",
+			"volume_path": "` + tempDir + `",
+			"dir_name": "test-dir",
 			"file_contents": "test-content",
 			"ttl_to_delete": "1m",
 			"num_expected_files": 1
@@ -621,7 +637,8 @@ func TestGroupConfig_JSONEdgeCases(t *testing.T) {
 
 	t.Run("zero duration", func(t *testing.T) {
 		jsonInput := `{
-			"dir": "` + tempDir + `",
+			"volume_path": "` + tempDir + `",
+			"dir_name": "test-dir",
 			"file_contents": "test-content",
 			"ttl_to_delete": "0s",
 			"num_expected_files": 1
@@ -638,7 +655,8 @@ func TestGroupConfig_JSONEdgeCases(t *testing.T) {
 
 	t.Run("very large duration", func(t *testing.T) {
 		jsonInput := `{
-			"dir": "` + tempDir + `",
+			"volume_path": "` + tempDir + `",
+			"dir_name": "test-dir",
 			"file_contents": "test-content",
 			"ttl_to_delete": "8760h",
 			"num_expected_files": 1
@@ -651,7 +669,8 @@ func TestGroupConfig_JSONEdgeCases(t *testing.T) {
 
 	t.Run("nanosecond precision", func(t *testing.T) {
 		jsonInput := `{
-			"dir": "` + tempDir + `",
+			"volume_path": "` + tempDir + `",
+			"dir_name": "test-dir",
 			"file_contents": "test-content",
 			"ttl_to_delete": "1000000000ns",
 			"num_expected_files": 1
@@ -664,7 +683,8 @@ func TestGroupConfig_JSONEdgeCases(t *testing.T) {
 
 	t.Run("malformed JSON", func(t *testing.T) {
 		jsonInput := `{
-			"dir": "` + tempDir + `",
+			"volume_path": "` + tempDir + `",
+			"dir_name": "test-dir",
 			"file_contents": "test-content",
 			"ttl_to_delete": "1m",
 			"num_expected_files": 1,
@@ -676,7 +696,8 @@ func TestGroupConfig_JSONEdgeCases(t *testing.T) {
 
 	t.Run("missing TTL field", func(t *testing.T) {
 		jsonInput := `{
-			"dir": "` + tempDir + `",
+			"volume_path": "` + tempDir + `",
+			"dir_name": "test-dir",
 			"file_contents": "test-content",
 			"num_expected_files": 1
 		}`
@@ -703,13 +724,15 @@ func TestGroupConfigs_Validate(t *testing.T) {
 	t.Run("all valid configs", func(t *testing.T) {
 		configs := Configs{
 			{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
+				DirName:          "test-dir-1",
 				FileContents:     "content-1",
 				TTLToDelete:      metav1.Duration{Duration: time.Minute},
 				NumExpectedFiles: 1,
 			},
 			{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
+				DirName:          "test-dir-2",
 				FileContents:     "content-2",
 				TTLToDelete:      metav1.Duration{Duration: 2 * time.Minute},
 				NumExpectedFiles: 2,
@@ -723,13 +746,15 @@ func TestGroupConfigs_Validate(t *testing.T) {
 	t.Run("one invalid config", func(t *testing.T) {
 		configs := Configs{
 			{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
+				DirName:          "test-dir-1",
 				FileContents:     "content-1",
 				TTLToDelete:      metav1.Duration{Duration: time.Minute},
 				NumExpectedFiles: 1,
 			},
 			{
-				Dir:              "", // Invalid: empty directory
+				VolumePath:       "", // Invalid: empty directory
+				DirName:          "test-dir-2",
 				FileContents:     "content-2",
 				TTLToDelete:      metav1.Duration{Duration: 2 * time.Minute},
 				NumExpectedFiles: 2,
@@ -737,19 +762,21 @@ func TestGroupConfigs_Validate(t *testing.T) {
 		}
 
 		err := configs.Validate()
-		assert.ErrorIs(t, err, ErrDirEmpty)
+		assert.ErrorIs(t, err, ErrVolumePathEmpty)
 	})
 
 	t.Run("multiple invalid configs", func(t *testing.T) {
 		configs := Configs{
 			{
-				Dir:              "", // Invalid: empty directory
+				VolumePath:       "", // Invalid: empty directory
+				DirName:          "test-dir-1",
 				FileContents:     "content-1",
 				TTLToDelete:      metav1.Duration{Duration: time.Minute},
 				NumExpectedFiles: 1,
 			},
 			{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
+				DirName:          "test-dir-2",
 				FileContents:     "", // Invalid: empty file contents
 				TTLToDelete:      metav1.Duration{Duration: 2 * time.Minute},
 				NumExpectedFiles: 2,
@@ -758,7 +785,7 @@ func TestGroupConfigs_Validate(t *testing.T) {
 
 		err := configs.Validate()
 		// Should return the first error encountered
-		assert.ErrorIs(t, err, ErrDirEmpty)
+		assert.ErrorIs(t, err, ErrVolumePathEmpty)
 	})
 }
 
@@ -774,7 +801,7 @@ func TestGroupConfigs_GetMemberConfigs(t *testing.T) {
 	t.Run("single config", func(t *testing.T) {
 		configs := Configs{
 			{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
 				FileContents:     "test-content",
 				TTLToDelete:      metav1.Duration{Duration: time.Minute},
 				NumExpectedFiles: 1,
@@ -786,7 +813,7 @@ func TestGroupConfigs_GetMemberConfigs(t *testing.T) {
 
 		member := memberConfigs[0]
 		assert.Equal(t, "test-machine-id", member.ID)
-		assert.Equal(t, tempDir, member.Dir)
+		assert.Equal(t, tempDir, member.VolumePath)
 		assert.Equal(t, "test-content", member.FileContents)
 		assert.Equal(t, time.Minute, member.TTLToDelete.Duration)
 		assert.Equal(t, 1, member.NumExpectedFiles)
@@ -796,13 +823,13 @@ func TestGroupConfigs_GetMemberConfigs(t *testing.T) {
 		tempDir2 := t.TempDir()
 		configs := Configs{
 			{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
 				FileContents:     "content-1",
 				TTLToDelete:      metav1.Duration{Duration: time.Minute},
 				NumExpectedFiles: 1,
 			},
 			{
-				Dir:              tempDir2,
+				VolumePath:       tempDir2,
 				FileContents:     "content-2",
 				TTLToDelete:      metav1.Duration{Duration: 2 * time.Minute},
 				NumExpectedFiles: 2,
@@ -815,7 +842,7 @@ func TestGroupConfigs_GetMemberConfigs(t *testing.T) {
 		// Check first member config
 		member1 := memberConfigs[0]
 		assert.Equal(t, "machine-123", member1.ID)
-		assert.Equal(t, tempDir, member1.Dir)
+		assert.Equal(t, tempDir, member1.VolumePath)
 		assert.Equal(t, "content-1", member1.FileContents)
 		assert.Equal(t, time.Minute, member1.TTLToDelete.Duration)
 		assert.Equal(t, 1, member1.NumExpectedFiles)
@@ -823,7 +850,7 @@ func TestGroupConfigs_GetMemberConfigs(t *testing.T) {
 		// Check second member config
 		member2 := memberConfigs[1]
 		assert.Equal(t, "machine-123", member2.ID)
-		assert.Equal(t, tempDir2, member2.Dir)
+		assert.Equal(t, tempDir2, member2.VolumePath)
 		assert.Equal(t, "content-2", member2.FileContents)
 		assert.Equal(t, 2*time.Minute, member2.TTLToDelete.Duration)
 		assert.Equal(t, 2, member2.NumExpectedFiles)
@@ -832,7 +859,7 @@ func TestGroupConfigs_GetMemberConfigs(t *testing.T) {
 	t.Run("different machine IDs", func(t *testing.T) {
 		configs := Configs{
 			{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
 				FileContents:     "shared-content",
 				TTLToDelete:      metav1.Duration{Duration: time.Minute},
 				NumExpectedFiles: 3,
@@ -850,7 +877,7 @@ func TestGroupConfigs_GetMemberConfigs(t *testing.T) {
 		assert.Equal(t, "machine-2", memberConfigs2[0].ID)
 
 		// Both should have the same group config data
-		assert.Equal(t, memberConfigs1[0].Dir, memberConfigs2[0].Dir)
+		assert.Equal(t, memberConfigs1[0].VolumePath, memberConfigs2[0].VolumePath)
 		assert.Equal(t, memberConfigs1[0].FileContents, memberConfigs2[0].FileContents)
 		assert.Equal(t, memberConfigs1[0].TTLToDelete.Duration, memberConfigs2[0].TTLToDelete.Duration)
 		assert.Equal(t, memberConfigs1[0].NumExpectedFiles, memberConfigs2[0].NumExpectedFiles)
@@ -859,7 +886,7 @@ func TestGroupConfigs_GetMemberConfigs(t *testing.T) {
 	t.Run("empty machine ID", func(t *testing.T) {
 		configs := Configs{
 			{
-				Dir:              tempDir,
+				VolumePath:       tempDir,
 				FileContents:     "test-content",
 				TTLToDelete:      metav1.Duration{Duration: time.Minute},
 				NumExpectedFiles: 1,

--- a/pkg/nfs-checker/member_config_test.go
+++ b/pkg/nfs-checker/member_config_test.go
@@ -20,7 +20,8 @@ func TestMemberConfig_Validate(t *testing.T) {
 			name: "valid config",
 			config: MemberConfig{
 				Config: Config{
-					Dir:              tempDir,
+					VolumePath:       tempDir,
+					DirName:          "test-dir",
 					FileContents:     "test-content",
 					TTLToDelete:      metav1.Duration{Duration: time.Minute},
 					NumExpectedFiles: 1,
@@ -33,46 +34,50 @@ func TestMemberConfig_Validate(t *testing.T) {
 			name: "empty directory",
 			config: MemberConfig{
 				Config: Config{
-					Dir:              "",
+					VolumePath:       "",
+					DirName:          "test-dir",
 					FileContents:     "test-content",
 					TTLToDelete:      metav1.Duration{Duration: time.Minute},
 					NumExpectedFiles: 1,
 				},
 				ID: "test-id",
 			},
-			wantErr: ErrDirEmpty,
+			wantErr: ErrVolumePathEmpty,
 		},
 		{
 			name: "relative directory path",
 			config: MemberConfig{
 				Config: Config{
-					Dir:              "relative/path",
+					VolumePath:       "relative/path",
+					DirName:          "test-dir",
 					FileContents:     "test-content",
 					TTLToDelete:      metav1.Duration{Duration: time.Minute},
 					NumExpectedFiles: 1,
 				},
 				ID: "test-id",
 			},
-			wantErr: ErrAbsDir,
+			wantErr: ErrVolumePathNotAbs,
 		},
 		{
 			name: "directory does not exist",
 			config: MemberConfig{
 				Config: Config{
-					Dir:              "/non/existent/dir",
+					VolumePath:       "/non/existent/dir",
+					DirName:          "test-dir",
 					FileContents:     "test-content",
 					TTLToDelete:      metav1.Duration{Duration: time.Minute},
 					NumExpectedFiles: 1,
 				},
 				ID: "test-id",
 			},
-			wantErr: ErrDirNotExists,
+			wantErr: ErrVolumePathNotExists,
 		},
 		{
 			name: "empty ID",
 			config: MemberConfig{
 				Config: Config{
-					Dir:              tempDir,
+					VolumePath:       tempDir,
+					DirName:          "test-dir",
 					FileContents:     "test-content",
 					TTLToDelete:      metav1.Duration{Duration: time.Minute},
 					NumExpectedFiles: 1,
@@ -85,7 +90,8 @@ func TestMemberConfig_Validate(t *testing.T) {
 			name: "empty file contents",
 			config: MemberConfig{
 				Config: Config{
-					Dir:              tempDir,
+					VolumePath:       tempDir,
+					DirName:          "test-dir",
 					FileContents:     "",
 					TTLToDelete:      metav1.Duration{Duration: time.Minute},
 					NumExpectedFiles: 1,
@@ -98,7 +104,8 @@ func TestMemberConfig_Validate(t *testing.T) {
 			name: "zero TTL",
 			config: MemberConfig{
 				Config: Config{
-					Dir:              tempDir,
+					VolumePath:       tempDir,
+					DirName:          "test-dir",
 					FileContents:     "test-content",
 					TTLToDelete:      metav1.Duration{Duration: 0},
 					NumExpectedFiles: 1,
@@ -111,7 +118,8 @@ func TestMemberConfig_Validate(t *testing.T) {
 			name: "zero expected files",
 			config: MemberConfig{
 				Config: Config{
-					Dir:              tempDir,
+					VolumePath:       tempDir,
+					DirName:          "test-dir",
 					FileContents:     "test-content",
 					TTLToDelete:      metav1.Duration{Duration: time.Minute},
 					NumExpectedFiles: 0,
@@ -147,7 +155,8 @@ func TestMemberConfigs_Validate(t *testing.T) {
 		configs := MemberConfigs{
 			{
 				Config: Config{
-					Dir:              tempDir,
+					VolumePath:       tempDir,
+					DirName:          "test-dir-1",
 					FileContents:     "content-1",
 					TTLToDelete:      metav1.Duration{Duration: time.Minute},
 					NumExpectedFiles: 1,
@@ -156,7 +165,8 @@ func TestMemberConfigs_Validate(t *testing.T) {
 			},
 			{
 				Config: Config{
-					Dir:              tempDir,
+					VolumePath:       tempDir,
+					DirName:          "test-dir-2",
 					FileContents:     "content-2",
 					TTLToDelete:      metav1.Duration{Duration: 2 * time.Minute},
 					NumExpectedFiles: 2,
@@ -173,7 +183,8 @@ func TestMemberConfigs_Validate(t *testing.T) {
 		configs := MemberConfigs{
 			{
 				Config: Config{
-					Dir:              tempDir,
+					VolumePath:       tempDir,
+					DirName:          "test-dir-1",
 					FileContents:     "content-1",
 					TTLToDelete:      metav1.Duration{Duration: time.Minute},
 					NumExpectedFiles: 1,
@@ -182,7 +193,8 @@ func TestMemberConfigs_Validate(t *testing.T) {
 			},
 			{
 				Config: Config{
-					Dir:              tempDir,
+					VolumePath:       tempDir,
+					DirName:          "test-dir-2",
 					FileContents:     "content-2",
 					TTLToDelete:      metav1.Duration{Duration: 2 * time.Minute},
 					NumExpectedFiles: 2,
@@ -199,7 +211,8 @@ func TestMemberConfigs_Validate(t *testing.T) {
 		configs := MemberConfigs{
 			{
 				Config: Config{
-					Dir:              tempDir,
+					VolumePath:       tempDir,
+					DirName:          "test-dir-1",
 					FileContents:     "content-1",
 					TTLToDelete:      metav1.Duration{Duration: time.Minute},
 					NumExpectedFiles: 1,
@@ -208,7 +221,8 @@ func TestMemberConfigs_Validate(t *testing.T) {
 			},
 			{
 				Config: Config{
-					Dir:              "", // Invalid: empty directory
+					VolumePath:       "", // Invalid: empty directory
+					DirName:          "test-dir-2",
 					FileContents:     "content-2",
 					TTLToDelete:      metav1.Duration{Duration: 2 * time.Minute},
 					NumExpectedFiles: 2,
@@ -218,14 +232,15 @@ func TestMemberConfigs_Validate(t *testing.T) {
 		}
 
 		err := configs.Validate()
-		assert.ErrorIs(t, err, ErrDirEmpty)
+		assert.ErrorIs(t, err, ErrVolumePathEmpty)
 	})
 
 	t.Run("multiple invalid configs", func(t *testing.T) {
 		configs := MemberConfigs{
 			{
 				Config: Config{
-					Dir:              "", // Invalid: empty directory
+					VolumePath:       "", // Invalid: empty directory
+					DirName:          "test-dir-1",
 					FileContents:     "content-1",
 					TTLToDelete:      metav1.Duration{Duration: time.Minute},
 					NumExpectedFiles: 1,
@@ -234,7 +249,8 @@ func TestMemberConfigs_Validate(t *testing.T) {
 			},
 			{
 				Config: Config{
-					Dir:              tempDir,
+					VolumePath:       tempDir,
+					DirName:          "test-dir-2",
 					FileContents:     "content-2",
 					TTLToDelete:      metav1.Duration{Duration: 2 * time.Minute},
 					NumExpectedFiles: 2,
@@ -245,14 +261,15 @@ func TestMemberConfigs_Validate(t *testing.T) {
 
 		err := configs.Validate()
 		// Should return the first error encountered
-		assert.ErrorIs(t, err, ErrDirEmpty)
+		assert.ErrorIs(t, err, ErrVolumePathEmpty)
 	})
 
 	t.Run("single config", func(t *testing.T) {
 		configs := MemberConfigs{
 			{
 				Config: Config{
-					Dir:              tempDir,
+					VolumePath:       tempDir,
+					DirName:          "test-dir",
 					FileContents:     "test-content",
 					TTLToDelete:      metav1.Duration{Duration: time.Minute},
 					NumExpectedFiles: 1,
@@ -269,7 +286,8 @@ func TestMemberConfigs_Validate(t *testing.T) {
 		configs := MemberConfigs{
 			{
 				Config: Config{
-					Dir:              tempDir,
+					VolumePath:       tempDir,
+					DirName:          "test-dir-1",
 					FileContents:     "content-1",
 					TTLToDelete:      metav1.Duration{Duration: time.Minute},
 					NumExpectedFiles: 1,
@@ -278,7 +296,8 @@ func TestMemberConfigs_Validate(t *testing.T) {
 			},
 			{
 				Config: Config{
-					Dir:              tempDir,
+					VolumePath:       tempDir,
+					DirName:          "test-dir-2",
 					FileContents:     "content-2",
 					TTLToDelete:      metav1.Duration{Duration: 2 * time.Minute},
 					NumExpectedFiles: 2,


### PR DESCRIPTION
> {"level":"info","ts":"2025-06-25T20:43:19.315+0530","caller":"nfs/component.go:144","msg":"nfs mount point found","volume_path":"/projects/data","device":"...","fs_type":"mynfs"}
{"level":"info","ts":"2025-06-25T20:43:19.318+0530","caller":"nfs-checker/checker.go:79","msg":"successfully wrote file","file":"/projects/data/ghtest/8b7c0b34e9394f9f92e7728d617e19bc"}
✔ successfully checked directory "/projects/data" with 1 files

---

> gpud scan --nfs-checker-configs '[{"volume_path":"/tmp","dir_name":"test","file_contents":"test content","ttl_to_delete":"1h","num_expected_files":1}]'
>
> {"level":"info","ts":"2025-06-25T20:45:05.755+0530","caller":"nfs/component.go:108","msg":"checking nfs"}
{"level":"warn","ts":"2025-06-25T20:45:05.755+0530","caller":"nfs/component.go:135","msg":"failed to find mount target device for /tmp","error":null}
✘ failed to find mount target device for /tmp

