### PR TITLE
[LEP-1874] [LEP-2000] feat(components, disk): retain/lookback events 2 weeks

### DIFF
--- a/components/disk/component.go
+++ b/components/disk/component.go
@@ -62,7 +62,7 @@ type component struct {
 	kmsgSyncer       *kmsg.Syncer
 
 	// lookbackPeriod defines how far back to query historical reboot and disk failure events
-	// when evaluating suggested repair actions. Default is 3 days.
+	// when evaluating suggested repair actions. Default is 14 days.
 	lookbackPeriod time.Duration
 
 	lastMu          sync.RWMutex
@@ -71,7 +71,7 @@ type component struct {
 
 const (
 	defaultRetryInterval  = 5 * time.Second
-	defaultLookbackPeriod = 3 * 24 * time.Hour // 3 days
+	defaultLookbackPeriod = 14 * 24 * time.Hour // 14 days
 )
 
 func New(gpudInstance *components.GPUdInstance) (components.Component, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -129,7 +129,7 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *lepconfig.Con
 	}
 
 	// by default, we only retain past 24 hours of events
-	eventStore, err := eventstore.New(dbRW, dbRO, 24*time.Hour)
+	eventStore, err := eventstore.New(dbRW, dbRO, 14*24*time.Hour)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open events database: %w", err)
 	}


### PR DESCRIPTION
Signed-off-by: Gyuho Lee <gyuhol@nvidia.com>
