### PR TITLE
Fix container deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
 # This Dockerfile is designed for multi-architecture builds using `docker buildx`.
-FROM ubuntu:24.04 AS builder
+
+# Define build arguments for OS, version, and CUDA.
+# Example: --build-arg OS_NAME=ubuntu --build-arg OS_VERSION=24.04
+ARG OS_NAME="ubuntu"
+ARG OS_VERSION="22.04"
+ARG CUDA_VERSION="12.4.1"
+
+FROM ${OS_NAME}:${OS_VERSION} AS builder
 
 # GPUD_VERSION is a mandatory build argument for the GPUd version to install.
 # Example: --build-arg GPUD_VERSION=v0.6.0
 ARG GPUD_VERSION
 # TARGETARCH is an automatic build argument provided by buildx (e.g., amd64, arm64).
 ARG TARGETARCH
+# Re-declare args to make them available inside this build stage.
+ARG OS_NAME
+ARG OS_VERSION
 
 RUN if [ -z "$GPUD_VERSION" ]; then \
         echo "\n\nERROR: The build argument 'GPUD_VERSION' is required.\n" >&2; \
@@ -18,18 +28,22 @@ RUN apt-get update && \
       ca-certificates \
       curl && \
     rm -rf /var/lib/apt/lists/* && \
-    URL="https://github.com/leptonai/gpud/releases/download/${GPUD_VERSION}/gpud_${GPUD_VERSION}_linux_${TARGETARCH}_ubuntu24.04.tgz" && \
+    URL="https://github.com/leptonai/gpud/releases/download/${GPUD_VERSION}/gpud_${GPUD_VERSION}_linux_${TARGETARCH}_${OS_NAME}${OS_VERSION}.tgz" && \
     curl -L "${URL}" | tar -xz -C /usr/local/bin/ gpud
 
-FROM debian:bookworm-slim
+# Use the NVIDIA CUDA runtime image as the final base. This provides the necessary
+# CUDA libraries to interact with the GPU driver.
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-${OS_NAME}${OS_VERSION}
 
-ARG GPUD_VERSION
-ARG TARGETARCH
-
+# Install required runtime dependencies not included in the NVIDIA CUDA runtime image.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      ca-certificates \
-      pciutils && \
+      pciutils \
+      dmidecode \
+      util-linux \
+      kmod \
+      docker.io \
+      containerd && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local/bin/gpud /usr/local/bin/gpud

--- a/README.md
+++ b/README.md
@@ -21,88 +21,88 @@ Most importantly, GPUd operates with minimal CPU and memory overhead in a non-cr
 
 ## Get Started
 
+The fastest way to see `gpud` in action is to watch our 40-second demo video below. For more detailed guides, see our [Tutorials page](./docs/TUTORIALS.md).
+
 <a href="https://www.youtube.com/watch?v=sq-7_Zrv7-8" target="_blank">
 <img src="https://i3.ytimg.com/vi/sq-7_Zrv7-8/maxresdefault.jpg" alt="gpud-2025-06-01-01-install-and-scan" />
 </a>
 
-See [Tutorials](./docs/TUTORIALS.md) for more.
-
 ### Installation
 
-To install from the official release on Linux and amd64 (x86_64) machine:
+To install from the official release on Linux amd64 (x86_64) machine:
 
 ```bash
 curl -fsSL https://pkg.gpud.dev/install.sh | sh
 ```
 
-To specify a version
+To specify a version:
 
 ```bash
 curl -fsSL https://pkg.gpud.dev/install.sh | sh -s v0.6.0
 ```
 
-Note that the install script doesn't support other architectures (arm64) and OSes (macos), yet.
+Note that the install script does not currenlty support other architectures (e.g., arm64) and OSes (e.g., macOS).
 
-### Run GPUd with Lepton Platform
+---
 
-Sign up at [lepton.ai](https://www.lepton.ai/) and get the workspace token from the ["Settings" and "Tokens" page](https://dashboard.lepton.ai/workspace-redirect/settings/api-tokens):
+### Run GPUd on a Host
 
-<img src="./assets/gpud-lepton.ai-machines-settings.png" width="80%" alt="GPUd lepton.ai machines settings">
+This section covers running `gpud` directly on a host machine.
 
-Copy the token and pass it to the `gpud up --token` flag:
+#### With `systemd` (Recommended for Linux)
 
-```bash
-sudo gpud up --token <LEPTON_AI_TOKEN>
-```
-
-You can go to the [dashboard](https://dashboard.lepton.ai/workspace-redirect/machines/self-managed-nodes) to check the self-managed machine status.
-
-### Run GPUd standalone
-
-For linux, run the following command to start the service:
+**Start the service:**
 
 ```bash
-sudo gpud up
+sudo gpud up [--token <LEPTON_AI_TOKEN>]
 ```
 
-You can also start with the standalone mode and later switch to the managed option:
+> **Note:** The optional `--token` connects `gpud` to the Lepton Platform. You can get a token from the [Settings > Tokens page](https://dashboard.lepton.ai/workspace-redirect/settings/api-tokens) on your dashboard. You can then view your machine's status on the [self-managed nodes dashboard](https://dashboard.lepton.ai/workspace-redirect/machines/self-managed-nodes).
 
-```bash
-# when the token is ready, run the following command
-sudo gpud login --token <LEPTON_AI_TOKEN>
-
-# to logout
-sudo gpud logout
-
-# to logout and reset the state file
-sudo gpud logout --reset-state
-```
-
-#### Run GPUd with Kubernetes
-
-The recommended way to deploy GPUd on Kubernetes is with our official [Helm chart](./deployments/helm/gpud/README.md).
-
-#### If your system doesn't have systemd
-
-To run on Mac (without systemd):
-
-```bash
-gpud run
-```
-
-Or
-
-```bash
-nohup sudo /usr/local/bin run &>> <your log file path> &
-```
-
-### Stop and uninstall
+**Stop the service:**
 
 ```bash
 sudo gpud down
-sudo rm /usr/local/bin
+```
+
+**Uninstall:**
+
+```bash
+sudo rm /usr/local/bin/gpud
 sudo rm /etc/systemd/system/gpud.service
 ```
+
+#### Without `systemd` (e.g., macOS)
+
+**Run in the foreground:**
+
+```bash
+gpud run [--token <LEPTON_AI_TOKEN>]
+```
+
+**Run in the background:**
+
+```bash
+nohup sudo /usr/local/bin/gpud run [--token <LEPTON_AI_TOKEN>] &>> <your_log_file_path> &
+```
+
+**Uninstall:**
+
+```bash
+sudo rm /usr/local/bin/gpud
+```
+
+---
+
+### Run GPUd with Kubernetes
+
+The recommended way to deploy GPUd on Kubernetes is with our official [Helm chart](./deployments/helm/gpud/README.md).
+
+### Build with Docker
+
+A Dockerfile is provided to build a container image from source. For complete instructions, please see our [Docker guide in CONTRIBUTING.md](CONTRIBUTING.md#building-with-docker).
+
+---
 
 ## Key Features
 
@@ -129,7 +129,7 @@ If you opt-in to log in to the Lepton AI platform, to assist you with more helpf
 
 GPUd is still in active development, regularly releasing new versions for critical bug fixes and new features. We strongly recommend always being on the latest version of GPUd.
 
-When GPUd is registered with the Lepton platform, the platform will automatically update GPUd to the latest version. To disable such auto-updates, if GPUd is run with systemd (default option for the `gpud up` command), you may add the flag `FLAGS="--enable-auto-update=false"` to the `/etc/default/gpud` environment file and restart the service.
+When GPUd is registered with the Lepton platform, the platform will automatically update GPUd to the latest version. To disable such auto-updates, if GPUd is run with `systemd` (default option for the `gpud up` command), you may add the flag `FLAGS="--enable-auto-update=false"` to the `/etc/default/gpud` environment file and restart the service.
 
 ## Learn more
 

--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -45,6 +45,8 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
 
       # --- Scheduling ---
+      # Mark this pod as a critical add-on to prevent eviction.
+      priorityClassName: "system-node-critical"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -59,9 +61,28 @@ spec:
       {{- end }}
 
       # --- Storage ---
-      {{- with .Values.volumes }}
       volumes:
-        {{- toYaml . | nindent 8 }}
+        - name: host-dev
+          hostPath:
+            path: /dev
+        - name: lib-gpud
+          hostPath:
+            path: /var/lib/gpud
+        - name: host-machine-id
+          hostPath:
+            path: /etc/machine-id
+            type: FileOrCreate
+        - name: host-dev-mem
+          hostPath:
+            path: /dev/mem
+            type: CharDevice
+        - name: host-kubelet-vol
+          hostPath:
+            path: /var/lib/kubelet
+            type: DirectoryOrCreate
+
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName }}
       {{- end }}
 
       # --- Containers ---
@@ -93,7 +114,17 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
 
-          {{- with .Values.volumeMounts }}
           volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            - name: host-dev
+              mountPath: /dev
+            - name: lib-gpud
+              mountPath: /var/lib/gpud
+            - name: host-machine-id
+              mountPath: /etc/machine-id
+              readOnly: true
+            - name: host-dev-mem
+              mountPath: /dev/mem
+              readOnly: true
+            - name: host-kubelet-vol
+              mountPath: /var/lib/kubelet
+              readOnly: true

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -22,6 +22,7 @@ gpud:
     - "--endpoint=gpud-manager-prod01.dgxc-lepton.nvidia.com"
     - "--enable-auto-update=false"
     - "--auto-update-exit-code=0"
+    # - "--gpu-count=8"
   # Telemetry and usage data collection settings.
   telemetry:
     # Set to false to disable collection of anonymous usage data.
@@ -55,7 +56,8 @@ updateStrategy:
 # Container-level security context.
 securityContext:
   # WARNING: This chart requires privileged access to the host node.
-  privileged: false
+  privileged: true
+  runAsUser: 0
 
 # Pod-level security context.
 podSecurityContext: {}
@@ -83,10 +85,8 @@ serviceAccount:
   # The name of the service account to use. If not set and create is true, a name is generated.
   name: ""
 
-# Additional volumes for the pod, e.g., for custom configuration files.
-volumes: []
-# Additional volume mounts for the container.
-volumeMounts: []
+# The name of the runtime class to use for the pod (e.g., "nvidia").
+runtimeClassName: null
 
 # Node selector, tolerations, and affinity for pod scheduling.
 nodeSelector: {}


### PR DESCRIPTION
### Changes

**Dockerfile:**
- use CUDA runtime image as Docker base to include the necessary CUDA libraries to interact with the GPU driver
- expose additional build arguments with defaults (OS_NAME=ubuntu, OS_VERSION=22.04, CUDA_VERSION=12.4.1) 
- install missing runtime dependencies (dmidecode, util-linux, kmod, docker, containerd)
- update documentation

**Helm:**
- mark the GPUd pod as a critical add-on to prevent eviction
- set a privileged security context by default
- mount necessary volumes
- add an optional runtimeClassName for better integration with GPU nodes