### PR TITLE
[LEP-1262] feat(status): add package status table to status command

### DIFF
--- a/pkg/gpud-manager/packages/packages.go
+++ b/pkg/gpud-manager/packages/packages.go
@@ -1,6 +1,14 @@
 package packages
 
-import "time"
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/olekukonko/tablewriter"
+)
 
 type PackageInfo struct {
 	Name          string
@@ -30,3 +38,79 @@ func (a PackageStatuses) Len() int { return len(a) }
 func (a PackageStatuses) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 
 func (a PackageStatuses) Less(i, j int) bool { return a[i].Name < a[j].Name }
+
+func (ps PackageStatuses) RenderTable(wr io.Writer) {
+	table := tablewriter.NewWriter(wr)
+	table.SetHeader([]string{"Package Name", "Status", "Progress", "Version", "Time Elapsed", "Est. Time Left"})
+
+	// Configure table style
+	table.SetBorder(true)
+	table.SetRowLine(true)
+	table.SetAutoWrapText(false)
+
+	for _, status := range ps {
+		// Determine status text
+		statusText := "Not Installed"
+		if status.IsInstalled {
+			statusText = "✅"
+		} else if status.Installing {
+			statusText = "Installing"
+		}
+
+		// Create progress bar
+		progressBar := createProgressBar(status.Progress, 20)
+		progressText := fmt.Sprintf("%s %d%%", progressBar, status.Progress)
+
+		// Calculate time elapsed and time left
+		var timeElapsed, timeLeft string
+		if status.TotalTime > 0 {
+			elapsed := time.Duration(float64(status.TotalTime) * float64(status.Progress) / 100)
+			timeElapsed = humanize.Time(time.Now().Add(-elapsed))
+
+			if status.Progress < 100 && status.Progress > 0 {
+				remaining := time.Duration(float64(status.TotalTime) * float64(100-status.Progress) / 100)
+				timeLeft = humanize.Time(time.Now().Add(remaining))
+			} else if status.Progress == 0 {
+				timeLeft = "Not started"
+			} else {
+				timeLeft = "Complete"
+			}
+		} else {
+			timeElapsed = "N/A"
+			timeLeft = "N/A"
+		}
+
+		// Version info
+		versionInfo := status.CurrentVersion
+		if status.TargetVersion != "" && status.TargetVersion != status.CurrentVersion {
+			versionInfo = fmt.Sprintf("%s → %s", status.CurrentVersion, status.TargetVersion)
+		}
+
+		table.Append([]string{
+			status.Name,
+			statusText,
+			progressText,
+			versionInfo,
+			timeElapsed,
+			timeLeft,
+		})
+	}
+
+	table.Render()
+}
+
+// createProgressBar creates a visual progress bar
+func createProgressBar(progress int, width int) string {
+	if progress < 0 {
+		progress = 0
+	}
+	if progress > 100 {
+		progress = 100
+	}
+
+	filled := int(float64(width) * float64(progress) / 100)
+	empty := width - filled
+
+	bar := "[" + strings.Repeat("=", filled) + strings.Repeat(" ", empty) + "]"
+	return bar
+}


### PR DESCRIPTION
e.g.,

```
+-----------------------+--------+-----------------------------+-------------------------+---------------+----------------+
|     PACKAGE NAME      | STATUS |          PROGRESS           |         VERSION         | TIME ELAPSED  | EST  TIME LEFT |
+-----------------------+--------+-----------------------------+-------------------------+---------------+----------------+
| containerd            | ✅     | [====================] 100% | 1.7.20                  | 1 minute ago  | Complete       |
+-----------------------+--------+-----------------------------+-------------------------+---------------+----------------+
| init                  | ✅     | [====================] 100% | 1.0.0                   | 5 minutes ago | Complete       |
+-----------------------+--------+-----------------------------+-------------------------+---------------+----------------+
| kubelet               | ✅     | [====================] 100% | 1.31.5                  | 1 minute ago  | Complete       |
+-----------------------+--------+-----------------------------+-------------------------+---------------+----------------+
| kubelet-network       | ✅     | [====================] 100% | 1.0.0                   | 1 minute ago  | Complete       |
+-----------------------+--------+-----------------------------+-------------------------+---------------+----------------+
| nvidia-driver         | ✅     | [====================] 100% | 535.247.01 → 550.144.03 | 2 minutes ago | Complete       |
+-----------------------+--------+-----------------------------+-------------------------+---------------+----------------+
| nvidia-fabric-manager | ✅     | [====================] 100% | 535.247.01              | 1 minute ago  | Complete       |
+-----------------------+--------+-----------------------------+-------------------------+---------------+----------------+
| nvidia-infiniband     | ✅     | [====================] 100% | 1.0.0                   | 1 minute ago  | Complete       |
+-----------------------+--------+-----------------------------+-------------------------+---------------+----------------+
| reboot                | ✅     | [====================] 100% | 1.0.0                   | 5 seconds ago | Complete       |
+-----------------------+--------+-----------------------------+-------------------------+---------------+----------------+
| tailscale             | ✅     | [====================] 100% | 1.80.0                  | 1 minute ago  | Complete       |
+-----------------------+--------+-----------------------------+-------------------------+---------------+----------------+
```