### PR TITLE
[LEP-1270] [LEP-1325] feat(gpu-counts): do not return events externally

### DIFF
--- a/components/accelerator/nvidia/gpu-counts/component.go
+++ b/components/accelerator/nvidia/gpu-counts/component.go
@@ -128,14 +128,10 @@ func (c *component) LastHealthStates() apiv1.HealthStates {
 }
 
 func (c *component) Events(ctx context.Context, since time.Time) (apiv1.Events, error) {
-	if c.eventBucket == nil {
-		return nil, nil
-	}
-	evs, err := c.eventBucket.Get(ctx, since)
-	if err != nil {
-		return nil, err
-	}
-	return evs.Events(), nil
+	// gpu count mismatch events are ONLY used internally within this package
+	// solely to evaluate the suggested actions
+	// so we don't need to return any events externally
+	return nil, nil
 }
 
 func (c *component) Close() error {

--- a/components/accelerator/nvidia/gpu-counts/component_test.go
+++ b/components/accelerator/nvidia/gpu-counts/component_test.go
@@ -345,6 +345,42 @@ func TestComponent_Events(t *testing.T) {
 	assert.Nil(t, events)
 }
 
+// TestComponent_Events_Simple tests the Events method with different time values
+func TestComponent_Events_Simple(t *testing.T) {
+	tests := []struct {
+		name  string
+		since time.Time
+	}{
+		{
+			name:  "events since 1 hour ago",
+			since: time.Now().Add(-time.Hour),
+		},
+		{
+			name:  "events since 1 day ago",
+			since: time.Now().Add(-24 * time.Hour),
+		},
+		{
+			name:  "events since epoch",
+			since: time.Unix(0, 0),
+		},
+		{
+			name:  "events since future time",
+			since: time.Now().Add(time.Hour),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			c := &component{}
+
+			events, err := c.Events(ctx, tt.since)
+			assert.NoError(t, err)
+			assert.Nil(t, events)
+		})
+	}
+}
+
 // TestComponent_Close tests the Close method
 func TestComponent_Close(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Only use them internally within this package,
to evaluate the suggested actions.

Signed-off-by: Gyuho Lee <gyuhol@nvidia.com>
