### PR TITLE
test(pkg/file, nfs-checker): fix flaky t.TempDir() removal

### DIFF
--- a/components/disk/component_test.go
+++ b/components/disk/component_test.go
@@ -444,10 +444,11 @@ func TestMountTargetUsages(t *testing.T) {
 	}
 
 	t.Run("track mount target", func(t *testing.T) {
-		// Create a temp dir to use as mount target
-		tempDir := t.TempDir()
+		tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
 
-		c := createTestComponent(ctx, []string{}, []string{tempDir})
+		c := createTestComponent(ctx, []string{}, []string{tmpDir})
 		defer c.Close()
 
 		c.getBlockDevicesFunc = func(ctx context.Context) (disk.BlockDevices, error) {
@@ -468,15 +469,16 @@ func TestMountTargetUsages(t *testing.T) {
 
 		assert.NotNil(t, lastCheckResult)
 		assert.Equal(t, apiv1.HealthStateTypeHealthy, lastCheckResult.health)
-		assert.Contains(t, lastCheckResult.MountTargetUsages, tempDir)
-		assert.Equal(t, mockMountOutput, lastCheckResult.MountTargetUsages[tempDir])
+		assert.Contains(t, lastCheckResult.MountTargetUsages, tmpDir)
+		assert.Equal(t, mockMountOutput, lastCheckResult.MountTargetUsages[tmpDir])
 	})
 
 	t.Run("mount target error handling", func(t *testing.T) {
-		// Create a temp dir to use as mount target
-		tempDir := t.TempDir()
+		tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
+		require.NoError(t, err)
+		defer os.RemoveAll(tmpDir)
 
-		c := createTestComponent(ctx, []string{}, []string{tempDir})
+		c := createTestComponent(ctx, []string{}, []string{tmpDir})
 		defer c.Close()
 
 		c.getBlockDevicesFunc = func(ctx context.Context) (disk.BlockDevices, error) {

--- a/components/os/file_descriptors_test.go
+++ b/components/os/file_descriptors_test.go
@@ -9,10 +9,12 @@ import (
 )
 
 func TestGetLimit(t *testing.T) {
-	// Create a temporary file with test data
-	tempDir := t.TempDir()
-	testPath := filepath.Join(tempDir, "file-max")
-	err := os.WriteFile(testPath, []byte("1000000\n"), 0644)
+	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	testPath := filepath.Join(tmpDir, "file-max")
+	err = os.WriteFile(testPath, []byte("1000000\n"), 0644)
 	assert.NoError(t, err)
 
 	// Test valid case
@@ -21,11 +23,11 @@ func TestGetLimit(t *testing.T) {
 	assert.Equal(t, uint64(1000000), limit)
 
 	// Test error cases
-	_, err = getLimit(filepath.Join(tempDir, "nonexistent-file"))
+	_, err = getLimit(filepath.Join(tmpDir, "nonexistent-file"))
 	assert.Error(t, err)
 
 	// Test invalid content
-	invalidPath := filepath.Join(tempDir, "invalid-file-max")
+	invalidPath := filepath.Join(tmpDir, "invalid-file-max")
 	err = os.WriteFile(invalidPath, []byte("not-a-number\n"), 0644)
 	assert.NoError(t, err)
 	_, err = getLimit(invalidPath)
@@ -33,10 +35,12 @@ func TestGetLimit(t *testing.T) {
 }
 
 func TestGetFileHandles(t *testing.T) {
-	// Create a temporary file with test data
-	tempDir := t.TempDir()
-	testPath := filepath.Join(tempDir, "file-nr")
-	err := os.WriteFile(testPath, []byte("1000 500 10000\n"), 0644)
+	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	testPath := filepath.Join(tmpDir, "file-nr")
+	err = os.WriteFile(testPath, []byte("1000 500 10000\n"), 0644)
 	assert.NoError(t, err)
 
 	// Test valid case
@@ -46,11 +50,11 @@ func TestGetFileHandles(t *testing.T) {
 	assert.Equal(t, uint64(500), unused)
 
 	// Test error cases
-	_, _, err = getFileHandles(filepath.Join(tempDir, "nonexistent-file"))
+	_, _, err = getFileHandles(filepath.Join(tmpDir, "nonexistent-file"))
 	assert.Error(t, err)
 
 	// Test invalid content - wrong number of fields
-	invalidPath1 := filepath.Join(tempDir, "invalid-file-nr-1")
+	invalidPath1 := filepath.Join(tmpDir, "invalid-file-nr-1")
 	err = os.WriteFile(invalidPath1, []byte("1000 500\n"), 0644)
 	assert.NoError(t, err)
 	_, _, err = getFileHandles(invalidPath1)
@@ -58,14 +62,14 @@ func TestGetFileHandles(t *testing.T) {
 	assert.Contains(t, err.Error(), "unexpected number of fields")
 
 	// Test invalid content - not numbers
-	invalidPath2 := filepath.Join(tempDir, "invalid-file-nr-2")
+	invalidPath2 := filepath.Join(tmpDir, "invalid-file-nr-2")
 	err = os.WriteFile(invalidPath2, []byte("a b c\n"), 0644)
 	assert.NoError(t, err)
 	_, _, err = getFileHandles(invalidPath2)
 	assert.Error(t, err)
 
 	// Test invalid content - second field not a number
-	invalidPath3 := filepath.Join(tempDir, "invalid-file-nr-3")
+	invalidPath3 := filepath.Join(tmpDir, "invalid-file-nr-3")
 	err = os.WriteFile(invalidPath3, []byte("1000 b 10000\n"), 0644)
 	assert.NoError(t, err)
 	_, _, err = getFileHandles(invalidPath3)

--- a/pkg/file/timeout_io_test.go
+++ b/pkg/file/timeout_io_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestStatWithTimeout_Success(t *testing.T) {
-	// Create a temporary directory for testing
 	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	// Create a file in the directory
 	testFile := filepath.Join(tmpDir, "testfile")
@@ -32,9 +32,9 @@ func TestStatWithTimeout_Success(t *testing.T) {
 }
 
 func TestStatWithTimeout_Timeout(t *testing.T) {
-	// Create a temporary directory for testing
 	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	// Create a file in the directory
 	testFile := filepath.Join(tmpDir, "testfile")
@@ -54,9 +54,9 @@ func TestStatWithTimeout_Timeout(t *testing.T) {
 }
 
 func TestStatWithTimeout_ContextCanceled(t *testing.T) {
-	// Create a temporary directory for testing
 	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	// Create a file in the directory
 	testFile := filepath.Join(tmpDir, "testfile")
@@ -89,6 +89,7 @@ func TestMkdirAllWithTimeout_Success(t *testing.T) {
 
 	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	testPath := filepath.Join(tmpDir, "test", "nested", "dir")
 
@@ -109,6 +110,7 @@ func TestMkdirAllWithTimeout_Timeout(t *testing.T) {
 
 	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	// Test timeout scenario
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
@@ -125,6 +127,7 @@ func TestWriteFileWithTimeout_Success(t *testing.T) {
 
 	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	testFile := filepath.Join(tmpDir, "test.txt")
 	testData := []byte("test content")
@@ -146,6 +149,7 @@ func TestWriteFileWithTimeout_Timeout(t *testing.T) {
 
 	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	// Test timeout scenario
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
@@ -162,6 +166,7 @@ func TestWriteFileWithTimeout_Canceled(t *testing.T) {
 
 	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	// Test canceled context scenario
 	ctx, cancel := context.WithCancel(context.Background())
@@ -177,6 +182,7 @@ func TestReadFileWithTimeout_Success(t *testing.T) {
 
 	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	testFile := filepath.Join(tmpDir, "test.txt")
 	testData := []byte("test content")
@@ -197,6 +203,7 @@ func TestReadFileWithTimeout_FileNotFound(t *testing.T) {
 
 	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	// Test file not found
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -211,6 +218,7 @@ func TestReadFileWithTimeout_Timeout(t *testing.T) {
 
 	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	testFile := filepath.Join(tmpDir, "test.txt")
 	require.NoError(t, os.WriteFile(testFile, []byte("content"), 0644))
@@ -230,6 +238,7 @@ func TestReadFileWithTimeout_Canceled(t *testing.T) {
 
 	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	testFile := filepath.Join(tmpDir, "test.txt")
 	require.NoError(t, os.WriteFile(testFile, []byte("content"), 0644))
@@ -250,6 +259,7 @@ func TestAllOperationsWithContextScenarios(t *testing.T) {
 
 	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	tests := []struct {
 		name      string

--- a/pkg/nfs-checker/checker_test.go
+++ b/pkg/nfs-checker/checker_test.go
@@ -12,12 +12,14 @@ import (
 )
 
 func TestNewChecker(t *testing.T) {
-	tempDir := t.TempDir()
+	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	t.Run("valid config", func(t *testing.T) {
 		cfg := &MemberConfig{
 			Config: Config{
-				VolumePath:   tempDir,
+				VolumePath:   tmpDir,
 				DirName:      "test-dir",
 				FileContents: "test-content",
 			},
@@ -48,12 +50,13 @@ func TestNewChecker(t *testing.T) {
 }
 
 func TestChecker_Write(t *testing.T) {
-	tempDir, err := os.MkdirTemp(t.TempDir(), "test")
+	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	cfg := &MemberConfig{
 		Config: Config{
-			VolumePath:   tempDir,
+			VolumePath:   tmpDir,
 			DirName:      "test-dir",
 			FileContents: "test-content",
 		},
@@ -71,14 +74,14 @@ func TestChecker_Write(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Verify file was created with correct content
-		filePath := filepath.Join(tempDir, "test-dir", "test-id")
+		filePath := filepath.Join(tmpDir, "test-dir", "test-id")
 		content, err := os.ReadFile(filePath)
 		assert.NoError(t, err)
 		assert.Equal(t, "test-content", string(content))
 	})
 
 	t.Run("write to non-existent directory", func(t *testing.T) {
-		subDir := filepath.Join(tempDir, "subdir")
+		subDir := filepath.Join(tmpDir, "subdir")
 
 		// Create the directory first
 		err := os.MkdirAll(subDir, 0755)
@@ -112,6 +115,7 @@ func TestChecker_Write(t *testing.T) {
 	t.Run("timeout during mkdir operation", func(t *testing.T) {
 		timeoutTempDir, err := os.MkdirTemp(t.TempDir(), "test")
 		require.NoError(t, err)
+		defer os.RemoveAll(timeoutTempDir)
 
 		cfg := &MemberConfig{
 			Config: Config{
@@ -139,6 +143,7 @@ func TestChecker_Write(t *testing.T) {
 	t.Run("context canceled during mkdir operation", func(t *testing.T) {
 		cancelTempDir, err := os.MkdirTemp(t.TempDir(), "test")
 		require.NoError(t, err)
+		defer os.RemoveAll(cancelTempDir)
 
 		cfg := &MemberConfig{
 			Config: Config{
@@ -165,6 +170,7 @@ func TestChecker_Write(t *testing.T) {
 	t.Run("timeout during write operation", func(t *testing.T) {
 		timeoutTempDir, err := os.MkdirTemp(t.TempDir(), "test")
 		require.NoError(t, err)
+		defer os.RemoveAll(timeoutTempDir)
 
 		cfg := &MemberConfig{
 			Config: Config{
@@ -197,6 +203,7 @@ func TestChecker_Write(t *testing.T) {
 	t.Run("context canceled during write operation", func(t *testing.T) {
 		cancelTempDir, err := os.MkdirTemp(t.TempDir(), "test")
 		require.NoError(t, err)
+		defer os.RemoveAll(cancelTempDir)
 
 		cfg := &MemberConfig{
 			Config: Config{
@@ -321,14 +328,15 @@ func TestChecker_Write(t *testing.T) {
 }
 
 func TestChecker_Clean(t *testing.T) {
-	tempDir, err := os.MkdirTemp(t.TempDir(), "test")
+	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	dirName := "clean-test-dir"
 
 	cfg := &MemberConfig{
 		Config: Config{
-			VolumePath:   tempDir,
+			VolumePath:   tmpDir,
 			DirName:      dirName,
 			FileContents: "test-content",
 		},
@@ -346,7 +354,7 @@ func TestChecker_Clean(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify file exists
-	file := filepath.Join(tempDir, dirName, "test-id")
+	file := filepath.Join(tmpDir, dirName, "test-id")
 	_, err = os.Stat(file)
 	assert.NoError(t, err)
 
@@ -360,14 +368,15 @@ func TestChecker_Clean(t *testing.T) {
 }
 
 func TestChecker_Check(t *testing.T) {
-	tempDir, err := os.MkdirTemp(t.TempDir(), "test")
+	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	t.Run("successful check with expected files", func(t *testing.T) {
 		dirName := "success-test-dir"
 		cfg := &MemberConfig{
 			Config: Config{
-				VolumePath:   tempDir,
+				VolumePath:   tmpDir,
 				DirName:      dirName,
 				FileContents: "test-content",
 			},
@@ -387,9 +396,9 @@ func TestChecker_Check(t *testing.T) {
 		ctx3, cancel3 := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel3()
 		result := checker.Check(ctx3)
-		targetDir := filepath.Join(tempDir, dirName)
+		targetDir := filepath.Join(tmpDir, dirName)
 		assert.Equal(t, targetDir, result.Dir)
-		assert.Equal(t, "correctly read/wrote on \""+tempDir+"\"", result.Message)
+		assert.Equal(t, "correctly read/wrote on \""+tmpDir+"\"", result.Message)
 		assert.Empty(t, result.Error)
 	})
 
@@ -397,7 +406,7 @@ func TestChecker_Check(t *testing.T) {
 		dirName := "not-found-test-dir"
 		cfg := &MemberConfig{
 			Config: Config{
-				VolumePath:   tempDir,
+				VolumePath:   tmpDir,
 				DirName:      dirName,
 				FileContents: "test-content",
 			},
@@ -412,7 +421,7 @@ func TestChecker_Check(t *testing.T) {
 		ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel2()
 		result := checker.Check(ctx2)
-		expectedDir := filepath.Join(tempDir, dirName)
+		expectedDir := filepath.Join(tmpDir, dirName)
 		assert.Equal(t, expectedDir, result.Dir)
 		assert.Contains(t, result.Error, "failed to read file")
 		assert.Contains(t, result.Error, "no such file or directory")
@@ -454,7 +463,7 @@ func TestChecker_Check(t *testing.T) {
 		dirName := "timeout-read-test-dir"
 		cfg := &MemberConfig{
 			Config: Config{
-				VolumePath:   tempDir,
+				VolumePath:   tmpDir,
 				DirName:      dirName,
 				FileContents: "test-content",
 			},
@@ -477,7 +486,7 @@ func TestChecker_Check(t *testing.T) {
 		time.Sleep(10 * time.Millisecond) // Ensure context expires
 
 		result := checker.Check(timeoutCtx)
-		expectedDir := filepath.Join(tempDir, dirName)
+		expectedDir := filepath.Join(tmpDir, dirName)
 		assert.Equal(t, expectedDir, result.Dir)
 		assert.Equal(t, "failed", result.Message)
 		assert.Contains(t, result.Error, "failed to read file")
@@ -489,7 +498,7 @@ func TestChecker_Check(t *testing.T) {
 		dirName := "canceled-read-test-dir"
 		cfg := &MemberConfig{
 			Config: Config{
-				VolumePath:   tempDir,
+				VolumePath:   tmpDir,
 				DirName:      dirName,
 				FileContents: "test-content",
 			},
@@ -511,7 +520,7 @@ func TestChecker_Check(t *testing.T) {
 		cancel() // Cancel immediately
 
 		result := checker.Check(canceledCtx)
-		expectedDir := filepath.Join(tempDir, dirName)
+		expectedDir := filepath.Join(tmpDir, dirName)
 		assert.Equal(t, expectedDir, result.Dir)
 		assert.Equal(t, "failed", result.Message)
 		assert.Contains(t, result.Error, "failed to read file")
@@ -522,14 +531,15 @@ func TestChecker_Check(t *testing.T) {
 
 // TestChecker_Check_TimeoutErrorField tests the TimeoutError field in CheckResult
 func TestChecker_Check_TimeoutErrorField(t *testing.T) {
-	tempDir, err := os.MkdirTemp(t.TempDir(), "test")
+	tmpDir, err := os.MkdirTemp(t.TempDir(), "test")
 	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
 
 	t.Run("timeout error sets TimeoutError to true", func(t *testing.T) {
 		dirName := "timeout-error-test-dir"
 		cfg := &MemberConfig{
 			Config: Config{
-				VolumePath:   tempDir,
+				VolumePath:   tmpDir,
 				DirName:      dirName,
 				FileContents: "test-content",
 			},
@@ -552,7 +562,7 @@ func TestChecker_Check_TimeoutErrorField(t *testing.T) {
 		time.Sleep(10 * time.Millisecond) // Ensure context expires
 
 		result := checker.Check(timeoutCtx)
-		expectedDir := filepath.Join(tempDir, dirName)
+		expectedDir := filepath.Join(tmpDir, dirName)
 		assert.Equal(t, expectedDir, result.Dir)
 		assert.Equal(t, "failed", result.Message)
 		assert.Contains(t, result.Error, "failed to read file")
@@ -564,7 +574,7 @@ func TestChecker_Check_TimeoutErrorField(t *testing.T) {
 		dirName := "canceled-error-test-dir"
 		cfg := &MemberConfig{
 			Config: Config{
-				VolumePath:   tempDir,
+				VolumePath:   tmpDir,
 				DirName:      dirName,
 				FileContents: "test-content",
 			},
@@ -586,7 +596,7 @@ func TestChecker_Check_TimeoutErrorField(t *testing.T) {
 		cancel() // Cancel immediately
 
 		result := checker.Check(canceledCtx)
-		expectedDir := filepath.Join(tempDir, dirName)
+		expectedDir := filepath.Join(tmpDir, dirName)
 		assert.Equal(t, expectedDir, result.Dir)
 		assert.Equal(t, "failed", result.Message)
 		assert.Contains(t, result.Error, "failed to read file")
@@ -598,7 +608,7 @@ func TestChecker_Check_TimeoutErrorField(t *testing.T) {
 		dirName := "not-found-error-test-dir"
 		cfg := &MemberConfig{
 			Config: Config{
-				VolumePath:   tempDir,
+				VolumePath:   tmpDir,
 				DirName:      dirName,
 				FileContents: "test-content",
 			},
@@ -613,7 +623,7 @@ func TestChecker_Check_TimeoutErrorField(t *testing.T) {
 		ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel2()
 		result := checker.Check(ctx2)
-		expectedDir := filepath.Join(tempDir, dirName)
+		expectedDir := filepath.Join(tmpDir, dirName)
 		assert.Equal(t, expectedDir, result.Dir)
 		assert.Equal(t, "failed", result.Message)
 		assert.Contains(t, result.Error, "failed to read file")
@@ -625,7 +635,7 @@ func TestChecker_Check_TimeoutErrorField(t *testing.T) {
 		dirName := "success-error-test-dir"
 		cfg := &MemberConfig{
 			Config: Config{
-				VolumePath:   tempDir,
+				VolumePath:   tmpDir,
 				DirName:      dirName,
 				FileContents: "test-content",
 			},
@@ -645,9 +655,9 @@ func TestChecker_Check_TimeoutErrorField(t *testing.T) {
 		ctx3, cancel3 := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel3()
 		result := checker.Check(ctx3)
-		targetDir := filepath.Join(tempDir, dirName)
+		targetDir := filepath.Join(tmpDir, dirName)
 		assert.Equal(t, targetDir, result.Dir)
-		assert.Equal(t, "correctly read/wrote on \""+tempDir+"\"", result.Message)
+		assert.Equal(t, "correctly read/wrote on \""+tmpDir+"\"", result.Message)
 		assert.Empty(t, result.Error)
 		assert.False(t, result.TimeoutError, "TimeoutError should be false for successful operation")
 	})


### PR DESCRIPTION
```
=== NAME  TestWriteFileWithTimeout_Canceled
    testing.go:1267: TempDir RemoveAll cleanup: unlinkat /tmp/TestWriteFileWithTimeout_Canceled3492319807/001: directory not empty
--- FAIL: TestWriteFileWithTimeout_Canceled (0.00s)
```

```
=== RUN   TestChecker_Write/comprehensive_timeout_scenarios/successful_operation
{"level":"info","ts":"2025-07-16T15:09:51.099Z","caller":"nfs-checker/checker.go:76","msg":"successfully wrote file","file":"/tmp/TestChecker_Writecomprehensive_timeout_scenariossuccessful_operation1726555776/001/scenario-test-dir/scenario-checker"}
--- FAIL: TestChecker_Write (0.03s)
```

Signed-off-by: Gyuho Lee <gyuhol@nvidia.com>
