### PR TITLE
[LEP-3790] fix(nvidia/fabric-manager): skip V3 fabric API on older drivers to prevent crash

### DIFF
--- a/pkg/nvidia-query/nvml/device/device_test.go
+++ b/pkg/nvidia-query/nvml/device/device_test.go
@@ -1,0 +1,179 @@
+package device
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMinDriverVersionForV3FabricAPI(t *testing.T) {
+	t.Parallel()
+
+	// Verify the constant is set correctly per NVIDIA documentation
+	// nvmlDeviceGetGpuFabricInfoV was introduced in driver 550
+	// See: https://docs.nvidia.com/deploy/nvml-api/change-log.html
+	assert.Equal(t, 550, MinDriverVersionForV3FabricAPI,
+		"MinDriverVersionForV3FabricAPI should be 550 per NVIDIA NVML changelog")
+}
+
+func TestWithDriverMajor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		driverMajor   int
+		expectedMajor int
+	}{
+		{
+			name:          "driver version 535 (old driver)",
+			driverMajor:   535,
+			expectedMajor: 535,
+		},
+		{
+			name:          "driver version 550 (minimum for V3 API)",
+			driverMajor:   550,
+			expectedMajor: 550,
+		},
+		{
+			name:          "driver version 560 (newer driver)",
+			driverMajor:   560,
+			expectedMajor: 560,
+		},
+		{
+			name:          "driver version 0 (uninitialized)",
+			driverMajor:   0,
+			expectedMajor: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			op := &Op{}
+			opt := WithDriverMajor(tt.driverMajor)
+			opt(op)
+
+			assert.Equal(t, tt.expectedMajor, op.DriverMajor)
+		})
+	}
+}
+
+func TestOpApplyOpts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("multiple options applied correctly", func(t *testing.T) {
+		t.Parallel()
+
+		op := &Op{}
+		opts := []OpOption{
+			WithDriverMajor(550),
+			WithGPULost(),
+			WithGPURequiresReset(),
+			WithFabricHealthUnhealthy(),
+		}
+		op.applyOpts(opts)
+
+		assert.Equal(t, 550, op.DriverMajor)
+		assert.True(t, op.GPULost)
+		assert.True(t, op.GPURequiresReset)
+		assert.True(t, op.FabricHealthUnhealthy)
+	})
+
+	t.Run("driver major can be overwritten", func(t *testing.T) {
+		t.Parallel()
+
+		op := &Op{}
+		opts := []OpOption{
+			WithDriverMajor(535),
+			WithDriverMajor(550), // overwrite
+		}
+		op.applyOpts(opts)
+
+		assert.Equal(t, 550, op.DriverMajor)
+	})
+}
+
+func TestNvDeviceDriverMajorField(t *testing.T) {
+	t.Parallel()
+
+	// Test that the driverMajor field is correctly set on nvDevice
+	// We can't directly test nvDevice since it's private, but we can verify
+	// the Op struct correctly stores the value
+
+	tests := []struct {
+		name        string
+		driverMajor int
+		expectV3API bool // whether V3 API should be attempted
+	}{
+		{
+			name:        "driver 535 should skip V3 API",
+			driverMajor: 535,
+			expectV3API: false,
+		},
+		{
+			name:        "driver 549 should skip V3 API",
+			driverMajor: 549,
+			expectV3API: false,
+		},
+		{
+			name:        "driver 550 should use V3 API",
+			driverMajor: 550,
+			expectV3API: true,
+		},
+		{
+			name:        "driver 560 should use V3 API",
+			driverMajor: 560,
+			expectV3API: true,
+		},
+		{
+			name:        "driver 0 (uninitialized) should skip V3 API",
+			driverMajor: 0,
+			expectV3API: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Verify the logic matches expectations
+			shouldUseV3 := tt.driverMajor >= MinDriverVersionForV3FabricAPI
+			assert.Equal(t, tt.expectV3API, shouldUseV3,
+				"driver major %d: expected V3 API usage = %v", tt.driverMajor, tt.expectV3API)
+		})
+	}
+}
+
+func TestDriverVersionBoundaryConditions(t *testing.T) {
+	t.Parallel()
+
+	// Test boundary conditions around the minimum driver version
+	tests := []struct {
+		driverMajor int
+		expectV3    bool
+		description string
+	}{
+		{driverMajor: 548, expectV3: false, description: "two versions below minimum"},
+		{driverMajor: 549, expectV3: false, description: "one version below minimum"},
+		{driverMajor: 550, expectV3: true, description: "exactly at minimum"},
+		{driverMajor: 551, expectV3: true, description: "one version above minimum"},
+		{driverMajor: 552, expectV3: true, description: "two versions above minimum"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.description, func(t *testing.T) {
+			t.Parallel()
+
+			shouldUseV3 := tt.driverMajor >= MinDriverVersionForV3FabricAPI
+			require.Equal(t, tt.expectV3, shouldUseV3,
+				"driver %d: V3 API should be %s",
+				tt.driverMajor,
+				map[bool]string{true: "enabled", false: "disabled"}[tt.expectV3])
+		})
+	}
+}

