### PR TITLE
perf(pkg/kmsg): dedup kmsg events by minute

### DIFF
--- a/pkg/kmsg/deduper.go
+++ b/pkg/kmsg/deduper.go
@@ -8,12 +8,19 @@ import (
 )
 
 const (
-	defaultCacheExpiration    = 15 * time.Minute
-	defaultCachePurgeInterval = 30 * time.Minute
+	// round down to the nearest minute
+	defaultCacheKeyTruncateSeconds = 60
+	defaultCacheExpiration         = 15 * time.Minute
+	defaultCachePurgeInterval      = 30 * time.Minute
 )
 
 func (m Message) cacheKey() string {
-	return fmt.Sprintf("%d-%s", m.Timestamp.Unix(), m.Message)
+	unixSeconds := m.Timestamp.Unix()
+
+	// round down to the nearest minute
+	truncated := unixSeconds - (unixSeconds % defaultCacheKeyTruncateSeconds)
+
+	return fmt.Sprintf("%d-%s", truncated, m.Message)
 }
 
 // caches the log lines and its frequencies


### PR DESCRIPTION
We will have other perf optimizations in the events,
but without getting to the db package, this is the
simplest approach.

- dedup kmsg events by minute
- add test for deduper

c.f., https://github.com/leptonai/gpud/pull/967