### PR TITLE
[LEP-3329] fix(nvidia/fabric-manager): do not skip activeness check when fabric state is supported

### DIFF
--- a/pkg/nvidia-query/nvml/device/fabric_state.go
+++ b/pkg/nvidia-query/nvml/device/fabric_state.go
@@ -15,24 +15,32 @@ import (
 // FabricState represents fabric state information for a GPU device.
 // This struct encapsulates all fabric-related data from V3 and V1 APIs.
 type FabricState struct {
-	CliqueID      uint32
-	ClusterUUID   string
-	State         uint8
-	Status        nvml.Return
-	HealthMask    uint32
+	CliqueID    uint32
+	ClusterUUID string
+	State       uint8
+	Status      nvml.Return
+	HealthMask  uint32
+
+	// HealthSummary is the health summary of the fabric.
+	// This is a uint8 value that can be converted to a string using FabricSummaryToString.
+	// NOTE: "NVIDIA H100 80GB HBM3" returns nvml.GPU_FABRIC_HEALTH_SUMMARY_NOT_SUPPORTED.
 	HealthSummary uint8
 }
 
 // FabricStateEntry represents a displayable fabric state entry with formatted fields.
 // This is used for rendering fabric state information in human-readable format.
 type FabricStateEntry struct {
-	GPUUUID     string               `json:"gpu_uuid"`
-	CliqueID    uint32               `json:"clique_id"`
-	ClusterUUID string               `json:"cluster_uuid,omitempty"`
-	State       string               `json:"state"`
-	Status      string               `json:"status"`
-	Summary     string               `json:"summary,omitempty"`
-	Health      FabricHealthSnapshot `json:"health"`
+	GPUUUID     string `json:"gpu_uuid"`
+	CliqueID    uint32 `json:"clique_id"`
+	ClusterUUID string `json:"cluster_uuid,omitempty"`
+	State       string `json:"state"`
+	Status      string `json:"status"`
+
+	// Summary is converted from HealthSummary using FabricSummaryToString.
+	// NOTE: "NVIDIA H100 80GB HBM3" returns nvml.GPU_FABRIC_HEALTH_SUMMARY_NOT_SUPPORTED.
+	Summary string `json:"summary,omitempty"`
+
+	Health FabricHealthSnapshot `json:"health"`
 }
 
 // FabricHealthSnapshot represents the health status of fabric components.


### PR DESCRIPTION
Got

```json
    "component": "accelerator-nvidia-fabric-manager",
    "states": [
      {
        "time": "2025-11-20T03:08:36Z",
        "component": "accelerator-nvidia-fabric-manager",
        "name": "accelerator-nvidia-fabric-manager",
        "health": "Healthy",
        "reason": "NVIDIA-H100-80GB-HBM3 checked fabric state",
        "extra_info": {
          "data": "{\"fabric_manager_active\":false,
```

But for NVIDIA-H100-80GB-HBM3, we should get "fabric_manager_active" true.

Fixed via alpha.12

```
    "component": "accelerator-nvidia-fabric-manager",
    "states": [
      {
        "time": "2025-11-20T04:46:02Z",
        "component": "accelerator-nvidia-fabric-manager",
        "name": "accelerator-nvidia-fabric-manager",
        "health": "Unhealthy",
        "reason": "NVIDIA-H100-80GB-HBM3 checked fabric state; fabric manager found but not active",
        "extra_info": {
          "data": "{\"fabric_manager_active\":false,\"fabric_state_supported\":true,\"
```

After restart

```
    "component": "accelerator-nvidia-fabric-manager",
    "states": [
      {
        "time": "2025-11-20T04:49:02Z",
        "component": "accelerator-nvidia-fabric-manager",
        "name": "accelerator-nvidia-fabric-manager",
        "health": "Healthy",
        "reason": "fabric manager found and active",
        "extra_info": {
          "data": "{\"fabric_manager_active\":true,\"fabric_state_supported\":true,\"fabric_states\":[{\"gpu_uuid\":\"GPU-237607dc-9acc-a45b-8d64-cd9dea461c5b\",\"clique_id\":0,\"state\":\"Completed\",\"status\":\"Success\",\"summary\":\"Not Supported\",\"health\":{\"bandwidth\":\"Not Supported\",\"route_recovery_in_progress\":\"Not Supported\",\"route_unhealthy\":\"Not Supported\",\"access_timeout_recovery\":\"Not Supported\"}},{\"gpu_uuid\":\"GPU-2c40be1e-c5ab-264b-d632-92d482897167\",\"clique_id\":0,\"state\":\"Completed\",\"status\":\"Success\",\"summary\":\"Not Supported\",\"health\":{
```