### PR TITLE
[LEP-4748] fix(login): persist health-check 403 failures so gpud status surfaces auth errors

### DIFF
--- a/cmd/gpud/status/command.go
+++ b/cmd/gpud/status/command.go
@@ -66,15 +66,19 @@ func Command(cliContext *cli.Context) error {
 	}
 	log.Logger.Debugw("successfully read login success", "file", stateFile)
 
-	if err := checkLoginSuccess(loginSuccess, machineID); err != nil {
-		return err
-	}
-
+	// Read the latest session activity FIRST so we can cross-check it against
+	// the historical login-success timestamp. This lets us warn operators when
+	// the original login succeeded but the session is now failing (e.g. expired token).
 	log.Logger.Debugw("displaying login status from session_states table")
-	if err := displayLoginStatus(rootCtx, dbRO); err != nil {
+	lastState, err := displayLoginStatus(rootCtx, dbRO)
+	if err != nil {
 		return fmt.Errorf("failed to display login status: %w", err)
 	}
 	log.Logger.Debugw("successfully displayed login status")
+
+	if err := checkLoginSuccess(loginSuccess, machineID, lastState); err != nil {
+		return err
+	}
 
 	var active bool
 	if systemd.SystemctlExists() {

--- a/cmd/gpud/status/utils.go
+++ b/cmd/gpud/status/utils.go
@@ -14,7 +14,7 @@ import (
 	"github.com/leptonai/gpud/pkg/sqlite"
 )
 
-func checkLoginSuccess(loginSuccess, machineID string) error {
+func checkLoginSuccess(loginSuccess, machineID string, lastState *sessionstates.State) error {
 	if loginSuccess == "" {
 		return nil
 	}
@@ -26,12 +26,20 @@ func checkLoginSuccess(loginSuccess, machineID string) error {
 	loginTimeUTC := time.Unix(ts, 0)
 	nowUTC := time.Now().UTC()
 	loginTimeHumanized := humanize.RelTime(loginTimeUTC, nowUTC, "ago", "from now")
-	fmt.Printf("%s login success at %s (machine id: %s)\n", cmdcommon.CheckMark, loginTimeHumanized, machineID)
+
+	// If the most recent session activity is a failure that happened after the
+	// original login success, the token is likely expired or invalid.
+	// Show a warning instead of a green checkmark to avoid misleading operators.
+	if lastState != nil && !lastState.Success && lastState.Timestamp > ts {
+		fmt.Printf("%s login success at %s (machine id: %s) -- but session is currently failing, see login activity above\n", cmdcommon.WarningSign, loginTimeHumanized, machineID)
+	} else {
+		fmt.Printf("%s login success at %s (machine id: %s)\n", cmdcommon.CheckMark, loginTimeHumanized, machineID)
+	}
 
 	return nil
 }
 
-func displayLoginStatus(ctx context.Context, dbRO *sql.DB) error {
+func displayLoginStatus(ctx context.Context, dbRO *sql.DB) (*sessionstates.State, error) {
 	status, err := sessionstates.ReadLast(ctx, dbRO)
 	if err != nil {
 		// Handle the case where the session_states table doesn't exist yet.
@@ -39,14 +47,14 @@ func displayLoginStatus(ctx context.Context, dbRO *sql.DB) error {
 		// or if the database was created with an older version that didn't have this table.
 		if sqlite.IsNoSuchTableError(err) {
 			fmt.Printf("No login activity recorded\n")
-			return nil
+			return nil, nil
 		}
-		return fmt.Errorf("failed to read login status: %w", err)
+		return nil, fmt.Errorf("failed to read login status: %w", err)
 	}
 
 	if status == nil {
 		fmt.Printf("No login activity recorded\n")
-		return nil
+		return nil, nil
 	}
 
 	statusTimeUTC := time.Unix(status.Timestamp, 0)
@@ -62,12 +70,12 @@ func displayLoginStatus(ctx context.Context, dbRO *sql.DB) error {
 	// Check for any failures and warn if present
 	hasFailures, err := sessionstates.HasAnyFailures(ctx, dbRO)
 	if err != nil {
-		return fmt.Errorf("failed to check for login failures: %w", err)
+		return nil, fmt.Errorf("failed to check for login failures: %w", err)
 	}
 
 	if hasFailures {
 		fmt.Printf("%s warning: there are login failure entries in the history\n", cmdcommon.WarningSign)
 	}
 
-	return nil
+	return status, nil
 }

--- a/cmd/gpud/status/utils_test.go
+++ b/cmd/gpud/status/utils_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	cmdcommon "github.com/leptonai/gpud/cmd/common"
+	sessionstates "github.com/leptonai/gpud/pkg/session/states"
 	"github.com/leptonai/gpud/pkg/sqlite"
 )
 
@@ -24,13 +25,15 @@ func TestCheckLoginSuccess(t *testing.T) {
 		name          string
 		loginSuccess  string
 		machineID     string
+		lastState     *sessionstates.State
 		expectedError error
 		expectedOut   string
 	}{
 		{
-			name:          "valid timestamp",
+			name:          "valid timestamp no last state",
 			loginSuccess:  strconv.FormatInt(time.Now().Add(-1*time.Hour).Unix(), 10),
 			machineID:     "test-machine-123",
+			lastState:     nil,
 			expectedError: nil,
 			expectedOut:   fmt.Sprintf("%s login success at", cmdcommon.CheckMark),
 		},
@@ -38,6 +41,7 @@ func TestCheckLoginSuccess(t *testing.T) {
 			name:          "empty login success",
 			loginSuccess:  "",
 			machineID:     "test-machine-456",
+			lastState:     nil,
 			expectedError: nil,
 			expectedOut:   "", // No output expected when loginSuccess is empty
 		},
@@ -45,6 +49,7 @@ func TestCheckLoginSuccess(t *testing.T) {
 			name:          "invalid timestamp",
 			loginSuccess:  "invalid-timestamp",
 			machineID:     "test-machine-789",
+			lastState:     nil,
 			expectedError: fmt.Errorf("failed to parse login success: strconv.ParseInt: parsing \"invalid-timestamp\": invalid syntax"),
 			expectedOut:   "",
 		},
@@ -52,6 +57,19 @@ func TestCheckLoginSuccess(t *testing.T) {
 			name:          "future timestamp",
 			loginSuccess:  strconv.FormatInt(time.Now().Add(1*time.Hour).Unix(), 10),
 			machineID:     "test-machine-future",
+			lastState:     nil,
+			expectedError: nil,
+			expectedOut:   fmt.Sprintf("%s login success at", cmdcommon.CheckMark),
+		},
+		{
+			name:         "valid timestamp with last state success",
+			loginSuccess: strconv.FormatInt(time.Now().Add(-1*time.Hour).Unix(), 10),
+			machineID:    "test-machine-ok",
+			lastState: &sessionstates.State{
+				Timestamp: time.Now().Unix(),
+				Success:   true,
+				Message:   "Session connected successfully",
+			},
 			expectedError: nil,
 			expectedOut:   fmt.Sprintf("%s login success at", cmdcommon.CheckMark),
 		},
@@ -64,7 +82,7 @@ func TestCheckLoginSuccess(t *testing.T) {
 			r, w, _ := os.Pipe()
 			os.Stdout = w
 
-			err := checkLoginSuccess(tt.loginSuccess, tt.machineID)
+			err := checkLoginSuccess(tt.loginSuccess, tt.machineID, tt.lastState)
 
 			// Restore stdout
 			require.NoError(t, w.Close())
@@ -96,6 +114,80 @@ func TestCheckLoginSuccess(t *testing.T) {
 			if tt.loginSuccess != "" && err == nil {
 				// Should contain "ago" or "from now"
 				assert.True(t, strings.Contains(output, "ago") || strings.Contains(output, "from now"))
+			}
+		})
+	}
+}
+
+// TestCheckLoginSuccessStaleDetection verifies that checkLoginSuccess shows a
+// warning when the most recent session activity is a failure newer than the
+// original login success timestamp. This is the user-facing part of the LEP-4748 fix.
+func TestCheckLoginSuccessStaleDetection(t *testing.T) {
+	loginTS := time.Now().Add(-24 * time.Hour).Unix() // Login was 24h ago
+
+	tests := []struct {
+		name        string
+		lastState   *sessionstates.State
+		wantWarning bool
+	}{
+		{
+			name: "failure newer than login shows warning",
+			lastState: &sessionstates.State{
+				Timestamp: time.Now().Unix(), // Failure is NOW, much newer than login
+				Success:   false,
+				Message:   "HTTP 403: forbidden",
+			},
+			wantWarning: true,
+		},
+		{
+			name: "failure older than login shows checkmark",
+			lastState: &sessionstates.State{
+				Timestamp: loginTS - 3600, // Failure BEFORE login
+				Success:   false,
+				Message:   "HTTP 403: forbidden",
+			},
+			wantWarning: false,
+		},
+		{
+			name: "success newer than login shows checkmark",
+			lastState: &sessionstates.State{
+				Timestamp: time.Now().Unix(),
+				Success:   true,
+				Message:   "ok",
+			},
+			wantWarning: false,
+		},
+		{
+			name:        "nil last state shows checkmark",
+			lastState:   nil,
+			wantWarning: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			old := os.Stdout
+			r, w, _ := os.Pipe()
+			os.Stdout = w
+
+			loginSuccess := strconv.FormatInt(loginTS, 10)
+			err := checkLoginSuccess(loginSuccess, "machine-stale-test", tt.lastState)
+
+			require.NoError(t, w.Close())
+			os.Stdout = old
+
+			var buf bytes.Buffer
+			_, _ = io.Copy(&buf, r)
+			output := buf.String()
+
+			require.NoError(t, err)
+
+			if tt.wantWarning {
+				assert.Contains(t, output, cmdcommon.WarningSign, "Expected warning sign for stale login")
+				assert.Contains(t, output, "session is currently failing, see login activity above")
+			} else {
+				assert.Contains(t, output, cmdcommon.CheckMark, "Expected checkmark for valid login")
+				assert.NotContains(t, output, "session is currently failing, see login activity above")
 			}
 		})
 	}
@@ -133,7 +225,7 @@ func TestDisplayLoginStatus(t *testing.T) {
 
 		// Call displayLoginStatus - should not return an error
 		ctx := context.Background()
-		err = displayLoginStatus(ctx, dbRO)
+		state, err := displayLoginStatus(ctx, dbRO)
 
 		// Restore stdout
 		require.NoError(t, w.Close())
@@ -144,8 +236,86 @@ func TestDisplayLoginStatus(t *testing.T) {
 		_, _ = io.Copy(&buf, r)
 		output := buf.String()
 
-		// Verify no error and appropriate output
+		// Verify no error, nil state, and appropriate output
 		require.NoError(t, err, "displayLoginStatus should not return an error for missing table")
+		assert.Nil(t, state, "Should return nil state when no table exists")
 		assert.Contains(t, output, "No login activity recorded")
+	})
+
+	t.Run("returns last failure state", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dbFile := filepath.Join(tmpDir, "test.db")
+
+		dbRW, err := sqlite.Open(dbFile)
+		require.NoError(t, err)
+
+		require.NoError(t, sessionstates.CreateTable(context.Background(), dbRW))
+
+		// Insert a failure entry
+		failTS := time.Now().Unix()
+		require.NoError(t, sessionstates.Insert(context.Background(), dbRW, failTS, false, "HTTP 403: forbidden"))
+		_ = dbRW.Close()
+
+		dbRO, err := sqlite.Open(dbFile, sqlite.WithReadOnly(true))
+		require.NoError(t, err)
+		defer func() { _ = dbRO.Close() }()
+
+		old := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		state, err := displayLoginStatus(context.Background(), dbRO)
+
+		require.NoError(t, w.Close())
+		os.Stdout = old
+
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		output := buf.String()
+
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		assert.False(t, state.Success)
+		assert.Equal(t, failTS, state.Timestamp)
+		assert.Contains(t, output, "login activity: failure")
+		assert.Contains(t, output, "HTTP 403")
+		assert.Contains(t, output, "warning: there are login failure entries")
+	})
+
+	t.Run("returns last success state", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		dbFile := filepath.Join(tmpDir, "test.db")
+
+		dbRW, err := sqlite.Open(dbFile)
+		require.NoError(t, err)
+
+		require.NoError(t, sessionstates.CreateTable(context.Background(), dbRW))
+
+		successTS := time.Now().Unix()
+		require.NoError(t, sessionstates.Insert(context.Background(), dbRW, successTS, true, "ok"))
+		_ = dbRW.Close()
+
+		dbRO, err := sqlite.Open(dbFile, sqlite.WithReadOnly(true))
+		require.NoError(t, err)
+		defer func() { _ = dbRO.Close() }()
+
+		old := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		state, err := displayLoginStatus(context.Background(), dbRO)
+
+		require.NoError(t, w.Close())
+		os.Stdout = old
+
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		output := buf.String()
+
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		assert.True(t, state.Success)
+		assert.Contains(t, output, "login activity: success")
+		assert.NotContains(t, output, "warning")
 	})
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -524,6 +524,18 @@ func (s *Session) startReader(ctx context.Context, readerExit chan any, jar *coo
 	s.processReaderResponse(resp, goroutineCloseCh, pipeFinishCh)
 }
 
+// healthCheckHTTPError is returned by checkServerHealth when the control plane
+// responds with a non-OK HTTP status. It carries the status code and response
+// body so callers (e.g. keepAlive) can decide whether to persist the failure.
+type healthCheckHTTPError struct {
+	statusCode int
+	body       string
+}
+
+func (e *healthCheckHTTPError) Error() string {
+	return fmt.Sprintf("server health check failed: HTTP %d: %s", e.statusCode, e.body)
+}
+
 func (s *Session) checkServerHealth(ctx context.Context, jar *cookiejar.Jar, token string) error {
 	u, err := url.Parse(s.epControlPlane)
 	if err != nil {
@@ -554,7 +566,12 @@ func (s *Session) checkServerHealth(ctx context.Context, jar *cookiejar.Jar, tok
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("server health check failed: %s", resp.Status)
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		body := string(bodyBytes)
+		if len(body) > 500 {
+			body = body[:500]
+		}
+		return &healthCheckHTTPError{statusCode: resp.StatusCode, body: body}
 	}
 	return nil
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -509,9 +509,19 @@ func (s *Session) startReader(ctx context.Context, readerExit chan any, jar *coo
 	if resp.StatusCode != http.StatusOK {
 		log.Logger.Warnw("session reader: request resp not ok -- retrying", "status", resp.Status, "statusCode", resp.StatusCode)
 
-		// Persist 403 Forbidden errors to session_states table
-		if resp.StatusCode == http.StatusForbidden {
-			s.persistLoginFailure(ctx, resp)
+		// Persist authentication-related failures to session_states so "gpud status" surfaces them.
+		// The server returns 401/403 for auth errors, but may also return 500 with
+		// "failed to validate token" when the token is invalid (server-side bug).
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusInternalServerError {
+			bodyBytes, _ := io.ReadAll(resp.Body)
+			body := string(bodyBytes)
+			if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized || strings.Contains(body, "failed to validate token") {
+				message := fmt.Sprintf("HTTP %d: %s", resp.StatusCode, body)
+				if len(message) > 500 {
+					message = message[:500]
+				}
+				s.persistLoginStatus(ctx, false, message)
+			}
 		}
 
 		close(pipeFinishCh)
@@ -675,21 +685,6 @@ func (s *Session) handleReaderPipe(respBody io.ReadCloser, closec, finish chan a
 	}
 }
 
-func (s *Session) persistLoginFailure(ctx context.Context, resp *http.Response) {
-	// Read response body to get error message
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Logger.Warnw("failed to read response body for login failure", "error", err)
-		return
-	}
-
-	message := fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(bodyBytes))
-	if len(message) > 500 {
-		message = message[:500] // Truncate long messages
-	}
-
-	s.persistLoginStatus(ctx, false, message)
-}
 
 func (s *Session) persistLoginStatus(ctx context.Context, success bool, message string) {
 	stateFile := config.StateFilePath(s.dataDir)

--- a/pkg/session/session_keepalive.go
+++ b/pkg/session/session_keepalive.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/cookiejar"
+	"strings"
 	"time"
 
 	"github.com/leptonai/gpud/pkg/log"
@@ -73,12 +74,16 @@ func (s *Session) keepAlive() {
 			if err := s.checkServerHealthFunc(ctx, jar, ""); err != nil {
 				log.Logger.Errorf("session keep alive: error checking server health: %v", err)
 
-				// Persist HTTP 403 Forbidden errors from health check to session_states,
+				// Persist authentication-related failures from health check to session_states,
 				// so that "gpud status" can surface them. Without this, a rejected token
 				// causes silent retry loops and "gpud status" never sees the failure.
+				// The server may return 401/403 for auth errors, or 500 with
+				// "failed to validate token" when the token is invalid.
 				var httpErr *healthCheckHTTPError
-				if errors.As(err, &httpErr) && httpErr.statusCode == http.StatusForbidden {
-					s.persistLoginStatus(ctx, false, fmt.Sprintf("HTTP %d: %s", httpErr.statusCode, httpErr.body))
+				if errors.As(err, &httpErr) {
+					if httpErr.statusCode == http.StatusForbidden || httpErr.statusCode == http.StatusUnauthorized || strings.Contains(httpErr.body, "failed to validate token") {
+						s.persistLoginStatus(ctx, false, fmt.Sprintf("HTTP %d: %s", httpErr.statusCode, httpErr.body))
+					}
 				}
 
 				cancel()

--- a/pkg/session/session_keepalive.go
+++ b/pkg/session/session_keepalive.go
@@ -2,6 +2,9 @@ package session
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net/http"
 	"net/http/cookiejar"
 	"time"
 
@@ -69,6 +72,15 @@ func (s *Session) keepAlive() {
 			// TODO: we can remove it once we migrate to gpud-gateway
 			if err := s.checkServerHealthFunc(ctx, jar, ""); err != nil {
 				log.Logger.Errorf("session keep alive: error checking server health: %v", err)
+
+				// Persist HTTP 403 Forbidden errors from health check to session_states,
+				// so that "gpud status" can surface them. Without this, a rejected token
+				// causes silent retry loops and "gpud status" never sees the failure.
+				var httpErr *healthCheckHTTPError
+				if errors.As(err, &httpErr) && httpErr.statusCode == http.StatusForbidden {
+					s.persistLoginStatus(ctx, false, fmt.Sprintf("HTTP %d: %s", httpErr.statusCode, httpErr.body))
+				}
+
 				cancel()
 				continue
 			}

--- a/pkg/session/session_keepalive_health_check_test.go
+++ b/pkg/session/session_keepalive_health_check_test.go
@@ -1,0 +1,271 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sessionstates "github.com/leptonai/gpud/pkg/session/states"
+	"github.com/leptonai/gpud/pkg/sqlite"
+)
+
+// TestKeepAliveHealthCheck403PersistsFailure verifies that when checkServerHealth
+// returns an HTTP 403 error, the keepAlive loop persists the failure to session_states
+// so that "gpud status" can surface it.
+//
+// This is the core fix for LEP-4748: previously, health-check 403s were only logged
+// to stderr, leaving "gpud status" blind to auth failures after token invalidation.
+func TestKeepAliveHealthCheck403PersistsFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create the state file and session_states table up front,
+	// because persistLoginStatus opens it by path.
+	stateFile := tmpDir + "/gpud.state"
+	dbSetup, err := sqlite.Open(stateFile)
+	require.NoError(t, err)
+	require.NoError(t, sessionstates.CreateTable(context.Background(), dbSetup))
+	require.NoError(t, dbSetup.Close())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := &Session{
+		ctx:     ctx,
+		dataDir: tmpDir,
+		reader:  make(chan Body, 20),
+		writer:  make(chan Body, 20),
+		closer:  &closeOnce{closer: make(chan any)},
+	}
+
+	// Simulate health check returning 403 Forbidden
+	var healthCheckCalls int32
+	s.checkServerHealthFunc = func(ctx context.Context, jar *cookiejar.Jar, token string) error {
+		count := atomic.AddInt32(&healthCheckCalls, 1)
+		// Return 403 on first call, then cancel to stop the loop
+		if count >= 2 {
+			cancel()
+		}
+		return &healthCheckHTTPError{
+			statusCode: http.StatusForbidden,
+			body:       `{"error_code":"forbidden","error_summary":"Forbidden"}`,
+		}
+	}
+
+	s.timeAfterFunc = func(d time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	}
+	s.timeSleepFunc = func(d time.Duration) {}
+
+	// These should never be called since health check fails before reader/writer start
+	s.startReaderFunc = func(ctx context.Context, readerExit chan any, jar *cookiejar.Jar) {
+		t.Fatal("startReader should not be called when health check fails")
+	}
+	s.startWriterFunc = func(ctx context.Context, writerExit chan any, jar *cookiejar.Jar) {
+		t.Fatal("startWriter should not be called when health check fails")
+	}
+
+	// Run keepAlive and wait for it to process the 403
+	done := make(chan struct{})
+	go func() {
+		s.keepAlive()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("keepAlive did not exit in time")
+	}
+
+	// Verify the failure was persisted to session_states
+	dbRO, err := sqlite.Open(stateFile, sqlite.WithReadOnly(true))
+	require.NoError(t, err)
+	defer func() { _ = dbRO.Close() }()
+
+	state, err := sessionstates.ReadLast(context.Background(), dbRO)
+	require.NoError(t, err)
+	require.NotNil(t, state, "Expected a session state entry to be persisted after 403 health check")
+
+	assert.False(t, state.Success, "Session state should indicate failure")
+	assert.Contains(t, state.Message, "HTTP 403")
+	assert.Contains(t, state.Message, "Forbidden")
+}
+
+// TestKeepAliveHealthCheckNon403DoesNotPersist verifies that non-403 health check
+// errors (e.g. 500s) do NOT persist to session_states. Only 403 (auth failure)
+// warrants a persistent record, since other errors are transient.
+func TestKeepAliveHealthCheckNon403DoesNotPersist(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	stateFile := tmpDir + "/gpud.state"
+	dbSetup, err := sqlite.Open(stateFile)
+	require.NoError(t, err)
+	require.NoError(t, sessionstates.CreateTable(context.Background(), dbSetup))
+	require.NoError(t, dbSetup.Close())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := &Session{
+		ctx:     ctx,
+		dataDir: tmpDir,
+		reader:  make(chan Body, 20),
+		writer:  make(chan Body, 20),
+		closer:  &closeOnce{closer: make(chan any)},
+	}
+
+	var healthCheckCalls int32
+	s.checkServerHealthFunc = func(ctx context.Context, jar *cookiejar.Jar, token string) error {
+		count := atomic.AddInt32(&healthCheckCalls, 1)
+		if count >= 2 {
+			cancel()
+		}
+		// Return a 500 error (not 403)
+		return &healthCheckHTTPError{
+			statusCode: http.StatusInternalServerError,
+			body:       "internal server error",
+		}
+	}
+
+	s.timeAfterFunc = func(d time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	}
+	s.timeSleepFunc = func(d time.Duration) {}
+	s.startReaderFunc = func(ctx context.Context, readerExit chan any, jar *cookiejar.Jar) {
+		t.Fatal("startReader should not be called when health check fails")
+	}
+	s.startWriterFunc = func(ctx context.Context, writerExit chan any, jar *cookiejar.Jar) {
+		t.Fatal("startWriter should not be called when health check fails")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		s.keepAlive()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("keepAlive did not exit in time")
+	}
+
+	// Verify no failure was persisted (500 is transient, not auth failure)
+	dbRO, err := sqlite.Open(stateFile, sqlite.WithReadOnly(true))
+	require.NoError(t, err)
+	defer func() { _ = dbRO.Close() }()
+
+	state, err := sessionstates.ReadLast(context.Background(), dbRO)
+	require.NoError(t, err)
+	assert.Nil(t, state, "No session state should be persisted for non-403 errors")
+}
+
+// TestKeepAliveHealthCheckNetworkErrorDoesNotPersist verifies that plain network
+// errors (not HTTP errors) don't persist to session_states.
+func TestKeepAliveHealthCheckNetworkErrorDoesNotPersist(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	stateFile := tmpDir + "/gpud.state"
+	dbSetup, err := sqlite.Open(stateFile)
+	require.NoError(t, err)
+	require.NoError(t, sessionstates.CreateTable(context.Background(), dbSetup))
+	require.NoError(t, dbSetup.Close())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := &Session{
+		ctx:     ctx,
+		dataDir: tmpDir,
+		reader:  make(chan Body, 20),
+		writer:  make(chan Body, 20),
+		closer:  &closeOnce{closer: make(chan any)},
+	}
+
+	var healthCheckCalls int32
+	s.checkServerHealthFunc = func(ctx context.Context, jar *cookiejar.Jar, token string) error {
+		count := atomic.AddInt32(&healthCheckCalls, 1)
+		if count >= 2 {
+			cancel()
+		}
+		// Plain network error (not healthCheckHTTPError)
+		return fmt.Errorf("dial tcp: connection refused")
+	}
+
+	s.timeAfterFunc = func(d time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	}
+	s.timeSleepFunc = func(d time.Duration) {}
+	s.startReaderFunc = func(ctx context.Context, readerExit chan any, jar *cookiejar.Jar) {
+		t.Fatal("startReader should not be called when health check fails")
+	}
+	s.startWriterFunc = func(ctx context.Context, writerExit chan any, jar *cookiejar.Jar) {
+		t.Fatal("startWriter should not be called when health check fails")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		s.keepAlive()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("keepAlive did not exit in time")
+	}
+
+	dbRO, err := sqlite.Open(stateFile, sqlite.WithReadOnly(true))
+	require.NoError(t, err)
+	defer func() { _ = dbRO.Close() }()
+
+	state, err := sessionstates.ReadLast(context.Background(), dbRO)
+	require.NoError(t, err)
+	assert.Nil(t, state, "No session state should be persisted for network errors")
+}
+
+// TestHealthCheckHTTPErrorType verifies the healthCheckHTTPError type behavior.
+func TestHealthCheckHTTPErrorType(t *testing.T) {
+	t.Run("implements error interface", func(t *testing.T) {
+		err := &healthCheckHTTPError{statusCode: 403, body: "forbidden"}
+		var e error = err
+		assert.Contains(t, e.Error(), "HTTP 403")
+		assert.Contains(t, e.Error(), "forbidden")
+	})
+
+	t.Run("errors.As extracts the type", func(t *testing.T) {
+		var err error = &healthCheckHTTPError{statusCode: 403, body: "test body"}
+		var target *healthCheckHTTPError
+		require.True(t, errors.As(err, &target))
+		assert.Equal(t, 403, target.statusCode)
+		assert.Equal(t, "test body", target.body)
+	})
+
+	t.Run("errors.As returns false for plain error", func(t *testing.T) {
+		err := fmt.Errorf("plain error")
+		var target *healthCheckHTTPError
+		assert.False(t, errors.As(err, &target))
+	})
+
+	t.Run("errors.As works through wrapping", func(t *testing.T) {
+		inner := &healthCheckHTTPError{statusCode: 500, body: "wrapped"}
+		err := fmt.Errorf("outer: %w", inner)
+		var target *healthCheckHTTPError
+		require.True(t, errors.As(err, &target))
+		assert.Equal(t, 500, target.statusCode)
+	})
+}

--- a/pkg/session/session_keepalive_health_check_test.go
+++ b/pkg/session/session_keepalive_health_check_test.go
@@ -101,9 +101,84 @@ func TestKeepAliveHealthCheck403PersistsFailure(t *testing.T) {
 	assert.Contains(t, state.Message, "Forbidden")
 }
 
+// TestKeepAliveHealthCheck500TokenValidationPersistsFailure verifies that when
+// checkServerHealth returns an HTTP 500 error with "failed to validate token" body,
+// the keepAlive loop persists the failure to session_states. The control plane may
+// return 500 instead of 403 for auth failures (server-side bug).
+func TestKeepAliveHealthCheck500TokenValidationPersistsFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	stateFile := tmpDir + "/gpud.state"
+	dbSetup, err := sqlite.Open(stateFile)
+	require.NoError(t, err)
+	require.NoError(t, sessionstates.CreateTable(context.Background(), dbSetup))
+	require.NoError(t, dbSetup.Close())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := &Session{
+		ctx:     ctx,
+		dataDir: tmpDir,
+		reader:  make(chan Body, 20),
+		writer:  make(chan Body, 20),
+		closer:  &closeOnce{closer: make(chan any)},
+	}
+
+	var healthCheckCalls int32
+	s.checkServerHealthFunc = func(ctx context.Context, jar *cookiejar.Jar, token string) error {
+		count := atomic.AddInt32(&healthCheckCalls, 1)
+		if count >= 2 {
+			cancel()
+		}
+		// Simulate: server returns 500 with "failed to validate token" instead of 403
+		return &healthCheckHTTPError{
+			statusCode: http.StatusInternalServerError,
+			body:       `{"code":"InternalFailure","message":"failed to validate token"}`,
+		}
+	}
+
+	s.timeAfterFunc = func(d time.Duration) <-chan time.Time {
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	}
+	s.timeSleepFunc = func(d time.Duration) {}
+	s.startReaderFunc = func(ctx context.Context, readerExit chan any, jar *cookiejar.Jar) {
+		t.Fatal("startReader should not be called when health check fails")
+	}
+	s.startWriterFunc = func(ctx context.Context, writerExit chan any, jar *cookiejar.Jar) {
+		t.Fatal("startWriter should not be called when health check fails")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		s.keepAlive()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("keepAlive did not exit in time")
+	}
+
+	dbRO, err := sqlite.Open(stateFile, sqlite.WithReadOnly(true))
+	require.NoError(t, err)
+	defer func() { _ = dbRO.Close() }()
+
+	state, err := sessionstates.ReadLast(context.Background(), dbRO)
+	require.NoError(t, err)
+	require.NotNil(t, state, "Expected session state to be persisted for 500 with token validation failure")
+
+	assert.False(t, state.Success, "Session state should indicate failure")
+	assert.Contains(t, state.Message, "HTTP 500")
+	assert.Contains(t, state.Message, "failed to validate token")
+}
+
 // TestKeepAliveHealthCheckNon403DoesNotPersist verifies that non-403 health check
-// errors (e.g. 500s) do NOT persist to session_states. Only 403 (auth failure)
-// warrants a persistent record, since other errors are transient.
+// errors (e.g. generic 500s) do NOT persist to session_states. Only auth failures
+// warrant a persistent record, since other errors are transient.
 func TestKeepAliveHealthCheckNon403DoesNotPersist(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
When a GPUd session token becomes invalid (e.g. expired or manually overwritten), the keepAlive loop's checkServerHealth call receives HTTP 403 but only logs the error — it never writes to the session_states table. This leaves "gpud status" blind to the failure, showing a stale "login success" from the original registration.

Fix two issues:
1. Return a structured healthCheckHTTPError from checkServerHealth so keepAlive can detect 403s and persist them to session_states via persistLoginStatus.
2. Have "gpud status" cross-check the control_plane_login_success timestamp against the latest session_states entry. If the most recent activity is a failure newer than the login, show a warning instead of a green checkmark.