### PR TITLE
[LEP-3113] feat(nvidia/xid,sxid): stop persisting SetHealthy events

### DIFF
--- a/components/accelerator/nvidia/sxid/component.go
+++ b/components/accelerator/nvidia/sxid/component.go
@@ -473,7 +473,7 @@ func (c *component) updateCurrentState() error {
 	if err != nil {
 		return fmt.Errorf("failed to get all events: %w", err)
 	}
-
+	localEvents = trimEventsAfterSetHealthy(localEvents)
 	events := mergeEvents(rebootEvents, localEvents)
 
 	c.mu.Lock()
@@ -501,4 +501,18 @@ func mergeEvents(a, b eventstore.Events) eventstore.Events {
 	})
 
 	return result
+}
+
+func trimEventsAfterSetHealthy(events eventstore.Events) eventstore.Events {
+	for idx, event := range events {
+		if event.Name == "SetHealthy" {
+			if idx == 0 {
+				return nil
+			}
+			trimmed := make(eventstore.Events, idx)
+			copy(trimmed, events[:idx])
+			return trimmed
+		}
+	}
+	return events
 }

--- a/components/accelerator/nvidia/sxid/health_state.go
+++ b/components/accelerator/nvidia/sxid/health_state.go
@@ -86,11 +86,6 @@ func evolveHealthyState(events eventstore.Events) (ret apiv1.HealthState) {
 			for v, count := range sxidRebootMap {
 				sxidRebootMap[v] = count + 1
 			}
-		} else if event.Name == "SetHealthy" {
-			lastHealth = healthStateHealthy
-			lastSuggestedAction = nil
-			lastSXidErr = nil
-			sxidRebootMap = make(map[uint64]int)
 		}
 	}
 	var reason string

--- a/components/accelerator/nvidia/sxid/health_state_test.go
+++ b/components/accelerator/nvidia/sxid/health_state_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiv1 "github.com/leptonai/gpud/api/v1"
@@ -80,14 +81,41 @@ func TestStateUpdateBasedOnEvents(t *testing.T) {
 		assert.Equal(t, apiv1.RepairActionTypeHardwareInspection, state.SuggestedActions.RepairActions[0])
 	})
 
