### PR TITLE
[LEP-4751] fix(fabric-manager): add event-level dedup to prevent duplicate events

### DIFF
--- a/components/accelerator/nvidia/fabric-manager/log_watcher.go
+++ b/components/accelerator/nvidia/fabric-manager/log_watcher.go
@@ -17,10 +17,11 @@ import (
 )
 
 type logLineProcessor struct {
-	ctx         context.Context
-	w           watcher
-	matchFunc   matchFunc
-	eventBucket eventstore.Bucket
+	ctx          context.Context
+	w            watcher
+	matchFunc    matchFunc
+	eventBucket  eventstore.Bucket
+	eventDeduper *eventDeduper
 }
 
 type matchFunc func(line string) (eventName string, message string)
@@ -32,10 +33,11 @@ func newLogLineProcessor(
 	eventBucket eventstore.Bucket,
 ) *logLineProcessor {
 	llp := &logLineProcessor{
-		ctx:         ctx,
-		w:           w,
-		matchFunc:   matchFunc,
-		eventBucket: eventBucket,
+		ctx:          ctx,
+		w:            w,
+		matchFunc:    matchFunc,
+		eventBucket:  eventBucket,
+		eventDeduper: newEventDeduper(defaultEventDedupWindow),
 	}
 	go llp.watch()
 	return llp
@@ -61,7 +63,19 @@ func (llp *logLineProcessor) watch() {
 				continue
 			}
 
-			// lookup to prevent duplicate event insertions
+			// Event-level dedup: coalesce repeated events with the same name+message
+			// within the configured window (e.g., 15 minutes) regardless of timestamp.
+			// This prevents noisy log sources from flooding the event store with
+			// semantically identical events that differ only in timestamp.
+			if llp.eventDeduper != nil {
+				if occurrences := llp.eventDeduper.addCache(ev.Name, ev.Message); occurrences > 1 {
+					log.Logger.Debugw("skipping duplicate event within dedup window", "occurrences", occurrences, "eventName", ev.Name)
+					continue
+				}
+			}
+
+			// Exact-match lookup to prevent duplicate event insertions across
+			// process restarts (the in-memory event deduper is cold after a restart).
 			cctx, ccancel := context.WithTimeout(llp.ctx, 15*time.Second)
 			found, err := llp.eventBucket.Find(cctx, ev)
 			ccancel()
@@ -188,7 +202,48 @@ const (
 
 	defaultCacheExpiration    = 5 * time.Minute
 	defaultCachePurgeInterval = 10 * time.Minute
+
+	// defaultEventDedupWindow defines the time window within which semantically
+	// identical events (same name + message) are coalesced into a single event.
+	// The raw-line deduper only catches duplicates with the same second-level
+	// timestamp, but fabric-manager errors like topology mismatch can repeat
+	// every second with a new timestamp. This event-level dedup ensures we
+	// report at most one event per window regardless of how often the error
+	// appears in the log.
+	defaultEventDedupWindow = 15 * time.Minute
 )
+
+// eventDeduper deduplicates matched events by name+message, ignoring timestamp.
+// This catches repeated errors that differ only in when they occurred.
+type eventDeduper struct {
+	cache  *cache.Cache
+	window time.Duration
+}
+
+func newEventDeduper(window time.Duration) *eventDeduper {
+	return &eventDeduper{
+		cache:  cache.New(window, window*2),
+		window: window,
+	}
+}
+
+// addCache returns the occurrence count for the event key (name + message).
+// Returns 1 on first occurrence within the window.
+func (d *eventDeduper) addCache(name, message string) int {
+	k := name + "_" + message
+
+	var freq int
+	cur, found := d.cache.Get(k)
+	if !found {
+		freq = 1
+	} else {
+		v, _ := cur.(int)
+		freq = v + 1
+	}
+
+	d.cache.Set(k, freq, d.window)
+	return freq
+}
 
 // defaultWatchCommands monitors both the fabric manager log file and systemd journal.
 // We monitor both sources because:

--- a/components/accelerator/nvidia/fabric-manager/log_watcher_test.go
+++ b/components/accelerator/nvidia/fabric-manager/log_watcher_test.go
@@ -1,6 +1,7 @@
 package fabricmanager
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -9,7 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/leptonai/gpud/pkg/eventstore"
 	"github.com/leptonai/gpud/pkg/process"
+	"github.com/leptonai/gpud/pkg/sqlite"
 )
 
 func TestParseLogLine(t *testing.T) {
@@ -438,6 +441,154 @@ func TestParallelLogWatching(t *testing.T) {
 		assert.True(t, contents["[INFO] Source1"], "should have source 1 output")
 		assert.True(t, contents["[INFO] Source2"], "should have source 2 output")
 	})
