### PR TITLE
fix(set-healthy): allow to provide empty components list, fix incorrect response struct in the client

### DIFF
--- a/client/v1/v1_set_healthy.go
+++ b/client/v1/v1_set_healthy.go
@@ -14,15 +14,15 @@ import (
 )
 
 // SetHealthyComponents sets specified components to healthy state
-func SetHealthyComponents(ctx context.Context, addr string, components []string, opts ...OpOption) error {
+func SetHealthyComponents(ctx context.Context, addr string, components []string, opts ...OpOption) ([]string, error) {
 	op := &Op{}
 	if err := op.applyOpts(opts); err != nil {
-		return err
+		return nil, err
 	}
 
 	reqURL, err := url.Parse(fmt.Sprintf("%s/v1/health-states/set-healthy", addr))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Add components to query parameters if specified
@@ -34,7 +34,7 @@ func SetHealthyComponents(ctx context.Context, addr string, components []string,
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL.String(), nil)
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	if op.requestContentType != "" {
@@ -46,30 +46,30 @@ func SetHealthyComponents(ctx context.Context, addr string, components []string,
 
 	resp, err := createDefaultHTTPClient().Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
 	}
 
 	var response struct {
-		Success []string          `json:"success,omitempty"`
+		Success []string          `json:"successful,omitempty"`
 		Failed  map[string]string `json:"failed,omitempty"`
 		Message string            `json:"message,omitempty"`
-		Code    string            `json:"code,omitempty"`
+		Code    int               `json:"code,omitempty"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		log.Logger.Warnf("failed to decode response: %v", err)
 		// Not a critical error if we got 200 OK
-		return nil
+		return nil, nil
 	}
 
 	if len(response.Failed) > 0 {
-		return fmt.Errorf("some components failed to set healthy: %v", response.Failed)
+		return nil, fmt.Errorf("some components failed to set healthy: %v", response.Failed)
 	}
 
-	return nil
+	return response.Success, nil
 }

--- a/client/v1/v1_set_healthy_test.go
+++ b/client/v1/v1_set_healthy_test.go
@@ -230,7 +230,7 @@ func TestSetHealthyComponents(t *testing.T) {
 			defer cancel()
 
 			// Call the function
-			err := SetHealthyComponents(ctx, server.URL, tt.components, opts...)
+			_, err := SetHealthyComponents(ctx, server.URL, tt.components, opts...)
 
 			// Check error
 			if tt.expectedError != "" {
@@ -246,7 +246,7 @@ func TestSetHealthyComponents(t *testing.T) {
 func TestSetHealthyComponents_InvalidURL(t *testing.T) {
 	// Test with invalid URL
 	ctx := context.Background()
-	err := SetHealthyComponents(ctx, "://invalid-url", []string{"disk"})
+	_, err := SetHealthyComponents(ctx, "://invalid-url", []string{"disk"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parse")
 }
@@ -263,7 +263,7 @@ func TestSetHealthyComponents_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := SetHealthyComponents(ctx, server.URL, []string{"disk"})
+	_, err := SetHealthyComponents(ctx, server.URL, []string{"disk"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "context canceled")
 }
@@ -273,7 +273,7 @@ func TestSetHealthyComponents_NetworkError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	err := SetHealthyComponents(ctx, "http://localhost:99999", []string{"disk"})
+	_, err := SetHealthyComponents(ctx, "http://localhost:99999", []string{"disk"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to make request")
 }
@@ -297,7 +297,7 @@ func TestSetHealthyComponents_ApplyOptsError(t *testing.T) {
 	// In a real scenario, you might want to refactor applyOpts to validate options.
 
 	ctx := context.Background()
-	err := SetHealthyComponents(ctx, server.URL, []string{"disk"}, customOpt)
+	_, err := SetHealthyComponents(ctx, server.URL, []string{"disk"}, customOpt)
 	// Currently this won't error because applyOpts doesn't validate
 	require.NoError(t, err)
 }

--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -600,7 +600,7 @@ sudo rm /etc/systemd/system/gpud.service
 			Name:      "set-healthy",
 			Aliases:   []string{"set-health"},
 			Usage:     "set the healthy state of components",
-			UsageText: "gpud set-healthy <components> [options]\n\n   <components>: comma-separated list of component names to set healthy",
+			UsageText: "gpud set-healthy <components> [options]\n\n   <components>: comma-separated list of component names to set healthy (if empty, sets all components).",
 			Action:    cmdsethealthy.CreateCommand(),
 			Flags: []cli.Flag{
 				&cli.StringFlag{

--- a/cmd/gpud/set-healthy/command.go
+++ b/cmd/gpud/set-healthy/command.go
@@ -45,24 +45,17 @@ func CreateCommand() func(*cli.Context) error {
 			}
 		}
 
-		// Skip if no components specified
-		if len(components) == 0 {
-			log.Logger.Debugw("no components specified, skipping set-healthy")
-			fmt.Printf("no components specified, skipping operation\n")
-			return nil
-		}
-
 		// Create a context with timeout
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
 		// Call the API to set components healthy
-		err = clientv1.SetHealthyComponents(ctx, serverAddr, components)
+		res, err := clientv1.SetHealthyComponents(ctx, serverAddr, components)
 		if err != nil {
 			return fmt.Errorf("failed to set components healthy: %w", err)
 		}
 
-		fmt.Printf("successfully set components to healthy: %s\n", strings.Join(components, ", "))
+		fmt.Printf("successfully set components to healthy: %s\n", strings.Join(res, ", "))
 		return nil
 	}
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -400,7 +400,7 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 			Expect(respBody.Failed).ToNot(HaveKey("disk"), "expected disk to not be in failed map")
 		})
 
-		It("returns error when components parameter is empty", func() {
+		It("allows empty components parameter", func() {
 			req, err := http.NewRequest(
 				"POST",
 				fmt.Sprintf("https://%s/v1/health-states/set-healthy", ep),
@@ -413,21 +413,21 @@ var _ = Describe("[GPUD E2E]", Ordered, func() {
 			resp, err := client.Do(req)
 			Expect(err).NotTo(HaveOccurred(), "failed to make request")
 			defer resp.Body.Close()
-			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
 			body, err := io.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred(), "failed to read response body")
 			GinkgoLogr.Info("/v1/health-states/set-healthy response for empty components", "response", string(body))
 
 			var respBody struct {
-				Code    interface{} `json:"code"`
-				Message string      `json:"message"`
+				Code       int               `json:"code"`
+				Message    string            `json:"message"`
+				Successful []string          `json:"successful"`
+				Failed     map[string]string `json:"failed"`
 			}
 
 			err = json.Unmarshal(body, &respBody)
 			Expect(err).NotTo(HaveOccurred(), "failed to unmarshal response body")
-			// The code field contains errdefs.ErrInvalidArgument which marshals to an empty object
-			Expect(respBody.Message).To(Equal("components parameter is required"))
 		})
 	})
 


### PR DESCRIPTION
**Summary of Changes**
These modifications fix the set-healthy API behavior to allow setting all health-settable components to healthy when no specific components are specified:

**Key Changes:**
1. Server Handler ( pkg/server/handlers_components.go)
- Removed requirement for  components parameter - now optional instead of mandatory
- When no components specified, only reports failures for components that were explicitly requested (avoids noise from non-health-settable components)
2. Client API ( client/v1/v1_set_healthy.go)
- Returns list of successfully set components instead of just error/nil
- Fixed JSON field name: success → successful (matches server response)
- Fixed type: Code field changed from  string to int
- Better visibility into which components were actually set to healthy
3. CLI Command ( cmd/gpud/set-healthy/command.go)
- Removed empty components check - allows calling without specifying components
- Displays actual successful components from server response instead of input list
4. Tests Updated
- E2E test now expects StatusOK instead of StatusBadRequest for empty components
- Client tests updated to handle new return signature