### PR TITLE
[LEP-2340] feat(nvidia/gsp-firmware-mode): fallback using kernel config file

### DIFF
--- a/pkg/nvidia-query/nvml/gsp_firmware.go
+++ b/pkg/nvidia-query/nvml/gsp_firmware.go
@@ -1,9 +1,13 @@
 package nvml
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/leptonai/gpud/pkg/log"
 	"github.com/leptonai/gpud/pkg/nvidia-query/nvml/device"
 )
 
@@ -40,4 +44,78 @@ func GetGSPFirmwareMode(uuid string, dev device.Device) (GSPFirmwareMode, error)
 	mode.Supported = supported
 
 	return mode, nil
+}
+
+// ValidateGSPFirmwareModeWithKernelConfig validates the GSP firmware mode against kernel module configuration.
+// This is necessary because NVML may report GSP as enabled even when it's disabled at the kernel level.
+//
+// Example of the discrepancy:
+// $ cat /etc/modprobe.d/nvidia.conf
+// options nvidia NVreg_EnableGpuFirmware=0
+//
+// $ nvidia-smi -q | grep "GSP"
+// GSP Firmware Version : N/A
+//
+// In this case, even though the kernel module has GSP disabled (NVreg_EnableGpuFirmware=0),
+// NVML might still report GSP as enabled. This function checks the kernel configuration
+// and overrides the NVML result when the kernel explicitly disables GSP.
+//
+// ref. https://docs.nvidia.com/vgpu/latest/grid-vgpu-user-guide/index.html#disabling-gsp
+func ValidateGSPFirmwareModeWithKernelConfig(mode GSPFirmwareMode, kernelConfigPath string) GSPFirmwareMode {
+	// If NVML already says GSP is disabled, no need to check further
+	if !mode.Enabled {
+		return mode
+	}
+
+	f, err := os.Open(kernelConfigPath)
+	if err != nil {
+		// If we can't read the config file, trust NVML but log it
+		if !os.IsNotExist(err) {
+			log.Logger.Warnw("failed to open kernel module config file -- reverting back to NVML result",
+				"path", kernelConfigPath,
+				"error", err,
+				"nvml_gsp_enabled", mode.Enabled,
+			)
+		}
+		return mode
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip comments and empty lines
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(line, "options nvidia") || strings.HasPrefix(line, "options	nvidia") {
+			if strings.Contains(line, "NVreg_EnableGpuFirmware=0") {
+				// kernel has GSP explicitly disabled, override NVML result
+				log.Logger.Warnw("NVML reports GSP firmware as enabled but kernel module config has it disabled, overriding to disabled",
+					"uuid", mode.UUID,
+					"bus_id", mode.BusID,
+					"kernel_config_path", kernelConfigPath,
+					"kernel_config_line", line,
+					"nvml_gsp_enabled", true,
+					"corrected_gsp_enabled", false,
+				)
+				mode.Enabled = false
+				return mode
+			}
+			// If NVreg_EnableGpuFirmware=1 or not present, trust NVML
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Logger.Warnw("error reading kernel module config file, trusting NVML result",
+			"path", kernelConfigPath,
+			"error", err,
+			"nvml_gsp_enabled", mode.Enabled,
+		)
+	}
+
+	return mode
 }

--- a/pkg/nvidia-query/nvml/gsp_firmware_test.go
+++ b/pkg/nvidia-query/nvml/gsp_firmware_test.go
@@ -2,10 +2,13 @@ package nvml
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/leptonai/gpud/pkg/nvidia-query/nvml/testutil"
 )
