### PR TITLE
[LEP-2540] fix(components): reduce noisy events with consecutive thresholds and time-based coalescing

### DIFF
--- a/components/accelerator/nvidia/peermem/component.go
+++ b/components/accelerator/nvidia/peermem/component.go
@@ -59,7 +59,13 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		}
 
 		if os.Geteuid() == 0 {
-			c.kmsgSyncer, err = kmsg.NewSyncer(cctx, Match, c.eventBucket)
+			c.kmsgSyncer, err = kmsg.NewSyncer(
+				cctx,
+				Match,
+				c.eventBucket,
+				// Peermem errors can spam during transient GPU/NIC issues; coalesce within 5 minutes to reduce event noise.
+				kmsg.WithCacheKeyTruncateSeconds(300),
+			)
 			if err != nil {
 				ccancel()
 				return nil, err

--- a/pkg/kmsg/syncer.go
+++ b/pkg/kmsg/syncer.go
@@ -19,14 +19,14 @@ type Syncer struct {
 
 type MatchFunc func(line string) (eventName string, message string)
 
-func NewSyncer(ctx context.Context, matchFunc MatchFunc, eventBucket eventstore.Bucket) (*Syncer, error) {
-	return newSyncer(ctx, nil, matchFunc, eventBucket)
+func NewSyncer(ctx context.Context, matchFunc MatchFunc, eventBucket eventstore.Bucket, opts ...OpOption) (*Syncer, error) {
+	return newSyncer(ctx, nil, matchFunc, eventBucket, opts...)
 }
 
-func newSyncer(ctx context.Context, watcher Watcher, matchFunc MatchFunc, eventBucket eventstore.Bucket) (*Syncer, error) {
+func newSyncer(ctx context.Context, watcher Watcher, matchFunc MatchFunc, eventBucket eventstore.Bucket, opts ...OpOption) (*Syncer, error) {
 	if watcher == nil {
 		var err error
-		watcher, err = NewWatcher()
+		watcher, err = NewWatcher(opts...)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- Add configurable cache key truncation for kmsg deduper to coalesce
  burst events within a time window (default 60s, configurable)
- containerd: require 5 consecutive socket missing checks before
  reporting unhealthy, reset counter on recovery
- disk: require 5 consecutive NFS stat timeouts per mount point
  before reporting degraded, reset counter on recovery
- peermem/disk: use 5-minute coalescing window for kmsg events
  to reduce noise during transient GPU/NIC/disk issues

Signed-off-by: Gyuho Lee <gyuhol@nvidia.com>