--- a/pkg/nvidia-query/nvml/device/fabric_state_test.go
+++ b/pkg/nvidia-query/nvml/device/fabric_state_test.go
@@ -151,3 +151,167 @@ func TestParseHealthMask(t *testing.T) {
 	assert.Equal(t, "False", health.RouteUnhealthy)
 	assert.Equal(t, "True", health.AccessTimeoutRecovery)
 }
+
+// TestDriverVersionGatingLogic tests the driver version comparison logic
+// that determines whether to use V3 or V1 fabric state API.
+// This is a unit test for the gating condition itself.
+func TestDriverVersionGatingLogic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		driverMajor int
+		expectV3API bool
+		description string
+	}{
+		{
+			name:        "driver 535 (old H100 driver)",
+			driverMajor: 535,
+			expectV3API: false,
+			description: "Driver 535.x does not have nvmlDeviceGetGpuFabricInfoV symbol",
+		},
+		{
+			name:        "driver 545 (pre-V3 API)",
+			driverMajor: 545,
+			expectV3API: false,
+			description: "Driver 545.x is before V3 API introduction",
+		},
+		{
+			name:        "driver 549 (boundary - one below minimum)",
+			driverMajor: 549,
+			expectV3API: false,
+			description: "Driver 549 is one version below the minimum required",
+		},
+		{
+			name:        "driver 550 (minimum for V3 API)",
+			driverMajor: 550,
+			expectV3API: true,
+			description: "Driver 550 introduced nvmlDeviceGetGpuFabricInfoV",
+		},
+		{
+			name:        "driver 551 (boundary - one above minimum)",
+			driverMajor: 551,
+			expectV3API: true,
+			description: "Driver 551 should support V3 API",
+		},
+		{
+			name:        "driver 560 (newer driver)",
+			driverMajor: 560,
+			expectV3API: true,
+			description: "Newer drivers should support V3 API",
+		},
+		{
+			name:        "driver 0 (uninitialized)",
+			driverMajor: 0,
+			expectV3API: false,
+			description: "Zero driver version (uninitialized) should skip V3 API",
+		},
+		{
+			name:        "driver -1 (invalid)",
+			driverMajor: -1,
+			expectV3API: false,
+			description: "Negative driver version should skip V3 API",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// This is the same condition used in GetFabricState()
+			shouldUseV3 := tt.driverMajor >= MinDriverVersionForV3FabricAPI
+			assert.Equal(t, tt.expectV3API, shouldUseV3,
+				"%s: driver %d should have V3 API = %v, got %v",
+				tt.description, tt.driverMajor, tt.expectV3API, shouldUseV3)
+		})
+	}
+}
+
+// TestFormatClusterUUID tests the UUID formatting function
+func TestFormatClusterUUID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    [16]uint8
+		expected string
+	}{
+		{
+			name:     "all zeros returns empty string",
+			input:    [16]uint8{},
+			expected: "",
+		},
+		{
+			name:     "valid UUID",
+			input:    [16]uint8{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+			expected: "01020304-0506-0708-090a-0b0c0d0e0f10",
+		},
+		{
+			name:     "UUID with mixed values",
+			input:    [16]uint8{0xaa, 0xbb, 0xcc, 0xdd, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb},
+			expected: "aabbccdd-0011-2233-4455-66778899aabb",
+		},
+		{
+			name:     "UUID with single non-zero byte",
+			input:    [16]uint8{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			expected: "01000000-0000-0000-0000-000000000000",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := formatClusterUUID(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestFabricStateToEntry tests the conversion of FabricState to FabricStateEntry
+func TestFabricStateToEntry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("healthy state with V3 fields", func(t *testing.T) {
+		t.Parallel()
+
+		state := FabricState{
+			CliqueID:      42,
+			ClusterUUID:   "test-cluster-uuid",
+			State:         nvml.GPU_FABRIC_STATE_COMPLETED,
+			Status:        nvml.SUCCESS,
+			HealthMask:    0,
+			HealthSummary: nvml.GPU_FABRIC_HEALTH_SUMMARY_HEALTHY,
+		}
+
+		entry := state.ToEntry("GPU-TEST-UUID")
+
+		assert.Equal(t, "GPU-TEST-UUID", entry.GPUUUID)
+		assert.Equal(t, uint32(42), entry.CliqueID)
+		assert.Equal(t, "test-cluster-uuid", entry.ClusterUUID)
+		assert.Equal(t, "Completed", entry.State)
+		assert.Equal(t, "Success", entry.Status)
+		assert.Equal(t, "Healthy", entry.Summary)
+	})
+
+	t.Run("V1 fallback state (no health summary)", func(t *testing.T) {
+		t.Parallel()
+
+		state := FabricState{
+			CliqueID:      777,
+			ClusterUUID:   "",
+			State:         nvml.GPU_FABRIC_STATE_COMPLETED,
+			Status:        nvml.SUCCESS,
+			HealthMask:    0,
+			HealthSummary: nvml.GPU_FABRIC_HEALTH_SUMMARY_NOT_SUPPORTED,
+		}
+
+		entry := state.ToEntry("GPU-V1-UUID")
+
+		assert.Equal(t, "GPU-V1-UUID", entry.GPUUUID)
+		assert.Equal(t, uint32(777), entry.CliqueID)
+		assert.Equal(t, "", entry.ClusterUUID)
+		assert.Equal(t, "Not Supported", entry.Summary)
+	})
+}

--- a/pkg/nvidia-query/nvml/instance.go
+++ b/pkg/nvidia-query/nvml/instance.go
@@ -202,8 +202,14 @@ func newInstance(refreshCtx context.Context, refreshNVML func(context.Context), 
 				return nil, err
 			}
 
-			// Build device options based on failure injector
+			// Build device options based on driver version and failure injector
 			var opts []device.OpOption
+
+			// Always pass driver major version so devices can gate V3 fabric API calls.
+			// nvmlDeviceGetGpuFabricInfoV requires driver >= 550; calling it on older
+			// drivers (e.g., 535.x) causes a symbol lookup crash.
+			opts = append(opts, device.WithDriverMajor(driverMajor))
+
 			if failureInjector != nil {
 				// Check if this UUID should inject GPU Lost error
 				for _, injectedUUID := range failureInjector.GPUUUIDsWithGPULost {


### PR DESCRIPTION
nvmlDeviceGetGpuFabricInfoV was introduced in driver 550. Calling it on
older drivers (e.g., 535.x) causes a symbol lookup error that crashes
the process with exit code 127 at the dynamic linker level.

This fix:
- Adds MinDriverVersionForV3FabricAPI constant (550) with documentation
- Passes driver major version to device creation via WithDriverMajor()
- Checks driver version before calling V3 API in GetFabricState()
- Logs a warning (once) when skipping V3 API due to old driver
- Falls back to V1 API (GetGpuFabricInfo) on older drivers

The V1 API provides basic fabric info but lacks health metrics
(HealthMask, HealthSummary) which are set to defaults.

Reference: https://docs.nvidia.com/deploy/nvml-api/change-log.html

Before

> gpud scan
>
> {"level":"info","ts":"2025-12-18T16:17:35.540+0530","caller":"fabric-manager/component.go:279","msg":"checking nvidia fabric manager"}
> gpud: symbol lookup error: gpud: undefined symbol: nvmlDeviceGetGpuFabricInfoV

After

> gpud scan
>
> {"level":"info","ts":"2025-12-18T17:30:41.418+0530","caller":"fabric-manager/component.go:279","msg":"checking nvidia fabric manager"}
{"level":"warn","ts":"2025-12-18T17:30:41.467+0530","caller":"device/fabric_state.go:311","msg":"skipping fabric state V3 API (nvmlDeviceGetGpuFabricInfoV) due to old driver version; V3 API requires driver >= 550","driverMajor":535,"minRequired":550}

health states:

```json
    "component": "accelerator-nvidia-fabric-manager",
    "states": [
      {
        "time": "2025-12-18T12:01:59Z",
        "component": "accelerator-nvidia-fabric-manager",
        "name": "accelerator-nvidia-fabric-manager",
        "health": "Healthy",
        "reason": "fabric manager found and active",
```