### PR TITLE
fix(containerd): recreate context for kubelet list calls

### DIFF
--- a/components/containerd/component.go
+++ b/components/containerd/component.go
@@ -179,8 +179,11 @@ func (c *component) Check() components.CheckResult {
 			}
 			return cr
 		}
+
 		var danglingCount int
+		cctx, ccancel = context.WithTimeout(c.ctx, 30*time.Second)
 		_, kubeletPods, err := kubelet.ListPodsFromKubeletReadOnlyPort(cctx, kubelet.DefaultKubeletReadOnlyPort)
+		ccancel()
 		if err != nil {
 			log.Logger.Errorf("error listing pods from kubelet: %v", err)
 		} else {


### PR DESCRIPTION
> {"level":"error","ts":"2025-07-09T17:34:54.964Z","msg":"error listing pods from kubelet: Get \"http://localhost:10255/pods\": context canceled"}