### PR TITLE
fix(disk): add xfs and vfat to DefaultFsTypeFunc to prevent false "no block device found" warnings

### DIFF
--- a/pkg/disk/lsblk.go
+++ b/pkg/disk/lsblk.go
@@ -104,7 +104,11 @@ func getBlockDevicesWithLsblk(
 		return nil, err
 	}
 	if len(devs) == 0 {
-		log.Logger.Warnw("no block device found from lsblk command", "lsblk", lsblkBin, "flags", flags, "output", string(b))
+		log.Logger.Warnw("no block device found after filtering (devices may have been excluded by fstype/device-type/mountpoint filters, check if your filesystem types like xfs/vfat are supported in DefaultFsTypeFunc)",
+			"lsblk", lsblkBin,
+			"flags", flags,
+			"rawOutputBytes", len(b),
+		)
 	}
 
 	return devs, nil

--- a/pkg/disk/lsblk_nested_test.go
+++ b/pkg/disk/lsblk_nested_test.go
@@ -184,9 +184,9 @@ func TestParseLsblkJSONRAIDChain(t *testing.T) {
 	}
 	require.NotNil(t, sda, "expected /dev/sda to be present")
 
-	// Should have 1 child: sda2 (linux_raid_member with RAID child)
-	// Note: sda1 is filtered out because it has vfat filesystem, which is not in DefaultFsTypeFunc
-	require.Len(t, sda.Children, 1, "expected one child (sda2)")
+	// Should have 2 children: sda1 (vfat EFI partition) and sda2 (linux_raid_member with RAID child)
+	// Note: sda1 is now included because vfat was added to DefaultFsTypeFunc to support EFI partitions
+	require.Len(t, sda.Children, 2, "expected two children (sda1 and sda2)")
 
 	// Find sda2 (the raid member)
 	var sda2 *BlockDevice

--- a/pkg/disk/lsblk_test.go
+++ b/pkg/disk/lsblk_test.go
@@ -571,10 +571,16 @@ func TestParseLsblkJSONWithParentNullMountpoint(t *testing.T) {
 	}
 	assert.True(t, foundP2, "nvme0n1p2 should be included in children")
 
-	// Verify vfat partitions are excluded due to fstype filter
+	// Verify vfat partitions with valid mountpoints are now included (added to DefaultFsTypeFunc)
+	// This is necessary to support EFI system partitions which use vfat
+	foundVfat := false
 	for _, child := range nvmeDevice.Children {
-		assert.NotEqual(t, "vfat", child.FSType, "vfat partitions should be filtered out by DefaultFsTypeFunc")
+		if child.FSType == "vfat" && child.MountPoint != "" {
+			foundVfat = true
+			break
+		}
 	}
