### PR TITLE
[LEP-2600] feat(containerd): add --containerd-socket-missing test flag for socket failure injection

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -305,6 +305,11 @@ sudo rm /etc/systemd/system/gpud.service
 					Usage:  "(testing purposes) simulate NVML Device().GetDevices() failure returning 'Unable to determine the device handle for GPU: Unknown Error'. Use to test gpud behavior when NVML loads but device enumeration fails (e.g., Xid 79).",
 					Hidden: true, // only for testing
 				},
+				cli.BoolFlag{
+					Name:   "containerd-socket-missing",
+					Usage:  "(testing purposes) simulate containerd socket file not existing. Use to test the consecutive socket missing threshold logic that reports healthy for first few checks before reporting unhealthy.",
+					Hidden: true, // only for testing
+				},
 			},
 		},
 		{
@@ -629,6 +634,11 @@ sudo rm /etc/systemd/system/gpud.service
 				cli.StringFlag{
 					Name:   "gpu-product-name",
 					Usage:  "(testing purposes) override the detected GPU product name to simulate different GPU types (e.g., set 'H100-SXM' on H100-PCIe to enable fabric state testing)",
+					Hidden: true, // only for testing
+				},
+				cli.BoolFlag{
+					Name:   "containerd-socket-missing",
+					Usage:  "(testing purposes) simulate containerd socket file not existing. Use to test the consecutive socket missing threshold logic.",
 					Hidden: true, // only for testing
 				},
 			},

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -225,6 +225,10 @@ func Command(cliContext *cli.Context) error {
 	// When enabled, Device().GetDevices() returns an error simulating Xid 79 or similar failures
 	nvmlDeviceGetDevicesError := cliContext.Bool("nvml-device-get-devices-error")
 
+	// Containerd socket missing error injection for testing
+	// When enabled, the containerd component will report the socket file as missing
+	containerdSocketMissing := cliContext.Bool("containerd-socket-missing")
+
 	ibExcludedDevices := parseInfinibandExcludeDevices(ibExcludeDevicesStr)
 	if len(ibExcludedDevices) > 0 {
 		log.Logger.Infow("excluding infiniband devices from monitoring", "devices", ibExcludedDevices)
@@ -246,6 +250,7 @@ func Command(cliContext *cli.Context) error {
 			GPUUUIDsWithFabricStateHealthSummaryUnhealthy: gpuUUIDsWithFabricStateHealthSummaryUnhealthy,
 			GPUProductNameOverride:                        gpuProductNameOverride,
 			NVMLDeviceGetDevicesError:                     nvmlDeviceGetDevicesError,
+			ContainerdSocketMissing:                       containerdSocketMissing,
 		}),
 	}
 

--- a/cmd/gpud/scan/command.go
+++ b/cmd/gpud/scan/command.go
@@ -40,6 +40,7 @@ func CreateCommand() func(*cli.Context) error {
 			cliContext.String("gpu-uuids-with-gpu-requires-reset"),
 			cliContext.String("gpu-uuids-with-fabric-state-health-summary-unhealthy"),
 			cliContext.String("gpu-product-name"),
+			cliContext.Bool("containerd-socket-missing"),
 			cliContext.Int("xid-reboot-threshold"),
 			cliContext.IsSet("xid-reboot-threshold"),
 			cliContext.Int("threshold-celsius-slowdown-margin"),
@@ -64,6 +65,7 @@ func cmdScan(
 	gpuUUIDsWithGPURequiresResetRaw string,
 	gpuUUIDsWithFabricStateHealthSummaryUnhealthyRaw string,
 	gpuProductNameOverride string,
+	containerdSocketMissing bool,
 	xidRebootThreshold int,
 	xidRebootThresholdIsSet bool,
 	temperatureMarginThresholdCelsius int,
@@ -154,6 +156,7 @@ func cmdScan(
 			GPUUUIDsWithGPURequiresReset:                  gpuUUIDsWithGPURequiresReset,
 			GPUUUIDsWithFabricStateHealthSummaryUnhealthy: gpuUUIDsWithFabricStateHealthSummaryUnhealthy,
 			GPUProductNameOverride:                        gpuProductNameOverride,
+			ContainerdSocketMissing:                       containerdSocketMissing,
 		}),
 	}
 	if zapLvl.Level() <= zap.DebugLevel { // e.g., info, warn, error

--- a/components/registry.go
+++ b/components/registry.go
@@ -66,6 +66,12 @@ type FailureInjector struct {
 	// scenario that occurs when NVML library loads but device enumeration fails (e.g., Xid 79).
 	// ref. https://github.com/leptonai/gpud/pull/1180
 	NVMLDeviceGetDevicesError bool
+
+	// ContainerdSocketMissing when true simulates containerd socket file not existing.
+	// This is useful for testing the consecutive socket missing threshold logic
+	// that reports healthy for the first few checks before reporting unhealthy.
+	// ref. https://github.com/leptonai/gpud/pull/1195
+	ContainerdSocketMissing bool
 }
 
 // InitFunc is the function that initializes a component.


### PR DESCRIPTION
Add a test flag to simulate containerd socket file not existing, enabling testing of the consecutive socket missing threshold logic introduced in LEP-2540 (commit 2bd52ccf).

Changes:
- Add ContainerdSocketMissing field to FailureInjector struct
- Add --containerd-socket-missing CLI flag to run and scan commands
- Override checkSocketExistsFunc in containerd New() when flag is set
- Add unit tests for failure injection and consecutive threshold behavior

This allows testing the socket missing error path which requires 5 consecutive checks before reporting unhealthy, without needing actual socket issues that have a narrow time window to trigger.