### PR TITLE
[LEP-510] fix(infiniband): remove hardware inspection for port threshold mismatches

### DIFF
--- a/components/accelerator/nvidia/infiniband/evaluate_threshold.go
+++ b/components/accelerator/nvidia/infiniband/evaluate_threshold.go
@@ -42,13 +42,14 @@ func evaluateHealthStateWithThresholds(thresholds infiniband.ExpectedPortStates,
 
 	unhealthy, err := infiniband.EvaluatePortsAndRate(ibports, atLeastPorts, atLeastRate)
 	if err != nil {
+		cr.unhealthyIBPorts = unhealthy
 		cr.health = apiv1.HealthStateTypeUnhealthy
-		cr.suggestedActions = &apiv1.SuggestedActions{
-			RepairActions: []apiv1.RepairActionType{apiv1.RepairActionTypeHardwareInspection},
-		}
 		cr.reason = err.Error()
 
-		cr.unhealthyIBPorts = unhealthy
+		// NOTE: do not set suggested actions to "apiv1.RepairActionTypeHardwareInspection" here
+		// since this port mismatch often self-recovers
+		// "apiv1.RepairActionTypeHardwareInspection" is reserved for irrecoverable hardware issues
+
 		return
 	}
 


### PR DESCRIPTION
HW Inspection is reserved for irrecoverable hardware issues,
while this port count mismatch often self-recovers.

Signed-off-by: Gyuho Lee <gyuhol@nvidia.com>
