### PR TITLE
chore: support gpud-gateway

### DIFF
--- a/pkg/session/session_keepalive.go
+++ b/pkg/session/session_keepalive.go
@@ -65,8 +65,8 @@ func (s *Session) keepAlive() {
 			// DO NOT CHANGE OR REMOVE THIS COOKIE JAR, DEPEND ON IT FOR STICKY SESSION
 			jar, _ := cookiejar.New(nil)
 
-			log.Logger.Infow("session keep alive: checking server health")
 			// DO NOT CHANGE OR REMOVE THIS SERVER HEALTH CHECK, DEPEND ON IT FOR STICKY SESSION
+			// TODO: we can remove it once we migrate to gpud-gateway
 			if err := s.checkServerHealthFunc(ctx, jar); err != nil {
 				log.Logger.Errorf("session keep alive: error checking server health: %v", err)
 				cancel()


### PR DESCRIPTION
1. If the control plane is gpud-gateway, there is no need to call the healthz endpoint, as gpud-gateway supports a cookie-less sticky session mechanism.
2. Add bearer token when sending login request