### PR TITLE
fix(nvidia/memory): handle getMemory "Not Supported" error gracefully

### DIFF
--- a/components/accelerator/nvidia/memory/component.go
+++ b/components/accelerator/nvidia/memory/component.go
@@ -146,8 +146,11 @@ func (c *component) Check() components.CheckResult {
 		metricUsedBytes.With(prometheus.Labels{"uuid": uuid}).Set(float64(mem.UsedBytes))
 		metricFreeBytes.With(prometheus.Labels{"uuid": uuid}).Set(float64(mem.FreeBytes))
 
+		log.Logger.Infow("memory", "uuid", uuid, "total", mem.TotalBytes, "reserved", mem.ReservedBytes, "used", mem.UsedBytes, "free", mem.FreeBytes, "used_percent", mem.UsedPercent)
 		usedPct, err := mem.GetUsedPercent()
 		if err != nil {
+			log.Logger.Warnw("error getting used percent", "error", err)
+
 			cr.err = err
 			cr.health = apiv1.HealthStateTypeUnhealthy
 			cr.reason = "error getting used percent"

--- a/pkg/nvidia-query/nvml/error.go
+++ b/pkg/nvidia-query/nvml/error.go
@@ -31,6 +31,7 @@ func IsNotSupportError(ret nvml.Return) bool {
 		return true
 	}
 
+	// e.g., "Not Supported"
 	e := normalizeNVMLReturnString(ret)
 	return strings.Contains(e, "not supported")
 }

--- a/pkg/nvidia-query/nvml/memory.go
+++ b/pkg/nvidia-query/nvml/memory.go
@@ -38,6 +38,9 @@ type Memory struct {
 }
 
 func (mem Memory) GetUsedPercent() (float64, error) {
+	if mem.UsedPercent == "" {
+		return 0.0, nil
+	}
 	return strconv.ParseFloat(mem.UsedPercent, 64)
 }
 
@@ -68,6 +71,7 @@ func GetMemory(uuid string, dev device.Device) (Memory, error) {
 			log.Logger.Warnw("failed to get device memory info v1", "error", nvml.ErrorString(retV1))
 
 			if IsNotSupportError(retV1) {
+				// e.g., "NVIDIA-GB10" NVIDIA RTX blackwell
 				log.Logger.Warnw("device memory info v1 is not supported", "error", nvml.ErrorString(retV1))
 
 				mem.Supported = false

--- a/pkg/nvidia-query/nvml/memory_test.go
+++ b/pkg/nvidia-query/nvml/memory_test.go
@@ -188,6 +188,14 @@ func TestMemoryGetUsedPercent(t *testing.T) {
 			},
 			expectedError: true,
 		},
+		{
+			name: "empty percent",
+			memory: Memory{
+				UsedPercent: "",
+			},
+			expectedValue: 0.0,
+			expectedError: false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fix

```
{"level":"info","ts":"2025-09-24T12:26:21.523Z","caller":"memory/component.go:105","msg":"checking nvidia gpu memory"}
{"level":"warn","ts":"2025-09-24T12:26:21.523Z","caller":"nvml/memory.go:59","msg":"failed to get device memory info v2, falling back to v1","error":"Not Supported"}
{"level":"warn","ts":"2025-09-24T12:26:21.523Z","caller":"nvml/memory.go:68","msg":"failed to get device memory info v1","error":"Not Supported"}
{"level":"warn","ts":"2025-09-24T12:26:21.523Z","caller":"nvml/memory.go:71","msg":"device memory info v1 is not supported","error":"Not Supported"}
{"level":"info","ts":"2025-09-24T12:26:21.523Z","caller":"memory/component.go:149","msg":"memory","uuid":"GPU-2dee1e25-b3b5-007e-2b55-79f2d0f2ebe5","total":0,"reserved":0,"used":0,"free":0,"used_percent":""}
{"level":"warn","ts":"2025-09-24T12:26:21.523Z","caller":"memory/component.go:152","msg":"error getting used percent","error":"strconv.ParseFloat: parsing \"\": invalid syntax"}
{"level":"warn","ts":"2025-09-24T12:26:21.523Z","caller":"memory/component.go:157","msg":"error getting used percent","error":"strconv.ParseFloat: parsing \"\": invalid syntax"}
✘ error getting used percent
+------------------------------------------+-------+----------+------+------+--------+
|                 GPU UUID                 | TOTAL | RESERVED | USED | FREE | USED % |
+------------------------------------------+-------+----------+------+------+--------+
| GPU-2dee1e25-b3b5-007e-2b55-79f2d0f2ebe5 |       |          |      |      |        |
+------------------------------------------+-------+----------+------+------+--------+
```