### PR TITLE
fix(systemd): unset NOTIFY_SOCKET after ready notification

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -685,7 +685,6 @@ func (s *Session) handleReaderPipe(respBody io.ReadCloser, closec, finish chan a
 	}
 }
 
-
 func (s *Session) persistLoginStatus(ctx context.Context, success bool, message string) {
 	stateFile := config.StateFilePath(s.dataDir)
 

--- a/pkg/systemd/notify.go
+++ b/pkg/systemd/notify.go
@@ -2,19 +2,44 @@ package systemd
 
 import (
 	"context"
+	"os"
 
 	sd "github.com/coreos/go-systemd/v22/daemon"
 
 	"github.com/leptonai/gpud/pkg/log"
 )
 
-// NotifyReady notifies systemd that the daemon is ready to serve requests
+// savedNotifySocket stores the NOTIFY_SOCKET path so we can still send
+// the stopping notification after the environment variable has been unset.
+var savedNotifySocket string
+
+// NotifyReady notifies systemd that the daemon is ready to serve requests.
+// It also unsets NOTIFY_SOCKET from the process environment to prevent
+// child processes from inheriting it and sending spurious notifications.
+// ref. https://github.com/leptonai/gpud/issues/1215
 func NotifyReady(_ context.Context) error {
-	return sdNotify(sd.SdNotifyReady)
+	savedNotifySocket = os.Getenv("NOTIFY_SOCKET")
+
+	// Pass unsetEnvironment=true so child processes won't inherit NOTIFY_SOCKET.
+	notified, err := sd.SdNotify(true, sd.SdNotifyReady)
+	log.Logger.Debugw("sd notification", "state", sd.SdNotifyReady, "notified", notified, "error", err)
+	return err
 }
 
-// NotifyStopping notifies systemd that the daemon is about to be stopped
+// NotifyStopping notifies systemd that the daemon is about to be stopped.
 func NotifyStopping(_ context.Context) error {
+	// Temporarily restore NOTIFY_SOCKET for this call since it was
+	// unset after NotifyReady to prevent child process inheritance.
+	if savedNotifySocket != "" {
+		if err := os.Setenv("NOTIFY_SOCKET", savedNotifySocket); err != nil {
+			log.Logger.Warnw("failed to restore NOTIFY_SOCKET", "error", err)
+		}
+		defer func() {
+			if err := os.Unsetenv("NOTIFY_SOCKET"); err != nil {
+				log.Logger.Warnw("failed to unset NOTIFY_SOCKET", "error", err)
+			}
+		}()
+	}
 	return sdNotify(sd.SdNotifyStopping)
 }
 


### PR DESCRIPTION
c.f., https://github.com/leptonai/gpud/pull/1216

## Summary
- Unsets `NOTIFY_SOCKET` from gpud's process environment after sending the `READY=1` notification, preventing all child processes from inheriting it
- Saves the socket path so `NotifyStopping()` can still send `STOPPING=1` at shutdown by temporarily restoring it
- Fixes the root cause of `systemd[1]: gpud.service: Got notification message from PID X, but reception only permitted for main PID Y` syslog spam

## Context
PR #1216 added `NotifyAccess=all` to the embedded service file, but machines upgraded via binary replacement (without re-running `gpud up`) still have the old unit file on disk. This fix works regardless of the service file configuration by preventing child processes from seeing `NOTIFY_SOCKET` in the first place.

Confirmed on `fargate-ip-10-50-108-125` (cluster `gcp-iad-slurm-2-ukzwrony`): running gpud v0.11.2, the on-disk service file was missing `NotifyAccess=all`, and `NOTIFY_SOCKET=/run/systemd/notify` was in the process environment.

## Test plan
- [x] Existing `TestNotifyReady`, `TestNotifyReady_Error`, `TestNotifyStopping`, `TestNotifyStopping_Error` all pass
- [x] Deploy to a node and verify no more "Got notification message from PID" syslog entries