### PR TITLE
[LEP-1439] feat(logout): --reset-state flag in case of events history re-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ You can also start with the standalone mode and later switch to the managed opti
 ```bash
 # when the token is ready, run the following command
 sudo gpud login --token <LEPTON_AI_TOKEN>
+
+# to logout
+sudo gpud logout
+
+# to logout and reset the state file
+sudo gpud logout --reset-state
 ```
 
 #### Run GPUd with Kubernetes

--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -577,6 +577,10 @@ sudo rm /etc/systemd/system/gpud.service
 					Name:  "log-level,l",
 					Usage: "set the logging level [debug, info, warn, error, fatal, panic, dpanic]",
 				},
+				&cli.BoolFlag{
+					Name:  "reset-state",
+					Usage: "reset the state file (otherwise, re-login may contain stale health data)",
+				},
 			},
 		},
 

--- a/cmd/gpud/logout/command.go
+++ b/cmd/gpud/logout/command.go
@@ -3,6 +3,8 @@ package logout
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/urfave/cli"
@@ -54,5 +56,24 @@ func Command(cliContext *cli.Context) error {
 	log.Logger.Debugw("successfully deleted metadata")
 
 	fmt.Printf("%s successfully logged out\n", cmdcommon.CheckMark)
+	fmt.Printf("\nPlease run 'rm -rf %s/gpud*' to remove the state file (otherwise, re-login may contain stale health data)\n\n", filepath.Dir(stateFile))
+
+	if cliContext.Bool("reset-state") {
+		log.Logger.Warnw("deleting state files", "state-file", stateFile)
+		if err := os.RemoveAll(stateFile); err != nil {
+			return err
+		}
+		if err := os.RemoveAll(stateFile + "-wal"); err != nil {
+			return err
+		}
+		if err := os.RemoveAll(stateFile + "-shm"); err != nil {
+			return err
+		}
+		if err := os.RemoveAll(filepath.Join(filepath.Dir(stateFile), "packages")); err != nil {
+			return err
+		}
+		log.Logger.Infow("successfully deleted state files", "state-file", stateFile)
+	}
+
 	return nil
 }

--- a/cmd/gpud/metadata/command.go
+++ b/cmd/gpud/metadata/command.go
@@ -74,7 +74,7 @@ func Command(cliContext *cli.Context) error {
 	defer dbRW.Close()
 	log.Logger.Debugw("successfully opened state file for writing")
 
-	log.Logger.Debugw("deleting metadata data")
+	log.Logger.Debugw("setting metadata", "key", setKey, "value", setValue)
 	if err := pkgmetadata.SetMetadata(rootCtx, dbRW, setKey, setValue); err != nil {
 		return fmt.Errorf("failed to update metadata: %w", err)
 	}


### PR DESCRIPTION
We cannot tell whether the previous events states are
from the same machine + same login, or from the same
machine + different login. Thus, we can only recommend
how to prevent such conflicting states, in case the
user wants to re-login, with the same machine.

Signed-off-by: Gyuho Lee <gyuhol@nvidia.com>
