### PR TITLE
[LEP-1109] feat(gpud.service): add CPU/memory resource limits to prevent runaway processes

### DIFF
--- a/pkg/gpud-manager/systemd/gpud.service
+++ b/pkg/gpud-manager/systemd/gpud.service
@@ -27,6 +27,43 @@ KillMode=control-group
 TimeoutStartSec=300
 CPUAccounting=true
 MemoryAccounting=true
+
+# Resource limits to prevent runaway processes
+# Baseline usage in production (128-core system): ~0.3% CPU (of total system), ~150MB RAM
+# CPU usage context: 0.3% in top = 0.3% of all cores combined
+# On a 128-core system, 0.3% total = ~38% of one core
+# 
+# CPU limit: 100% of one core (allows full core utilization while preventing runaway)
+# This provides headroom for:
+# - Initialization spikes
+# - Periodic intensive operations (scanning, health checks)
+# - Multiple component polling cycles overlapping
+# On a 128-core system: 100% of one core = 0.78% of total capacity
+# This is ~2.6x the baseline usage, providing reasonable headroom
+#
+# CPUQuota=100% = 1 full core
+# CPUQuota=200% = 2 full cores
+# CPUQuota=500% = 5 full cores
+CPUQuota=100%
+
+# Memory limit: 500MB (3.3x current usage for operational headroom)
+# Baseline ~150MB allows for:
+# - Temporary spikes during data collection
+# - Growth with more components enabled
+# - Buffer for goroutine/memory leak detection before restart
+MemoryMax=500M
+# Memory warning at 80% of limit (400MB)
+MemoryHigh=400M
+
+# Action when memory limit is hit - restart the service
+# This protects against memory leaks and runaway goroutines
+# Note: OOMPolicy requires systemd 243+
+OOMPolicy=kill
+
+# Restart on any failure including resource limit violations
+RestartPreventExitStatus=
+RestartForceExitStatus=SIGKILL
+
 User=root
 Group=root
 LimitNOFILE=40000


### PR DESCRIPTION
  In systemd:
  - CPUQuota=100% = 1 full core
  - CPUQuota=200% = 2 full cores
  - CPUQuota=500% = 5 full cores

ref. https://www.freedesktop.org/software/systemd/man/latest/systemd.resource-control.html