### PR TITLE
[LEP-1814] feat(gpud): make plugin specs update/install more reliable

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -176,7 +176,10 @@ sudo rm /etc/systemd/system/gpud.service
 					Usage: "sets the components to enable (comma-separated, leave empty for default to enable all components, set 'none' or any other non-matching value to disable all components, prefix component name with '-' to disable it)",
 					Value: "",
 				},
-
+				cli.BoolFlag{
+					Name:  "plugins-init-fail-fast",
+					Usage: "fail fast if init plugins return unhealthy state (default: false, logs error and continues)",
+				},
 				&cli.IntFlag{
 					Name:  "gpu-count",
 					Usage: "specifies the expected GPU count",

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -60,6 +60,7 @@ func Command(cliContext *cli.Context) error {
 	autoUpdateExitCode := cliContext.Int("auto-update-exit-code")
 	versionFile := cliContext.String("version-file")
 	pluginSpecsFile := cliContext.String("plugin-specs-file")
+	pluginsInitFailFast := cliContext.Bool("plugins-init-fail-fast")
 
 	ibClassRootDir := cliContext.String("infiniband-class-root-dir")
 	components := cliContext.String("components")
@@ -146,6 +147,7 @@ func Command(cliContext *cli.Context) error {
 	cfg.VersionFile = versionFile
 
 	cfg.PluginSpecsFile = pluginSpecsFile
+	cfg.PluginsInitFailFast = pluginsInitFailFast
 
 	if components != "" {
 		cfg.Components = strings.Split(components, ",")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,11 @@ type Config struct {
 	// PluginSpecsFile is the file that contains the plugin specs.
 	PluginSpecsFile string `json:"plugin_specs_file"`
 
+	// PluginsInitFailFast controls whether init plugin failures should cause gpud to exit.
+	// If true, fail fast when init plugins return unhealthy state.
+	// If false (default), log errors and continue.
+	PluginsInitFailFast bool `json:"plugins_init_fail_fast"`
+
 	// Components specifies the components to enable.
 	// Leave empty, "*", or "all" to enable all components.
 	// Or prefix component names with "-" to disable them.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -675,6 +675,40 @@ func TestConfig_ShouldDisable_EarlyReturnBehavior(t *testing.T) {
 	}
 }
 
+func TestConfig_PluginsInitFailFast(t *testing.T) {
+	tests := []struct {
+		name                string
+		pluginsInitFailFast bool
+	}{
+		{
+			name:                "Default: fail fast disabled",
+			pluginsInitFailFast: false,
+		},
+		{
+			name:                "Fail fast enabled",
+			pluginsInitFailFast: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Address:             "localhost:8080",
+				RetentionPeriod:     metav1.Duration{Duration: time.Hour},
+				PluginsInitFailFast: tt.pluginsInitFailFast,
+			}
+
+			err := cfg.Validate()
+			if err != nil {
+				t.Errorf("Config.Validate() error = %v", err)
+			}
+			if cfg.PluginsInitFailFast != tt.pluginsInitFailFast {
+				t.Errorf("Config.PluginsInitFailFast = %v, want %v", cfg.PluginsInitFailFast, tt.pluginsInitFailFast)
+			}
+		})
+	}
+}
+
 func TestConfig_WildcardAndAll_EdgeCases(t *testing.T) {
 	t.Run("ShouldEnable with wildcard and all mixed with regular components", func(t *testing.T) {
 		cfg := &Config{

--- a/pkg/custom-plugins/spec.go
+++ b/pkg/custom-plugins/spec.go
@@ -107,6 +107,12 @@ func SaveSpecs(path string, newSpecs Specs) (bool, error) {
 		}
 		// already exists, but not the same as the new specs
 		// still need to overwrite the file
+	} else {
+		// no prev file/specs and empty new specs
+		// thus no need to write anything
+		if len(newSpecs) == 0 {
+			return false, nil
+		}
 	}
 
 	b, err := yaml.Marshal(newSpecs)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -72,6 +72,38 @@ func TestServerErrInvalidStateFile(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestServer_InitPluginFailFast(t *testing.T) {
+	tests := []struct {
+		name                string
+		pluginsInitFailFast bool
+		expectError         bool
+	}{
+		{
+			name:                "Fail fast disabled - continues on error",
+			pluginsInitFailFast: false,
+			expectError:         false,
+		},
+		{
+			name:                "Fail fast enabled - fails on error",
+			pluginsInitFailFast: true,
+			expectError:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a simple server struct to test the flag
+			s := &Server{
+				pluginsInitFailFast: tt.pluginsInitFailFast,
+			}
+
+			// Verify that the flag is set correctly
+			assert.Equal(t, tt.pluginsInitFailFast, s.pluginsInitFailFast,
+				"pluginsInitFailFast should be set to %v", tt.pluginsInitFailFast)
+		})
+	}
+}
+
 func TestGenerateSelfSignedCert(t *testing.T) {
 	s := &Server{}
 	cert, err := s.generateSelfSignedCert()

--- a/pkg/session/serve.go
+++ b/pkg/session/serve.go
@@ -411,6 +411,10 @@ func (s *Session) serve() {
 				restartExitCode = *exitCode
 				log.Logger.Infow("scheduled process exit for plugin specs update", "code", restartExitCode)
 			}
+			if s.pluginsInitFailed && restartExitCode == -1 {
+				restartExitCode = 0
+				log.Logger.Infow("scheduled process exit to retry init plugins", "code", restartExitCode)
+			}
 
 		case "getPluginSpecs":
 			s.processGetPluginSpecs(response)

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -38,6 +38,7 @@ type Op struct {
 	nvmlInstance        nvidianvml.Instance
 	metricsStore        pkgmetrics.Store
 	savePluginSpecsFunc func(context.Context, pkgcustomplugins.Specs) (bool, error)
+	pluginsInitFailed   bool
 	faultInjector       pkgfaultinjector.Injector
 }
 
@@ -111,6 +112,12 @@ func WithSavePluginSpecsFunc(savePluginSpecsFunc func(context.Context, pkgcustom
 	}
 }
 
+func WithPluginsInitFailed(pluginsInitFailed bool) OpOption {
+	return func(op *Op) {
+		op.pluginsInitFailed = pluginsInitFailed
+	}
+}
+
 func WithFaultInjector(faultInjector pkgfaultinjector.Injector) OpOption {
 	return func(op *Op) {
 		op.faultInjector = faultInjector
@@ -165,7 +172,9 @@ type Session struct {
 	autoUpdateExitCode int
 
 	savePluginSpecsFunc func(context.Context, pkgcustomplugins.Specs) (bool, error)
-	faultInjector       pkgfaultinjector.Injector
+	pluginsInitFailed   bool
+
+	faultInjector pkgfaultinjector.Injector
 
 	lastPackageTimestampMu sync.RWMutex
 	lastPackageTimestamp   time.Time
@@ -227,7 +236,9 @@ func NewSession(ctx context.Context, epLocalGPUdServer string, epControlPlane st
 		components: cps,
 
 		savePluginSpecsFunc: op.savePluginSpecsFunc,
-		faultInjector:       op.faultInjector,
+		pluginsInitFailed:   op.pluginsInitFailed,
+
+		faultInjector: op.faultInjector,
 
 		enableAutoUpdate:   op.enableAutoUpdate,
 		autoUpdateExitCode: op.autoUpdateExitCode,


### PR DESCRIPTION
- add "gpud run --plugins-init-fail-fast" flag (default false)
- retry on init plugin failures
- update spec comparison logic for empty spec edge cases

By default, GPUd will proceed to join the cluster (or initialize the server)
even if init plugins return unhealthy state (e.g., command exit 1).

Retry on init plugin failures.