### PR TITLE
[LEP-3499] [LEP-3539] [LEP-3540] fix(nvidia/xid): separate sub-code fatality for XID 144-150, better reason message

### DIFF
--- a/components/accelerator/nvidia/xid/component_test.go
+++ b/components/accelerator/nvidia/xid/component_test.go
@@ -398,7 +398,7 @@ func TestXIDComponent_States(t *testing.T) {
 			},
 			wantState: []apiv1.HealthState{
 				{Health: apiv1.HealthStateTypeHealthy, SuggestedActions: nil},
-				{Health: apiv1.HealthStateTypeDegraded, SuggestedActions: &apiv1.SuggestedActions{RepairActions: []apiv1.RepairActionType{apiv1.RepairActionTypeRebootSystem}}},
+				{Health: apiv1.HealthStateTypeHealthy, SuggestedActions: &apiv1.SuggestedActions{RepairActions: []apiv1.RepairActionType{apiv1.RepairActionTypeRebootSystem}}},
 				{Health: apiv1.HealthStateTypeDegraded, SuggestedActions: &apiv1.SuggestedActions{RepairActions: []apiv1.RepairActionType{apiv1.RepairActionTypeRebootSystem}}},
 				{Health: apiv1.HealthStateTypeHealthy, SuggestedActions: nil},
 				{Health: apiv1.HealthStateTypeDegraded, SuggestedActions: &apiv1.SuggestedActions{RepairActions: []apiv1.RepairActionType{apiv1.RepairActionTypeRebootSystem}}},

--- a/components/accelerator/nvidia/xid/health_state_test.go
+++ b/components/accelerator/nvidia/xid/health_state_test.go
@@ -2,6 +2,7 @@ package xid
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -51,14 +52,17 @@ func TestStateUpdateBasedOnEvents(t *testing.T) {
 			createXidEvent(time.Time{}, 123, apiv1.EventTypeCritical, apiv1.RepairActionTypeRebootSystem),
 		}
 		state := evolveHealthyState(events, map[string]device.Device{"GPU-b850f46d-d5ea-c752-ddf3-c4453e44d3f7": mockDevice}, DefaultRebootThreshold)
-		assert.Equal(t, apiv1.HealthStateTypeDegraded, state.Health)
-		assert.Equal(t, "XID 123 (SPI PMU RPC Write Failure) detected on GPU PCI:0000:9b:00 UUID:GPU-b850f46d-d5ea-c752-ddf3-c4453e44d3f7", state.Reason)
+		assert.Equal(t, apiv1.HealthStateTypeUnhealthy, state.Health)
+		assert.Equal(t, "XID 123 SPI_PMU_RPC_WRITE_FAIL detected on GPU PCI:0000:9b:00 UUID:GPU-b850f46d-d5ea-c752-ddf3-c4453e44d3f7", state.Reason)
 	})
 
 	t.Run("fatal xid", func(t *testing.T) {
 		events := eventstore.Events{
 			createXidEvent(time.Time{}, 456, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
 		}
+		t.Logf("original type=%s", events[0].Type)
+		resolved := resolveXIDEvent(events[0], map[string]device.Device{"GPU-b850f46d-d5ea-c752-ddf3-c4453e44d3f7": mockDevice})
+		t.Logf("resolved type=%s msg=%s", resolved.Type, resolved.Message)
 		state := evolveHealthyState(events, map[string]device.Device{"GPU-b850f46d-d5ea-c752-ddf3-c4453e44d3f7": mockDevice}, DefaultRebootThreshold)
 		assert.Equal(t, apiv1.HealthStateTypeUnhealthy, state.Health)
 		assert.Equal(t, "XID 456 detected on GPU PCI:0000:9b:00 UUID:GPU-b850f46d-d5ea-c752-ddf3-c4453e44d3f7", state.Reason)
@@ -121,7 +125,7 @@ func TestStateUpdateBasedOnEvents(t *testing.T) {
 		require.NotNil(t, state.SuggestedActions)
 		require.NotEmpty(t, state.SuggestedActions.RepairActions)
 		assert.Equal(t, apiv1.RepairActionTypeRebootSystem, state.SuggestedActions.RepairActions[0])
-		assert.Equal(t, apiv1.HealthStateTypeUnhealthy, state.Health)
+		assert.Equal(t, apiv1.HealthStateTypeDegraded, state.Health)
 	})
 
 	t.Run("invalid xid", func(t *testing.T) {
@@ -187,4 +191,213 @@ func Test_xidErrorEventDetailJSON(t *testing.T) {
 		assert.Equal(t, xidErr.Xid, unmarshaled.Xid)
 		assert.Nil(t, unmarshaled.SuggestedActionsByGPUd)
 	})
+}
+
+func Test_newXIDErrorReasonWithDetail_SubCode(t *testing.T) {
+	reason := newXIDErrorReasonWithDetail(145, 0, "RLW_CTRL", "", "PCI:0000:04:00", 0, nil)
+
+	assert.Equal(t, "XID 145.0 (err status 0x00000000) NVLINK_RLW_ERROR detected on GPU PCI:0000:04:00", reason)
+}
+
+// Test_MatchToEventMessageFlowFormatsMnemonic verifies that the event message uses the catalog
+// mnemonic and omits subcodes when none are present in the parsed log.
+func Test_MatchToEventMessageFlowFormatsMnemonic(t *testing.T) {
+	testCases := []struct {
+		name            string
+		kmsgLine        string
+		expectedMessage string
+	}{
+		{
+			name:            "RLW_CTRL message",
+			kmsgLine:        "NVRM: Xid (PCI:0000:04:00): 145, RLW_CTRL Nonfatal XC0 i0 Link 00 (0x00000003 0x80000000 0x00000000 0x00000000)",
+			expectedMessage: "XID 145.0 (err status 0x00000000) NVLINK_RLW_ERROR detected on GPU PCI:0000:04:00",
+		},
+		{
+			name:            "RLW_REMAP message",
+			kmsgLine:        "NVRM: Xid (PCI:0000:04:00): 145, RLW_REMAP Nonfatal XC0 i0 Link 00 (0x00000004 0x00000001 0x00000000 0x00000000)",
+			expectedMessage: "XID 145.0 (err status 0x00000000) NVLINK_RLW_ERROR detected on GPU PCI:0000:04:00",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			xidErr := Match(tc.kmsgLine)
+			require.NotNil(t, xidErr, "Match should return non-nil")
+			require.NotNil(t, xidErr.Detail, "Detail should be populated")
+
+			xidPayload := xidErrorEventDetail{
+				DeviceUUID: xidErr.DeviceUUID,
+				Xid:        uint64(xidErr.Xid),
+			}
+			if xidErr.Detail != nil {
+				xidPayload.SubCode = xidErr.Detail.SubCode
+				xidPayload.SubCodeDescription = xidErr.Detail.SubCodeDescription
+				xidPayload.InvestigatoryHint = xidErr.Detail.InvestigatoryHint
+				xidPayload.Description = xidErr.Detail.Description
+			}
+
+			reason := newXIDErrorReasonWithDetail(int(xidPayload.Xid), xidPayload.SubCode, xidPayload.SubCodeDescription, xidPayload.InvestigatoryHint, xidPayload.DeviceUUID, xidPayload.ErrorStatus, nil)
+
+			assert.Equal(t, tc.expectedMessage, reason)
+			assert.Contains(t, reason, "145.0", "dot subcode should be present for NVLink")
+		})
+	}
+}
+
+// Test_SubCodeDifferentiatesSameUnit verifies that errors with the same Unit but
+// different decoded sub-codes produce distinct user-facing messages.
+func Test_SubCodeDifferentiatesSameUnit(t *testing.T) {
+	testCases := []struct {
+		name         string
+		kmsgLine     string
+		subCodeValue int
+	}{
+		{
+			name:         "NETIR_LINK_EVT with peer device subcode",
+			kmsgLine:     "NVRM: Xid (PCI:0000:00:00): 149, NETIR_LINK_EVT Fatal XC0 i0 Link 00 (0x025001c6 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000)",
+			subCodeValue: 37,
+		},
+		{
+			name:         "NETIR_LINK_EVT with software subcode",
+			kmsgLine:     "NVRM: Xid (PCI:0000:00:00): 149, NETIR_LINK_EVT Fatal XC0 i0 Link 00 (0x026001c6 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000)",
+			subCodeValue: 38,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Step 1: Parse the kmsg line
+			xidErr := Match(tc.kmsgLine)
+			require.NotNil(t, xidErr, "Match should return non-nil")
+			require.NotNil(t, xidErr.Detail, "Detail should be populated")
+
+			// Step 2: Verify the InvestigatoryHint is set correctly
+			assert.NotEmpty(t, xidErr.Detail.InvestigatoryHint, "InvestigatoryHint should be set")
+
+			// Step 3: Create the event detail payload (simulating component.go)
+			xidPayload := xidErrorEventDetail{
+				DeviceUUID:         xidErr.DeviceUUID,
+				Xid:                uint64(xidErr.Xid),
+				SubCode:            xidErr.Detail.SubCode,
+				SubCodeDescription: xidErr.Detail.SubCodeDescription,
+				InvestigatoryHint:  xidErr.Detail.InvestigatoryHint,
+				Description:        xidErr.Detail.Description,
+			}
+
+			// Step 4: Generate the user-facing reason message
+			reason := newXIDErrorReasonWithDetail(int(xidPayload.Xid), xidPayload.SubCode, xidPayload.SubCodeDescription, xidPayload.InvestigatoryHint, xidPayload.DeviceUUID, xidPayload.ErrorStatus, nil)
+
+			assert.Contains(t, reason, "NVLINK_NETIR_ERROR", "Message should use mnemonic")
+			assert.Contains(t, reason, "149.", "Message should include dot sub-code when present")
+			assert.Contains(t, reason, "149."+fmt.Sprintf("%d", tc.subCodeValue))
+		})
+	}
+}
+
+// Test_InvestigatoryHintFiltering verifies that IGNORE and CONTACT_SUPPORT
+// Investigatory values are filtered out, while other values are passed through.
+func Test_InvestigatoryHintFiltering(t *testing.T) {
+	testCases := []struct {
+		name        string
+		kmsgLine    string
+		expectHint  bool
+		expectedVal string // empty means expect no hint
+	}{
+		{
+			name:        "INVESTIGATE_PEER_DEVICE passes through",
+			kmsgLine:    "NVRM: Xid (PCI:0000:00:00): 149, NETIR_LINK_EVT Fatal XC0 i0 Link 00 (0x025001c6 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000)",
+			expectHint:  true,
+			expectedVal: "INVESTIGATE_PEER_DEVICE",
+		},
+		{
+			name:        "INVESTIGATE_SW/USER passes through",
+			kmsgLine:    "NVRM: Xid (PCI:0000:00:00): 149, NETIR_LINK_EVT Fatal XC0 i0 Link 00 (0x026001c6 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000)",
+			expectHint:  true,
+			expectedVal: "INVESTIGATE_SW/USER",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			xidErr := Match(tc.kmsgLine)
+			require.NotNil(t, xidErr, "Match should return non-nil")
+			require.NotNil(t, xidErr.Detail, "Detail should be populated")
+
+			if tc.expectHint {
+				assert.Equal(t, tc.expectedVal, xidErr.Detail.InvestigatoryHint, "InvestigatoryHint should match expected value")
+			} else {
+				assert.Empty(t, xidErr.Detail.InvestigatoryHint, "InvestigatoryHint should be empty for filtered values")
+			}
+		})
+	}
+}
+
+// Test_NewXIDErrorReasonWithDetail_Format verifies that the new user-facing format uses
+// numeric subcodes (when present) and catalog mnemonics.
+func Test_NewXIDErrorReasonWithDetail_Format(t *testing.T) {
+	t.Run("with subcode", func(t *testing.T) {
+		reason := newXIDErrorReasonWithDetail(149, 37, "NETIR_LINK_EVT", "INVESTIGATE_PEER_DEVICE", "PCI:0000:00:00", 0, nil)
+		assert.Equal(t, "XID 149.37 (err status 0x00000000) NVLINK_NETIR_ERROR detected on GPU PCI:0000:00:00", reason)
+	})
+
+	t.Run("without subcode", func(t *testing.T) {
+		reason := newXIDErrorReasonWithDetail(149, 0, "NETIR_LINK_EVT", "", "PCI:0000:00:00", 0, nil)
+		assert.Equal(t, "XID 149.0 (err status 0x00000000) NVLINK_NETIR_ERROR detected on GPU PCI:0000:00:00", reason)
+	})
+
+	t.Run("different subcodes produce different messages", func(t *testing.T) {
+		reasonPeer := newXIDErrorReasonWithDetail(149, 37, "NETIR_LINK_EVT", "INVESTIGATE_PEER_DEVICE", "PCI:0000:00:00", 0, nil)
+		reasonSoftware := newXIDErrorReasonWithDetail(149, 38, "NETIR_LINK_EVT", "INVESTIGATE_SW/USER", "PCI:0000:00:00", 0, nil)
+
+		assert.NotEqual(t, reasonPeer, reasonSoftware)
+		assert.Contains(t, reasonPeer, "149.37")
+		assert.Contains(t, reasonSoftware, "149.38")
+	})
+}
+
+// Test_StatusAwareMessages covers the exact lines requested by the user and ensures severity/message are correct.
+func Test_StatusAwareMessages(t *testing.T) {
+	cases := []struct {
+		name          string
+		line          string
+		expectedMsg   string
+		expectedEvent apiv1.EventType
+		expectedSub   int
+	}{
+		{
+			name:          "SAW_MVB nonfatal should stay warning",
+			line:          "NVRM: Xid (PCI:0000:01:00): 144, SAW_MVB Nonfatal XC0 i0 Link 0 (0x00000001 0x00000008 0x00000000 0x00000000 0x00000000 0x00000000)",
+			expectedMsg:   "XID 144.0 (err status 0x00000008) NVLINK_SAW_ERROR detected on GPU PCI:0000:01:00",
+			expectedEvent: apiv1.EventTypeWarning,
+			expectedSub:   0,
+		},
+		{
+			name:          "NETIR_LINK_EVT subcode 38",
+			line:          "NVRM: Xid (PCI:0000:00:00): 149, NETIR_LINK_EVT Fatal XC0 i0 Link 00 (0x026001c6 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000)",
+			expectedMsg:   "XID 149.38 (err status 0x00000000) NVLINK_NETIR_ERROR detected on GPU PCI:0000:00:00",
+			expectedEvent: apiv1.EventTypeFatal,
+			expectedSub:   38,
+		},
+		{
+			name:          "NETIR_LINK_EVT subcode 37",
+			line:          "NVRM: Xid (PCI:0000:00:00): 149, NETIR_LINK_EVT Fatal XC0 i0 Link 00 (0x025001c6 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000)",
+			expectedMsg:   "XID 149.37 (err status 0x00000000) NVLINK_NETIR_ERROR detected on GPU PCI:0000:00:00",
+			expectedEvent: apiv1.EventTypeFatal,
+			expectedSub:   37,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			xidErr := Match(tc.line)
+			require.NotNil(t, xidErr)
+			require.NotNil(t, xidErr.Detail)
+
+			reason := newXIDErrorReasonWithDetail(xidErr.Xid, xidErr.Detail.SubCode, xidErr.Detail.SubCodeDescription, xidErr.Detail.InvestigatoryHint, xidErr.DeviceUUID, xidErr.Detail.ErrorStatus, nil)
+
+			assert.Equal(t, tc.expectedMsg, reason)
+			assert.Equal(t, tc.expectedEvent, xidErr.Detail.EventType)
+			assert.Equal(t, tc.expectedSub, xidErr.Detail.SubCode)
+		})
+	}
 }

