### PR TITLE
[LEP-1172] feat(update): use auto-update-exit-code for systemd managed gpud updates

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -158,8 +158,7 @@ sudo rm /etc/systemd/system/gpud.service
 				},
 				&cli.IntFlag{
 					Name:  "auto-update-exit-code",
-					Usage: "specifies the exit code to exit with when auto updating (default: -1 to disable exit code)",
-					Value: -1,
+					Usage: "specifies the exit code to exit with when auto updating (set -1 to disable exit code)",
 				},
 				cli.StringFlag{
 					Name:  "plugin-specs-file",

--- a/cmd/gpud/update/command.go
+++ b/cmd/gpud/update/command.go
@@ -40,7 +40,12 @@ func Command(cliContext *cli.Context) error {
 		url = version.DefaultURLPrefix
 	}
 
-	return pkgupdate.Update(ver, url)
+	if err = pkgupdate.UpdateExecutable(ver, url, true); err != nil {
+		return err
+	}
+
+	fmt.Printf("gpud updated to %s -- please restart gpud to finish the update\n", ver)
+	return nil
 }
 
 func CommandCheck(cliContext *cli.Context) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,17 +55,12 @@ type Config struct {
 	disabledComponents map[string]any `json:"-"`
 }
 
-var ErrInvalidAutoUpdateExitCode = errors.New("auto_update_exit_code is only valid when auto_update is enabled")
-
 func (config *Config) Validate() error {
 	if config.Address == "" {
 		return errors.New("address is required")
 	}
 	if config.RetentionPeriod.Duration < time.Minute {
 		return fmt.Errorf("retention_period must be at least 1 minute, got %d", config.RetentionPeriod.Duration)
-	}
-	if !config.EnableAutoUpdate && config.AutoUpdateExitCode != -1 {
-		return ErrInvalidAutoUpdateExitCode
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -26,12 +26,6 @@ func TestConfigValidate_AutoUpdateExitCode(t *testing.T) {
 			autoUpdateExitCode: -1,
 			wantErr:            false,
 		},
-		{
-			name:               "Invalid: Auto update disabled with non-default exit code",
-			enableAutoUpdate:   false,
-			autoUpdateExitCode: 0,
-			wantErr:            true,
-		},
 	}
 
 	for _, tt := range tests {
@@ -48,10 +42,6 @@ func TestConfigValidate_AutoUpdateExitCode(t *testing.T) {
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Config.Validate() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if tt.wantErr && err != ErrInvalidAutoUpdateExitCode {
-				t.Errorf("Config.Validate() error = %v, want %v", err, ErrInvalidAutoUpdateExitCode)
 			}
 		})
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -48,16 +48,6 @@ func TestServerConfigValidation(t *testing.T) {
 			},
 			expectedErr: "retention_period must be at least 1 minute",
 		},
-		{
-			name: "invalid auto update exit code",
-			config: &config.Config{
-				Address:            "localhost:8080",
-				RetentionPeriod:    metav1.Duration{Duration: time.Hour},
-				EnableAutoUpdate:   false,
-				AutoUpdateExitCode: 1,
-			},
-			expectedErr: "auto_update_exit_code is only valid when auto_update is enabled",
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -14,7 +14,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	// Should fail with non-root error
-	err := Update("0.0.1", DefaultUpdateURL)
+	err := UpdateExecutable("0.0.1", DefaultUpdateURL, true)
 	if err == nil {
 		t.Error("Expected error when running Update as non-root")
 	}
@@ -23,7 +23,7 @@ func TestUpdate(t *testing.T) {
 // TestUpdateOnlyBinary tests the UpdateOnlyBinary function signature
 func TestUpdateOnlyBinary(t *testing.T) {
 	// This should fail with download error
-	err := UpdateOnlyBinary("0.0.1", DefaultUpdateURL)
+	err := UpdateExecutable("0.0.1", DefaultUpdateURL, false)
 	if err == nil {
 		t.Error("Expected error when running UpdateOnlyBinary")
 	}


### PR DESCRIPTION
This fixes the issue where the control plane only
gets the error message "session closed" when it
triggers the GPUd updates.

Signed-off-by: Gyuho Lee <gyuhol@nvidia.com>