+	assert.True(t, foundVfat, "vfat partitions with valid mountpoints should be included by DefaultFsTypeFunc")
 }
 
 func TestParseLsblkJSONParentChildFiltering(t *testing.T) {

--- a/pkg/disk/lsblk_xfs_vfat_test.go
+++ b/pkg/disk/lsblk_xfs_vfat_test.go
@@ -1,0 +1,142 @@
+package disk
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseLsblkJSONWithXFSAndVFAT tests that xfs and vfat filesystems are correctly
+// detected and included. This test uses real-world data from a system with:
+//   - /dev/nvme4n1p1: vfat filesystem mounted at /boot/efi (EFI System Partition)
+//   - /dev/nvme4n1p2: xfs filesystem mounted at / (root partition)
+//   - /dev/nvme0n1: LVM2_member with ext4 child mounted at /lepton-data-disk
+//
+// This test was added to verify the fix for the "no block device found" warning
+// that occurred when systems used xfs (common in RHEL/CentOS) or vfat (required for EFI).
+//
+// See: DefaultFsTypeFunc in options.go for supported filesystem types.
+func TestParseLsblkJSONWithXFSAndVFAT(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("testdata/lsblk.xfs_vfat.json")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Parse with default filters - this should NOT filter out xfs/vfat devices
+	devs, err := parseLsblkJSON(
+		ctx,
+		data,
+		WithFstype(DefaultFsTypeFunc),
+		WithDeviceType(DefaultDeviceTypeFunc),
+		WithMountPoint(DefaultMountPointFunc),
+	)
+	require.NoError(t, err)
+
+	// Should find devices (not empty - this was the original bug)
+	require.NotEmpty(t, devs, "should find block devices with xfs/vfat filesystems")
+
+	// Build a map for easier lookup
+	devMap := make(map[string]*BlockDevice)
+	for i := range devs {
+		devMap[devs[i].Name] = &devs[i]
+	}
+
+	// Test 1: Verify nvme4n1 is present (has xfs and vfat children)
+	nvme4n1, ok := devMap["/dev/nvme4n1"]
+	require.True(t, ok, "nvme4n1 should be present because it has children with valid mountpoints")
+	require.NotEmpty(t, nvme4n1.Children, "nvme4n1 should have children")
+
+	// Test 2: Verify xfs root partition is included
+	foundXFSRoot := false
+	for _, child := range nvme4n1.Children {
+		if child.Name == "/dev/nvme4n1p2" {
+			foundXFSRoot = true
+			assert.Equal(t, "xfs", child.FSType, "root partition should have xfs filesystem")
+			assert.Equal(t, "/", child.MountPoint, "root partition should be mounted at /")
+			assert.Equal(t, "part", child.Type)
+		}
+	}
+	assert.True(t, foundXFSRoot, "xfs root partition (/dev/nvme4n1p2) should be included")
+
+	// Test 3: Verify vfat EFI partition is included
+	foundVFATEFI := false
+	for _, child := range nvme4n1.Children {
+		if child.Name == "/dev/nvme4n1p1" {
+			foundVFATEFI = true
+			assert.Equal(t, "vfat", child.FSType, "EFI partition should have vfat filesystem")
+			assert.Equal(t, "/boot/efi", child.MountPoint, "EFI partition should be mounted at /boot/efi")
+			assert.Equal(t, "part", child.Type)
+		}
+	}
+	assert.True(t, foundVFATEFI, "vfat EFI partition (/dev/nvme4n1p1) should be included")
+
+	// Test 4: Verify LVM with ext4 is also included
+	nvme0n1, ok := devMap["/dev/nvme0n1"]
+	require.True(t, ok, "nvme0n1 should be present (LVM2_member)")
+	assert.Equal(t, "LVM2_member", nvme0n1.FSType)
+	require.NotEmpty(t, nvme0n1.Children, "nvme0n1 should have LVM children")
+
+	foundLVM := false
+	for _, child := range nvme0n1.Children {
+		if child.Name == "/dev/mapper/lepton_vg-lepton_lv" {
+			foundLVM = true
+			assert.Equal(t, "lvm", child.Type)
+			assert.Equal(t, "ext4", child.FSType)
+			assert.Equal(t, "/lepton-data-disk", child.MountPoint)
+		}
+	}
+	assert.True(t, foundLVM, "LVM logical volume should be included")
+
+	// Test 5: Verify loop devices are filtered out (type "loop" not in DefaultDeviceTypeFunc)
+	for _, dev := range devs {
+		assert.NotEqual(t, "loop", dev.Type, "loop devices should be filtered out by DefaultDeviceTypeFunc")
+	}
+
+	// Test 6: Verify sda (empty disk with no mountpoint) is filtered out
+	_, hasSDA := devMap["/dev/sda"]
+	assert.False(t, hasSDA, "sda should be filtered out (no mountpoint and no children with mountpoints)")
+}
+
+// TestDefaultFsTypeFuncIncludesXFSAndVFAT verifies that xfs and vfat are in DefaultFsTypeFunc.
+// These filesystem types are widely used:
+//   - xfs: Default filesystem for RHEL 7+, CentOS 7+, Rocky Linux, AlmaLinux, Fedora Server
+//   - vfat: Required for EFI System Partitions (ESP) per UEFI specification
+func TestDefaultFsTypeFuncIncludesXFSAndVFAT(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		fstype   string
+		expected bool
+		desc     string
+	}{
+		// Should be included
+		{"", true, "empty string (unformatted parent disks)"},
+		{"ext4", true, "ext4 (most common Linux filesystem)"},
+		{"xfs", true, "xfs (default for RHEL/CentOS/Rocky Linux)"},
+		{"vfat", true, "vfat (required for EFI System Partitions)"},
+		{"LVM2_member", true, "LVM2_member (LVM physical volumes)"},
+		{"linux_raid_member", true, "linux_raid_member (software RAID)"},
+		{"raid0", true, "raid0 (RAID-0 devices)"},
+		{"nfs", true, "nfs (Network File System)"},
+		{"nfs4", true, "nfs4 (NFS version 4)"},
+
+		// Should NOT be included
+		{"squashfs", false, "squashfs (snap/loop mounts)"},
+		{"tmpfs", false, "tmpfs (temporary filesystem)"},
+		{"devtmpfs", false, "devtmpfs (device filesystem)"},
+		{"btrfs", false, "btrfs (not included by default)"},
+		{"ntfs", false, "ntfs (Windows filesystem)"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.fstype, func(t *testing.T) {
+			result := DefaultFsTypeFunc(tc.fstype)
+			assert.Equal(t, tc.expected, result, "DefaultFsTypeFunc(%q) - %s", tc.fstype, tc.desc)
+		})
+	}
+}

