### PR TITLE
fix(helm): use subshell for pipefail test to avoid POSIX special builtin exit

### DIFF
--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -179,7 +179,10 @@ spec:
             - |
               set -o errexit
               set -o nounset
-              set -o pipefail 2>/dev/null || true  # pipefail not supported in dash (Ubuntu's /bin/sh)
+              # pipefail not supported in dash (Ubuntu's /bin/sh).
+              # POSIX special builtins (like `set`) cause the shell to exit on failure
+              # even in `|| true` constructs. A subshell safely isolates the test.
+              if ( set -o pipefail ) 2>/dev/null; then set -o pipefail; fi
 
               tmp_file="${OUTPUT_FILE}.tmp"
               mkdir -p "$(dirname "${OUTPUT_FILE}")"
@@ -233,7 +236,10 @@ spec:
               # - pipefail: Pipeline fails if any command fails (not just the last)
               set -o errexit
               set -o nounset
-              set -o pipefail 2>/dev/null || true  # pipefail not supported in dash (Ubuntu's /bin/sh)
+              # pipefail not supported in dash (Ubuntu's /bin/sh).
+              # POSIX special builtins (like `set`) cause the shell to exit on failure
+              # even in `|| true` constructs. A subshell safely isolates the test.
+              if ( set -o pipefail ) 2>/dev/null; then set -o pipefail; fi
 
               # --- OPTIONAL: Read configuration from Kubernetes node labels ---
               # If nodeLabelExporter sidecar is enabled, it writes node labels to this file.
@@ -390,7 +396,10 @@ spec:
             - |
               set -o errexit
               set -o nounset
-              set -o pipefail 2>/dev/null || true  # pipefail not supported in dash (Ubuntu's /bin/sh)
+              # pipefail not supported in dash (Ubuntu's /bin/sh).
+              # POSIX special builtins (like `set`) cause the shell to exit on failure
+              # even in `|| true` constructs. A subshell safely isolates the test.
+              if ( set -o pipefail ) 2>/dev/null; then set -o pipefail; fi
 
               tmp_file="${OUTPUT_FILE}.tmp"
               mkdir -p "$(dirname "${OUTPUT_FILE}")"


### PR DESCRIPTION
`set -o pipefail 2>/dev/null || true` causes immediate shell exit (code 2) with empty logs when /bin/sh is dash (Ubuntu/Debian default).

In POSIX, `set` is a special builtin — its failures are fatal to the shell even inside `|| true` constructs. Wrapping in a subshell isolates the test: the subshell exits on failure but the parent shell is unaffected.

Tested on Hetzner cx23 nodes with Ubuntu 24.04, Kubernetes 1.35, containerd CRI. Before fix: CrashLoopBackOff. After fix: pods Running, /healthz and /v1/info endpoints returning metrics for all 34 components.