+}
+
+func TestEventDeduper(t *testing.T) {
+	t.Parallel()
+
+	t.Run("first occurrence returns 1", func(t *testing.T) {
+		d := newEventDeduper(15 * time.Minute)
+		assert.Equal(t, 1, d.addCache("event_name", "event message"))
+	})
+
+	t.Run("second occurrence returns 2", func(t *testing.T) {
+		d := newEventDeduper(15 * time.Minute)
+		d.addCache("event_name", "event message")
+		assert.Equal(t, 2, d.addCache("event_name", "event message"))
+	})
+
+	t.Run("different event names have independent counts", func(t *testing.T) {
+		d := newEventDeduper(15 * time.Minute)
+		assert.Equal(t, 1, d.addCache("event_a", "same message"))
+		assert.Equal(t, 1, d.addCache("event_b", "same message"))
+		assert.Equal(t, 2, d.addCache("event_a", "same message"))
+	})
+
+	t.Run("different messages have independent counts", func(t *testing.T) {
+		d := newEventDeduper(15 * time.Minute)
+		assert.Equal(t, 1, d.addCache("event_name", "message 1"))
+		assert.Equal(t, 1, d.addCache("event_name", "message 2"))
+		assert.Equal(t, 2, d.addCache("event_name", "message 1"))
+	})
+
+	t.Run("expiration resets count", func(t *testing.T) {
+		d := newEventDeduper(10 * time.Millisecond)
+		assert.Equal(t, 1, d.addCache("event_name", "message"))
+		assert.Equal(t, 2, d.addCache("event_name", "message"))
+		time.Sleep(30 * time.Millisecond)
+		assert.Equal(t, 1, d.addCache("event_name", "message"), "should be first occurrence again after expiration")
+	})
+}
+
+func TestEventDedupDefaultWindow(t *testing.T) {
+	t.Parallel()
+
+	// Verify the default event dedup window is 15 minutes.
+	assert.Equal(t, 15*time.Minute, defaultEventDedupWindow)
+}
+
+// TestLogLineProcessorEventDedup verifies that the logLineProcessor deduplicates
+// repeated events with different timestamps but the same name+message within the
+// event dedup window. This is the scenario described in the bug: the same
+// fabric-manager error repeats every second, each with a new timestamp.
+func TestLogLineProcessorEventDedup(t *testing.T) {
+	t.Parallel()
+
+	dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+	defer cleanup()
+
+	store, err := eventstore.New(dbRW, dbRO, eventstore.DefaultRetention)
+	require.NoError(t, err)
+
+	bucket, err := store.Bucket(Name)
+	require.NoError(t, err)
+	defer bucket.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan logLine, 100)
+	mw := &mockWatcher{ch: ch}
+
+	llp := newLogLineProcessor(ctx, mw, Match, bucket)
+	defer llp.close()
+
+	// Simulate 60 topology mismatch errors arriving every second
+	// (mimics the reproduction script from the bug report).
+	base := time.Date(2026, time.April, 1, 16, 37, 0, 0, time.UTC)
+	for i := range 60 {
+		ch <- logLine{
+			ts:      base.Add(time.Duration(i) * time.Second),
+			content: "[ERROR] [tid 99999] detected number of NVSwitches don't match with any supported system topology, aborting fabric manager",
+		}
+	}
+
+	// Give the processor goroutine time to drain the channel and insert events.
+	require.Eventually(t, func() bool {
+		events, err := bucket.Get(ctx, base.Add(-time.Minute))
+		if err != nil {
+			return false
+		}
+		// At least one event should be present.
+		return len(events) >= 1
+	}, 5*time.Second, 50*time.Millisecond, "expected at least one event to be inserted")
+
+	// Verify only 1 event was inserted (all duplicates were deduped).
+	events, err := bucket.Get(ctx, base.Add(-time.Minute))
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(events), "expected exactly 1 event after dedup, got %d", len(events))
+	assert.Equal(t, eventNVSwitchTopologyMismatch, events[0].Name)
+	assert.Equal(t, messageNVSwitchTopologyMismatch, events[0].Message)
+}
+
+// TestLogLineProcessorEventDedupDifferentEvents verifies that distinct event
+// types are NOT suppressed by the event deduper.
+func TestLogLineProcessorEventDedupDifferentEvents(t *testing.T) {
+	t.Parallel()
+
+	dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+	defer cleanup()
+
+	store, err := eventstore.New(dbRW, dbRO, eventstore.DefaultRetention)
+	require.NoError(t, err)
+
+	bucket, err := store.Bucket(Name)
+	require.NoError(t, err)
+	defer bucket.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan logLine, 100)
+	mw := &mockWatcher{ch: ch}
+
+	llp := newLogLineProcessor(ctx, mw, Match, bucket)
+	defer llp.close()
+
+	base := time.Date(2026, time.April, 1, 16, 37, 0, 0, time.UTC)
+
+	// Send two different event types
+	ch <- logLine{
+		ts:      base,
+		content: "[ERROR] [tid 99999] detected number of NVSwitches don't match with any supported system topology, aborting fabric manager",
+	}
+	ch <- logLine{
+		ts:      base.Add(time.Second),
+		content: "[ERROR] [tid 841] detected NVSwitch fatal error 20034 on fid 0 on NVSwitch pci bus id 00000000:86:00.0 physical id 3 port 33",
+	}
+
+	// Wait for both events to be processed.
+	require.Eventually(t, func() bool {
+		events, err := bucket.Get(ctx, base.Add(-time.Minute))
+		if err != nil {
+			return false
+		}
+		return len(events) >= 2
+	}, 5*time.Second, 50*time.Millisecond, "expected 2 distinct events to be inserted")
+
+	events, err := bucket.Get(ctx, base.Add(-time.Minute))
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(events), "different event types should not be deduped against each other")
 }
 
 func TestDefaultWatchCommandsSyntax(t *testing.T) {


### PR DESCRIPTION
The existing deduper uses timestamp+content as cache key, so repeated errors arriving every second (each with a new timestamp) bypass dedup entirely. The eventBucket.Find() also matches on exact timestamp, so it also fails to catch these.

Add an event-level deduper (keyed by event name + message, ignoring timestamp) with a 15-minute window. This coalesces semantically identical events regardless of how frequently they appear in the log.

Fixes the scenario where 60 topology mismatch errors in 60 seconds produce 60 events instead of 1.

ref. https://github.com/leptonai/gpud/pull/1223