### PR TITLE
[LEP-1175] feat(disk): purge events on set healthy

### DIFF
--- a/components/disk/component.go
+++ b/components/disk/component.go
@@ -39,6 +39,8 @@ type component struct {
 
 	retryInterval time.Duration
 
+	getTimeNowFunc func() time.Time
+
 	getBlockDevicesFunc func(ctx context.Context) (disk.BlockDevices, error)
 
 	getExt4PartitionsFunc func(ctx context.Context) (disk.Partitions, error)
@@ -75,6 +77,10 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		cancel: ccancel,
 
 		retryInterval: defaultRetryInterval,
+
+		getTimeNowFunc: func() time.Time {
+			return time.Now().UTC()
+		},
 
 		rebootEventStore: gpudInstance.RebootEventStore,
 		lookbackPeriod:   defaultLookbackPeriod,
@@ -202,7 +208,7 @@ func (c *component) Check() components.CheckResult {
 	log.Logger.Infow("checking disk")
 
 	cr := &checkResult{
-		ts: time.Now().UTC(),
+		ts: c.getTimeNowFunc(),
 
 		health: apiv1.HealthStateTypeHealthy,
 		reason: "ok",

--- a/components/disk/component_failure_resolution_test.go
+++ b/components/disk/component_failure_resolution_test.go
@@ -44,6 +44,9 @@ func TestDiskFailureResolutionAfterReboot(t *testing.T) {
 			eventBucket:             mockBucket,
 			rebootEventStore:        mockRebootStore,
 			mountPointsToTrackUsage: map[string]struct{}{},
+			getTimeNowFunc: func() time.Time {
+				return now
+			},
 			getExt4PartitionsFunc: func(ctx context.Context) (disk.Partitions, error) {
 				return disk.Partitions{}, nil
 			},
@@ -516,6 +519,9 @@ func TestFailureReasonMapCleanup(t *testing.T) {
 		eventBucket:             mockBucket,
 		rebootEventStore:        mockRebootStore,
 		mountPointsToTrackUsage: map[string]struct{}{},
+		getTimeNowFunc: func() time.Time {
+			return now
+		},
 		getExt4PartitionsFunc: func(ctx context.Context) (disk.Partitions, error) {
 			return disk.Partitions{}, nil
 		},

--- a/components/disk/component_suggested_actions_test.go
+++ b/components/disk/component_suggested_actions_test.go
@@ -347,6 +347,9 @@ func TestComponent_Check_SuggestedActions(t *testing.T) {
 		rebootEventStore: mockRebootStore,
 		eventBucket:      eventBucket,
 		lookbackPeriod:   96 * time.Hour,
+		getTimeNowFunc: func() time.Time {
+			return now
+		},
 		getExt4PartitionsFunc: func(ctx context.Context) (disk.Partitions, error) {
 			return disk.Partitions{}, nil
 		},
@@ -396,6 +399,9 @@ func TestComponent_Check_NoSpaceLeftNotSuggested(t *testing.T) {
 		rebootEventStore: mockRebootStore,
 		eventBucket:      eventBucket,
 		lookbackPeriod:   96 * time.Hour,
+		getTimeNowFunc: func() time.Time {
+			return now
+		},
 		getExt4PartitionsFunc: func(ctx context.Context) (disk.Partitions, error) {
 			return disk.Partitions{}, nil
 		},
@@ -509,6 +515,9 @@ func TestLookbackPeriod(t *testing.T) {
 		rebootEventStore: mockRebootStore,
 		eventBucket:      eventBucket,
 		lookbackPeriod:   3 * 24 * time.Hour, // 3 days
+		getTimeNowFunc: func() time.Time {
+			return now
+		},
 		getExt4PartitionsFunc: func(ctx context.Context) (disk.Partitions, error) {
 			// Return at least one partition so the component doesn't exit early
 			return disk.Partitions{
@@ -651,6 +660,9 @@ func TestComponent_Check_DeduplicationAndSorting(t *testing.T) {
 		rebootEventStore: mockRebootStore,
 		eventBucket:      eventBucket,
 		lookbackPeriod:   time.Hour, // 1 hour lookback
+		getTimeNowFunc: func() time.Time {
+			return now
+		},
 		getExt4PartitionsFunc: func(ctx context.Context) (disk.Partitions, error) {
 			return disk.Partitions{
 				{

--- a/components/disk/set_healthy.go
+++ b/components/disk/set_healthy.go
@@ -1,0 +1,28 @@
+package disk
+
+import (
+	"context"
+	"time"
+
+	"github.com/leptonai/gpud/components"
+	"github.com/leptonai/gpud/pkg/log"
+)
+
+var _ components.HealthSettable = &component{}
+
+func (c *component) SetHealthy() error {
+	log.Logger.Infow("set healthy event received for disk")
+
+	if c.eventBucket != nil {
+		now := c.getTimeNowFunc()
+		cctx, cancel := context.WithTimeout(c.ctx, 10*time.Second)
+		purged, err := c.eventBucket.Purge(cctx, now.Unix())
+		cancel()
+		if err != nil {
+			return err
+		}
+		log.Logger.Infow("successfully purged disk events", "count", purged)
+	}
+
+	return nil
+}

--- a/components/disk/set_healthy_test.go
+++ b/components/disk/set_healthy_test.go
@@ -1,0 +1,158 @@
+package disk
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leptonai/gpud/components"
+)
+
+func TestComponent_SetHealthy(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMocks    func(*mockEventBucket)
+		expectedError error
+		checkResult   func(*testing.T, *mockEventBucket)
+	}{
+		{
+			name: "successful purge with event bucket",
+			setupMocks: func(mb *mockEventBucket) {
+				mb.On("Purge", mock.Anything, mock.AnythingOfType("int64")).Return(10, nil)
+			},
+			expectedError: nil,
+			checkResult: func(t *testing.T, mb *mockEventBucket) {
+				mb.AssertCalled(t, "Purge", mock.Anything, mock.AnythingOfType("int64"))
+			},
+		},
+		{
+			name: "purge returns error",
+			setupMocks: func(mb *mockEventBucket) {
+				mb.On("Purge", mock.Anything, mock.AnythingOfType("int64")).Return(0, errors.New("purge failed"))
+			},
+			expectedError: errors.New("purge failed"),
+			checkResult: func(t *testing.T, mb *mockEventBucket) {
+				mb.AssertCalled(t, "Purge", mock.Anything, mock.AnythingOfType("int64"))
+			},
+		},
+		{
+			name:          "nil event bucket - no error",
+			setupMocks:    nil,
+			expectedError: nil,
+			checkResult:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Create a test component
+			gpudInstance := &components.GPUdInstance{
+				RootCtx: ctx,
+			}
+
+			comp, err := New(gpudInstance)
+			require.NoError(t, err)
+			defer comp.Close()
+
+			c := comp.(*component)
+
+			// Set up a fixed time for testing
+			fixedTime := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+			c.getTimeNowFunc = func() time.Time {
+				return fixedTime
+			}
+
+			// Set up mocks if needed
+			if tt.setupMocks != nil {
+				mockBucket := &mockEventBucket{}
+				tt.setupMocks(mockBucket)
+				// Add the Close expectation for the mock
+				mockBucket.On("Close").Return()
+				c.eventBucket = mockBucket
+
+				// Verify the interface implementation at compile time
+				var _ components.HealthSettable = c
+			}
+
+			// Call SetHealthy
+			err = c.SetHealthy()
+
+			// Check error
+			if tt.expectedError != nil {
+				assert.EqualError(t, err, tt.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Check mock expectations
+			if tt.checkResult != nil && c.eventBucket != nil {
+				tt.checkResult(t, c.eventBucket.(*mockEventBucket))
+
+				// Verify that Purge was called with the correct timestamp
+				mockBucket := c.eventBucket.(*mockEventBucket)
+				calls := mockBucket.Calls
+				for _, call := range calls {
+					if call.Method == "Purge" {
+						timestamp := call.Arguments[1].(int64)
+						assert.Equal(t, fixedTime.Unix(), timestamp)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestComponent_SetHealthy_ContextTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Create a test component
+	gpudInstance := &components.GPUdInstance{
+		RootCtx: ctx,
+	}
+
+	comp, err := New(gpudInstance)
+	require.NoError(t, err)
+	defer comp.Close()
+
+	c := comp.(*component)
+
+	// Set up mock that simulates a slow Purge operation
+	mockBucket := &mockEventBucket{}
+	mockBucket.On("Purge", mock.Anything, mock.AnythingOfType("int64")).Run(func(args mock.Arguments) {
+		ctx := args.Get(0).(context.Context)
+		// Wait for context to be canceled
+		<-ctx.Done()
+	}).Return(0, context.Canceled)
+	mockBucket.On("Close").Return()
+
+	c.eventBucket = mockBucket
+
+	// Cancel context before calling SetHealthy to ensure it handles context properly
+	cancel()
+
+	// Call SetHealthy - should handle canceled context gracefully
+	err = c.SetHealthy()
+	assert.Error(t, err)
+}
+
+func TestComponent_ImplementsHealthSettable(t *testing.T) {
+	// This test ensures that component implements the HealthSettable interface
+	ctx := context.Background()
+	gpudInstance := &components.GPUdInstance{
+		RootCtx: ctx,
+	}
+
+	comp, err := New(gpudInstance)
+	require.NoError(t, err)
+	defer comp.Close()
+
+	// This will fail to compile if component doesn't implement HealthSettable
+	var _ components.HealthSettable = comp.(*component)
+}


### PR DESCRIPTION
Now that we are using events to evaluate suggested
actions, we need to purge events on set healthy.

Signed-off-by: Gyuho Lee <gyuhol@nvidia.com>
