### PR TITLE
fix(nvidia/infiniband): handle ACCESS_REG kernel error in mlx device query, allow device exclusion

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -239,6 +239,11 @@ sudo rm /etc/systemd/system/gpud.service
 				},
 
 				cli.StringFlag{
+					Name:  "infiniband-exclude-devices",
+					Usage: "comma-separated list of InfiniBand device names to exclude from monitoring (e.g., 'mlx5_0,mlx5_1'). Use this to skip devices with restricted Physical Functions (PFs) that cause kernel errors (mlx5_cmd_out_err ACCESS_REG). Common on NVIDIA DGX, Umbriel, and GB200 systems. See https://github.com/leptonai/gpud/issues/1164",
+					Value: "",
+				},
+				cli.StringFlag{
 					Name:   "infiniband-class-root-dir",
 					Usage:  "(testing purposes) sets the infiniband class root directory (leave empty for default)",
 					Value:  "",
@@ -561,6 +566,11 @@ sudo rm /etc/systemd/system/gpud.service
 					Hidden: true, // only for testing
 				},
 				cli.StringFlag{
+					Name:  "infiniband-exclude-devices",
+					Usage: "comma-separated list of InfiniBand device names to exclude from monitoring (e.g., 'mlx5_0,mlx5_1'). Use this to skip devices with restricted Physical Functions (PFs) that cause kernel errors (mlx5_cmd_out_err ACCESS_REG). Common on NVIDIA DGX, Umbriel, and GB200 systems. See https://github.com/leptonai/gpud/issues/1164",
+					Value: "",
+				},
+				cli.StringFlag{
 					Name:   "gpu-uuids-with-row-remapping-pending",
 					Usage:  "set the comma-separated gpu uuids with row remapping pending",
 					Hidden: true, // only for testing
@@ -646,6 +656,11 @@ sudo rm /etc/systemd/system/gpud.service
 					Usage:  "sets the infiniband class root directory (leave empty for default)",
 					Value:  "",
 					Hidden: true, // only for testing
+				},
+				cli.StringFlag{
+					Name:  "infiniband-exclude-devices",
+					Usage: "comma-separated list of InfiniBand device names to exclude from monitoring (e.g., 'mlx5_0,mlx5_1'). Use this to skip devices with restricted Physical Functions (PFs) that cause kernel errors (mlx5_cmd_out_err ACCESS_REG). Common on NVIDIA DGX, Umbriel, and GB200 systems. See https://github.com/leptonai/gpud/issues/1164",
+					Value: "",
 				},
 			},
 		},

--- a/cmd/gpud/command/command_test.go
+++ b/cmd/gpud/command/command_test.go
@@ -1,0 +1,39 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppHasInfinibandExcludeDevicesFlag(t *testing.T) {
+	t.Parallel()
+
+	app := App()
+
+	wantCommands := map[string]bool{
+		"run":            false,
+		"scan":           false,
+		"custom-plugins": false,
+	}
+
+	for _, cmd := range app.Commands {
+		if _, ok := wantCommands[cmd.Name]; !ok {
+			continue
+		}
+
+		foundFlag := false
+		for _, f := range cmd.Flags {
+			if f.GetName() == "infiniband-exclude-devices" {
+				foundFlag = true
+				break
+			}
+		}
+		require.Truef(t, foundFlag, "command %q is missing --infiniband-exclude-devices", cmd.Name)
+		wantCommands[cmd.Name] = true
+	}
+
+	for cmdName, foundCmd := range wantCommands {
+		require.Truef(t, foundCmd, "expected command %q to exist", cmdName)
+	}
+}

--- a/cmd/gpud/run/command_test.go
+++ b/cmd/gpud/run/command_test.go
@@ -1,0 +1,47 @@
+package run
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseInfinibandExcludeDevices(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "empty",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "commas and spaces only",
+			input: " , , ",
+			want:  nil,
+		},
+		{
+			name:  "single device",
+			input: "mlx5_0",
+			want:  []string{"mlx5_0"},
+		},
+		{
+			name:  "multiple devices with spaces and empties",
+			input: " mlx5_0, ,mlx5_1 ,",
+			want:  []string{"mlx5_0", "mlx5_1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := parseInfinibandExcludeDevices(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/components/accelerator/nvidia/infiniband/component_production_scenarios_test.go
+++ b/components/accelerator/nvidia/infiniband/component_production_scenarios_test.go
@@ -243,7 +243,7 @@ func TestDormantPortHandling(t *testing.T) {
 					AtLeastRate:  400,
 				}
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 				// 8 healthy ports (meeting threshold) + 4 dormant ports
 				return createMixedDevices(8, 4), nil
 			},
@@ -289,7 +289,7 @@ func TestDormantPortHandling(t *testing.T) {
 					AtLeastRate:  400,
 				}
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 				// Only 7 healthy ports (threshold failure)
 				return createMixedDevices(7, 5), nil
 			},
