### PR TITLE
[LEP-3107] feat(host): replace "uptime -s" with boottime syscall for reboot store

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -625,6 +625,10 @@ sudo rm /etc/systemd/system/gpud.service
 					Name:  "log-level,l",
 					Usage: "set the logging level [debug, info, warn, error, fatal, panic, dpanic]",
 				},
+				&cli.BoolFlag{
+					Name:  "reboot-history",
+					Usage: "show reboot history recorded by gpud (default: false)",
+				},
 				&cli.StringFlag{
 					Name:  "set-key",
 					Usage: "metadata key to set/update",

--- a/pkg/host/init.go
+++ b/pkg/host/init.go
@@ -212,6 +212,16 @@ func BootTimeUnixSeconds() uint64 {
 	return currentBootTimeUnixSeconds
 }
 
+// BootTime returns the host boot time in UTC. A zero value indicates the boot
+// time could not be determined during initialization.
+func BootTime() time.Time {
+	if currentBootTimeUnixSeconds == 0 {
+		return time.Time{}
+	}
+
+	return time.Unix(int64(currentBootTimeUnixSeconds), 0).UTC()
+}
+
 func BootID() string {
 	return currentBootID
 }

--- a/pkg/host/reboot.go
+++ b/pkg/host/reboot.go
@@ -1,12 +1,10 @@
 package host
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	stdos "os"
-	"os/exec"
 	"time"
 
 	"github.com/leptonai/gpud/pkg/log"
@@ -125,31 +123,4 @@ func runReboot(ctx context.Context, cmd string) error {
 	// actually, this should not print if reboot worked
 	log.Logger.Infow("successfully rebooted", "command", cmd)
 	return nil
-}
-
-func LastReboot(ctx context.Context) (time.Time, error) {
-	cmd := exec.CommandContext(ctx, "uptime", "-s")
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err := cmd.Run()
-	if err != nil {
-		return time.Time{}, err
-	}
-	lines := bytes.Split(out.Bytes(), []byte{'\n'})
-	return LastRebootHelper(lines)
-}
-
-// LastRebootHelper parses the last reboot time from the output of "uptime -s".
-func LastRebootHelper(lines [][]byte) (time.Time, error) {
-	if len(lines) == 0 || len(lines[0]) == 0 {
-		return time.Time{}, errors.New("invalid output from uptime")
-	}
-
-	// Convert the first line to a string and parse it as a time.
-	rebootTimeStr := string(lines[0])
-	rebootTime, err := time.ParseInLocation("2006-01-02 15:04:05", rebootTimeStr, time.Local)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return rebootTime.UTC(), nil
 }

--- a/pkg/host/reboot_test.go
+++ b/pkg/host/reboot_test.go
@@ -17,49 +17,14 @@ func TestRunReboot(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestLastRebootHelper(t *testing.T) {
-	tests := []struct {
-		name    string
-		lines   [][]byte
-		want    time.Time
-		wantErr bool
-	}{
-		{
-			name: "valid time format",
-			lines: [][]byte{
-				[]byte("2025-02-10 14:30:00"),
-			},
-			want: func() time.Time {
-				// Calculate expected result the same way as LastRebootHelper
-				t, _ := time.ParseInLocation("2006-01-02 15:04:05", "2025-02-10 14:30:00", time.Local)
-				return t.UTC()
-			}(),
-			wantErr: false,
-		},
-		{
-			name:    "empty input",
-			lines:   [][]byte{},
-			wantErr: true,
-		},
-		{
-			name: "invalid time format",
-			lines: [][]byte{
-				[]byte("invalid-time"),
-			},
-			wantErr: true,
-		},
-	}
+func TestBootTime(t *testing.T) {
+	original := currentBootTimeUnixSeconds
+	defer func() { currentBootTimeUnixSeconds = original }()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := LastRebootHelper(tt.lines)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("LastRebootHelper() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !tt.wantErr && !got.Equal(tt.want) {
-				t.Errorf("LastRebootHelper() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	currentBootTimeUnixSeconds = 0
+	assert.True(t, BootTime().IsZero())
+
+	expected := time.Unix(1_700_000_000, 0).UTC()
+	currentBootTimeUnixSeconds = uint64(expected.Unix())
+	assert.True(t, BootTime().Equal(expected))
 }

--- a/pkg/session/health_states.go
+++ b/pkg/session/health_states.go
@@ -23,8 +23,8 @@ func (s *Session) getHealthStates(payload Request) (apiv1.GPUdComponentHealthSta
 		allComponents = payload.Components
 	}
 
-	// use BootTimeUnixSeconds which reads directly from system sources
-	// avoiding timezone parsing issues with "uptime -s"
+	// use BootTimeUnixSeconds which reads directly from system sources via syscall
+	// cached at initialization for performance and reliability
 	bootTimeUnix := pkghost.BootTimeUnixSeconds()
 	rebootTime := time.Unix(int64(bootTimeUnix), 0)
 

--- a/pkg/session/session_serve_test.go
+++ b/pkg/session/session_serve_test.go
@@ -271,7 +271,7 @@ func TestGetStatesFromComponent(t *testing.T) {
 		registry.On("Get", "component1").Return(comp)
 		comp.On("LastHealthStates").Return(healthStates)
 
-		// Pass a non-nil rebootTime to avoid calling pkghost.LastReboot
+		// Pass a non-nil rebootTime to avoid calling pkghost.BootTime
 		rebootTime := time.Now().Add(-10 * time.Minute)
 
 		result := session.getHealthStatesFromComponent("component1", rebootTime)


### PR DESCRIPTION
```
$ gpud metadata --reboot-history

machine_id: ...
node_group: ...
private_ip: ...
public_ip: ...
region: ...
token: ...
endpoint: gpud-manager-prod01.dgxc-lepton.nvidia.com

Reboot History:
TIME (UTC)            AGE           MESSAGE
2025-10-19T06:56:06Z  1 week ago    system reboot detected 2025-10-19 06:56:06 +0000 UTC
2025-10-13T08:45:13Z  2 weeks ago   system reboot detected 2025-10-13 08:45:13 +0000 UTC
2025-10-12T10:47:01Z  2 weeks ago   system reboot detected 2025-10-12 10:47:01 +0000 UTC
2025-10-02T05:35:33Z  3 weeks ago   system reboot detected 2025-10-02 05:35:33 +0000 UTC
2025-10-01T08:53:01Z  4 weeks ago   system reboot detected 2025-10-01 08:53:01 +0000 UTC
2025-09-29T19:15:25Z  1 month ago   system reboot detected 2025-09-29 19:15:25 +0000 UTC
2025-09-03T13:59:28Z  1 month ago   system reboot detected 2025-09-03 13:59:28 +0000 UTC
2025-08-12T11:38:20Z  2 months ago  system reboot detected 2025-08-12 11:38:20 +0000 UTC
2025-07-28T08:12:02Z  3 months ago  system reboot detected 2025-07-28 08:12:02 +0000 UTC
2025-07-24T21:32:17Z  3 months ago  system reboot detected 2025-07-24 21:32:17 +0000 UTC
2025-07-22T13:22:11Z  3 months ago  system reboot detected 2025-07-22 13:22:11 +0000 UTC
2025-07-09T20:38:00Z  3 months ago  system reboot detected 2025-07-09 20:38:00 +0000 UTC
2025-07-07T12:44:46Z  3 months ago  system reboot detected 2025-07-07 12:44:46 +0000 UTC
2025-05-31T15:08:27Z  5 months ago  system reboot detected 2025-05-31 15:08:27 +0000 UTC
```