### PR TITLE
feat(helm/gpud): allow to override default gpud command

### DIFF
--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -220,8 +220,10 @@ spec:
           # Privileged access is required for hardware inspection and low-level system access.
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-
           command:
+{{- if .Values.gpud.commandOverride }}
+            {{- toYaml .Values.gpud.commandOverride | nindent 12 }}
+{{- else }}
             - /bin/sh
             - -ec
             - |
@@ -290,6 +292,7 @@ spec:
               # Using exec ensures gpud receives signals directly (important for graceful shutdown).
               echo "Starting: /usr/local/bin/gpud $*"
               exec /usr/local/bin/gpud "$@"
+{{- end }}
 
           env:
             - name: GPUD_NO_USAGE_STATS

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -60,6 +60,9 @@ gpud:
   # Set to false in security-sensitive environments where these features aren't needed.
   mountHostProc: true
 
+  # Override the default command for the gpud container.
+  commandOverride: []
+
 # Reference to one or more secrets to be used for pulling images from private registries.
 # Example for NVIDIA NGC registry (nvcr.io):
 #


### PR DESCRIPTION
This PR adds new `gpud.commandOverride` helm parameter that allows to override default command for gpud container. Fixes #1202 