### PR TITLE
make gpud port number configurable

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -176,7 +176,7 @@ sudo rm /etc/systemd/system/gpud.service
 				&cli.StringFlag{
 					Name:  "listen-address",
 					Usage: "set the listen address",
-					Value: fmt.Sprintf("0.0.0.0:%d", pkgconfig.DefaultGPUdPort),
+					Value: fmt.Sprintf("0.0.0.0:%d", pkgconfig.GPUdPortNumber()),
 				},
 				&cli.BoolFlag{
 					Name:  "pprof",

--- a/cmd/gpud/compact/command.go
+++ b/cmd/gpud/compact/command.go
@@ -47,9 +47,9 @@ func Command(cliContext *cli.Context) error {
 		}
 	}
 
-	portOpen := isPortOpen(config.DefaultGPUdPort)
+	portOpen := isPortOpen(config.GPUdPortNumber())
 	if portOpen {
-		return fmt.Errorf("gpud is running on port %d (must be stopped before running compact)", config.DefaultGPUdPort)
+		return fmt.Errorf("gpud is running on port %d (must be stopped before running compact)", config.GPUdPortNumber())
 	}
 
 	log.Logger.Infow("successfully checked gpud is not running")

--- a/cmd/gpud/compact/command_test.go
+++ b/cmd/gpud/compact/command_test.go
@@ -81,7 +81,7 @@ func TestCommand_ReturnsErrorWhenPortOpen(t *testing.T) {
 
 	err := Command(cliContext)
 	require.Error(t, err)
-	assert.Equal(t, fmt.Sprintf("gpud is running on port %d (must be stopped before running compact)", config.DefaultGPUdPort), err.Error())
+	assert.Equal(t, fmt.Sprintf("gpud is running on port %d (must be stopped before running compact)", config.GPUdPortNumber()), err.Error())
 }
 
 func TestCommand_Success(t *testing.T) {

--- a/cmd/gpud/list-plugins/command.go
+++ b/cmd/gpud/list-plugins/command.go
@@ -30,7 +30,7 @@ func Command(cliContext *cli.Context) error {
 	// Get the server address from the flag, default to http://localhost:<Default GPUd port>
 	serverAddr := cliContext.String("server")
 	if serverAddr == "" {
-		serverAddr = fmt.Sprintf("https://localhost:%d", config.DefaultGPUdPort)
+		serverAddr = fmt.Sprintf("https://localhost:%d", config.GPUdPortNumber())
 	}
 
 	// Get custom plugins

--- a/cmd/gpud/run-plugin-group/command.go
+++ b/cmd/gpud/run-plugin-group/command.go
@@ -33,7 +33,7 @@ func Command(cliContext *cli.Context) error {
 	// Get the server address from the flag, default to http://localhost:<Default GPUd port>
 	serverAddr := cliContext.String("server")
 	if serverAddr == "" {
-		serverAddr = fmt.Sprintf("https://localhost:%d", config.DefaultGPUdPort)
+		serverAddr = fmt.Sprintf("https://localhost:%d", config.GPUdPortNumber())
 	}
 
 	// Create a context with timeout

--- a/cmd/gpud/set-healthy/command.go
+++ b/cmd/gpud/set-healthy/command.go
@@ -29,7 +29,7 @@ func CreateCommand() func(*cli.Context) error {
 		// Get the server address from the flag, default to https://localhost:<Default GPUd port>
 		serverAddr := cliContext.String("server")
 		if serverAddr == "" {
-			serverAddr = fmt.Sprintf("https://localhost:%d", config.DefaultGPUdPort)
+			serverAddr = fmt.Sprintf("https://localhost:%d", config.GPUdPortNumber())
 		}
 
 		// Get the components from the positional argument

--- a/cmd/gpud/status/command.go
+++ b/cmd/gpud/status/command.go
@@ -106,7 +106,7 @@ func Command(cliContext *cli.Context) error {
 
 	if err := clientv1.BlockUntilServerReady(
 		rootCtx,
-		fmt.Sprintf("https://localhost:%d", config.DefaultGPUdPort),
+		fmt.Sprintf("https://localhost:%d", config.GPUdPortNumber()),
 	); err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func Command(cliContext *cli.Context) error {
 	for {
 		var err error
 		cctx, ccancel := context.WithTimeout(rootCtx, 15*time.Second)
-		lastPackageStatus, err = clientv1.GetPackageStatus(cctx, fmt.Sprintf("https://localhost:%d%s", config.DefaultGPUdPort, server.URLPathAdminPackages))
+		lastPackageStatus, err = clientv1.GetPackageStatus(cctx, fmt.Sprintf("https://localhost:%d%s", config.GPUdPortNumber(), server.URLPathAdminPackages))
 		ccancel()
 		if err != nil {
 			fmt.Printf("%s failed to get package status: %v\n", cmdcommon.WarningSign, err)

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -16,7 +16,7 @@ import (
 const (
 	DefaultAPIVersion = "v1"
 	DefaultDataDir    = "/var/lib/gpud"
-	defaultGPUdPort   = 15132
+	DefaultGPUdPort   = 15132
 )
 
 var (
@@ -146,12 +146,12 @@ func VersionFilePath(dataDir string) string {
 func GPUdPortNumber() int {
 	portStr, found := stdos.LookupEnv("GPUD_PORT")
 	if !found {
-		return defaultGPUdPort
+		return DefaultGPUdPort
 	}
 
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
-		return defaultGPUdPort
+		return DefaultGPUdPort
 	}
 
 	return port

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	stdos "os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,8 +15,8 @@ import (
 
 const (
 	DefaultAPIVersion = "v1"
-	DefaultGPUdPort   = 15132
 	DefaultDataDir    = "/var/lib/gpud"
+	defaultGPUdPort   = 15132
 )
 
 var (
@@ -43,7 +44,7 @@ func DefaultConfig(ctx context.Context, opts ...OpOption) (*Config, error) {
 
 	cfg := &Config{
 		APIVersion:       DefaultAPIVersion,
-		Address:          fmt.Sprintf(":%d", DefaultGPUdPort),
+		Address:          fmt.Sprintf(":%d", GPUdPortNumber()),
 		DataDir:          dataDir,
 		RetentionPeriod:  DefaultRetentionPeriod,
 		CompactPeriod:    DefaultCompactPeriod,
@@ -140,4 +141,18 @@ func PackagesDir(dataDir string) string {
 // VersionFilePath returns the version file path under the dataDir.
 func VersionFilePath(dataDir string) string {
 	return filepath.Join(dataDir, "target_version")
+}
+
+func GPUdPortNumber() int {
+	portStr, found := stdos.LookupEnv("GPUD_PORT")
+	if !found {
+		return defaultGPUdPort
+	}
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return defaultGPUdPort
+	}
+
+	return port
 }

--- a/pkg/config/default_test.go
+++ b/pkg/config/default_test.go
@@ -20,7 +20,7 @@ func TestDefaultConfig(t *testing.T) {
 
 		// Check basic properties that don't depend on the environment
 		assert.Equal(t, DefaultAPIVersion, cfg.APIVersion)
-		assert.Equal(t, fmt.Sprintf(":%d", DefaultGPUdPort), cfg.Address)
+		assert.Equal(t, fmt.Sprintf(":%d", GPUdPortNumber()), cfg.Address)
 		assert.Equal(t, DefaultRetentionPeriod, cfg.RetentionPeriod)
 		assert.Equal(t, DefaultCompactPeriod, cfg.CompactPeriod)
 		assert.False(t, cfg.Pprof)


### PR DESCRIPTION
I'd like to be able to choose the port number that gpud exposes.

This change renames `DefaultGPUdPort` to `defaultGPUdPort` to scope its visibility to the config package, and exposes a function `GPUdPortNumber()` that reads env var GPUD_PORT but falls back to defaultGPUdPort if it's missing or not an int.

It would be nice to factor this such that the port number is considered only when building the config (in DefaultConfig()) with a nice error message if it's malformed. But today `DefaultGPUdPort` (now `GPUdPortNumber()` is used throughout the codebase, so I decided to propose this surgical change to start.