### PR TITLE
[LEP-4109] fix(nvidia/fabric-manager): handle GH200 without NVSwitch correctly, treat NV_WARN_NOTHING_TO_DO as healthy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ docker login nvcr.io
 # The repository for the image (e.g., nvcr.io/leptonai/gpud)
 export IMAGE_REPO="your-registry/gpud"
 # The git tag version
-export GIT_TAG="v0.9.1"
+export GIT_TAG="v..."
 # Critical dependencies
 export OS_NAME="ubuntu"
 export OS_VERSION="22.04"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ curl -fsSL https://pkg.gpud.dev/install.sh | sh
 To specify a version:
 
 ```bash
-curl -fsSL https://pkg.gpud.dev/install.sh | sh -s v0.9.1
+curl -fsSL https://pkg.gpud.dev/install.sh | sh -s v0.10.0
 ```
 
 The install script also currently support other architectures (e.g., arm64) and OSes (e.g., macOS).

--- a/components/accelerator/nvidia/fabric-manager/component.go
+++ b/components/accelerator/nvidia/fabric-manager/component.go
@@ -370,6 +370,21 @@ func (c *component) Check() components.CheckResult {
 			}
 		}
 
+		// Skip fabric state check if NVSwitch hardware is not detected.
+		// Some GPU configurations (e.g., GH200 standalone, PCIe cards) support the fabric state
+		// API at the product level but don't have NVSwitch hardware. In these cases, the NVML
+		// fabric state API returns "Not Supported" which should not be treated as unhealthy.
+		// This check must happen BEFORE collectFabricState() to avoid false unhealthy reports.
+		// Ref: https://www.nvidia.com/en-us/data-center/grace-hopper-superchip/
+		// Ref: https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/index.html
+		if !c.testingMode && c.checkNVSwitchExistsFunc != nil && !c.checkNVSwitchExistsFunc() {
+			log.Logger.Infow("skipping fabric state check because NVSwitch not detected")
+			cr.health = apiv1.HealthStateTypeHealthy
+			cr.reason = c.nvmlInstance.ProductName() + ": NVSwitch not detected, skipping fabric state check"
+			cr.FabricStateReason = cr.reason
+			return cr
+		}
+
 		report := c.collectFabricStateFunc()
 		cr.FabricStates = report.Entries
 		if report.Reason != "" {
@@ -460,6 +475,23 @@ func (c *component) Check() components.CheckResult {
 	if !active {
 		cr.FabricManagerActive = false
 
+		// Check if FM reported "nothing to do" - this is not an error condition.
+		// It means FM started but found no NVSwitch devices to manage.
+		// This commonly happens on:
+		// - GH200 standalone systems (NVLink-C2C only, no NVSwitch)
+		// - Simple NVLink bridge configurations (2 GPUs with NVLink, no switch)
+		// - PCIe GPU configurations
+		// Ref: https://forums.developer.nvidia.com/t/nvidia-fabricmanager-running-error-with-nv-warn-nothing-to-do/272899
+		// Ref: https://github.com/NVIDIA/gpu-operator/issues/610
+		if c.hasNothingToDoEvent() {
+			log.Logger.Infow("fabric manager reported nothing to do, treating as healthy")
+			if cr.health != apiv1.HealthStateTypeUnhealthy {
+				cr.health = apiv1.HealthStateTypeHealthy
+			}
+			cr.reason = appendReason(cr.reason, "fabric manager has nothing to do (no NVSwitch devices)")
+			return cr
+		}
+
 		if cr.health == "" || cr.health == apiv1.HealthStateTypeHealthy {
 			cr.health = apiv1.HealthStateTypeUnhealthy
 		}
@@ -485,6 +517,33 @@ func appendReason(existing, addition string) string {
 		return existing
 	}
 	return existing + "; " + addition
+}
+
+// hasNothingToDoEvent checks if the fabric manager has recently reported NV_WARN_NOTHING_TO_DO.
+// This indicates that FM started but found no NVSwitch devices to manage, which is a healthy state.
+func (c *component) hasNothingToDoEvent() bool {
+	if c.eventBucket == nil {
+		return false
+	}
+
+	// Check for events in the last 10 minutes
+	ctx, cancel := context.WithTimeout(c.ctx, 10*time.Second)
+	defer cancel()
+
+	since := time.Now().Add(-10 * time.Minute)
+	events, err := c.eventBucket.Get(ctx, since)
+	if err != nil {
+		log.Logger.Warnw("failed to query events for nothing_to_do check", "error", err)
+		return false
+	}
+
+	for _, ev := range events {
+		if ev.Name == EventNVSwitchNothingToDo {
+			log.Logger.Debugw("found nothing_to_do event", "event_time", ev.Time)
+			return true
+		}
+	}
+	return false
 }
 
 // checkFMExists returns true if the fabric manager executable is found in the system.

--- a/components/containerd/component_test.go
+++ b/components/containerd/component_test.go
@@ -3851,6 +3851,9 @@ func TestContainerdSocketMissingFailureInjectorIntegration(t *testing.T) {
 		return true
 	}
 
+	// Disable uptime check so it doesn't override the health state when containerd uptime < threshold
+	c.getContainerdUptimeFunc = nil
+
 	// The checkSocketExistsFunc is already overridden to return false by the failure injector
 
 	// Run checks and verify the consecutive threshold behavior

--- a/deployments/helm/gpud/Chart.yaml
+++ b/deployments/helm/gpud/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: gpud
 description: GPUd Helm chart for Kubernetes
 type: application
-version: 0.9.1
-appVersion: "v0.9.1"
+version: 0.10.0
+appVersion: "v0.10.0"
 icon: https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -10,7 +10,7 @@ gpud up
 To specify a version
 
 ```bash
-curl -fsSL https://pkg.gpud.dev/install.sh | sh -s v0.9.1
+curl -fsSL https://pkg.gpud.dev/install.sh | sh -s v0.10.0
 ```
 
 Then open [localhost:15132](https://localhost:15132) for the local web UI.

--- a/docs/TUTORIALS.md
+++ b/docs/TUTORIALS.md
@@ -34,7 +34,7 @@ sudo systemctl stop gpud.service
 sudo rm -f /usr/sbin/gpud
 sudo rm -f /usr/local/bin/gpud
 
-curl -fsSL https://pkg.gpud.dev/install.sh | sh -s v0.9.1
+curl -fsSL https://pkg.gpud.dev/install.sh | sh -s v0.10.0
 which gpud
 
 # (optional) if you already installed an old GPUd

--- a/pkg/nvidia/product/capabilities_test.go
+++ b/pkg/nvidia/product/capabilities_test.go
@@ -196,6 +196,26 @@ func TestSupportedFMByGPUProduct(t *testing.T) {
 			gpuProductName: "NVIDIA H200 PCIe",
 			expected:       false,
 		},
+		// GH200 (Grace Hopper) tests - NVSwitch presence varies by deployment
+		// Standalone GH200 has no NVSwitch, DGX GH200 has NVSwitch
+		// Since we can't determine from product name alone, we return false
+		// and let component-level NVSwitch detection handle it.
+		// Ref: https://www.nvidia.com/en-us/data-center/grace-hopper-superchip/
+		{
+			name:           "GH200 does not support (standalone config)",
+			gpuProductName: "NVIDIA-GH200-144G-HBM3e",
+			expected:       false,
+		},
+		{
+			name:           "GH200 lowercase",
+			gpuProductName: "nvidia gh200",
+			expected:       false,
+		},
+		{
+			name:           "GH200 Grace Hopper Superchip",
+			gpuProductName: "NVIDIA GH200 Grace Hopper Superchip",
+			expected:       false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -286,6 +306,31 @@ func TestSupportFabricStateByGPUProduct(t *testing.T) {
 		{
 			name:           "Empty string",
 			gpuProductName: "",
+			expected:       false,
+		},
+		// GH200 (Grace Hopper) tests - important because "gh200" contains "h200" substring
+		// Without explicit handling, GH200 would incorrectly match the "h200" pattern.
+		// GH200 fabric state depends on NVSwitch presence (standalone vs DGX GH200).
+		// Ref: https://www.nvidia.com/en-us/data-center/grace-hopper-superchip/
+		// Ref: https://www.nvidia.com/en-in/data-center/dgx-gh200/
+		{
+			name:           "GH200 does not support fabric state (standalone config)",
+			gpuProductName: "NVIDIA-GH200-144G-HBM3e",
+			expected:       false,
+		},
+		{
+			name:           "GH200 lowercase",
+			gpuProductName: "nvidia gh200",
+			expected:       false,
+		},
+		{
+			name:           "GH200 Grace Hopper Superchip full name",
+			gpuProductName: "NVIDIA GH200 Grace Hopper Superchip",
+			expected:       false,
+		},
+		{
+			name:           "GH200 with memory size",
+			gpuProductName: "NVIDIA GH200 480GB",
 			expected:       false,
 		},
 	}


### PR DESCRIPTION
GH200 (Grace Hopper Superchip) was incorrectly marked as "unhealthy" when deployed without NVSwitch. This happened because:

1. Product name matching bug: "GH200" contains "H200" as substring, causing GH200 to incorrectly match H200's fabric state support.

2. Check order issue: Fabric state check happened before NVSwitch existence check, causing "Not Supported" state to be flagged as unhealthy before the component could detect no NVSwitch was present.

This fix:
- Adds explicit GH200 handling in product capabilities to avoid the substring collision with H200
- Adds NVSwitch existence check within the fabric state block, before calling collectFabricState(), to skip the check when no NVSwitch hardware is detected
- Adds test cases for GH200 product name variations

GH200 has two deployment modes:
- Standalone: NVLink-C2C only (CPU↔GPU), no NVSwitch, no fabric manager
- DGX GH200: NVLink Switch System for multi-node, with NVSwitch

Ref: https://www.nvidia.com/en-us/data-center/grace-hopper-superchip/
Ref: https://www.nvidia.com/en-in/data-center/dgx-gh200/
Ref: https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/