@@ -320,7 +320,7 @@ func createTestComponent(checkTime time.Time, store infinibandstore.Store, stick
 				AtLeastRate:  400,
 			}
 		},
-		getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+		getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 			if portsHealthy {
 				return createHealthyDevices(8, 400), nil
 			}

--- a/components/accelerator/nvidia/infiniband/component_read_class_test.go
+++ b/components/accelerator/nvidia/infiniband/component_read_class_test.go
@@ -52,8 +52,8 @@ func TestComponentReadClass(t *testing.T) {
 		getThresholdsFunc: func() types.ExpectedPortStates {
 			return threshold
 		},
-		getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-			return infinibandclass.LoadDevices(classRootDir)
+		getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+			return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 		},
 	}
 
@@ -325,8 +325,8 @@ func TestComponentReadClass_FlapDetection(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(classRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -388,8 +388,8 @@ func TestComponentReadClass_FlapDetection(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(classRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -440,8 +440,8 @@ func TestComponentReadClass_FlapDetection(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(classRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -510,8 +510,8 @@ func TestComponentReadClass_DropDetection(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(classRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -564,8 +564,8 @@ func TestComponentReadClass_DropDetection(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(classRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -612,8 +612,8 @@ func TestComponentReadClass_DropDetection(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(classRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -690,8 +690,8 @@ func TestComponentReadClass_CombinedFlapAndDrop(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(classRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -780,8 +780,8 @@ func TestComponentReadClass_ErrorCounterRates(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(classRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -820,8 +820,8 @@ func TestComponentReadClass_ErrorCounterRates(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(classRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -870,8 +870,8 @@ func TestComponentReadClass_ErrorCounterRates(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(classRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -934,8 +934,8 @@ func TestComponentReadClass_EdgeCases(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(classRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -984,8 +984,8 @@ func TestComponentReadClass_EdgeCases(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(subClassRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(subClassRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -1036,8 +1036,8 @@ func TestComponentReadClass_EdgeCases(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(classRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -1083,8 +1083,8 @@ func TestComponentReadClass_EdgeCases(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(classRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -1201,10 +1201,10 @@ func TestComponentReadClass_12PortsMeetingThresholdsWithEvents(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 				// The test data has 8 InfiniBand ports (mlx5_0, mlx5_1, mlx5_4-9)
 				// We'll modify some to be down but still meet the threshold
-				return infinibandclass.LoadDevices(classRootDir)
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -1301,8 +1301,8 @@ func TestComponentReadClass_12PortsMeetingThresholdsWithEvents(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(classRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -1413,11 +1413,11 @@ func TestComponentReadClass_RealisticScenarioWith12IBPorts(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 				// Mock the realistic scenario based on ibstat output
 				// Note: The test data directory might not have all these devices,
 				// so we'll configure the available ones to match the pattern
-				return infinibandclass.LoadDevices(classRootDir)
+				return infinibandclass.LoadDevices(classRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -1513,8 +1513,8 @@ func TestComponentReadClass_RealisticScenarioWith12IBPorts(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(subClassRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(subClassRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -1618,8 +1618,8 @@ func TestComponentReadClass_RealisticScenarioWith12IBPorts(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(subClassRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(subClassRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 
@@ -1709,8 +1709,8 @@ func TestComponentReadClass_RealisticScenarioWith12IBPorts(t *testing.T) {
 			getThresholdsFunc: func() types.ExpectedPortStates {
 				return threshold
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
-				return infinibandclass.LoadDevices(subClassRootDir)
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
+				return infinibandclass.LoadDevices(subClassRootDir, infinibandclass.WithIgnoreFiles(ignoreFiles))
 			},
 		}
 

--- a/components/accelerator/nvidia/infiniband/component_recovery_sticky_test.go
+++ b/components/accelerator/nvidia/infiniband/component_recovery_sticky_test.go
@@ -51,7 +51,7 @@ func TestRecoveryStickyWindow(t *testing.T) {
 				AtLeastRate:  400,
 			}
 		},
-		getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+		getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 			// Initially, port mlx5_7 is down
 			if currentTime.Before(portRecoveryTime) {
 				return createMixedDevices(7, 1), nil // 7 healthy, 1 down (mlx5_7)
@@ -144,7 +144,7 @@ func TestMultipleRecoveries(t *testing.T) {
 				AtLeastRate:  400,
 			}
 		},
-		getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+		getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 			if portsHealthy {
 				return createHealthyDevices(8, 400), nil
 			}
@@ -240,7 +240,7 @@ func TestDormantPortsWithRecovery(t *testing.T) {
 				AtLeastRate:  400,
 			}
 		},
-		getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+		getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 			if activePortHealthy {
 				// 8 active healthy ports + 4 dormant ports
 				return createMixedDevices(8, 4), nil

--- a/components/accelerator/nvidia/infiniband/component_simple_test.go
+++ b/components/accelerator/nvidia/infiniband/component_simple_test.go
@@ -44,7 +44,7 @@ func TestSimpleDropProcessing(t *testing.T) {
 					AtLeastRate:  400,
 				}
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 				// All thresholds met
 				return createHealthyDevices(8, 400), nil
 			},
@@ -84,7 +84,7 @@ func TestSimpleDropProcessing(t *testing.T) {
 					AtLeastRate:  400,
 				}
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 				// Only 7 ports - thresholds failing
 				return createHealthyDevices(7, 400), nil
 			},

--- a/components/accelerator/nvidia/infiniband/component_sticky_comprehensive_test.go
+++ b/components/accelerator/nvidia/infiniband/component_sticky_comprehensive_test.go
@@ -152,7 +152,7 @@ func TestComprehensiveStickyWindowScenarios(t *testing.T) {
 						AtLeastRate:  400,
 					}
 				},
-				getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+				getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 					if tt.thresholdsFailing {
 						return createHealthyDevices(7, 400), nil // Below threshold
 					}
@@ -209,7 +209,7 @@ func TestStickyWindowTransitions(t *testing.T) {
 				AtLeastRate:  400,
 			}
 		},
-		getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+		getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 			if portsHealthy {
 				return createHealthyDevices(8, 400), nil
 			}
@@ -323,7 +323,7 @@ func TestDormantPortFiltering(t *testing.T) {
 				AtLeastRate:  400,
 			}
 		},
-		getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+		getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 			// All ports healthy now
 			return createHealthyDevices(8, 400), nil
 		},
@@ -378,7 +378,7 @@ func TestEdgeCasesAndErrorConditions(t *testing.T) {
 					AtLeastRate:  400,
 				}
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 				return createHealthyDevices(8, 400), nil
 			},
 		}
@@ -423,7 +423,7 @@ func TestEdgeCasesAndErrorConditions(t *testing.T) {
 					AtLeastRate:  400,
 				}
 			},
-			getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+			getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 				return createHealthyDevices(8, 400), nil
 			},
 		}

--- a/components/accelerator/nvidia/infiniband/component_sticky_debug_test.go
+++ b/components/accelerator/nvidia/infiniband/component_sticky_debug_test.go
@@ -45,7 +45,7 @@ func TestDebugThresholdFailingOldDrop(t *testing.T) {
 				AtLeastRate:  400,
 			}
 		},
-		getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+		getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 			// Return 7 healthy ports (below threshold)
 			return createHealthyDevices(7, 400), nil
 		},
@@ -174,7 +174,7 @@ func TestThreeConditionsIndependently(t *testing.T) {
 						AtLeastRate:  400,
 					}
 				},
-				getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+				getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 					devices := createHealthyDevices(healthyPorts, 400)
 					if healthyPorts > 0 {
 						devices[healthyPorts-1].Name = "mlx5_test"

--- a/components/accelerator/nvidia/infiniband/component_sticky_drop_test.go
+++ b/components/accelerator/nvidia/infiniband/component_sticky_drop_test.go
@@ -37,7 +37,7 @@ func TestDropStickyWindow(t *testing.T) {
 				AtLeastRate:  400,
 			}
 		},
-		getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+		getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 			// Return 8 healthy ports (meeting threshold)
 			return createHealthyDevices(8, 400), nil
 		},
@@ -90,7 +90,7 @@ func TestDropStickyWindow(t *testing.T) {
 			EventReason: "mlx5_7 port 1 down since " + dropTime.Format(time.RFC3339),
 		},
 	}
-	c.getClassDevicesFunc = func() (infinibandclass.Devices, error) {
+	c.getClassDevicesFunc = func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 		// Return 7 healthy ports (mlx5_0 to mlx5_6) and 1 down port (mlx5_7)
 		devices := createHealthyDevices(7, 400) // mlx5_0 to mlx5_6
 		// Add mlx5_7 as a down port
@@ -124,7 +124,7 @@ func TestDropStickyWindow(t *testing.T) {
 			EventReason: "mlx5_1 port 1 flapping",
 		},
 	}
-	c.getClassDevicesFunc = func() (infinibandclass.Devices, error) {
+	c.getClassDevicesFunc = func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 		return createHealthyDevices(8, 400), nil // Thresholds met
 	}
 
@@ -154,7 +154,7 @@ func TestDropStickyWindowEdgeCases(t *testing.T) {
 				AtLeastRate:  400,
 			}
 		},
-		getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+		getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 			// Machine has 12 ports total, but only 8 are required
 			// 4 dormant ports should not trigger alerts when healthy
 			return createMixedDevices(8, 4), nil // 8 healthy, 4 dormant
@@ -185,7 +185,7 @@ func TestDropStickyWindowEdgeCases(t *testing.T) {
 	// Dormant ports should not cause issues when outside sticky window
 
 	// Now make one of the required ports fail (threshold violation)
-	c.getClassDevicesFunc = func() (infinibandclass.Devices, error) {
+	c.getClassDevicesFunc = func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 		return createMixedDevices(7, 5), nil // Only 7 healthy, 5 dormant
 	}
 
@@ -219,7 +219,7 @@ func TestDropStickyWindowDisabled(t *testing.T) {
 				AtLeastRate:  400,
 			}
 		},
-		getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+		getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 			return createHealthyDevices(8, 400), nil
 		},
 	}
@@ -266,7 +266,7 @@ func TestDropStickyWindowRecoveryLongOutage(t *testing.T) {
 				AtLeastRate:  400,
 			}
 		},
-		getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+		getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 			if portsHealthy {
 				return createHealthyDevices(8, 400), nil
 			}

--- a/components/accelerator/nvidia/infiniband/evaluate_threshold_test.go
+++ b/components/accelerator/nvidia/infiniband/evaluate_threshold_test.go
@@ -40,7 +40,7 @@ func TestCheckWithEmptyIbportsToEvaluate(t *testing.T) {
 		},
 		nvmlInstance: &mockNVMLInstance{exists: true, productName: "Tesla V100"},
 		eventBucket:  mockBucket,
-		getClassDevicesFunc: func() (infinibandclass.Devices, error) {
+		getClassDevicesFunc: func(ignoreFiles map[string]struct{}) (infinibandclass.Devices, error) {
 			return mockDevices, nil
 		},
 		getThresholdsFunc: func() types.ExpectedPortStates {

--- a/components/accelerator/nvidia/infiniband/kmsg_matcher.go
+++ b/components/accelerator/nvidia/infiniband/kmsg_matcher.go
@@ -24,11 +24,44 @@ const (
 	eventPortModuleHighTemperature   = "port_module_high_temperature"
 	regexPortModuleHighTemperature   = `Port module event.*High Temperature`
 	messagePortModuleHighTemperature = "Overheated MLX5 adapter"
+
+	// ACCESS_REG (opcode 0x805) is an mlx5 firmware command used to read/write
+	// hardware registers on Mellanox/NVIDIA InfiniBand adapters. When the mlx5
+	// driver attempts to access registers on certain Physical Functions (PFs)
+	// that are restricted by firmware (common on NVIDIA DGX, Umbriel systems,
+	// and other converged systems with ConnectX-7), the kernel logs errors like:
+	//
+	// e.g.,
+	// [...] mlx5_cmd_out_err:838:(pid 1441871): ACCESS_REG(0x805) op_mod(0x1) failed, status bad resource(0x5), syndrome (0x305684), err(-22)
+	// [...] mlx5_core 0000:d2:00.0: mlx5_cmd_out_err:838:(pid 268269): ACCESS_REG(0x805) op_mod(0x1) failed
+	//
+	// These errors flood dmesg/kmsg when monitoring tools (like gpud, node_exporter)
+	// read InfiniBand counter files from /sys/class/infiniband/mlx5_*/ports/*/counters/.
+	// The counter reads trigger the driver to issue ACCESS_REG commands, which fail
+	// on restricted PFs that are managed by the system firmware rather than the OS.
+	//
+	// WHY THIS HAPPENS:
+	// On converged GPU+network systems (DGX, Umbriel, GB200), some InfiniBand ports
+	// are "internal" (for NVLink/NVSwitch fabric) and their PFs have restricted access.
+	// The firmware controls these ports directly, blocking userspace register access.
+	//
+	// SOLUTION:
+	// Use --infiniband-exclude-devices flag to exclude problematic devices from monitoring.
+	// Example: --infiniband-exclude-devices=mlx5_0,mlx5_1
+	//
+	// ref.
+	// https://github.com/prometheus/node_exporter/issues/3434
+	// https://github.com/leptonai/gpud/issues/1164
+	// https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/mellanox/mlx5/core/cmd.c
+	eventAccessRegFailed   = "access_reg_failed"
+	regexAccessRegFailed   = `mlx5_cmd_out_err.*ACCESS_REG.*failed`
+	messageAccessRegFailed = "MLX5 ACCESS_REG command failed - device may have restricted PF access"
 )
 
 var (
 	compiledPCIPowerInsufficient      = regexp.MustCompile(regexPCIPowerInsufficient)
 	compiledPortModuleHighTemperature = regexp.MustCompile(regexPortModuleHighTemperature)
+	compiledAccessRegFailed           = regexp.MustCompile(regexAccessRegFailed)
 )
 
 // HasPCIPowerInsufficient returns true if the line indicates that the power inefficient event has been detected.
@@ -44,6 +77,20 @@ func HasPCIPowerInsufficient(line string) bool {
 // ref. https://github.com/torvalds/linux/blob/ac9c34d1e45a4c25174ced4fc0cfc33ff3ed08c7/drivers/net/ethernet/mellanox/mlx5/core/events.c#L252-L254
 func HasPortModuleHighTemperature(line string) bool {
 	if match := compiledPortModuleHighTemperature.FindStringSubmatch(line); match != nil {
+		return true
+	}
+	return false
+}
+
+// HasAccessRegFailed returns true if the line indicates that an ACCESS_REG command failed.
+// This typically happens on systems with restricted InfiniBand Physical Functions (PFs),
+// such as NVIDIA DGX or Umbriel systems with ConnectX-7 adapters.
+//
+// ref.
+// https://github.com/prometheus/node_exporter/issues/3434
+// https://github.com/leptonai/gpud/issues/1164
+func HasAccessRegFailed(line string) bool {
+	if match := compiledAccessRegFailed.FindStringSubmatch(line); match != nil {
 		return true
 	}
 	return false
@@ -69,5 +116,6 @@ func getMatches() []match {
 	return []match{
 		{check: HasPCIPowerInsufficient, eventName: eventPCIPowerInsufficient, regex: regexPCIPowerInsufficient, message: messagePCIPowerInsufficient},
 		{check: HasPortModuleHighTemperature, eventName: eventPortModuleHighTemperature, regex: regexPortModuleHighTemperature, message: messagePortModuleHighTemperature},
+		{check: HasAccessRegFailed, eventName: eventAccessRegFailed, regex: regexAccessRegFailed, message: messageAccessRegFailed},
 	}
 }

--- a/pkg/config/common/config.go
+++ b/pkg/config/common/config.go
@@ -2,4 +2,19 @@ package common
 
 type ToolOverwrites struct {
 	InfinibandClassRootDir string `json:"infiniband_class_root_dir"`
+
+	// ExcludedInfinibandDevices is a list of InfiniBand device names to exclude from monitoring.
+	// Device names should be like "mlx5_0", "mlx5_1", etc. (not full paths).
+	//
+	// This is useful for excluding devices that have restricted Physical Functions (PFs)
+	// and cause kernel errors (mlx5_cmd_out_err ACCESS_REG) when queried.
+	// This is common on NVIDIA DGX, Umbriel, and GB200 systems with ConnectX-7 adapters
+	// where some ports are managed by system firmware.
+	//
+	// Example: ["mlx5_0", "mlx5_1"]
+	//
+	// ref.
+	// https://github.com/prometheus/node_exporter/issues/3434
+	// https://github.com/leptonai/gpud/issues/1164
+	ExcludedInfinibandDevices []string `json:"excluded_infiniband_devices"`
 }

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -36,6 +36,22 @@ func WithInfinibandClassRootDir(p string) OpOption {
 	}
 }
 
+// WithExcludedInfinibandDevices sets the list of InfiniBand device names to exclude from monitoring.
+// Device names should be like "mlx5_0", "mlx5_1", etc. (not full paths).
+//
+// This is useful for excluding devices that have restricted Physical Functions (PFs)
+// and cause kernel errors (mlx5_cmd_out_err ACCESS_REG) when queried.
+// This is common on NVIDIA DGX, Umbriel, and GB200 systems with ConnectX-7 adapters.
+//
+// ref.
+// https://github.com/prometheus/node_exporter/issues/3434
+// https://github.com/leptonai/gpud/issues/1164
+func WithExcludedInfinibandDevices(devices []string) OpOption {
+	return func(op *Op) {
+		op.ExcludedInfinibandDevices = devices
+	}
+}
+
 func WithFailureInjector(injector *components.FailureInjector) OpOption {
 	return func(op *Op) {
 		op.FailureInjector = injector

--- a/pkg/config/options_test.go
+++ b/pkg/config/options_test.go
@@ -52,3 +52,12 @@ func TestWithFailureInjector(t *testing.T) {
 		})
 	}
 }
+
+func TestWithExcludedInfinibandDevices(t *testing.T) {
+	t.Parallel()
+
+	op := &Op{}
+	WithExcludedInfinibandDevices([]string{"mlx5_0", "mlx5_1"})(op)
+
+	assert.Equal(t, []string{"mlx5_0", "mlx5_1"}, op.ExcludedInfinibandDevices)
+}


### PR DESCRIPTION
Problem
-------
On NVIDIA DGX, Umbriel, and GB200 systems with ConnectX-7 adapters, some
Physical Functions (PFs) are restricted by system firmware. When gpud reads
InfiniBand counter files from /sys/class/infiniband/mlx5_*/ports/*/counters/,
the mlx5 driver executes ACCESS_REG commands (opcode 0x805) to query the
firmware. For restricted PFs, these commands fail and flood the kernel log:

>  mlx5_cmd_out_err:835:(pid 18360): ACCESS_REG(0x805) op_mod(0x1) failed,
>  status bad operation(0x2), syndrome (0x9a6171), err(-22)

The err(-22) corresponds to EINVAL, which is returned to userspace. This
kernel log spam obscures legitimate errors and impacts system diagnostics.

Solution
--------
This change provides two complementary mechanisms to handle these errors:

1. Proactive exclusion via --infiniband-exclude-devices flag:
   Completely skips specified devices before any sysfs reads occur.

2. Reactive caching via ignoreFiles:
   Caches file paths that return EINVAL to avoid repeated reads.

The key difference:

  Without flag: First read still triggers kernel errors (then cached)
  With flag:    No kernel errors at all (device never touched)

For systems where you know which devices have restricted PFs, use the flag
to prevent kernel errors entirely. For unknown environments, the EINVAL
caching prevents repeated errors after the first poll.

Changes
-------
- Add ACCESS_REG kmsg pattern detection for visibility/alerting
- Refactor LoadDevices to use variadic options pattern (OpOption)
- Add --infiniband-exclude-devices CLI flag (e.g., "mlx5_0,mlx5_1")
- Add ExcludedInfinibandDevices to config
- Document EINVAL (-22) to ACCESS_REG correlation with source links

ref. https://github.com/prometheus/node_exporter/issues/3434
ref. https://github.com/leptonai/gpud/issues/1164