@@ -102,4 +105,225 @@ func TestGetGSPFirmwareMode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateGSPFirmwareModeWithKernelConfig(t *testing.T) {
+	testCases := []struct {
+		name                string
+		inputMode           GSPFirmwareMode
+		kernelConfigContent string
+		expectedMode        GSPFirmwareMode
+		createFile          bool
+	}{
+		{
+			name: "NVML enabled but kernel config disabled - should override to disabled",
+			inputMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   true,
+				Supported: true,
+			},
+			kernelConfigContent: "options nvidia NVreg_EnableGpuFirmware=0\n",
+			expectedMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   false, // Should be overridden to false
+				Supported: true,
+			},
+			createFile: true,
+		},
+		{
+			name: "NVML enabled and kernel config enabled - should remain enabled",
+			inputMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   true,
+				Supported: true,
+			},
+			kernelConfigContent: "options nvidia NVreg_EnableGpuFirmware=1\n",
+			expectedMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   true, // Should remain true
+				Supported: true,
+			},
+			createFile: true,
+		},
+		{
+			name: "NVML disabled - no need to check kernel config",
+			inputMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   false,
+				Supported: true,
+			},
+			kernelConfigContent: "options nvidia NVreg_EnableGpuFirmware=1\n",
+			expectedMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   false, // Should remain false (NVML takes precedence when disabled)
+				Supported: true,
+			},
+			createFile: true,
+		},
+		{
+			name: "Kernel config with tabs instead of spaces",
+			inputMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   true,
+				Supported: true,
+			},
+			kernelConfigContent: "options	nvidia	NVreg_EnableGpuFirmware=0\n",
+			expectedMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   false, // Should be overridden to false
+				Supported: true,
+			},
+			createFile: true,
+		},
+		{
+			name: "Kernel config with multiple parameters",
+			inputMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   true,
+				Supported: true,
+			},
+			kernelConfigContent: "options nvidia NVreg_EnableGpuFirmware=0 NVreg_EnablePCIeGen3=1\n",
+			expectedMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   false, // Should be overridden to false
+				Supported: true,
+			},
+			createFile: true,
+		},
+		{
+			name: "Kernel config with comments",
+			inputMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   true,
+				Supported: true,
+			},
+			kernelConfigContent: "# This is a comment\noptions nvidia NVreg_EnableGpuFirmware=0\n# Another comment\n",
+			expectedMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   false, // Should be overridden to false
+				Supported: true,
+			},
+			createFile: true,
+		},
+		{
+			name: "Kernel config file doesn't exist - trust NVML",
+			inputMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   true,
+				Supported: true,
+			},
+			kernelConfigContent: "",
+			expectedMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   true, // Should remain true (trust NVML)
+				Supported: true,
+			},
+			createFile: false,
+		},
+		{
+			name: "Kernel config without GSP parameter - trust NVML",
+			inputMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   true,
+				Supported: true,
+			},
+			kernelConfigContent: "options nvidia NVreg_EnablePCIeGen3=1\n",
+			expectedMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   true, // Should remain true (no GSP parameter)
+				Supported: true,
+			},
+			createFile: true,
+		},
+		{
+			name: "Empty kernel config file - trust NVML",
+			inputMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   true,
+				Supported: true,
+			},
+			kernelConfigContent: "",
+			expectedMode: GSPFirmwareMode{
+				UUID:      "gpu-uuid-123",
+				BusID:     "0000:01:00.0",
+				Enabled:   true, // Should remain true (empty file)
+				Supported: true,
+			},
+			createFile: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a temporary directory for the test
+			tmpDir, err := os.MkdirTemp("", "gsp-test-*")
+			require.NoError(t, err)
+			defer os.RemoveAll(tmpDir)
+
+			configPath := filepath.Join(tmpDir, "nvidia.conf")
+
+			if tc.createFile {
+				// Create the kernel config file with test content
+				err = os.WriteFile(configPath, []byte(tc.kernelConfigContent), 0644)
+				require.NoError(t, err)
+			}
+
+			// Call the validation function
+			result := ValidateGSPFirmwareModeWithKernelConfig(tc.inputMode, configPath)
+
+			// Check the result
+			assert.Equal(t, tc.expectedMode, result)
+		})
+	}
+}
+
+func TestValidateGSPFirmwareModeWithKernelConfig_RealWorldExample(t *testing.T) {
+	// Test with a real-world example configuration that shows the problem
+	tmpDir, err := os.MkdirTemp("", "gsp-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	configPath := filepath.Join(tmpDir, "nvidia.conf")
+
+	// Create a config file that matches the user's reported configuration
+	configContent := `# NVIDIA kernel module configuration
+# Disable GSP firmware to avoid XID errors
+options nvidia NVreg_EnableGpuFirmware=0
+`
+	err = os.WriteFile(configPath, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	// Simulate NVML reporting GSP as enabled (the problem scenario)
+	inputMode := GSPFirmwareMode{
+		UUID:      "GPU-12345678-1234-1234-1234-123456789012",
+		BusID:     "0000:3b:00.0",
+		Enabled:   true, // NVML says enabled
+		Supported: true,
+	}
+
+	// Validate against kernel config
+	result := ValidateGSPFirmwareModeWithKernelConfig(inputMode, configPath)
+
+	// Should be corrected to disabled based on kernel config
+	assert.False(t, result.Enabled, "GSP should be disabled based on kernel config")
+	assert.True(t, result.Supported, "GSP support status should not change")
+	assert.Equal(t, inputMode.UUID, result.UUID, "UUID should not change")
+	assert.Equal(t, inputMode.BusID, result.BusID, "BusID should not change")
 }


### PR DESCRIPTION
NVML may report GSP as enabled even when it's disabled at the kernel level.
Fallback mechanism to validate the GSP firmware mode against kernel module configuration.

```
$ cat /etc/modprobe.d/nvidia.conf
options nvidia NVreg_EnableGpuFirmware=0

$ nvidia-smi -q | grep "GSP"
    GSP Firmware Version                  : N/A
```

Signed-off-by: Gyuho Lee <gyuhol@nvidia.com>
