### PR TITLE
[LEP-3928] fix(pkg/process): add WithAllowDetachedProcess (false by default)

### DIFF
--- a/pkg/custom-plugins/run_bash_script_test.go
+++ b/pkg/custom-plugins/run_bash_script_test.go
@@ -167,7 +167,7 @@ type MockRunner struct {
 	mock.Mock
 }
 
-func (m *MockRunner) RunUntilCompletion(ctx context.Context, script string) ([]byte, int32, error) {
+func (m *MockRunner) RunUntilCompletion(ctx context.Context, script string, opts ...process.OpOption) ([]byte, int32, error) {
 	args := m.Called(ctx, script)
 	return args.Get(0).([]byte), int32(args.Int(1)), args.Error(2)
 }

--- a/pkg/gpud-manager/controllers/package_controller.go
+++ b/pkg/gpud-manager/controllers/package_controller.go
@@ -338,39 +338,20 @@ func (c *PackageController) statusRunner(ctx context.Context) {
 	}
 }
 
-// defaultWaitForDetach is the grace period to wait before killing the process group
-// when Close() is called. This is essential for package scripts that spawn background
-// processes intended to outlive the parent shell.
-//
-// USE CASE: Package installation scripts commonly end with patterns like:
-//
-//	sleep 10 && systemctl restart gpud &
-//
-// This pattern schedules a delayed restart of gpud after the installation completes.
-// The "&" causes bash to background the command and exit immediately, but the
-// backgrounded "sleep 10 && systemctl restart gpud" should continue running.
-//
-// Without a grace period, when Close() is called (after bash exits), it would
-// immediately kill the entire process group (including the backgrounded command),
-// preventing the scheduled restart from occurring.
-//
-// WHY 2 MINUTES:
-//   - We assume 2 minutes is sufficient for any reasonable detached command to complete.
-//     Typical use cases like "sleep N && systemctl restart gpud" or similar delayed
-//     operations should finish well within this window.
-//   - This is intentionally conservative to prevent process leaks from unconventional
-//     long-running commands in bash scripts. If a script spawns a long-running process,
-//     it should use systemd to manage it properly, not rely on backgrounding.
-//   - This strikes a balance between allowing legitimate delayed operations and
-//     preventing indefinite waits or process leaks.
-const defaultWaitForDetach = 2 * time.Minute
-
 func runCommand(ctx context.Context, script, arg string, result *string) error {
 	var ops []process.OpOption
 
-	// Always set a grace period to handle backgrounded commands in package scripts.
-	// See defaultWaitForDetach documentation for details on why this is necessary.
-	ops = append(ops, process.WithWaitForDetach(defaultWaitForDetach))
+	// WithAllowDetachedProcess(true) allows backgrounded commands (using "&")
+	// to continue running after the script exits. This is critical for package
+	// installation scripts that use patterns like:
+	//   sleep 10 && systemctl restart gpud &
+	//
+	// Without WithAllowDetachedProcess(true):
+	// - The "&" does not take effect - backgrounded processes are killed on Close()
+	// - Package init.sh waits 10s and restarts instead of returning instantly
+	// - Package controller thinks installation is blocking
+	// - This causes delayed package installations and repeated restart loops
+	ops = append(ops, process.WithAllowDetachedProcess(true))
 
 	if result == nil {
 		f, err := os.OpenFile(filepath.Join(filepath.Dir(script), arg+".log"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)

--- a/pkg/process/options.go
+++ b/pkg/process/options.go
@@ -33,20 +33,13 @@ type Op struct {
 
 	restartConfig *RestartConfig
 
-	// waitForDetach specifies a grace period to wait in Close() before killing
-	// the process group. This is useful for commands that spawn background processes
-	// that should outlive the parent, such as:
-	//
-	//   sleep 10 && systemctl restart gpud &
-	//
-	// In this pattern, the bash script exits immediately (after backgrounding the command),
-	// but the backgrounded "sleep 10 && systemctl restart gpud" should continue running.
-	// Without a grace period, Close() would immediately kill the entire process group,
-	// preventing the delayed restart from occurring.
-	//
-	// With WithWaitForDetach(15*time.Second), Close() will wait up to 15 seconds
-	// for the backgrounded process to complete before sending kill signals.
-	waitForDetach time.Duration
+	// allowDetachedProcess controls whether backgrounded processes can outlive the parent.
+	// When true, Setpgid is NOT used, allowing backgrounded commands like
+	// "sleep 10 && systemctl restart gpud &" to continue running after the parent exits.
+	// When false (default), Setpgid is used to create a process group, and Close()
+	// will kill all processes in the group together - this is safer and prevents
+	// orphaned processes but prevents the "&" background pattern from working.
+	allowDetachedProcess bool
 }
 
 const DefaultBashScriptFilePattern = "gpud-*.bash"
@@ -209,39 +202,37 @@ func WithRestartConfig(config RestartConfig) OpOption {
 	}
 }
 
-// WithWaitForDetach sets a grace period to wait in Close() before killing
-// the process group. This is essential for commands that spawn background
-// processes intended to outlive the parent shell.
+// WithAllowDetachedProcess controls whether backgrounded processes can outlive the parent shell.
 //
-// USE CASE - Delayed Service Restart:
+// When allow=true:
+//   - Setpgid is NOT set (processes run in parent's process group)
+//   - Only the direct child process (shell) is killed on Close()
+//   - Backgrounded processes (using "&") become orphans and continue running
+//   - USE THIS for scripts that end with patterns like: "sleep 10 && systemctl restart gpud &"
 //
-//	sleep 10 && systemctl restart gpud &
+// When allow=false (DEFAULT):
+//   - Setpgid is set (creates a new process group)
+//   - Close() kills the entire process group (parent AND all children)
+//   - Safer behavior that prevents orphaned/leaked processes
+//   - USE THIS for normal commands where you want clean process cleanup
 //
-// This pattern is common in deployment scripts where gpud needs to be restarted
-// after a delay (e.g., to allow installation scripts to complete). The "&" causes
-// bash to background the command and exit immediately.
+// Example use case for allow=true:
 //
-// THE PROBLEM:
-// When using process groups (Setpgid=true), the backgrounded command shares the
-// same Process Group ID (PGID) as the parent bash. When Close() is called, it
-// sends SIGKILL to -PGID, killing ALL processes in the group - including the
-// backgrounded "sleep 10 && systemctl restart gpud" that should continue running.
-//
-// THE SOLUTION:
-// With WithWaitForDetach(15*time.Second), Close() will wait up to 15 seconds
-// for all processes in the group to complete before sending kill signals.
-// If the backgrounded process completes within the grace period (e.g., after
-// the 10-second sleep and restart), no kill signals are sent.
+//	Package installation scripts often end with:
+//	  sleep 10 && systemctl restart gpud &
+//	This schedules a delayed restart of gpud after the script exits.
+//	Without allowDetachedProcess=true, the backgrounded command would be killed
+//	when Close() is called.
 //
 // Example:
 //
 //	p, err := New(
 //	    WithBashScriptContentsToRun(deployScript),
-//	    WithWaitForDetach(15*time.Second),
+//	    WithAllowDetachedProcess(true),
 //	)
-func WithWaitForDetach(d time.Duration) OpOption {
+func WithAllowDetachedProcess(allow bool) OpOption {
 	return func(op *Op) {
-		op.waitForDetach = d
+		op.allowDetachedProcess = allow
 	}
 }
 

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -31,22 +31,19 @@ type Process interface {
 	// Closes the process (aborts if still running) and waits for it to exit.
 	// Cleans up the process resources.
 	//
-	// CLOSE/CANCEL SEMANTICS WITH GRACE PERIOD:
-	// If the process was created with WithWaitForDetach, Close() will wait for the
-	// specified grace period before sending kill signals to the process group. This
-	// allows backgrounded processes (e.g., "sleep 10 && systemctl restart gpud &")
-	// to complete naturally before cleanup.
+	// CLOSE BEHAVIOR DEPENDS ON allowDetachedProcess:
 	//
-	// During the grace period:
-	//   - Periodically checks if the process group has exited (every 100ms)
-	//   - Returns early if all processes exit before the grace period expires
-	//   - Respects context cancellation (ctx.Done()) to abort the wait early
-	//   - Only sends kill signals if processes are still running after the grace period
+	// With WithAllowDetachedProcess(true):
+	//   - Only kills the direct child process
+	//   - Backgrounded processes (e.g., "sleep 10 && systemctl restart gpud &")
+	//     become orphans and continue running
+	//   - Use this for scripts that need to spawn long-running background processes
 	//
-	// Without WithWaitForDetach (default):
-	//   - Immediately cancels the process context (triggers cmd.Cancel() -> SIGKILL)
-	//   - Sends SIGTERM to the process group
-	//   - Falls back to SIGKILL after 3 seconds if needed
+	// Without WithAllowDetachedProcess (default):
+	//   - Kills the entire process group (parent AND all children)
+	//   - Cancels the process context (triggers cmd.Cancel() -> SIGKILL)
+	//   - Sends SIGTERM to the process group, falls back to SIGKILL after 3 seconds
+	//   - Safer behavior that prevents orphaned/leaked processes
 	Close(ctx context.Context) error
 	// Returns true if the process is closed.
 	Closed() bool
@@ -130,10 +127,10 @@ type process struct {
 	// input bytes to feed to the command's stdin
 	getStdinBytesReader func() *bytes.Reader
 
-	// waitForDetach is a grace period to wait in Close() before killing the process group.
-	// This allows backgrounded commands like "sleep 10 && systemctl restart gpud &" to complete.
-	// See WithWaitForDetach for detailed documentation.
-	waitForDetach time.Duration
+	// allowDetachedProcess controls whether backgrounded processes can outlive the parent.
+	// When true, Setpgid is NOT used, allowing backgrounded processes to become orphans.
+	// See WithAllowDetachedProcess for detailed documentation.
+	allowDetachedProcess bool
 }
 
 func New(opts ...OpOption) (Process, error) {
@@ -215,7 +212,7 @@ func New(opts ...OpOption) (Process, error) {
 
 		restartConfig: op.restartConfig,
 
-		waitForDetach: op.waitForDetach,
+		allowDetachedProcess: op.allowDetachedProcess,
 	}
 
 	if op.runAsBashScript && op.runBashInline {
@@ -295,56 +292,45 @@ func (p *process) startCommand() error {
 	}
 	p.cmd.Env = p.envs
 
-	// Create a new process group for this command and all its children.
+	// Conditionally create a new process group for this command and all its children.
 	//
-	// When running shell commands that spawn background processes (e.g., "cmd1 & cmd2 & wait"),
-	// the shell creates child processes that are NOT automatically terminated when we kill the
-	// parent shell. Without process groups:
-	//   1. Go's Process.Signal() only sends signals to the direct child (the shell)
-	//   2. Backgrounded processes (cmd1, cmd2) become orphaned and reparented to PID 1
-	//   3. These orphaned processes continue running indefinitely (process leak)
+	// When allowDetachedProcess is FALSE (default):
+	//   - Setpgid=true creates a process group where all children share the same PGID
+	//   - Close() can kill the entire group at once using syscall.Kill(-pgid, signal)
+	//   - This prevents orphaned/leaked processes
 	//
-	// With Setpgid=true:
-	//   1. The shell and ALL its children share the same Process Group ID (PGID)
-	//   2. The PGID equals the shell's PID
-	//   3. We can kill the entire group at once using syscall.Kill(-pgid, signal)
-	//
-	// EXAMPLE SCENARIO (fabric-manager log watcher):
-	//   Command: "tail -f /var/log/fabricmanager.log & journalctl -u nvidia-fabricmanager -f & wait"
-	//   Without Setpgid: Killing bash leaves tail and journalctl running forever
-	//   With Setpgid: Killing -PGID terminates bash, tail, AND journalctl together
+	// When allowDetachedProcess is TRUE:
+	//   - Setpgid is NOT set (processes run in parent's process group)
+	//   - Only the direct child process is killed on Close()
+	//   - Backgrounded processes (using "&") become orphans and continue running
+	//   - This is required for scripts with patterns like: "sleep 10 && systemctl restart gpud &"
 	//
 	// NOTE: This is Unix/Linux specific. On Windows, process groups work differently.
-	p.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if !p.allowDetachedProcess {
+		p.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	// Set a custom Cancel function to kill the entire process group when context is canceled.
-	// Without this, Go's default context cancellation (exec.CommandContext) only calls
-	// os.Process.Kill() on the parent process, leaving any backgrounded child processes
-	// as orphans (reparented to PID 1) that continue running indefinitely.
-	//
-	// By killing the negative PGID (-pgid), we send SIGKILL to ALL processes in the group,
-	// ensuring consistent cleanup behavior with the Close() method.
-	//
-	// DESIGN NOTE: We intentionally use SIGKILL (immediate termination) rather than
-	// SIGTERM (graceful shutdown) here. This is appropriate for gpud's use cases like
-	// the fabric-manager log watcher (tail -f, journalctl -f) which don't need cleanup time.
-	//
-	// If graceful shutdown is needed in the future, consider:
-	//   1. Send SIGTERM first, wait briefly (e.g., 500ms), then SIGKILL
-	//   2. Or add a configurable grace period option (WithGracefulShutdownTimeout)
-	//   3. Or move signal sending to Close() only (before calling p.cancel())
-	p.cmd.Cancel = func() error {
-		if p.cmd.Process == nil {
+		// Set a custom Cancel function to kill the entire process group when context is canceled.
+		// Without this, Go's default context cancellation (exec.CommandContext) only calls
+		// os.Process.Kill() on the parent process, leaving any backgrounded child processes
+		// as orphans (reparented to PID 1) that continue running indefinitely.
+		//
+		// By killing the negative PGID (-pgid), we send SIGKILL to ALL processes in the group,
+		// ensuring consistent cleanup behavior with the Close() method.
+		p.cmd.Cancel = func() error {
+			if p.cmd.Process == nil {
+				return nil
+			}
+			pgid := p.cmd.Process.Pid
+			// Use SIGKILL for context cancellation since we want immediate termination.
+			// ESRCH ("no such process") is expected if the group already exited.
+			if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+				return err
+			}
 			return nil
 		}
-		pgid := p.cmd.Process.Pid
-		// Use SIGKILL for context cancellation since we want immediate termination.
-		// ESRCH ("no such process") is expected if the group already exited.
-		if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
-			return err
-		}
-		return nil
 	}
+	// When allowDetachedProcess is true, we don't set Setpgid or a custom Cancel function.
+	// The default behavior (os.Process.Kill on direct child only) is what we want.
 
 	switch {
 	case p.outputFile != nil:
@@ -398,22 +384,22 @@ func (p *process) StartAndWaitForCombinedOutput(ctx context.Context) ([]byte, er
 	}
 	p.cmd.Env = p.envs
 
-	// Use process groups for consistent behavior with Start().
+	// Conditionally use process groups for consistent behavior with Start().
 	// See detailed comments in startCommand() for why this is necessary.
-	p.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if !p.allowDetachedProcess {
+		p.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	// Kill the entire process group when context is canceled.
-	// See startCommand() for detailed comments on why we use SIGKILL (immediate termination)
-	// rather than SIGTERM (graceful shutdown) - this is intentional for gpud's use cases.
-	p.cmd.Cancel = func() error {
-		if p.cmd.Process == nil {
+		// Kill the entire process group when context is canceled.
+		p.cmd.Cancel = func() error {
+			if p.cmd.Process == nil {
+				return nil
+			}
+			pgid := p.cmd.Process.Pid
+			if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+				return err
+			}
 			return nil
 		}
-		pgid := p.cmd.Process.Pid
-		if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
-			return err
-		}
-		return nil
 	}
 
 	// ref. "os/exec" "CombinedOutput"
@@ -551,127 +537,60 @@ func (p *process) Close(ctx context.Context) error {
 		return errors.New("process not started")
 	}
 
-	// GRACE PERIOD FOR BACKGROUNDED PROCESSES:
-	// If waitForDetach is set, wait for the specified duration before sending any
-	// kill signals. This is essential for commands that spawn background processes
-	// intended to outlive the parent shell.
-	//
-	// USE CASE: Deployment scripts often end with:
-	//
-	//   sleep 10 && systemctl restart gpud &
-	//
-	// Here, bash backgrounds the command and exits immediately. Without a grace period,
-	// Close() would immediately send SIGKILL to the entire process group (including
-	// the backgrounded "sleep 10 && systemctl restart gpud"), preventing the delayed
-	// restart from occurring.
-	//
-	// With waitForDetach, we:
-	//   1. Wait for the grace period for all processes in the group to complete naturally
-	//   2. Periodically check if the process group still exists (using kill -0)
-	//   3. If the group exits within the grace period, skip sending kill signals
-	//   4. If still running after the grace period, proceed with normal kill sequence
-	//
-	// This allows backgrounded processes like delayed restarts to complete, while
-	// still providing cleanup for processes that don't exit on their own.
-	processGroupGone := false
-	if p.waitForDetach > 0 && p.cmd.Process != nil {
-		pgid := p.cmd.Process.Pid
-		log.Logger.Debugw("waiting for detached processes to complete",
-			"pgid", pgid,
-			"gracePeriod", p.waitForDetach,
-		)
-
-		// Check periodically if the process group has exited.
-		// Using kill(pgid, 0) to check existence without sending a signal.
-		checkInterval := 100 * time.Millisecond
-		deadline := time.Now().Add(p.waitForDetach)
-
-	gracePeriodLoop:
-		for time.Now().Before(deadline) {
-			if err := syscall.Kill(-pgid, 0); err == syscall.ESRCH {
-				// ESRCH means "no such process" - the process group has exited
-				log.Logger.Debugw("process group exited within grace period", "pgid", pgid)
-				processGroupGone = true
-				break gracePeriodLoop
-			}
-			// Process group still exists, wait before checking again
-			select {
-			case <-ctx.Done():
-				// Context canceled during grace period, proceed to kill
-				log.Logger.Infow("context canceled during grace period, proceeding to kill", "pgid", pgid)
-				break gracePeriodLoop
-			case <-time.After(checkInterval):
-				// Continue checking
-			}
-		}
-
-		if !processGroupGone {
-			log.Logger.Debugw("grace period expired, proceeding to kill process group", "pgid", pgid)
-		}
-	}
-
 	// Cancel the context. This triggers cmd.Cancel() which sends SIGKILL to the
-	// process group. We also send SIGTERM below for completeness, but note that due to
-	// the race between these two signals, graceful shutdown is not guaranteed.
-	//
-	// DESIGN NOTE: For gpud's use cases (tail -f, journalctl -f log watchers), immediate
-	// termination is acceptable. If graceful shutdown becomes needed, the fix is to:
-	//   1. Send SIGTERM first (before p.cancel())
-	//   2. Wait for process exit or timeout
-	//   3. Then call p.cancel() as a fallback
+	// process group (if Setpgid was used).
 	p.cancel()
 
-	if p.cmd.Process != nil && !processGroupGone {
-		// Kill the entire process group, not just the parent process.
-		//
-		// WHY WE USE NEGATIVE PID:
-		// When we set Setpgid=true in startCommand(), the process and all its children
-		// share the same Process Group ID (PGID), which equals the parent's PID.
-		// Using syscall.Kill with a NEGATIVE pid sends the signal to every process
-		// in that group:
-		//   - syscall.Kill(pid, signal)  -> kills only the process with that PID
-		//   - syscall.Kill(-pid, signal) -> kills ALL processes in the group with PGID=pid
-		//
-		// WHY THIS MATTERS:
-		// Consider a command like: "tail -f file & journalctl -f & wait"
-		//   - Parent bash shell (PID=1000, PGID=1000)
-		//   - Child tail process (PID=1001, PGID=1000)  <- same group!
-		//   - Child journalctl process (PID=1002, PGID=1000)  <- same group!
-		//
-		// Without negative PID: Only bash (1000) receives SIGTERM
-		//   -> tail and journalctl become orphans, reparented to init (PID 1)
-		//   -> They keep running forever (PROCESS LEAK!)
-		//
-		// With negative PID: syscall.Kill(-1000, SIGTERM) sends to ALL three processes
-		//   -> bash, tail, AND journalctl all receive SIGTERM
-		//   -> Clean shutdown with no orphaned processes
-		//
-		// NOTE: If the process group no longer exists (already exited), Kill returns
-		// ESRCH ("no such process") which we handle gracefully.
-		pgid := p.cmd.Process.Pid
-		finished := false
-		if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
-			if err == syscall.ESRCH {
-				// ESRCH means "no such process" - the process group already exited
-				finished = true
-			} else {
-				log.Logger.Warnw("failed to send SIGTERM to process group", "pgid", pgid, "error", err)
+	if p.cmd.Process != nil {
+		if p.allowDetachedProcess {
+			// When allowDetachedProcess is true, we only kill the direct child process.
+			// Backgrounded processes (using "&") become orphans and continue running.
+			// This is required for scripts with patterns like:
+			//   sleep 10 && systemctl restart gpud &
+			pid := p.cmd.Process.Pid
+			if err := p.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+				if err != os.ErrProcessDone && err != syscall.ESRCH {
+					log.Logger.Warnw("failed to send SIGTERM to process", "pid", pid, "error", err)
+				}
 			}
-		}
-		if !finished {
-			// NOTE: Since we called p.cancel() above, p.ctx.Done() will fire immediately.
-			// This means the 3-second timeout is effectively bypassed - SIGKILL was already
-			// sent via cmd.Cancel(). This select exists for the edge case where cmd.Cancel
-			// fails or isn't set, providing a fallback SIGKILL after 3 seconds.
-			select {
-			case <-p.ctx.Done():
-				// Context already canceled - cmd.Cancel() should have sent SIGKILL
-			case <-time.After(3 * time.Second):
-				// Fallback: force kill if still running after 3 seconds
-				if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
-					// Don't warn on ESRCH - process may have exited between SIGTERM and SIGKILL
-					if err != syscall.ESRCH {
-						log.Logger.Warnw("failed to send SIGKILL to process group", "pgid", pgid, "error", err)
+		} else {
+			// When allowDetachedProcess is false (default), kill the entire process group.
+			//
+			// WHY WE USE NEGATIVE PID:
+			// When we set Setpgid=true in startCommand(), the process and all its children
+			// share the same Process Group ID (PGID), which equals the parent's PID.
+			// Using syscall.Kill with a NEGATIVE pid sends the signal to every process
+			// in that group:
+			//   - syscall.Kill(pid, signal)  -> kills only the process with that PID
+			//   - syscall.Kill(-pid, signal) -> kills ALL processes in the group with PGID=pid
+			//
+			// NOTE: If the process group no longer exists (already exited), Kill returns
+			// ESRCH ("no such process") which we handle gracefully.
+			pgid := p.cmd.Process.Pid
+			finished := false
+			if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
+				if err == syscall.ESRCH {
+					// ESRCH means "no such process" - the process group already exited
+					finished = true
+				} else {
+					log.Logger.Warnw("failed to send SIGTERM to process group", "pgid", pgid, "error", err)
+				}
+			}
+			if !finished {
+				// NOTE: Since we called p.cancel() above, p.ctx.Done() will fire immediately.
+				// This means the 3-second timeout is effectively bypassed - SIGKILL was already
+				// sent via cmd.Cancel(). This select exists for the edge case where cmd.Cancel
+				// fails or isn't set, providing a fallback SIGKILL after 3 seconds.
+				select {
+				case <-p.ctx.Done():
+					// Context already canceled - cmd.Cancel() should have sent SIGKILL
+				case <-time.After(3 * time.Second):
+					// Fallback: force kill if still running after 3 seconds
+					if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
+						// Don't warn on ESRCH - process may have exited between SIGTERM and SIGKILL
+						if err != syscall.ESRCH {
+							log.Logger.Warnw("failed to send SIGKILL to process group", "pgid", pgid, "error", err)
+						}
 					}
 				}
 			}

--- a/pkg/process/process_detach_test.go
+++ b/pkg/process/process_detach_test.go
@@ -10,27 +10,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestBackgroundProcessKilledWithoutGracePeriod demonstrates the bug where
+// TestBackgroundProcessKilledByDefault demonstrates the default behavior where
 // backgrounded processes like "sleep 2 && touch /tmp/marker &" get killed
-// when Close() is called, even though they should continue running.
+// when Close() is called because the entire process group is terminated.
 //
-// This test shows that WITHOUT WithWaitForDetach, the backgrounded process
-// is killed and the marker file is never created.
+// This is the SAFE default behavior that prevents orphaned/leaked processes.
 //
-// USE CASE: Deployment scripts often end with:
+// USE CASE FOR OVERRIDING:
+// Deployment scripts often end with:
 //
 //	sleep 10 && systemctl restart gpud &
 //
 // This pattern allows the script to exit immediately while scheduling a
-// delayed restart. Without the grace period fix, the backgrounded command
-// gets killed when the process group is terminated.
-func TestBackgroundProcessKilledWithoutGracePeriod(t *testing.T) {
+// delayed restart. For such scripts, use WithAllowDetachedProcess(true).
+func TestBackgroundProcessKilledByDefault(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.Skip("Skipping process group test in CI environment")
 	}
 
 	// Create a unique marker file path
-	markerFile := filepath.Join(os.TempDir(), "gpud-test-no-grace-"+time.Now().Format("20060102150405"))
+	markerFile := filepath.Join(os.TempDir(), "gpud-test-default-"+time.Now().Format("20060102150405"))
 	defer func() { _ = os.Remove(markerFile) }()
 
 	// Remove marker file if it exists
@@ -39,8 +38,8 @@ func TestBackgroundProcessKilledWithoutGracePeriod(t *testing.T) {
 	// This script backgrounds a command that:
 	// 1. Sleeps for 1 second
 	// 2. Creates a marker file
-	// Without grace period, the backgrounded process will be killed before
-	// it can create the marker file.
+	// With default behavior (Setpgid=true), the backgrounded process will be killed
+	// when Close() terminates the process group.
 	script := `#!/bin/bash
 # Background a delayed file creation
 # This simulates "sleep 10 && systemctl restart gpud &"
@@ -50,10 +49,10 @@ sleep 1 && touch "` + markerFile + `" &
 exit 0
 `
 
-	// Create process WITHOUT grace period
+	// Create process WITHOUT WithAllowDetachedProcess (default behavior)
 	p, err := New(
 		WithBashScriptContentsToRun(script),
-		// NOTE: No WithWaitForDetach - this demonstrates the bug
+		// NOTE: No WithAllowDetachedProcess - uses safe default (Setpgid=true)
 	)
 	require.NoError(t, err)
 
@@ -82,28 +81,27 @@ exit 0
 	time.Sleep(2 * time.Second)
 
 	// Check if marker file was created
-	// WITHOUT grace period, it should NOT exist (background process was killed)
+	// With default behavior (Setpgid=true), it should NOT exist (background process was killed)
 	_, err = os.Stat(markerFile)
 	require.True(t, os.IsNotExist(err),
-		"BUG CONFIRMED: Without grace period, marker file should NOT exist "+
-			"because the backgrounded process was killed. If this test fails, "+
-			"it means the bug has been inadvertently fixed or the test setup is wrong.")
-	t.Log("Confirmed: Background process was killed (marker file not created)")
+		"DEFAULT BEHAVIOR CONFIRMED: Without WithAllowDetachedProcess, marker file should NOT exist "+
+			"because the entire process group (including backgrounded processes) was killed.")
+	t.Log("Confirmed: Background process was killed by process group termination (safe default)")
 }
 
-// TestBackgroundProcessCompletesWithGracePeriod demonstrates the fix.
-// With WithWaitForDetach, the backgrounded process is allowed to complete
-// before the process group is killed.
+// TestBackgroundProcessCompletesWithAllowDetachedProcess demonstrates that
+// with WithAllowDetachedProcess(true), backgrounded processes are allowed to
+// continue running after the parent shell exits.
 //
-// This test shows that WITH WithWaitForDetach, the backgrounded process
-// completes and creates the marker file.
-func TestBackgroundProcessCompletesWithGracePeriod(t *testing.T) {
+// This test shows that WITH WithAllowDetachedProcess(true), the backgrounded
+// process becomes an orphan and continues to run.
+func TestBackgroundProcessCompletesWithAllowDetachedProcess(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.Skip("Skipping process group test in CI environment")
 	}
 
 	// Create a unique marker file path
-	markerFile := filepath.Join(os.TempDir(), "gpud-test-with-grace-"+time.Now().Format("20060102150405"))
+	markerFile := filepath.Join(os.TempDir(), "gpud-test-detached-"+time.Now().Format("20060102150405"))
 	defer func() { _ = os.Remove(markerFile) }()
 
 	// Remove marker file if it exists
@@ -119,10 +117,10 @@ sleep 1 && touch "` + markerFile + `" &
 exit 0
 `
 
-	// Create process WITH grace period - this is the fix!
+	// Create process WITH WithAllowDetachedProcess(true) - allows orphaned processes
 	p, err := New(
 		WithBashScriptContentsToRun(script),
-		WithWaitForDetach(3*time.Second), // Wait up to 3 seconds for background processes
+		WithAllowDetachedProcess(true), // Allow background processes to become orphans
 	)
 	require.NoError(t, err)
 
@@ -143,252 +141,37 @@ exit 0
 		t.Fatal("timeout waiting for bash to exit")
 	}
 
-	// Close the process - with grace period, it will wait for the
-	// backgrounded process to complete before killing
-	t.Log("Calling Close() - will wait for grace period...")
-	start := time.Now()
+	// Close the process - with WithAllowDetachedProcess(true), only the direct
+	// child process is killed, allowing backgrounded processes to continue
+	t.Log("Calling Close() - only kills direct child, not backgrounded processes")
 	require.NoError(t, p.Close(ctx))
-	elapsed := time.Since(start)
-	t.Logf("Close() returned after %v", elapsed)
 
-	// Check if marker file was created
-	// WITH grace period, it SHOULD exist (background process was allowed to complete)
-	_, err = os.Stat(markerFile)
-	require.NoError(t, err,
-		"FIX CONFIRMED: With grace period, marker file SHOULD exist "+
-			"because the backgrounded process was allowed to complete. "+
-			"If this test fails, the fix is not working correctly.")
-	t.Log("Confirmed: Background process completed (marker file created)")
-}
-
-// TestGracePeriodExpiresIfProcessTakesTooLong tests that if the backgrounded
-// process takes longer than the grace period, it gets killed after the timeout.
-func TestGracePeriodExpiresIfProcessTakesTooLong(t *testing.T) {
-	if os.Getenv("CI") != "" {
-		t.Skip("Skipping process group test in CI environment")
-	}
-
-	// Create a unique marker file path
-	markerFile := filepath.Join(os.TempDir(), "gpud-test-expired-"+time.Now().Format("20060102150405"))
-	defer func() { _ = os.Remove(markerFile) }()
-
-	// Remove marker file if it exists
-	_ = os.Remove(markerFile)
-
-	// This script backgrounds a command that takes 5 seconds,
-	// but we'll only wait 1 second
-	script := `#!/bin/bash
-# Background a long-running file creation
-sleep 5 && touch "` + markerFile + `" &
-
-# Exit immediately
-exit 0
-`
-
-	// Create process with SHORT grace period (1 second)
-	// The backgrounded process takes 5 seconds, so it will be killed
-	p, err := New(
-		WithBashScriptContentsToRun(script),
-		WithWaitForDetach(1*time.Second), // Only wait 1 second
-	)
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	// Start the process
-	require.NoError(t, p.Start(ctx))
-	t.Logf("Process started with PID: %d", p.PID())
-
-	// Wait for bash to exit
-	select {
-	case err := <-p.Wait():
-		require.NoError(t, err)
-		t.Log("Bash script exited successfully")
-	case <-time.After(3 * time.Second):
-		t.Fatal("timeout waiting for bash to exit")
-	}
-
-	// Close the process - will wait 1 second, then kill
-	t.Log("Calling Close() - will wait 1 second grace period then kill...")
-	start := time.Now()
-	require.NoError(t, p.Close(ctx))
-	elapsed := time.Since(start)
-	t.Logf("Close() returned after %v", elapsed)
-
-	// Grace period should have been approximately 1 second
-	require.Greater(t, elapsed, 800*time.Millisecond, "should have waited for grace period")
-	require.Less(t, elapsed, 2*time.Second, "should not wait longer than grace period + overhead")
-
-	// Wait a bit more to ensure the background process would have completed if not killed
-	time.Sleep(5 * time.Second)
-
-	// Check if marker file was created
-	// It should NOT exist because the process was killed after grace period expired
-	_, err = os.Stat(markerFile)
-	require.True(t, os.IsNotExist(err),
-		"Grace period should have expired and killed the process before "+
-			"it could create the marker file")
-	t.Log("Confirmed: Background process was killed after grace period expired")
-}
-
-// TestGracePeriodWithQuickProcess tests that if the backgrounded process
-// completes quickly (before grace period), Close() returns early without
-// waiting for the full grace period.
-func TestGracePeriodWithQuickProcess(t *testing.T) {
-	if os.Getenv("CI") != "" {
-		t.Skip("Skipping process group test in CI environment")
-	}
-
-	// Create a unique marker file path
-	markerFile := filepath.Join(os.TempDir(), "gpud-test-quick-"+time.Now().Format("20060102150405"))
-	defer func() { _ = os.Remove(markerFile) }()
-
-	// Remove marker file if it exists
-	_ = os.Remove(markerFile)
-
-	// This script backgrounds a command that completes in 500ms
-	script := `#!/bin/bash
-# Background a quick file creation
-sleep 0.5 && touch "` + markerFile + `" &
-
-# Exit immediately
-exit 0
-`
-
-	// Create process with LONG grace period (10 seconds)
-	// But the backgrounded process only takes 500ms
-	p, err := New(
-		WithBashScriptContentsToRun(script),
-		WithWaitForDetach(10*time.Second), // Long grace period
-	)
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-
-	// Start the process
-	require.NoError(t, p.Start(ctx))
-	t.Logf("Process started with PID: %d", p.PID())
-
-	// Wait for bash to exit
-	select {
-	case err := <-p.Wait():
-		require.NoError(t, err)
-		t.Log("Bash script exited successfully")
-	case <-time.After(3 * time.Second):
-		t.Fatal("timeout waiting for bash to exit")
-	}
-
-	// Close the process - should return early when background process completes
-	t.Log("Calling Close() - should return early when background process completes...")
-	start := time.Now()
-	require.NoError(t, p.Close(ctx))
-	elapsed := time.Since(start)
-	t.Logf("Close() returned after %v", elapsed)
-
-	// Should return much faster than the 10 second grace period
-	// (background process takes ~500ms + polling overhead)
-	require.Less(t, elapsed, 3*time.Second,
-		"Close() should return early when background process completes, "+
-			"not wait for full grace period")
-
-	// Check if marker file was created
-	_, err = os.Stat(markerFile)
-	require.NoError(t, err,
-		"Background process should have completed and created marker file")
-	t.Log("Confirmed: Close() returned early after background process completed")
-}
-
-// TestGracePeriodContextCancelation tests that if the caller's context is
-// canceled during the grace period, Close() proceeds to kill immediately.
-func TestGracePeriodContextCancelation(t *testing.T) {
-	if os.Getenv("CI") != "" {
-		t.Skip("Skipping process group test in CI environment")
-	}
-
-	// Create a unique marker file path
-	markerFile := filepath.Join(os.TempDir(), "gpud-test-ctx-cancel-"+time.Now().Format("20060102150405"))
-	defer func() { _ = os.Remove(markerFile) }()
-
-	// Remove marker file if it exists
-	_ = os.Remove(markerFile)
-
-	// This script backgrounds a long-running command
-	script := `#!/bin/bash
-# Background a long-running file creation
-sleep 10 && touch "` + markerFile + `" &
-
-# Exit immediately
-exit 0
-`
-
-	// Create process with long grace period
-	p, err := New(
-		WithBashScriptContentsToRun(script),
-		WithWaitForDetach(30*time.Second), // Very long grace period
-	)
-	require.NoError(t, err)
-
-	// Create a context that we'll cancel during Close()
-	ctx, cancel := context.WithCancel(context.Background())
-
-	// Start the process
-	require.NoError(t, p.Start(ctx))
-	t.Logf("Process started with PID: %d", p.PID())
-
-	// Wait for bash to exit
-	select {
-	case err := <-p.Wait():
-		require.NoError(t, err)
-		t.Log("Bash script exited successfully")
-	case <-time.After(3 * time.Second):
-		t.Fatal("timeout waiting for bash to exit")
-	}
-
-	// Cancel context after a short delay (in a goroutine)
-	go func() {
-		time.Sleep(500 * time.Millisecond)
-		t.Log("Canceling context...")
-		cancel()
-	}()
-
-	// Close the process - should respect context cancellation
-	t.Log("Calling Close() - context will be canceled after 500ms...")
-	start := time.Now()
-	require.NoError(t, p.Close(ctx))
-	elapsed := time.Since(start)
-	t.Logf("Close() returned after %v", elapsed)
-
-	// Should return quickly after context cancellation, not wait full grace period
-	require.Less(t, elapsed, 2*time.Second,
-		"Close() should respect context cancellation and return early")
-
-	// Wait to ensure the background process would have created the file if not killed
+	// Wait for the backgrounded process to complete (sleep 1 + buffer)
 	time.Sleep(2 * time.Second)
 
 	// Check if marker file was created
-	// It should NOT exist because context was canceled and process was killed
+	// WITH WithAllowDetachedProcess(true), it SHOULD exist
 	_, err = os.Stat(markerFile)
-	require.True(t, os.IsNotExist(err),
-		"Context cancellation should have interrupted grace period and killed process")
-	t.Log("Confirmed: Context cancellation interrupted grace period")
+	require.NoError(t, err,
+		"FIX CONFIRMED: With WithAllowDetachedProcess(true), marker file SHOULD exist "+
+			"because the backgrounded process was allowed to become an orphan and continue running.")
+	t.Log("Confirmed: Background process completed (marker file created)")
 }
 
-// TestNoGracePeriodByDefault ensures that without WithWaitForDetach,
-// Close() kills the process group immediately (existing behavior preserved).
-func TestNoGracePeriodByDefault(t *testing.T) {
+// TestCloseReturnsQuicklyByDefault tests that without WithAllowDetachedProcess,
+// Close() kills the process group immediately (fast cleanup).
+func TestCloseReturnsQuicklyByDefault(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.Skip("Skipping process group test in CI environment")
 	}
 
-	// Create a process WITHOUT grace period
+	// Create a process WITHOUT WithAllowDetachedProcess (default behavior)
 	p, err := New(
 		WithBashScriptContentsToRun(`#!/bin/bash
 sleep 100 &
 exit 0
 `),
-		// NOTE: No WithWaitForDetach
+		// NOTE: No WithAllowDetachedProcess - uses safe default (Setpgid=true)
 	)
 	require.NoError(t, err)
 
@@ -405,13 +188,13 @@ exit 0
 		t.Fatal("timeout")
 	}
 
-	// Close should return immediately (no grace period)
+	// Close should return quickly because it kills the process group immediately
 	start := time.Now()
 	require.NoError(t, p.Close(ctx))
 	elapsed := time.Since(start)
 
-	// Without grace period, Close() should return quickly
+	// Without WithAllowDetachedProcess (default), Close() should return quickly
 	require.Less(t, elapsed, 500*time.Millisecond,
-		"Without grace period, Close() should return immediately")
-	t.Logf("Close() returned after %v (no grace period)", elapsed)
+		"Default behavior: Close() should return quickly after killing process group")
+	t.Logf("Close() returned after %v (fast process group termination)", elapsed)
 }

--- a/pkg/process/runner.go
+++ b/pkg/process/runner.go
@@ -15,5 +15,7 @@ type Runner interface {
 	// RunUntilCompletion starts a bash script, blocks until it finishes,
 	// and returns the output and the exit code.
 	// Whether to return an error when there is already a process running is up to the implementation.
-	RunUntilCompletion(ctx context.Context, script string) ([]byte, int32, error)
+	// Optional OpOption arguments can be passed to customize process behavior
+	// (e.g., WithAllowDetachedProcess(true) for scripts with backgrounded commands).
+	RunUntilCompletion(ctx context.Context, script string, opts ...OpOption) ([]byte, int32, error)
 }

--- a/pkg/session/session_serve_test.go
+++ b/pkg/session/session_serve_test.go
@@ -21,6 +21,7 @@ import (
 	pkgkmsgwriter "github.com/leptonai/gpud/pkg/kmsg/writer"
 	"github.com/leptonai/gpud/pkg/log"
 	"github.com/leptonai/gpud/pkg/metrics"
+	"github.com/leptonai/gpud/pkg/process"
 )
 
 // Mock implementations
@@ -166,7 +167,7 @@ type mockProcessRunner struct {
 	mock.Mock
 }
 
-func (m *mockProcessRunner) RunUntilCompletion(ctx context.Context, command string) ([]byte, int32, error) {
+func (m *mockProcessRunner) RunUntilCompletion(ctx context.Context, command string, opts ...process.OpOption) ([]byte, int32, error) {
 	args := m.Called(ctx, command)
 	return args.Get(0).([]byte), int32(args.Int(1)), args.Error(2)
 }


### PR DESCRIPTION
Replace the unreliable grace period mechanism with a cleaner boolean option
that controls process group behavior:

- WithAllowDetachedProcess(false) [DEFAULT]: Uses Setpgid=true, kills entire
  process group on Close() - safe default preventing orphaned processes
- WithAllowDetachedProcess(true): No Setpgid, only kills direct child -
  allows backgrounded commands like "sleep 10 && systemctl restart gpud &"
  to become orphans and continue running

This replaces the previous WithWaitForDetach approach which relied on polling
the process group status during a grace period - that was unreliable because
it depended on timing rather than process structure.