--- a/pkg/disk/options.go
+++ b/pkg/disk/options.go
@@ -83,9 +83,23 @@ func DefaultMatchFuncDeviceType(deviceType string) bool {
 	return deviceType == "disk" // not "part" partitions
 }
 
+// DefaultFsTypeFunc returns true for common filesystem types.
+// This function is used by the disk component to filter which filesystems to monitor.
+//
+// Supported filesystem types:
+//   - "": Empty/unformatted (parent disks)
+//   - "ext4": Most common Linux filesystem
+//   - "xfs": Default for RHEL 7+, CentOS 7+, Rocky Linux, AlmaLinux, Fedora Server
+//   - "vfat": Required for EFI System Partitions (ESP) per UEFI specification
+//   - "LVM2_member": LVM physical volumes
+//   - "linux_raid_member": Software RAID members
+//   - "raid0": RAID-0 devices
+//   - "nfs*": Network File System (e.g., nfs, nfs4)
 func DefaultFsTypeFunc(fsType string) bool {
 	return fsType == "" ||
 		fsType == "ext4" ||
+		fsType == "xfs" ||
+		fsType == "vfat" ||
 		fsType == "LVM2_member" ||
 		fsType == "linux_raid_member" ||
 		fsType == "raid0" ||

--- a/pkg/disk/testdata/lsblk.xfs_vfat.json
+++ b/pkg/disk/testdata/lsblk.xfs_vfat.json
@@ -1,0 +1,137 @@
+{
+   "blockdevices": [
+      {
+         "name": "/dev/loop0",
+         "type": "loop",
+         "size": 62652416,
+         "rota": false,
+         "serial": null,
+         "wwn": null,
+         "vendor": null,
+         "model": null,
+         "rev": null,
+         "mountpoint": "/snap/core20/2321",
+         "fstype": "squashfs",
+         "fsused": "62652416",
+         "partuuid": null
+      },{
+         "name": "/dev/loop1",
+         "type": "loop",
+         "size": 62455808,
+         "rota": false,
+         "serial": null,
+         "wwn": null,
+         "vendor": null,
+         "model": null,
+         "rev": null,
+         "mountpoint": "/snap/core20/2690",
+         "fstype": "squashfs",
+         "fsused": "62521344",
+         "partuuid": null
+      },{
+         "name": "/dev/loop2",
+         "type": "loop",
+         "size": 81137664,
+         "rota": false,
+         "serial": null,
+         "wwn": null,
+         "vendor": null,
+         "model": null,
+         "rev": null,
+         "mountpoint": "/snap/lxd/29353",
+         "fstype": "squashfs",
+         "fsused": "81264640",
+         "partuuid": null
+      },{
+         "name": "/dev/sda",
+         "type": "disk",
+         "size": 0,
+         "rota": true,
+         "serial": "Linux_File-Stor_Gadget-0:0",
+         "wwn": null,
+         "vendor": "Linux   ",
+         "model": "File-Stor Gadget",
+         "rev": "0612",
+         "mountpoint": null,
+         "fstype": null,
+         "fsused": null,
+         "partuuid": null
+      },{
+         "name": "/dev/nvme0n1",
+         "type": "disk",
+         "size": 3840755982336,
+         "rota": false,
+         "serial": "S7UTNG0Y512362",
+         "wwn": "eui.37555430595123620025384700000001",
+         "vendor": null,
+         "model": "SAMSUNG MZTL63T8HFLT-00AW7",
+         "rev": null,
+         "mountpoint": null,
+         "fstype": "LVM2_member",
+         "fsused": null,
+         "partuuid": null,
+         "children": [
+            {
+               "name": "/dev/mapper/lepton_vg-lepton_lv",
+               "type": "lvm",
+               "size": 15363014131712,
+               "rota": false,
+               "serial": null,
+               "wwn": null,
+               "vendor": null,
+               "model": null,
+               "rev": null,
+               "mountpoint": "/lepton-data-disk",
+               "fstype": "ext4",
+               "fsused": "1182228480",
+               "partuuid": null
+            }
+         ]
+      },{
+         "name": "/dev/nvme4n1",
+         "type": "disk",
+         "size": 1920383410176,
+         "rota": false,
+         "serial": "S666NT0XC03235",
+         "wwn": "eui.3636363058c032350025385400000001",
+         "vendor": null,
+         "model": "SAMSUNG MZ1L21T9HCLS-00A07",
+         "rev": null,
+         "mountpoint": null,
+         "fstype": null,
+         "fsused": null,
+         "partuuid": null,
+         "children": [
+            {
+               "name": "/dev/nvme4n1p1",
+               "type": "part",
+               "size": 536870912,
+               "rota": false,
+               "serial": null,
+               "wwn": "eui.3636363058c032350025385400000001",
+               "vendor": null,
+               "model": null,
+               "rev": null,
+               "mountpoint": "/boot/efi",
+               "fstype": "vfat",
+               "fsused": "6623232",
+               "partuuid": "4305fe72-a9b6-46e0-8602-d90d78685c7f"
+            },{
+               "name": "/dev/nvme4n1p2",
+               "type": "part",
+               "size": 1919844089856,
+               "rota": false,
+               "serial": null,
+               "wwn": "eui.3636363058c032350025385400000001",
+               "vendor": null,
+               "model": null,
+               "rev": null,
+               "mountpoint": "/",
+               "fstype": "xfs",
+               "fsused": "31333236736",
+               "partuuid": "08957ba6-97b0-4202-9535-8b8653797c5a"
+            }
+         ]
+      }
+   ]
+}


### PR DESCRIPTION
The DefaultFsTypeFunc was missing common filesystem types, causing all block devices to be filtered out on systems using xfs or vfat filesystems:

- xfs: Default filesystem for RHEL 7+, CentOS 7+, Rocky Linux, AlmaLinux, Fedora Server - very common in enterprise/cloud environments
- vfat: Required for EFI System Partitions (ESP) per UEFI specification - present on virtually ALL modern UEFI-based systems

When a system has xfs root partition (e.g., /dev/nvme4n1p2 mounted at /) and vfat EFI partition (e.g., /dev/nvme4n1p1 mounted at /boot/efi), the fstype filter was excluding both partitions. Since the parent disk has no mountpoint, it was also filtered out, resulting in zero devices found.

Changes:
- Add "xfs" and "vfat" to DefaultFsTypeFunc with documentation
- Improve the warning log message to mention filtering and suggest checking DefaultFsTypeFunc for supported filesystem types
- Add test data (lsblk.xfs_vfat.json) from real-world lsblk output
- Add comprehensive unit tests for xfs/vfat filesystem detection