-	t.Run("SetHealthy", func(t *testing.T) {
-		events := eventstore.Events{
-			{Name: "SetHealthy"},
-			createSXidEvent(time.Time{}, 789, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
-		}
+	t.Run("EmptyEvents_ReturnsHealthy", func(t *testing.T) {
+		events := eventstore.Events{}
 		state := evolveHealthyState(events)
 		assert.Equal(t, apiv1.HealthStateTypeHealthy, state.Health)
 		assert.Nil(t, state.SuggestedActions)
+		assert.Equal(t, "SXIDComponent is healthy", state.Reason)
+	})
+
+	t.Run("rebootCountingResetAfterPurgeMatchesLegacy", func(t *testing.T) {
+		now := time.Now()
+		localEvents := eventstore.Events{
+			createSXidEvent(now, 94, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
+			{Time: now.Add(-1 * time.Minute), Name: "SetHealthy"},
+			createSXidEvent(now.Add(-2*time.Minute), 94, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
+			createSXidEvent(now.Add(-4*time.Minute), 94, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
+		}
+
+		trimmed := trimEventsAfterSetHealthy(localEvents)
+		require.Len(t, trimmed, 1)
+		assert.Equal(t, now.Unix(), trimmed[0].Time.Unix())
+
+		rebootEvents := eventstore.Events{
+			{Time: now.Add(-3 * time.Minute), Name: "reboot"},
+			{Time: now.Add(-5 * time.Minute), Name: "reboot"},
+		}
+
+		merged := mergeEvents(rebootEvents, trimmed)
+		require.Len(t, merged, 3)
+		assert.Equal(t, []string{"error_sxid", "reboot", "reboot"}, []string{merged[0].Name, merged[1].Name, merged[2].Name})
+
+		state := evolveHealthyState(merged)
+		require.NotNil(t, state.SuggestedActions)
+		require.NotEmpty(t, state.SuggestedActions.RepairActions)
+		assert.Equal(t, apiv1.RepairActionTypeRebootSystem, state.SuggestedActions.RepairActions[0])
+		assert.Equal(t, apiv1.HealthStateTypeUnhealthy, state.Health)
 	})
 
 	t.Run("invalid sxid", func(t *testing.T) {

--- a/components/accelerator/nvidia/sxid/set_healthy.go
+++ b/components/accelerator/nvidia/sxid/set_healthy.go
@@ -1,9 +1,10 @@
 package sxid
 
 import (
-	apiv1 "github.com/leptonai/gpud/api/v1"
+	"context"
+	"time"
+
 	"github.com/leptonai/gpud/components"
-	"github.com/leptonai/gpud/pkg/eventstore"
 	"github.com/leptonai/gpud/pkg/log"
 )
 
@@ -12,17 +13,22 @@ var _ components.HealthSettable = &component{}
 func (c *component) SetHealthy() error {
 	log.Logger.Infow("set healthy event received for sxid")
 
-	setHealthyEvent := &eventstore.Event{
-		Component: Name,
-		Time:      c.getTimeNowFunc(),
-		Name:      "SetHealthy",
-		Type:      string(apiv1.EventTypeInfo),
+	if c.eventBucket != nil {
+		now := c.getTimeNowFunc()
+		cctx, cancel := context.WithTimeout(c.ctx, 10*time.Second)
+		purged, err := c.eventBucket.Purge(cctx, now.Unix())
+		cancel()
+		if err != nil {
+			return err
+		}
+		log.Logger.Infow("successfully purged sxid events", "count", purged)
 	}
 
-	select {
-	case c.extraEventCh <- setHealthyEvent:
-	default:
-		log.Logger.Debugw("channel full, set healthy event skipped")
+	// Immediately update current state to reflect the purge
+	// This matches the old behavior where SetHealthy event triggered immediate state update
+	if err := c.updateCurrentState(); err != nil {
+		log.Logger.Errorw("failed to update current state after purge", "error", err)
+		return err
 	}
 
 	return nil

--- a/components/accelerator/nvidia/xid/component.go
+++ b/components/accelerator/nvidia/xid/component.go
@@ -526,7 +526,7 @@ func (c *component) updateCurrentState() error {
 	if err != nil {
 		return fmt.Errorf("failed to get all events: %w", err)
 	}
-
+	localEvents = trimEventsAfterSetHealthy(localEvents)
 	events := mergeEvents(rebootEvents, localEvents)
 
 	c.mu.Lock()
@@ -554,4 +554,18 @@ func mergeEvents(a, b eventstore.Events) eventstore.Events {
 	})
 
 	return result
+}
+
+func trimEventsAfterSetHealthy(events eventstore.Events) eventstore.Events {
+	for idx, event := range events {
+		if event.Name == "SetHealthy" {
+			if idx == 0 {
+				return nil
+			}
+			trimmed := make(eventstore.Events, idx)
+			copy(trimmed, events[:idx])
+			return trimmed
+		}
+	}
+	return events
 }

--- a/components/accelerator/nvidia/xid/health_state.go
+++ b/components/accelerator/nvidia/xid/health_state.go
@@ -89,11 +89,6 @@ func evolveHealthyState(events eventstore.Events, devices map[string]device.Devi
 			for v, count := range xidRebootMap {
 				xidRebootMap[v] = count + 1
 			}
-		} else if event.Name == "SetHealthy" {
-			lastHealth = healthStateHealthy
-			lastSuggestedAction = nil
-			lastXidErr = nil
-			xidRebootMap = make(map[uint64]int)
 		}
 	}
 	var reason string


### PR DESCRIPTION
- purge component buckets and refresh state immediately, eliminating new SetHealthy records in event store
- trim legacy SetHealthy markers before merging with reboot history so reboot counters reset exactly as before
- extend unit coverage for purge semantics, reboot-count parity, and immediate health updates

This preserves prior behaviour for the reboot escalation logic:

Reboot Counting Logic - IDENTICAL Behavior

Scenario: XID → Reboot → XID → Reboot → XID (3 times, should suggest HARDWARE_INSPECTION)

Before:

```
   After SetHealthy@T5, New XID@T6:
   Events = [XID@T6, SetHealthy@T5, XID@T4, Reboot@T3, XID@T2, Reboot@T1, XID@T0]

   evolveHealthyState processes oldest→newest:
     T0: XID → map[94]=0, action=REBOOT
     T1: Reboot → map[94]=1
     T2: XID → count=1<2, action=REBOOT
     T3: Reboot → map[94]=2
     T4: XID → count=2≥2, action=HARDWARE_INSPECTION
     T5: SetHealthy → map={} ← RESET
     T6: XID → map[94]=0, action=REBOOT ← FRESH START

   Result: action=REBOOT ✓
```

After:

```
   After Purge@T5, New XID@T6:
   Events = [XID@T6, Reboot@T3, Reboot@T1]  ← Old XIDs purged, reboots preserved

   evolveHealthyState processes oldest→newest:
     T1: Reboot → for v in map{} → NO-OP (map empty, no XIDs yet)
     T3: Reboot → for v in map{} → NO-OP (map empty, no XIDs yet)
     T6: XID → map[94]=0, action=REBOOT ← FRESH START

   Result: action=REBOOT ✓

   IDENTICAL OUTCOME - Both produce action=REBOOT with count=0
```
