### PR TITLE
[LEP-3581] fix(nvidia/memory): sysinfo fallback for DGX Spark (GB10)

### DIFF
--- a/pkg/machine-info/machine_info.go
+++ b/pkg/machine-info/machine_info.go
@@ -325,9 +325,10 @@ func GetMachineGPUInfo(nvmlInstance nvidianvml.Instance) (*apiv1.MachineGPUInfo,
 		Architecture: nvmlInstance.Architecture(),
 	}
 
+	productName := nvmlInstance.ProductName()
 	for uuid, dev := range nvmlInstance.Devices() {
 		if info.Memory == "" {
-			gpuMemory, err := nvidiamemory.GetMemory(uuid, dev)
+			gpuMemory, err := nvidiamemory.GetMemory(uuid, dev, productName, mem.VirtualMemoryWithContext)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
> {"level":"warn","ts":"2025-12-05T04:45:04.257Z","caller":"memory/memory.go:77","msg":"failed to get device memory info v2, falling back to v1","error":"Not Supported"}
{"level":"warn","ts":"2025-12-05T04:45:04.257Z","caller":"memory/memory.go:86","msg":"failed to get device memory info v1","error":"Not Supported"}
{"level":"warn","ts":"2025-12-05T04:45:04.257Z","caller":"memory/memory.go:97","msg":"NVML memory APIs not supported for unified memory device, falling back to system memory","product_name":"NVIDIA-GB10","error":"Not Supported"}

```json
    "component": "accelerator-nvidia-memory",
    "states": [
      {
        "time": "2025-12-05T04:46:00Z",
        "component": "accelerator-nvidia-memory",
        "name": "accelerator-nvidia-memory",
        "health": "Healthy",
        "reason": "all 1 GPU(s) were checked, no memory issue found",
        "extra_info": {
          "data": "{\"memories\":[{\"uuid\":\"GPU-2dee1e25-b3b5-007e-2b55-79f2d0f2ebe5\",\"bus_id\":\"000f:01:00.0\",\"total_bytes\":128501256192,\"total_humanized\":\"120 GiB\",\"reserved_bytes\":0,\"reserved_humanized\":\"\",\"used_bytes\":
6910320640,\"used_humanized\":\"6.4 GiB\",\"free_bytes\":7976902656,\"free_humanized\":\"7.4 GiB\",\"used_percent\":\"5.38\",\"supported\":true,\"is_unified_memory\":true}]}"
        }
      }
    ]
  }
```