### PR TITLE
[LEP-3336] feat(session/login): show login failures in "gpud status"

### DIFF
--- a/cmd/gpud/status/command.go
+++ b/cmd/gpud/status/command.go
@@ -67,6 +67,12 @@ func Command(cliContext *cli.Context) error {
 		return err
 	}
 
+	log.Logger.Debugw("displaying login status from session_states table")
+	if err := displayLoginStatus(rootCtx, dbRO); err != nil {
+		return fmt.Errorf("failed to display login status: %w", err)
+	}
+	log.Logger.Debugw("successfully displayed login status")
+
 	var active bool
 	if systemd.SystemctlExists() {
 		active, err = systemd.IsActive("gpud.service")

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -13,6 +13,7 @@ import (
 	pkgmetadata "github.com/leptonai/gpud/pkg/metadata"
 	nvidianvml "github.com/leptonai/gpud/pkg/nvidia-query/nvml"
 	"github.com/leptonai/gpud/pkg/server"
+	sessionstates "github.com/leptonai/gpud/pkg/session/states"
 	"github.com/leptonai/gpud/pkg/sqlite"
 	"github.com/leptonai/gpud/pkg/systemd"
 )
@@ -66,6 +67,12 @@ func Login(ctx context.Context, cfg LoginConfig) error {
 		return fmt.Errorf("failed to create metadata table: %w", err)
 	}
 	log.Logger.Debugw("successfully created metadata table")
+
+	log.Logger.Debugw("creating session states table")
+	if err := sessionstates.CreateTable(ctx, dbRW); err != nil {
+		return fmt.Errorf("failed to create session states table: %w", err)
+	}
+	log.Logger.Debugw("successfully created session states table")
 
 	log.Logger.Debugw("reading machine ID")
 	prevMachineID, err := pkgmetadata.ReadMachineID(ctx, dbRO)

--- a/pkg/session/states/states.go
+++ b/pkg/session/states/states.go
@@ -1,0 +1,116 @@
+// Package states provides tracking of login success and failure events as well as
+// the state of ongoing session loops (token expiration, etc.).
+package states
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	pkgmetricsrecorder "github.com/leptonai/gpud/pkg/metrics/recorder"
+)
+
+const (
+	tableNameSessionStates = "session_states"
+	columnTimestamp        = "timestamp"
+	columnSuccess          = "success"
+	columnMessage          = "message"
+)
+
+// CreateTable creates the table for session state tracking.
+func CreateTable(ctx context.Context, dbRW *sql.DB) error {
+	_, err := dbRW.ExecContext(ctx, fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+	%s INTEGER NOT NULL,
+	%s INTEGER NOT NULL,
+	%s TEXT
+);`, tableNameSessionStates, columnTimestamp, columnSuccess, columnMessage))
+	return err
+}
+
+// State represents a single login/session status entry.
+type State struct {
+	Timestamp int64
+	Success   bool
+	Message   string
+}
+
+// Insert inserts a new login status entry.
+func Insert(ctx context.Context, dbRW *sql.DB, timestamp int64, success bool, message string) error {
+	successInt := 0
+	if success {
+		successInt = 1
+	}
+
+	start := time.Now()
+	_, err := dbRW.ExecContext(ctx, fmt.Sprintf(`
+INSERT INTO %s (%s, %s, %s) VALUES (?, ?, ?)`,
+		tableNameSessionStates, columnTimestamp, columnSuccess, columnMessage),
+		timestamp, successInt, message)
+	pkgmetricsrecorder.RecordSQLiteInsertUpdate(time.Since(start).Seconds())
+	if err != nil {
+		return err
+	}
+
+	start = time.Now()
+	_, err = dbRW.ExecContext(ctx, fmt.Sprintf(`
+DELETE FROM %s 
+WHERE %s NOT IN (
+	SELECT %s FROM %s 
+	ORDER BY %s DESC 
+	LIMIT 10
+)`, tableNameSessionStates, columnTimestamp, columnTimestamp, tableNameSessionStates, columnTimestamp))
+	pkgmetricsrecorder.RecordSQLiteInsertUpdate(time.Since(start).Seconds())
+
+	return err
+}
+
+// ReadLast returns the most recent login status entry.
+// Returns nil if no entries exist.
+func ReadLast(ctx context.Context, dbRO *sql.DB) (*State, error) {
+	var timestamp int64
+	var successInt int
+	var message string
+
+	start := time.Now()
+	err := dbRO.QueryRowContext(ctx, fmt.Sprintf(`
+SELECT %s, %s, %s FROM %s 
+ORDER BY %s DESC 
+LIMIT 1`, columnTimestamp, columnSuccess, columnMessage, tableNameSessionStates, columnTimestamp)).Scan(&timestamp, &successInt, &message)
+	pkgmetricsrecorder.RecordSQLiteSelect(time.Since(start).Seconds())
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &State{
+		Timestamp: timestamp,
+		Success:   successInt == 1,
+		Message:   message,
+	}, nil
+}
+
+// HasAnyFailures checks if there are any failure entries in the table.
+func HasAnyFailures(ctx context.Context, dbRO *sql.DB) (bool, error) {
+	var count int
+
+	start := time.Now()
+	err := dbRO.QueryRowContext(ctx, fmt.Sprintf(`
+SELECT COUNT(*) FROM %s WHERE %s = 0`, tableNameSessionStates, columnSuccess)).Scan(&count)
+	pkgmetricsrecorder.RecordSQLiteSelect(time.Since(start).Seconds())
+
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return count > 0, nil
+}

--- a/pkg/session/states/states_test.go
+++ b/pkg/session/states/states_test.go
@@ -1,0 +1,285 @@
+package states
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/leptonai/gpud/pkg/sqlite"
+)
+
+func TestCreateTable(t *testing.T) {
+	ctx := context.Background()
+	dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+	defer cleanup()
+
+	err := CreateTable(ctx, dbRW)
+	if err != nil {
+		t.Fatalf("failed to create session_states table: %v", err)
+	}
+
+	// Verify table was created by inserting a record
+	err = Insert(ctx, dbRW, time.Now().Unix(), true, "test message")
+	if err != nil {
+		t.Fatalf("failed to insert into session_states table: %v", err)
+	}
+
+	// Verify we can read from the table
+	status, err := ReadLast(ctx, dbRO)
+	if err != nil {
+		t.Fatalf("failed to read from session_states table: %v", err)
+	}
+	if status == nil {
+		t.Fatal("expected status to be non-nil")
+	}
+}
+
+func TestInsert(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		timestamp int64
+		success   bool
+		message   string
+	}{
+		{
+			name:      "success entry",
+			timestamp: time.Now().Unix(),
+			success:   true,
+			message:   "Session connected successfully",
+		},
+		{
+			name:      "failure entry",
+			timestamp: time.Now().Unix() + 1,
+			success:   false,
+			message:   "HTTP 403: Forbidden",
+		},
+		{
+			name:      "empty message",
+			timestamp: time.Now().Unix() + 2,
+			success:   true,
+			message:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fresh database for each subtest
+			dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+			defer cleanup()
+
+			err := CreateTable(ctx, dbRW)
+			if err != nil {
+				t.Fatalf("failed to create session_states table: %v", err)
+			}
+
+			err = Insert(ctx, dbRW, tt.timestamp, tt.success, tt.message)
+			if err != nil {
+				t.Fatalf("failed to insert login status: %v", err)
+			}
+
+			status, err := ReadLast(ctx, dbRO)
+			if err != nil {
+				t.Fatalf("failed to read login status: %v", err)
+			}
+			if status == nil {
+				t.Fatal("expected status to be non-nil")
+			}
+			if status.Timestamp != tt.timestamp {
+				t.Errorf("expected timestamp %d, got %d", tt.timestamp, status.Timestamp)
+			}
+			if status.Success != tt.success {
+				t.Errorf("expected success %v, got %v", tt.success, status.Success)
+			}
+			if status.Message != tt.message {
+				t.Errorf("expected message %q, got %q", tt.message, status.Message)
+			}
+		})
+	}
+}
+
+func TestInsertPrunesOldEntries(t *testing.T) {
+	ctx := context.Background()
+	dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+	defer cleanup()
+
+	err := CreateTable(ctx, dbRW)
+	if err != nil {
+		t.Fatalf("failed to create session_states table: %v", err)
+	}
+
+	// Insert 15 entries
+	baseTime := time.Now().Unix()
+	for i := 0; i < 15; i++ {
+		err := Insert(ctx, dbRW, baseTime+int64(i), true, "test message")
+		if err != nil {
+			t.Fatalf("failed to insert login status: %v", err)
+		}
+	}
+
+	// Count remaining entries (Insert cleans up automatically)
+	var count int
+	err = dbRO.QueryRowContext(ctx, "SELECT COUNT(*) FROM session_states").Scan(&count)
+	if err != nil {
+		t.Fatalf("failed to count entries: %v", err)
+	}
+	if count != 10 {
+		t.Errorf("expected 10 entries after cleanup, got %d", count)
+	}
+
+	// Verify the latest entry is still present
+	status, err := ReadLast(ctx, dbRO)
+	if err != nil {
+		t.Fatalf("failed to read latest login status: %v", err)
+	}
+	if status == nil {
+		t.Fatal("expected status to be non-nil")
+	}
+	expectedLatestTimestamp := baseTime + 14
+	if status.Timestamp != expectedLatestTimestamp {
+		t.Errorf("expected latest timestamp %d, got %d", expectedLatestTimestamp, status.Timestamp)
+	}
+}
+
+func TestReadLast(t *testing.T) {
+	ctx := context.Background()
+	dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+	defer cleanup()
+
+	err := CreateTable(ctx, dbRW)
+	if err != nil {
+		t.Fatalf("failed to create session_states table: %v", err)
+	}
+
+	// Test reading from empty table
+	status, err := ReadLast(ctx, dbRO)
+	if err != nil {
+		t.Fatalf("failed to read from empty table: %v", err)
+	}
+	if status != nil {
+		t.Error("expected nil status from empty table")
+	}
+
+	// Insert multiple entries
+	baseTime := time.Now().Unix()
+	for i := 0; i < 5; i++ {
+		err := Insert(ctx, dbRW, baseTime+int64(i), i%2 == 0, "message")
+		if err != nil {
+			t.Fatalf("failed to insert login status: %v", err)
+		}
+	}
+
+	// Should return the latest entry
+	status, err = ReadLast(ctx, dbRO)
+	if err != nil {
+		t.Fatalf("failed to read latest login status: %v", err)
+	}
+	if status == nil {
+		t.Fatal("expected status to be non-nil")
+	}
+	expectedLatestTimestamp := baseTime + 4
+	if status.Timestamp != expectedLatestTimestamp {
+		t.Errorf("expected latest timestamp %d, got %d", expectedLatestTimestamp, status.Timestamp)
+	}
+}
+
+func TestHasAnyFailures(t *testing.T) {
+	ctx := context.Background()
+	dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+	defer cleanup()
+
+	err := CreateTable(ctx, dbRW)
+	if err != nil {
+		t.Fatalf("failed to create session_states table: %v", err)
+	}
+
+	// Empty table should have no failures
+	hasFailures, err := HasAnyFailures(ctx, dbRO)
+	if err != nil {
+		t.Fatalf("failed to check for failures: %v", err)
+	}
+	if hasFailures {
+		t.Error("expected no failures in empty table")
+	}
+
+	// Insert only success entries
+	baseTime := time.Now().Unix()
+	for i := 0; i < 3; i++ {
+		err := Insert(ctx, dbRW, baseTime+int64(i), true, "success message")
+		if err != nil {
+			t.Fatalf("failed to insert login status: %v", err)
+		}
+	}
+
+	hasFailures, err = HasAnyFailures(ctx, dbRO)
+	if err != nil {
+		t.Fatalf("failed to check for failures: %v", err)
+	}
+	if hasFailures {
+		t.Error("expected no failures with only success entries")
+	}
+
+	// Insert a failure entry
+	err = Insert(ctx, dbRW, baseTime+3, false, "failure message")
+	if err != nil {
+		t.Fatalf("failed to insert login status: %v", err)
+	}
+
+	hasFailures, err = HasAnyFailures(ctx, dbRO)
+	if err != nil {
+		t.Fatalf("failed to check for failures: %v", err)
+	}
+	if !hasFailures {
+		t.Error("expected to detect failure entry")
+	}
+}
+
+func TestInsertPreservesLatestEntries(t *testing.T) {
+	ctx := context.Background()
+	dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+	defer cleanup()
+
+	err := CreateTable(ctx, dbRW)
+	if err != nil {
+		t.Fatalf("failed to create session_states table: %v", err)
+	}
+
+	// Insert 15 entries with different timestamps
+	baseTime := time.Now().Unix()
+	for i := 0; i < 15; i++ {
+		success := i%3 != 0 // Mix of success and failure
+		err := Insert(ctx, dbRW, baseTime+int64(i), success, "message")
+		if err != nil {
+			t.Fatalf("failed to insert login status: %v", err)
+		}
+	}
+
+	// Read all remaining entries (Insert cleans up automatically)
+	rows, err := dbRO.QueryContext(ctx, "SELECT timestamp FROM session_states ORDER BY timestamp ASC")
+	if err != nil {
+		t.Fatalf("failed to query entries: %v", err)
+	}
+	defer rows.Close()
+
+	var timestamps []int64
+	for rows.Next() {
+		var ts int64
+		if err := rows.Scan(&ts); err != nil {
+			t.Fatalf("failed to scan timestamp: %v", err)
+		}
+		timestamps = append(timestamps, ts)
+	}
+
+	if len(timestamps) != 10 {
+		t.Fatalf("expected 10 timestamps, got %d", len(timestamps))
+	}
+
+	// Verify we have the latest 10 entries
+	for i, ts := range timestamps {
+		expected := baseTime + int64(5+i) // Should have entries 5-14
+		if ts != expected {
+			t.Errorf("expected timestamp %d at position %d, got %d", expected, i, ts)
+		}
+	}
+}


### PR DESCRIPTION
Address:

> {"level":"warn","ts":"2025-11-15T23:55:04.393+0530","msg":"session reader: request resp not ok -- retrying","status":"403 Forbidden","statusCode":403}
{"level":"warn","ts":"2025-11-15T23:55:04.393+0530","msg":"session writer: error making request","error":"Post \https://gpud-gateway.dgxc-lepton.nvidia.com/api/v1/session\: context canceled"}

Test case:

```
gpud status

✔ login success at 9 seconds ago (machine id: 130ee2c9-c3c1-11f0-9170-2611f529d046)
✔ login activity: success at 9 seconds ago
✔ gpud.service is active
✔ successfully checked gpud status
✔ successfully checked gpud health
no packages found
```

Manipulate the token and restart:

```
systemctl stop gpud
gpud metadata --set-key token --set-value nvapi-stg-invalid
systemctl restart gpud
```

Confirm that now `gpud status` shows expired/invalid token status:

```
gpud status

✔ login success at 12 minutes ago (machine id: 130ee2c9-c3c1-11f0-9170-2611f529d046)
✘ login activity: failure at now - HTTP 403: {"error_code":"EP-10700-7","error_summary":"Forbidden","error_id":"8500e370-240c-412e-b069-ee3c005447ec"}
✘ warning: there are login failure entries in the history
```
