### PR TITLE
fix(components): adding missing path for Jetson platform

### DIFF
--- a/components/library/component.go
+++ b/components/library/component.go
@@ -51,11 +51,16 @@ var (
 		"/usr/lib/aarch64-linux-gnu",
 		"/usr/lib/x86_64-linux-gnu/nvidia/current",
 		"/usr/lib/aarch64-linux-gnu/nvidia/current",
+		// Note(Yangqing): the following path is added to support the case of Jetson Orin where
+		// the libraries are installed in /usr/lib/aarch64-linux-gnu/nvidia without the "current" symlink.
+		"/usr/lib/aarch64-linux-gnu/nvidia",
 		"/lib64",
 		"/lib/x86_64-linux-gnu",
 		"/lib/aarch64-linux-gnu",
 		"/lib/x86_64-linux-gnu/nvidia/current",
 		"/lib/aarch64-linux-gnu/nvidia/current",
+		// Note(Yangqing): similar to the "/usr/lib/aarch64-linux-gnu/nvidia" above.
+		"/lib/aarch64-linux-gnu/nvidia",
 	}
 )
 


### PR DESCRIPTION
This was discovered while I was experimenting with Jetson. Without this, gpud scan will show:

'''
{"level":"info","ts":"2025-07-19T22:56:28.502-0700","caller":"library/component.go:154","msg":"checking library"}
✘ library "libnvidia-ml.so" does not exist
resolved_libraries:
- /usr/lib/aarch64-linux-gnu/nvidia/libcuda.so.1.1
'''

And after this change:
"""
{"level":"info","ts":"2025-07-19T22:57:02.288-0700","caller":"library/component.go:159","msg":"checking library"}
✔ all libraries exist
resolved_libraries:
- /usr/lib/aarch64-linux-gnu/nvidia/libcuda.so.1.1
- /usr/lib/aarch64-linux-gnu/nvidia/libnvidia-ml.so.1
"""

It should not have any side effects for platforms that do not have these paths present.