### PR TITLE
fix(tailscale): detect logged-out state when systemd service is still active

### DIFF
--- a/components/tailscale/component.go
+++ b/components/tailscale/component.go
@@ -4,6 +4,7 @@ package tailscale
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
@@ -26,6 +27,7 @@ type component struct {
 
 	checkTailscaledInstalled func() bool
 	checkServiceActiveFunc   func() (bool, error)
+	checkTailscaleStatusFunc func() (string, error)
 
 	lastMu          sync.RWMutex
 	lastCheckResult *checkResult
@@ -42,6 +44,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		checkServiceActiveFunc: func() (bool, error) {
 			return systemd.IsActive("tailscaled")
 		},
+		checkTailscaleStatusFunc: checkTailscaleStatus,
 	}
 	return c, nil
 }
@@ -125,6 +128,22 @@ func (c *component) Check() components.CheckResult {
 		}
 	}
 
+	if c.checkTailscaleStatusFunc != nil {
+		cr.BackendState, cr.err = c.checkTailscaleStatusFunc()
+		if cr.err != nil {
+			cr.health = apiv1.HealthStateTypeUnhealthy
+			cr.reason = "tailscaled service is active but failed to check tailscale status"
+			log.Logger.Warnw(cr.reason, "error", cr.err)
+			return cr
+		}
+		if cr.BackendState != "Running" {
+			cr.health = apiv1.HealthStateTypeUnhealthy
+			cr.reason = fmt.Sprintf("tailscaled service is active but tailscale is not running (state: %s)", cr.BackendState)
+			log.Logger.Warnw(cr.reason, "backendState", cr.BackendState)
+			return cr
+		}
+	}
+
 	cr.health = apiv1.HealthStateTypeHealthy
 	cr.reason = "tailscaled service is active/running"
 
