### PR TITLE
[LEP-2644] fix incorrect parsing of containerd version string

### DIFF
--- a/pkg/containerd/cri.go
+++ b/pkg/containerd/cri.go
@@ -242,8 +242,10 @@ func GetVersionFromCli(ctx context.Context) (string, error) {
 	return parseContainerdVersion(string(out))
 }
 
-// only matches "1.7.25" when "containerd containerd.io 1.7.25 bcc810d6b9066471b0b6fa75f557a15a1cbf31bb"
-const regexContainerdVersion = `\s+(\d+\.\d+\.\d+)(?:\s+|$)`
+// matches "1.7.25" when "containerd containerd.io 1.7.25 bcc810d6b9066471b0b6fa75f557a15a1cbf31bb"
+// supports optional v in front of the version number
+// e.g., "containerd containerd.io v1.7.25 bcc810d6b9066471b0b6fa75f557a15a1cbf31bb"
+const regexContainerdVersion = `\s+v?(\d+\.\d+\.\d+)(?:\s+|$)`
 
 var reContainerdVersion = regexp.MustCompile(regexContainerdVersion)
 

--- a/pkg/containerd/cri_test.go
+++ b/pkg/containerd/cri_test.go
@@ -734,6 +734,12 @@ func TestParseContainerdVersion(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "standard containerd version output from a live system",
+			input:   "containerd github.com/containerd/containerd v1.7.20 7ab40557b20c33567c74c661d548661b631bbb37",
+			want:    "1.7.20",
+			wantErr: false,
+		},
+		{
 			name:    "different version number",
 			input:   "containerd containerd.io 1.6.21 abc123def456",
 			want:    "1.6.21",


### PR DESCRIPTION
After installing gpud v0.7.1 on an Ubuntu 24.04 system with containerd v1.7.20 I saw this in the cloud-init-output.log file:

```
installed gpud version v0.7.1 in the path /usr/local/bin/gpud
{"level":"warn","ts":"2025-10-06T13:57:10.859Z","caller":"machine-info/machine_info.go:77","msg":"failed to check containerd version","error":"invalid containerd version output: containerd containerd.io v1.7.28 b98a3aace656320842a23f4a392a33f46af97866\n"}
```

I tracked it down to incorrect test and regular expression, and fixed them.