### PR TITLE
[LEP-1219] feat(pkg/disk): metrics for getting disk usage (for NFS), re-enable disk usage tracking for nfs partitions

### DIFF
--- a/components/disk/component.go
+++ b/components/disk/component.go
@@ -84,7 +84,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		getNFSPartitionsFunc: func(ctx context.Context) (disk.Partitions, error) {
 			// statfs on nfs can incur network I/O or impact disk I/O performance
 			// do not track usage for nfs partitions
-			return disk.GetPartitions(ctx, disk.WithFstype(disk.DefaultNFSFsTypeFunc), disk.WithSkipUsage())
+			return disk.GetPartitions(ctx, disk.WithFstype(disk.DefaultNFSFsTypeFunc))
 		},
 
 		findMntFunc: disk.FindMnt,

--- a/pkg/disk/metrics.go
+++ b/pkg/disk/metrics.go
@@ -1,0 +1,32 @@
+package disk
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	pkgmetrics "github.com/leptonai/gpud/pkg/metrics"
+)
+
+var (
+	componentLabel = prometheus.Labels{
+		pkgmetrics.MetricComponentLabelKey: "disk",
+	}
+
+	metricGetUsageSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "gpud",
+			Subsystem: "disk",
+			Name:      "get_usage_seconds",
+			Help:      "time taken to get disk usage",
+
+			// want to track with lowest bound 0.001s (1ms) and highest bound 2.5s
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5},
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey, "mount_point"}, // label is the mount point
+	).MustCurryWith(componentLabel)
+)
+
+func init() {
+	pkgmetrics.MustRegister(
+		metricGetUsageSeconds,
+	)
+}


### PR DESCRIPTION
```
gpud_disk_get_usage_seconds_bucket{gpud_component="disk",mount_point="/projects/data",le="0.001"} 2
gpud_disk_get_usage_seconds_bucket{gpud_component="disk",mount_point="/projects/data",le="0.005"} 2
gpud_disk_get_usage_seconds_bucket{gpud_component="disk",mount_point="/projects/data",le="0.01"} 2
gpud_disk_get_usage_seconds_bucket{gpud_component="disk",mount_point="/projects/data",le="0.025"} 2
gpud_disk_get_usage_seconds_bucket{gpud_component="disk",mount_point="/projects/data",le="0.05"} 2
gpud_disk_get_usage_seconds_bucket{gpud_component="disk",mount_point="/projects/data",le="0.1"} 2
gpud_disk_get_usage_seconds_bucket{gpud_component="disk",mount_point="/projects/data",le="0.25"} 2
gpud_disk_get_usage_seconds_bucket{gpud_component="disk",mount_point="/projects/data",le="0.5"} 2
gpud_disk_get_usage_seconds_bucket{gpud_component="disk",mount_point="/projects/data",le="1"} 2
gpud_disk_get_usage_seconds_bucket{gpud_component="disk",mount_point="/projects/data",le="2.5"} 2
gpud_disk_get_usage_seconds_bucket{gpud_component="disk",mount_point="/projects/data",le="5"} 2
gpud_disk_get_usage_seconds_bucket{gpud_component="disk",mount_point="/projects/data",le="10"} 2
gpud_disk_get_usage_seconds_bucket{gpud_component="disk",mount_point="/projects/data",le="+Inf"} 2
```