### PR TITLE
[LEP-1385] [LEP-1468] fix(session, disk): make NFS validation non-blocking

### DIFF
--- a/pkg/session/serve_update_config.go
+++ b/pkg/session/serve_update_config.go
@@ -56,17 +56,20 @@ func (s *Session) processUpdateConfig(configMap map[string]string, resp *Respons
 				return
 			}
 
-			// Create a context with timeout for validation
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			err := updateCfgs.Validate(ctx)
-			cancel()
-			if err != nil {
-				log.Logger.Warnw("invalid nfs config but proceeding with update to allow the user to fix the config", "error", err)
-			}
+			// if NFS validation takes too long, it can block other session requests
+			// so we set a timeout and do it async
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				err := updateCfgs.Validate(ctx)
+				cancel()
+				if err != nil {
+					log.Logger.Warnw("invalid nfs config but proceeding with update to allow the user to fix the config", "error", err)
+				}
 
-			if s.setDefaultNFSGroupConfigsFunc != nil {
-				s.setDefaultNFSGroupConfigsFunc(updateCfgs)
-			}
+				if s.setDefaultNFSGroupConfigsFunc != nil {
+					s.setDefaultNFSGroupConfigsFunc(updateCfgs)
+				}
+			}()
 
 		default:
 			log.Logger.Warnw("unsupported component for updateConfig", "component", componentName)


### PR DESCRIPTION
So that, it doesn't block other session requests.

Before

> {"level":"error","ts":"2025-08-04T05:48:06.922Z","msg":"session reader: reader channel full, dropping message"}
{"level":"error","ts":"2025-08-04T05:48:15.461Z","msg":"session reader: reader channel full, dropping message"}
{"level":"error","ts":"2025-08-04T05:48:15.463Z","msg":"session reader: reader channel full, dropping message"}
{"level":"error","ts":"2025-08-04T05:48:26.932Z","msg":"session reader: error decoding response: EOF"}

After

no such message