@@ -136,6 +155,9 @@ var _ components.CheckResult = &checkResult{}
 type checkResult struct {
 	// TailscaledServiceActive is true if the tailscaled service is active.
 	TailscaledServiceActive bool `json:"tailscaled_service_active"`
+	// BackendState is the tailscale backend state from "tailscale status --json".
+	// Common values: "Running", "Stopped", "NeedsLogin", "NeedsMachineAuth", "Starting".
+	BackendState string `json:"backend_state,omitempty"`
 
 	// timestamp of the last check
 	ts time.Time

--- a/components/tailscale/component_test.go
+++ b/components/tailscale/component_test.go
@@ -20,6 +20,18 @@ func mockComponent(
 	isActive bool,
 	activeError error,
 ) *component {
+	return mockComponentWithStatus(ctx, isInstalled, isActive, activeError, "Running", nil)
+}
+
+// mockComponentWithStatus creates a component with mock functions including tailscale status check
+func mockComponentWithStatus(
+	ctx context.Context,
+	isInstalled bool,
+	isActive bool,
+	activeError error,
+	backendState string,
+	statusError error,
+) *component {
 	cctx, cancel := context.WithCancel(ctx)
 	c := &component{
 		ctx:    cctx,
@@ -29,6 +41,9 @@ func mockComponent(
 		},
 		checkServiceActiveFunc: func() (bool, error) {
 			return isActive, activeError
+		},
+		checkTailscaleStatusFunc: func() (string, error) {
+			return backendState, statusError
 		},
 	}
 	// Initialize lastCheckResult for tests that don't call CheckOnce
@@ -40,11 +55,20 @@ func mockComponent(
 			err:                     activeError,
 			reason:                  "tailscaled installed but tailscaled service is not active or failed to check",
 		}
+	case isInstalled && isActive && backendState == "Running" && statusError == nil:
+		c.lastCheckResult = &checkResult{
+			TailscaledServiceActive: true,
+			BackendState:            "Running",
+			health:                  apiv1.HealthStateTypeHealthy,
+			reason:                  "tailscaled service is active/running",
+		}
 	case isInstalled && isActive:
 		c.lastCheckResult = &checkResult{
 			TailscaledServiceActive: true,
-			health:                  apiv1.HealthStateTypeHealthy,
-			reason:                  "tailscaled service is active/running",
+			BackendState:            backendState,
+			health:                  apiv1.HealthStateTypeUnhealthy,
+			err:                     statusError,
+			reason:                  "tailscaled service is active but tailscale is not running",
 		}
 	default:
 		c.lastCheckResult = &checkResult{
@@ -134,28 +158,36 @@ func TestClose(t *testing.T) {
 
 func TestCheckOnce(t *testing.T) {
 	testCases := []struct {
-		name         string
-		isInstalled  bool
-		isActive     bool
-		activeError  error
-		expectActive bool
-		expectError  bool
-		expectReason string
+		name          string
+		isInstalled   bool
+		isActive      bool
+		activeError   error
+		backendState  string
+		statusError   error
+		expectActive  bool
+		expectError   bool
+		expectReason  string
+		expectBackend string
 	}{
 		{
-			name:         "tailscaled installed and active",
-			isInstalled:  true,
-			isActive:     true,
-			activeError:  nil,
-			expectActive: true,
-			expectError:  false,
-			expectReason: "tailscaled service is active/running",
+			name:          "tailscaled installed and active and running",
+			isInstalled:   true,
+			isActive:      true,
+			activeError:   nil,
+			backendState:  "Running",
+			statusError:   nil,
+			expectActive:  true,
+			expectError:   false,
+			expectReason:  "tailscaled service is active/running",
+			expectBackend: "Running",
 		},
 		{
 			name:         "tailscaled installed but not active",
 			isInstalled:  true,
 			isActive:     false,
 			activeError:  nil,
+			backendState: "Running",
+			statusError:  nil,
 			expectActive: false,
 			expectError:  false,
 			expectReason: "tailscaled installed but tailscaled service is not active or failed to check",
@@ -165,6 +197,8 @@ func TestCheckOnce(t *testing.T) {
 			isInstalled:  true,
 			isActive:     false,
 			activeError:  errors.New("test error"),
+			backendState: "Running",
+			statusError:  nil,
 			expectActive: false,
 			expectError:  true,
 			expectReason: "tailscaled installed but tailscaled service is not active or failed to check",
@@ -174,16 +208,53 @@ func TestCheckOnce(t *testing.T) {
 			isInstalled:  false,
 			isActive:     false,
 			activeError:  nil,
+			backendState: "",
+			statusError:  nil,
 			expectActive: false,
 			expectError:  false,
 			expectReason: "tailscaled is not installed",
+		},
+		{
+			name:          "tailscaled active but logged out (Stopped)",
+			isInstalled:   true,
+			isActive:      true,
+			activeError:   nil,
+			backendState:  "Stopped",
+			statusError:   nil,
+			expectActive:  true,
+			expectError:   false,
+			expectReason:  "tailscaled service is active but tailscale is not running (state: Stopped)",
+			expectBackend: "Stopped",
+		},
+		{
+			name:          "tailscaled active but needs login",
+			isInstalled:   true,
+			isActive:      true,
+			activeError:   nil,
+			backendState:  "NeedsLogin",
+			statusError:   nil,
+			expectActive:  true,
+			expectError:   false,
+			expectReason:  "tailscaled service is active but tailscale is not running (state: NeedsLogin)",
+			expectBackend: "NeedsLogin",
+		},
+		{
+			name:         "tailscaled active but status check failed",
+			isInstalled:  true,
+			isActive:     true,
+			activeError:  nil,
+			backendState: "",
+			statusError:  errors.New("tailscale status failed"),
+			expectActive: true,
+			expectError:  true,
+			expectReason: "tailscaled service is active but failed to check tailscale status",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			c := mockComponent(ctx, tc.isInstalled, tc.isActive, tc.activeError)
+			c := mockComponentWithStatus(ctx, tc.isInstalled, tc.isActive, tc.activeError, tc.backendState, tc.statusError)
 
 			_ = c.Check()
 
@@ -196,13 +267,13 @@ func TestCheckOnce(t *testing.T) {
 				"TailscaledServiceActive should match expected value")
 			assert.Equal(t, tc.expectReason, lastCheckResult.reason,
 				"Reason should match expected value")
+			if tc.expectBackend != "" {
+				assert.Equal(t, tc.expectBackend, lastCheckResult.BackendState,
+					"BackendState should match expected value")
+			}
 
 			if tc.expectError {
-				if tc.activeError != nil {
-					assert.Equal(t, tc.activeError, lastCheckResult.err, "Error should match expected error")
-				} else {
-					assert.NotNil(t, lastCheckResult.err, "Error should be set when expected")
-				}
+				assert.NotNil(t, lastCheckResult.err, "Error should be set when expected")
 			} else {
 				assert.Nil(t, lastCheckResult.err, "Error should not be set when not expected")
 			}
@@ -216,47 +287,70 @@ func TestStates(t *testing.T) {
 		isInstalled    bool
 		isActive       bool
 		activeError    error
+		backendState   string
+		statusError    error
 		expectedHealth apiv1.HealthStateType
-		expectedStatus bool
 	}{
 		{
-			name:           "tailscaled installed and active",
+			name:           "tailscaled installed and active and running",
 			isInstalled:    true,
 			isActive:       true,
 			activeError:    nil,
+			backendState:   "Running",
+			statusError:    nil,
 			expectedHealth: apiv1.HealthStateTypeHealthy,
-			expectedStatus: true,
 		},
 		{
 			name:           "tailscaled installed but not active",
 			isInstalled:    true,
 			isActive:       false,
 			activeError:    nil,
+			backendState:   "Running",
+			statusError:    nil,
 			expectedHealth: apiv1.HealthStateTypeUnhealthy,
-			expectedStatus: false,
 		},
 		{
 			name:           "tailscaled installed but error checking status",
 			isInstalled:    true,
 			isActive:       false,
 			activeError:    errors.New("test error"),
+			backendState:   "Running",
+			statusError:    nil,
 			expectedHealth: apiv1.HealthStateTypeUnhealthy,
-			expectedStatus: false,
 		},
 		{
 			name:           "tailscaled not installed",
 			isInstalled:    false,
 			isActive:       false,
 			activeError:    nil,
+			backendState:   "",
+			statusError:    nil,
 			expectedHealth: apiv1.HealthStateTypeHealthy,
-			expectedStatus: true,
+		},
+		{
+			name:           "tailscaled active but logged out",
+			isInstalled:    true,
+			isActive:       true,
+			activeError:    nil,
+			backendState:   "Stopped",
+			statusError:    nil,
+			expectedHealth: apiv1.HealthStateTypeUnhealthy,
+		},
+		{
+			name:           "tailscaled active but needs login",
+			isInstalled:    true,
+			isActive:       true,
+			activeError:    nil,
+			backendState:   "NeedsLogin",
+			statusError:    nil,
+			expectedHealth: apiv1.HealthStateTypeUnhealthy,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			c := mockComponent(ctx, tc.isInstalled, tc.isActive, tc.activeError)
+			c := mockComponentWithStatus(ctx, tc.isInstalled, tc.isActive, tc.activeError, tc.backendState, tc.statusError)
 
 			// Run CheckOnce to populate lastCheckResult
 			_ = c.Check()

--- a/components/tailscale/tailscale.go
+++ b/components/tailscale/tailscale.go
@@ -1,13 +1,17 @@
 package tailscale
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 
 	pkgfile "github.com/leptonai/gpud/pkg/file"
 	"github.com/leptonai/gpud/pkg/log"
+	"github.com/leptonai/gpud/pkg/process"
 )
 
 func checkTailscaleInstalled() bool {
@@ -63,6 +67,38 @@ func parseVersionFromOutput(out, name string) (string, error) {
 		return "", fmt.Errorf("invalid %s version output: %s", name, strings.TrimSpace(out))
 	}
 	return matches[1], nil
+}
+
+// tailscaleStatus represents the relevant fields from "tailscale status --json".
+type tailscaleStatus struct {
+	BackendState string `json:"BackendState"`
+}
+
+// checkTailscaleStatus runs "tailscale status --json" and returns the backend state.
+// Common BackendState values: "Running", "Stopped", "NeedsLogin", "NeedsMachineAuth", "Starting".
+func checkTailscaleStatus() (string, error) {
+	p, err := pkgfile.LocateExecutable("tailscale")
+	if err != nil {
+		return "", err
+	}
+
+	proc, err := process.New(process.WithCommand(p, "status", "--json"))
+	if err != nil {
+		return "", fmt.Errorf("failed to create tailscale status process: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	out, err := proc.StartAndWaitForCombinedOutput(ctx)
+	if err != nil {
+		return "", fmt.Errorf("tailscale status --json failed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	var status tailscaleStatus
+	if err := json.Unmarshal(out, &status); err != nil {
+		return "", fmt.Errorf("failed to parse tailscale status JSON: %w", err)
+	}
+	return status.BackendState, nil
 }
 
 // CheckTailscaleInstalled checks if the tailscale binary is installed.

--- a/pkg/process/utils_test.go
+++ b/pkg/process/utils_test.go
@@ -150,16 +150,20 @@ func TestReadAll(t *testing.T) {
 		assert.Equal(t, "hello world", output)
 	})
 
-	// Test 2: Multiple lines
+	// Test 2: Multiple lines (uses in-memory reader to avoid cmd.Wait pipe-close race)
 	t.Run("multiple lines", func(t *testing.T) {
-		// WHY: `echo` handling of `\n` escapes varies across `/bin/sh` implementations (e.g., bash-as-sh),
-		// so `printf` ensures deterministic multi-line output across platforms.
-		p, err := newTestProcess("sh", "-c", "printf '%s\\n' line1 line2 line3")
-		require.NoError(t, err)
+		stdoutReader := strings.NewReader("line1\nline2\nline3\n")
+		p := &testProcess{
+			stdout: io.NopCloser(stdoutReader),
+			waitCh: make(chan error, 1),
+		}
+		p.waitCh <- nil
+		close(p.waitCh)
+
 		lines := []string{}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		err = Read(
+		err := Read(
 			ctx,
 			p,
 			WithReadStdout(),


### PR DESCRIPTION

The health check only verified `systemctl is-active tailscaled`, which returns true even when tailscale is logged out (BackendState: "Stopped"). This caused gpud to report healthy while tailscale networking was down, leading to cascading calico/kubelet failures.

Now also runs `tailscale status --json` and checks the BackendState field. Any state other than "Running" (e.g. Stopped, NeedsLogin, NeedsMachineAuth) is reported as unhealthy.

Tested:

```json
    "component": "tailscale",
    "states": [
      {
        "time": "2026-04-03T16:00:42Z",
        "component": "tailscale",
        "name": "tailscale",
        "health": "Unhealthy",
        "reason": "tailscaled service is active but tailscale is not running (state: NeedsLogin)",
        "extra_info": {
          "data": "{\"tailscaled_service_active\":true,\"backend_state\":\"NeedsLogin\"}"
        }
      }
    ]
  }
```