--- a/components/accelerator/nvidia/xid/kmsg_extended_test.go
+++ b/components/accelerator/nvidia/xid/kmsg_extended_test.go
@@ -490,6 +490,14 @@ func TestMatchNVLinkExamples(t *testing.T) {
 		{"Log17 NETIR Fatal", "NVRM: Xid (PCI:0018:01:00): 149, NETIR Fatal XC0 i0 Link -1 (0x000fe406 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000)", 0, "NETIR", apiv1.EventTypeFatal, []apiv1.RepairActionType{apiv1.RepairActionTypeRebootSystem}},
 		{"Log18 NETIR_LINK_EVT", "NVRM: Xid (PCI:0018:01:00): 149, NETIR_LINK_EVT Fatal XC0 i0 Link 09 (0x004525c6 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000)", 4, "NETIR_LINK_EVT", apiv1.EventTypeFatal, []apiv1.RepairActionType{apiv1.RepairActionTypeRebootSystem}},
 		{"Log19 NETIR_LINK_EVT", "NVRM: Xid (PCI:0018:01:00): 149, NETIR_LINK_EVT Fatal XC0 i0 Link 09 (0x004525c6 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000)", 4, "NETIR_LINK_EVT", apiv1.EventTypeFatal, []apiv1.RepairActionType{apiv1.RepairActionTypeRebootSystem}},
+
+		// Test cases for RLW_CTRL and RLW_REMAP - verifies distinguishable subcode names
+		{"Log20 RLW_CTRL", "NVRM: Xid (PCI:0000:04:00): 145, RLW_CTRL Nonfatal XC0 i0 Link 00 (0x00000003 0x80000000 0x00000000 0x00000000)", 0, "RLW_CTRL", apiv1.EventTypeWarning, []apiv1.RepairActionType{apiv1.RepairActionTypeIgnoreNoActionRequired}},
+		{"Log21 RLW_REMAP", "NVRM: Xid (PCI:0000:04:00): 145, RLW_REMAP Nonfatal XC0 i0 Link 00 (0x00000004 0x00000001 0x00000000 0x00000000)", 0, "RLW_REMAP", apiv1.EventTypeWarning, []apiv1.RepairActionType{apiv1.RepairActionTypeHardwareInspection}},
+
+		// Test cases for XID 144 (SAW Error) - verifies different SAW subcodes are distinguishable
+		{"Log22 SAW_MVB", "NVRM: Xid (PCI:0000:04:00): 144, SAW_MVB Nonfatal XC0 i0 Link 00 (0x00000003 0x80000000 0x00000000 0x00000000)", 0, "SAW_MVB", apiv1.EventTypeWarning, nil},
+		{"Log23 SAW_EGR", "NVRM: Xid (PCI:0000:04:00): 144, SAW_EGR Nonfatal XC0 i0 Link 00 (0x00000004 0x00000001 0x00000000 0x00000000)", 0, "SAW_EGR", apiv1.EventTypeWarning, nil},
 	}
 
 	for _, tc := range tests {
@@ -502,8 +510,12 @@ func TestMatchNVLinkExamples(t *testing.T) {
 					assert.Equal(t, tc.expectedSub, xidErr.Detail.SubCode)
 					assert.Equal(t, tc.expectedDesc, xidErr.Detail.SubCodeDescription)
 					assert.Equal(t, tc.expectedEvent, xidErr.Detail.EventType)
-					if assert.NotNil(t, xidErr.Detail.SuggestedActionsByGPUd) {
-						assert.ElementsMatch(t, tc.expectedAction, xidErr.Detail.SuggestedActionsByGPUd.RepairActions)
+					if tc.expectedAction != nil {
+						if assert.NotNil(t, xidErr.Detail.SuggestedActionsByGPUd) {
+							for _, act := range tc.expectedAction {
+								assert.Contains(t, xidErr.Detail.SuggestedActionsByGPUd.RepairActions, act)
+							}
+						}
 					}
 				}
 			}

--- a/components/accelerator/nvidia/xid/nvlink_logs_test.go
+++ b/components/accelerator/nvidia/xid/nvlink_logs_test.go
@@ -1,0 +1,96 @@
+package xid
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apiv1 "github.com/leptonai/gpud/api/v1"
+)
+
+// Test_NVLinkLogCoverage verifies severity and formatted user-facing reason for a
+// representative set of NVLink5 XIDs (144-150) spanning many units/errorStatus values.
+func Test_NVLinkLogCoverage(t *testing.T) {
+	cases := []struct {
+		name          string
+		line          string
+		expectedEvent apiv1.EventType
+	}{
+		// XID 144 SAW_MVB
+		{"144_SAW_MVB_nonfatal", "NVRM: Xid (PCI:0000:04:00): 144, SAW_MVB Nonfatal XC0 i0 Link 00 (0x00000001 0x00000001 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"144_SAW_MVB_fatal", "NVRM: Xid (PCI:0000:04:00): 144, SAW_MVB Fatal XC0 i0 Link 00 (0x00000001 0x00000002 0x00000000 0x00000000)", apiv1.EventTypeFatal},
+
+		// XID 145 RLW*
+		{"145_RLW_CTRL_nonfatal", "NVRM: Xid (PCI:0000:04:00): 145, RLW_CTRL Nonfatal XC0 i0 Link 00 (0x00000003 0x80000000 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"145_RLW_REMAP_nonfatal", "NVRM: Xid (PCI:0000:04:00): 145, RLW_REMAP Nonfatal XC0 i0 Link 00 (0x00000004 0x00000001 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"145_RLW_REMAP_fatal", "NVRM: Xid (PCI:0000:04:00): 145, RLW_REMAP Fatal XC0 i0 Link 00 (0x00000004 0x00000040 0x00000000 0x00000000)", apiv1.EventTypeFatal},
+		{"145_RLW_REMAP_nonfatal_status100", "NVRM: Xid (PCI:0000:04:00): 145, RLW_REMAP Nonfatal XC0 i0 Link 00 (0x00000004 0x00000100 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"145_RLW_RSPCOL_nonfatal", "NVRM: Xid (PCI:0000:04:00): 145, RLW_RSPCOL Nonfatal XC0 i0 Link 00 (0x00000005 0x00000001 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"145_RLW_RSPCOL_fatal", "NVRM: Xid (PCI:0000:04:00): 145, RLW_RSPCOL Fatal XC0 i0 Link 00 (0x00000005 0x00000002 0x00000000 0x00000000)", apiv1.EventTypeFatal},
+		{"145_RLW_RXPIPE_nonfatal", "NVRM: Xid (PCI:0000:04:00): 145, RLW_RXPIPE Nonfatal XC0 i0 Link 00 (0x00000006 0x00000001 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"145_RLW_SRC_TRACK_fatal", "NVRM: Xid (PCI:0000:04:00): 145, RLW_SRC_TRACK Fatal XC0 i0 Link 00 (0x00000007 0x00000001 0x00000000 0x00000000)", apiv1.EventTypeFatal},
+		{"145_RLW_SRC_TRACK_nonfatal2", "NVRM: Xid (PCI:0000:04:00): 145, RLW_SRC_TRACK Nonfatal XC0 i0 Link 00 (0x00000007 0x00000002 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"145_RLW_SRC_TRACK_nonfatal4", "NVRM: Xid (PCI:0000:04:00): 145, RLW_SRC_TRACK Nonfatal XC0 i0 Link 00 (0x00000007 0x00000004 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"145_RLW_TAGSTATE_nonfatal", "NVRM: Xid (PCI:0000:04:00): 145, RLW_TAGSTATE Nonfatal XC0 i0 Link 00 (0x00000008 0x00000001 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"145_RLW_TAGSTATE_fatal", "NVRM: Xid (PCI:0000:04:00): 145, RLW_TAGSTATE Fatal XC0 i0 Link 00 (0x00000008 0x00000002 0x00000000 0x00000000)", apiv1.EventTypeFatal},
+
+		// XID 146 TLW*
+		{"146_TLW_CTRL_nonfatal", "NVRM: Xid (PCI:0000:04:00): 146, TLW_CTRL Nonfatal XC0 i0 Link 00 (0x00000009 0x00000001 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"146_TLW_CTRL_fatal", "NVRM: Xid (PCI:0000:04:00): 146, TLW_CTRL Fatal XC0 i0 Link 00 (0x00000009 0x00000004 0x00000000 0x00000000)", apiv1.EventTypeFatal},
+		{"146_TLW_RX_PIPE0_nonfatal", "NVRM: Xid (PCI:0000:04:00): 146, TLW_RX/TLW_RX_PIPE0 Nonfatal XC0 i0 Link 00 (0x0000000a 0x00000001 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"146_TLW_RX_PIPE0_fatal", "NVRM: Xid (PCI:0000:04:00): 146, TLW_RX/TLW_RX_PIPE0 Fatal XC0 i0 Link 00 (0x0000000a 0x00000004 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"146_TLW_RX_PIPE1_nonfatal", "NVRM: Xid (PCI:0000:04:00): 146, TLW_RX/TLW_RX_PIPE1 Nonfatal XC0 i0 Link 00 (0x0000000b 0x00000001 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"146_TLW_RX_PIPE1_fatal", "NVRM: Xid (PCI:0000:04:00): 146, TLW_RX/TLW_RX_PIPE1 Fatal XC0 i0 Link 00 (0x0000000b 0x00000004 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"146_TLW_TX_PIPE0_nonfatal", "NVRM: Xid (PCI:0000:04:00): 146, TLW_TX/TLW_TX_PIPE0 Nonfatal XC0 i0 Link 00 (0x0000000c 0x00000001 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"146_TLW_TX_PIPE0_fatal", "NVRM: Xid (PCI:0000:04:00): 146, TLW_TX/TLW_TX_PIPE0 Fatal XC0 i0 Link 00 (0x0000000c 0x00000004 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"146_TLW_TX_PIPE1_nonfatal", "NVRM: Xid (PCI:0000:04:00): 146, TLW_TX/TLW_TX_PIPE1 Nonfatal XC0 i0 Link 00 (0x0000000d 0x00000001 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"146_TLW_TX_PIPE1_fatal", "NVRM: Xid (PCI:0000:04:00): 146, TLW_TX/TLW_TX_PIPE1 Fatal XC0 i0 Link 00 (0x0000000d 0x00000004 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+
+		// XID 147 TREX
+		{"147_TREX_nonfatal", "NVRM: Xid (PCI:0000:04:00): 147, TREX Nonfatal XC0 i0 Link 00 (0x0000000e 0x00000001 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+
+		// XID 148 NVLPW
+		{"148_NVLPW_nonfatal", "NVRM: Xid (PCI:0000:04:00): 148, NVLPW_CTRL/NVLPW Nonfatal XC0 i0 Link 00 (0x0000000f 0x80000000 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+
+		// XID 149 NETIR variants
+		{"149_NETIR_INT_fatal", "NVRM: Xid (PCI:0000:04:00): 149, NETIR/NETIR_INT Fatal XC0 i0 Link 00 (0x00000018 0x00000000 0x00000000 0x00000000)", apiv1.EventTypeFatal},
+		{"149_NETIR_BER_EVENT_nonfatal", "NVRM: Xid (PCI:0000:04:00): 149, NETIR_BER_EVENT Nonfatal XC0 i0 Link 00 (0x00000013 0x00000000 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+		{"149_NETIR_MFDE_EVENT_fatal", "NVRM: Xid (PCI:0000:04:00): 149, NETIR_MFDE_EVENT Fatal XC0 i0 Link 00 (0x00000014 0x00000001 0x00000000 0x00000000)", apiv1.EventTypeFatal},
+		{"149_NETIR_MFDE_EVENT_nonfatal", "NVRM: Xid (PCI:0000:04:00): 149, NETIR_MFDE_EVENT Nonfatal XC0 i0 Link 00 (0x00000014 0x00000003 0x00000000 0x00000000)", apiv1.EventTypeWarning},
+
+		// Sample NETIR_LINK_EVT/NETIR_LINK_DOWN fatal variations (multiple intrinfo patterns)
+		{"149_NETIR_LINK_EVT_down_00000011", "NVRM: Xid (PCI:0000:04:00): 149, NETIR_LINK_EVT/NETIR_LINK_DOWN Fatal XC0 i0 Link 00 (0x00000011 0x00000000 0x00000000 0x00000000)", apiv1.EventTypeFatal},
+		{"149_NETIR_LINK_EVT_down_01000011", "NVRM: Xid (PCI:0000:04:00): 149, NETIR_LINK_EVT/NETIR_LINK_DOWN Fatal XC0 i0 Link 00 (0x01000011 0x00000000 0x00000000 0x00000000)", apiv1.EventTypeFatal},
+		{"149_NETIR_LINK_EVT_down_02500011", "NVRM: Xid (PCI:0000:04:00): 149, NETIR_LINK_EVT/NETIR_LINK_DOWN Fatal XC0 i0 Link 00 (0x02500011 0x00000000 0x00000000 0x00000000)", apiv1.EventTypeFatal},
+
+		// XID 150
+		{"150_MSE_WATCHDOG_fatal", "NVRM: Xid (PCI:0000:04:00): 150, MSE_WATCHDOG Fatal XC0 i0 Link 00 (0x00000000 0x00000000 0x00000000 0x00000000)", apiv1.EventTypeFatal},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			xidErr := Match(tc.line)
+			require.NotNil(t, xidErr)
+			require.NotNil(t, xidErr.Detail)
+
+			// Recompute reason with status-aware formatting.
+			reason := newXIDErrorReasonWithDetail(xidErr.Xid, xidErr.Detail.SubCode, xidErr.Detail.SubCodeDescription, xidErr.Detail.InvestigatoryHint, xidErr.DeviceUUID, xidErr.Detail.ErrorStatus, nil)
+
+			expectedReason := fmt.Sprintf("XID %d.%d (err status 0x%08x) %s detected on GPU %s",
+				xidErr.Xid,
+				xidErr.Detail.SubCode,
+				xidErr.Detail.ErrorStatus,
+				mnemonicForXID(xidErr.Xid),
+				xidErr.DeviceUUID,
+			)
+
+			assert.Equal(t, tc.expectedEvent, xidErr.Detail.EventType)
+			assert.Equal(t, expectedReason, reason)
+			// Ensure mnemonic appears only once (no redundant detail duplication).
+			assert.Equal(t, 1, strings.Count(reason, mnemonicForXID(xidErr.Xid)))
+		})
+	}
+}

--- a/components/accelerator/nvidia/xid/xid_test.go
+++ b/components/accelerator/nvidia/xid/xid_test.go
@@ -1,0 +1,55 @@
+package xid
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apiv1 "github.com/leptonai/gpud/api/v1"
+)
+
+// Status-aware detail selection for NVLink rules
+func Test_detailFromNVLinkInfo_StatusSpecific(t *testing.T) {
+	// Non-fatal SAW_MVB (errorStatus 0x8) should stay warning
+	infoWarn := &XidExtractedInfo{
+		Xid:         144,
+		SubCodeName: "SAW_MVB",
+		SubCode:     0,
+		Severity:    "Nonfatal",
+		Intrinfo:    0x00000021, // matches SAW_MVB pattern
+		ErrorStatus: 0x00000008,
+	}
+	detailWarn, ok := detailFromNVLinkInfo(infoWarn)
+	require.True(t, ok)
+	assert.Equal(t, apiv1.EventTypeWarning, detailWarn.EventType)
+
+	// Fatal SAW_MVB (errorStatus 0x2) should be fatal
+	infoFatal := &XidExtractedInfo{
+		Xid:         144,
+		SubCodeName: "SAW_MVB",
+		SubCode:     0,
+		Severity:    "Nonfatal", // log says Nonfatal but rule severity is Fatal
+		Intrinfo:    0x00000021,
+		ErrorStatus: 0x00000002,
+	}
+	detailFatal, ok := detailFromNVLinkInfo(infoFatal)
+	require.True(t, ok)
+	assert.Equal(t, apiv1.EventTypeFatal, detailFatal.EventType)
+	// Suggested action should come from the rule (RESET_GPU -> RebootSystem)
+	require.NotNil(t, detailFatal.SuggestedActionsByGPUd)
+	assert.Contains(t, detailFatal.SuggestedActionsByGPUd.RepairActions, apiv1.RepairActionTypeRebootSystem)
+
+	// Unknown errorStatus should fall back to base/subcode detail (warning)
+	infoUnknown := &XidExtractedInfo{
+		Xid:         144,
+		SubCodeName: "SAW_MVB",
+		SubCode:     0,
+		Severity:    "Nonfatal",
+		Intrinfo:    0x00000021,
+		ErrorStatus: 0xDEADBEEF,
+	}
+	detailUnknown, ok := detailFromNVLinkInfo(infoUnknown)
+	require.True(t, ok)
+	assert.Equal(t, apiv1.EventTypeWarning, detailUnknown.EventType)
+}


### PR DESCRIPTION
> NVRM: Xid (PCI:0000:01:00): 144, SAW_MVB Nonfatal XC0 i0 Link 0 (0x00000001 0x00000008 0x00000000 0x00000000 0x00000000 0x00000000)
- XID 144.0 (err status 0x00000008) NVLINK_SAW_ERROR detected on GPU PCI:0000:01:00
- Warning
    
> NVRM: Xid (PCI:0000:00:00): 149, NETIR_LINK_EVT Fatal XC0 i0 Link 00 (0x026001c6 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000)
- XID 149.38 (err status 0x00000000) NVLINK_NETIR_ERROR detected on GPU PCI:0000:00:00
- Fatal
    
> NVRM: Xid (PCI:0000:00:00): 149, NETIR_LINK_EVT Fatal XC0 i0 Link 00 (0x025001c6 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000)
- XID 149.37 (err status 0x00000000) NVLINK_NETIR_ERROR detected on GPU PCI:0000:00:00
- Fatal