### PR TITLE
[LEP-4622] fix(persistence-mode): persist events to event store so repair history is recorded

### DIFF
--- a/components/accelerator/nvidia/persistence-mode/component.go
+++ b/components/accelerator/nvidia/persistence-mode/component.go
@@ -16,6 +16,7 @@ import (
 
 	apiv1 "github.com/leptonai/gpud/api/v1"
 	"github.com/leptonai/gpud/components"
+	"github.com/leptonai/gpud/pkg/eventstore"
 	"github.com/leptonai/gpud/pkg/log"
 	nvmlerrors "github.com/leptonai/gpud/pkg/nvidia/errors"
 	nvidianvml "github.com/leptonai/gpud/pkg/nvidia/nvml"
@@ -24,6 +25,16 @@ import (
 
 // Name is the ID of the NVIDIA persistence mode component.
 const Name = "accelerator-nvidia-persistence-mode"
+
+const (
+	// EventNamePersistenceModeDisabled is emitted when persistence mode is detected as disabled.
+	EventNamePersistenceModeDisabled = "persistence_mode_disabled"
+
+	// EventKeyDeviceUUID stores the device UUID associated with the event.
+	EventKeyDeviceUUID = "device_uuid"
+	// EventKeyDeviceBusID stores the PCI bus ID associated with the event.
+	EventKeyDeviceBusID = "device_bus_id"
+)
 
 var _ components.Component = &component{}
 
@@ -35,6 +46,8 @@ type component struct {
 
 	nvmlInstance           nvidianvml.Instance
 	getPersistenceModeFunc func(uuid string, dev device.Device) (PersistenceMode, error)
+
+	eventBucket eventstore.Bucket
 
 	lastMu          sync.RWMutex
 	lastCheckResult *checkResult
@@ -52,6 +65,16 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		nvmlInstance:           gpudInstance.NVMLInstance,
 		getPersistenceModeFunc: GetPersistenceMode,
 	}
+
+	if gpudInstance.EventStore != nil {
+		var err error
+		c.eventBucket, err = gpudInstance.EventStore.Bucket(Name)
+		if err != nil {
+			ccancel()
+			return nil, err
+		}
+	}
+
 	return c, nil
 }
 
@@ -98,14 +121,26 @@ func (c *component) LastHealthStates() apiv1.HealthStates {
 	return lastCheckResult.HealthStates()
 }
 
-func (c *component) Events(_ context.Context, _ time.Time) (apiv1.Events, error) {
-	return nil, nil
+func (c *component) Events(ctx context.Context, since time.Time) (apiv1.Events, error) {
+	if c.eventBucket == nil {
+		return nil, nil
+	}
+
+	evs, err := c.eventBucket.Get(ctx, since)
+	if err != nil {
+		return nil, err
+	}
+	return evs.Events(), nil
 }
 
 func (c *component) Close() error {
 	log.Logger.Debugw("closing component")
 
 	c.cancel()
+
+	if c.eventBucket != nil {
+		c.eventBucket.Close()
+	}
 
 	return nil
 }
@@ -190,6 +225,36 @@ func (c *component) Check() components.CheckResult {
 	for _, pm := range cr.PersistenceModes {
 		if pm.Supported && !pm.Enabled {
 			notEnabled = append(notEnabled, fmt.Sprintf("%s persistence mode supported but not enabled", pm.UUID))
+
+			if c.eventBucket != nil {
+				ev := eventstore.Event{
+					Component: Name,
+					Time:      cr.ts,
+					Name:      EventNamePersistenceModeDisabled,
+					Type:      string(apiv1.EventTypeWarning),
+					Message:   fmt.Sprintf("GPU %s (%s) persistence mode is supported but not enabled", pm.UUID, pm.BusID),
+					ExtraInfo: map[string]string{
+						EventKeyDeviceUUID:  pm.UUID,
+						EventKeyDeviceBusID: pm.BusID,
+					},
+				}
+
+				findCtx, findCancel := context.WithTimeout(c.ctx, 15*time.Second)
+				found, findErr := c.eventBucket.Find(findCtx, ev)
+				findCancel()
+				if findErr != nil {
+					log.Logger.Warnw("error finding persistence mode event", "uuid", pm.UUID, "error", findErr)
+				} else if found == nil {
+					insertCtx, insertCancel := context.WithTimeout(c.ctx, 15*time.Second)
+					insertErr := c.eventBucket.Insert(insertCtx, ev)
+					insertCancel()
+					if insertErr != nil {
+						log.Logger.Warnw("error inserting persistence mode event", "uuid", pm.UUID, "error", insertErr)
+					} else {
+						log.Logger.Infow("recorded persistence mode disabled event", "uuid", pm.UUID, "bus_id", pm.BusID)
+					}
+				}
+			}
 		}
 	}
 

--- a/components/accelerator/nvidia/persistence-mode/component_test.go
+++ b/components/accelerator/nvidia/persistence-mode/component_test.go
@@ -14,11 +14,13 @@ import (
 
 	apiv1 "github.com/leptonai/gpud/api/v1"
 	"github.com/leptonai/gpud/components"
+	"github.com/leptonai/gpud/pkg/eventstore"
 	nvmlerrors "github.com/leptonai/gpud/pkg/nvidia/errors"
 	"github.com/leptonai/gpud/pkg/nvidia/nvml/device"
 	"github.com/leptonai/gpud/pkg/nvidia/nvml/lib"
 	"github.com/leptonai/gpud/pkg/nvidia/nvml/testutil"
 	nvidiaproduct "github.com/leptonai/gpud/pkg/nvidia/product"
+	"github.com/leptonai/gpud/pkg/sqlite"
 )
 
 // mockNVMLInstance implements the nvml.InstanceV2 interface for testing
@@ -100,6 +102,16 @@ func mockComponent(
 	devicesFunc func() map[string]device.Device,
 	getPersistenceModeFunc func(uuid string, dev device.Device) (PersistenceMode, error),
 ) components.Component {
+	return mockComponentWithBucket(ctx, devicesFunc, getPersistenceModeFunc, nil)
+}
+
+// mockComponentWithBucket creates a component with mocked functions and an optional event bucket.
+func mockComponentWithBucket(
+	ctx context.Context,
+	devicesFunc func() map[string]device.Device,
+	getPersistenceModeFunc func(uuid string, dev device.Device) (PersistenceMode, error),
+	bucket eventstore.Bucket,
+) components.Component {
 	cctx, cancel := context.WithCancel(ctx)
 
 	mockInstance := &mockNVMLInstance{
@@ -112,6 +124,7 @@ func mockComponent(
 		cancel:                 cancel,
 		nvmlInstance:           mockInstance,
 		getPersistenceModeFunc: getPersistenceModeFunc,
+		eventBucket:            bucket,
 		getTimeNowFunc: func() time.Time {
 			return time.Now().UTC()
 		},
@@ -480,13 +493,314 @@ func TestLastHealthStates_NoData(t *testing.T) {
 	assert.Equal(t, "no data yet", state.Reason)
 }
 
-func TestEvents(t *testing.T) {
+func TestEvents_NoBucket(t *testing.T) {
 	ctx := context.Background()
 	component := mockComponent(ctx, nil, nil)
 
 	events, err := component.Events(ctx, time.Now())
 	assert.NoError(t, err)
 	assert.Empty(t, events)
+}
+
+func TestEvents_WithBucket(t *testing.T) {
+	dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+	defer cleanup()
+
+	store, err := eventstore.New(dbRW, dbRO, eventstore.DefaultRetention)
+	require.NoError(t, err)
+
+	bucket, err := store.Bucket(Name)
+	require.NoError(t, err)
+	defer bucket.Close()
+
+	ctx := context.Background()
+
+	uuid := "gpu-uuid-123"
+	mockDeviceObj := &mock.Device{
+		GetUUIDFunc: func() (string, nvml.Return) {
+			return uuid, nvml.SUCCESS
+		},
+	}
+	mockDev := testutil.NewMockDevice(mockDeviceObj, "test-arch", "test-brand", "test-cuda", "test-pci")
+
+	devs := map[string]device.Device{uuid: mockDev}
+
+	comp := mustComponent(t, mockComponentWithBucket(
+		ctx,
+		func() map[string]device.Device { return devs },
+		func(_ string, _ device.Device) (PersistenceMode, error) {
+			return PersistenceMode{UUID: uuid, BusID: "0000:01:00.0", Supported: true, Enabled: false}, nil
+		},
+		bucket,
+	))
+
+	// Run a check to trigger event insertion
+	comp.Check()
+
+	// Query events via the component's Events() method
+	events, err := comp.Events(ctx, time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, EventNamePersistenceModeDisabled, events[0].Name)
+	assert.Equal(t, apiv1.EventTypeWarning, events[0].Type)
+}
+
+func TestCheck_EventRecordedOnPersistenceModeDisabled(t *testing.T) {
+	dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+	defer cleanup()
+
+	store, err := eventstore.New(dbRW, dbRO, eventstore.DefaultRetention)
+	require.NoError(t, err)
+
+	bucket, err := store.Bucket(Name)
+	require.NoError(t, err)
+	defer bucket.Close()
+
+	ctx := context.Background()
+
+	uuid := "gpu-uuid-abc"
+	busID := "0000:3b:00.0"
+	mockDeviceObj := &mock.Device{
+		GetUUIDFunc: func() (string, nvml.Return) {
+			return uuid, nvml.SUCCESS
+		},
+	}
+	mockDev := testutil.NewMockDevice(mockDeviceObj, "test-arch", "test-brand", "test-cuda", busID)
+
+	devs := map[string]device.Device{uuid: mockDev}
+
+	comp := mustComponent(t, mockComponentWithBucket(
+		ctx,
+		func() map[string]device.Device { return devs },
+		func(u string, _ device.Device) (PersistenceMode, error) {
+			return PersistenceMode{UUID: u, BusID: busID, Supported: true, Enabled: false}, nil
+		},
+		bucket,
+	))
+
+	// First check should insert an event
+	result := comp.Check()
+	cr, ok := result.(*checkResult)
+	require.True(t, ok)
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.health)
+
+	events, err := bucket.Get(ctx, time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, EventNamePersistenceModeDisabled, events[0].Name)
+	assert.Equal(t, uuid, events[0].ExtraInfo[EventKeyDeviceUUID])
+	assert.Equal(t, busID, events[0].ExtraInfo[EventKeyDeviceBusID])
+	assert.Contains(t, events[0].Message, uuid)
+	assert.Contains(t, events[0].Message, busID)
+}
+
+func TestCheck_EventDeduplication(t *testing.T) {
+	dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+	defer cleanup()
+
+	store, err := eventstore.New(dbRW, dbRO, eventstore.DefaultRetention)
+	require.NoError(t, err)
+
+	bucket, err := store.Bucket(Name)
+	require.NoError(t, err)
+	defer bucket.Close()
+
+	ctx := context.Background()
+
+	uuid := "gpu-uuid-dedup"
+	mockDeviceObj := &mock.Device{
+		GetUUIDFunc: func() (string, nvml.Return) {
+			return uuid, nvml.SUCCESS
+		},
+	}
+	mockDev := testutil.NewMockDevice(mockDeviceObj, "test-arch", "test-brand", "test-cuda", "test-pci")
+
+	devs := map[string]device.Device{uuid: mockDev}
+
+	comp := mustComponent(t, mockComponentWithBucket(
+		ctx,
+		func() map[string]device.Device { return devs },
+		func(u string, _ device.Device) (PersistenceMode, error) {
+			return PersistenceMode{UUID: u, BusID: "test-pci", Supported: true, Enabled: false}, nil
+		},
+		bucket,
+	))
+
+	// Run Check multiple times
+	comp.Check()
+	comp.Check()
+	comp.Check()
+
+	// Should still have only 1 event due to dedup
+	events, err := bucket.Get(ctx, time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	assert.Len(t, events, 1, "duplicate events should not be inserted")
+}
+
+func TestCheck_NoEventWhenPersistenceModeEnabled(t *testing.T) {
+	dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+	defer cleanup()
+
+	store, err := eventstore.New(dbRW, dbRO, eventstore.DefaultRetention)
+	require.NoError(t, err)
+
+	bucket, err := store.Bucket(Name)
+	require.NoError(t, err)
+	defer bucket.Close()
+
+	ctx := context.Background()
+
+	uuid := "gpu-uuid-ok"
+	mockDeviceObj := &mock.Device{
+		GetUUIDFunc: func() (string, nvml.Return) {
+			return uuid, nvml.SUCCESS
+		},
+	}
+	mockDev := testutil.NewMockDevice(mockDeviceObj, "test-arch", "test-brand", "test-cuda", "test-pci")
+
+	devs := map[string]device.Device{uuid: mockDev}
+
+	comp := mustComponent(t, mockComponentWithBucket(
+		ctx,
+		func() map[string]device.Device { return devs },
+		func(u string, _ device.Device) (PersistenceMode, error) {
+			return PersistenceMode{UUID: u, BusID: "test-pci", Supported: true, Enabled: true}, nil
+		},
+		bucket,
+	))
+
+	result := comp.Check()
+	cr, ok := result.(*checkResult)
+	require.True(t, ok)
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, cr.health)
+
+	// No events should be recorded
+	events, err := bucket.Get(ctx, time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	assert.Empty(t, events, "no events should be recorded when persistence mode is enabled")
+}
+
+func TestCheck_MultipleGPUsPartialEvents(t *testing.T) {
+	dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+	defer cleanup()
+
+	store, err := eventstore.New(dbRW, dbRO, eventstore.DefaultRetention)
+	require.NoError(t, err)
+
+	bucket, err := store.Bucket(Name)
+	require.NoError(t, err)
+	defer bucket.Close()
+
+	ctx := context.Background()
+
+	uuid1 := "gpu-uuid-enabled"
+	uuid2 := "gpu-uuid-disabled"
+
+	mockDevice1 := &mock.Device{
+		GetUUIDFunc: func() (string, nvml.Return) {
+			return uuid1, nvml.SUCCESS
+		},
+	}
+	mockDev1 := testutil.NewMockDevice(mockDevice1, "test-arch", "test-brand", "test-cuda", "0000:01:00.0")
+
+	mockDevice2 := &mock.Device{
+		GetUUIDFunc: func() (string, nvml.Return) {
+			return uuid2, nvml.SUCCESS
+		},
+	}
+	mockDev2 := testutil.NewMockDevice(mockDevice2, "test-arch", "test-brand", "test-cuda", "0000:02:00.0")
+
+	devs := map[string]device.Device{uuid1: mockDev1, uuid2: mockDev2}
+
+	comp := mustComponent(t, mockComponentWithBucket(
+		ctx,
+		func() map[string]device.Device { return devs },
+		func(u string, _ device.Device) (PersistenceMode, error) {
+			if u == uuid1 {
+				return PersistenceMode{UUID: u, BusID: "0000:01:00.0", Supported: true, Enabled: true}, nil
+			}
+			return PersistenceMode{UUID: u, BusID: "0000:02:00.0", Supported: true, Enabled: false}, nil
+		},
+		bucket,
+	))
+
+	comp.Check()
+
+	// Only the disabled GPU should have an event
+	events, err := bucket.Get(ctx, time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Len(t, events, 1, "only the disabled GPU should generate an event")
+	assert.Equal(t, uuid2, events[0].ExtraInfo[EventKeyDeviceUUID])
+}
+
+func TestNew_WithEventStore(t *testing.T) {
+	dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+	defer cleanup()
+
+	store, err := eventstore.New(dbRW, dbRO, eventstore.DefaultRetention)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	mockInstance := &mockNVMLInstance{
+		devicesFunc: func() map[string]device.Device { return nil },
+	}
+
+	gpudInstance := &components.GPUdInstance{
+		RootCtx:      ctx,
+		NVMLInstance: mockInstance,
+		EventStore:   store,
+	}
+
+	c, err := New(gpudInstance)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	tc, ok := c.(*component)
+	require.True(t, ok)
+	assert.NotNil(t, tc.eventBucket, "eventBucket should be set when EventStore is provided")
+}
+
+func TestCheck_NoEventWhenNotSupported(t *testing.T) {
+	dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+	defer cleanup()
+
+	store, err := eventstore.New(dbRW, dbRO, eventstore.DefaultRetention)
+	require.NoError(t, err)
+
+	bucket, err := store.Bucket(Name)
+	require.NoError(t, err)
+	defer bucket.Close()
+
+	ctx := context.Background()
+
+	uuid := "gpu-uuid-unsupported"
+	mockDeviceObj := &mock.Device{
+		GetUUIDFunc: func() (string, nvml.Return) {
+			return uuid, nvml.SUCCESS
+		},
+	}
+	mockDev := testutil.NewMockDevice(mockDeviceObj, "test-arch", "test-brand", "test-cuda", "test-pci")
+
+	devs := map[string]device.Device{uuid: mockDev}
+
+	comp := mustComponent(t, mockComponentWithBucket(
+		ctx,
+		func() map[string]device.Device { return devs },
+		func(u string, _ device.Device) (PersistenceMode, error) {
+			// Persistence mode not supported — disabled but not flagged
+			return PersistenceMode{UUID: u, BusID: "test-pci", Supported: false, Enabled: false}, nil
+		},
+		bucket,
+	))
+
+	result := comp.Check()
+	cr, ok := result.(*checkResult)
+	require.True(t, ok)
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, cr.health)
+
+	events, err := bucket.Get(ctx, time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	assert.Empty(t, events, "no events for unsupported persistence mode")
 }
 
 func TestStart(t *testing.T) {


### PR DESCRIPTION
The persistence-mode component detected disabled persistence mode and
reported unhealthy health state, but never recorded events to the event
store. This meant the entire unhealthy window was invisible in repair
history — once persistence mode was re-enabled, the transient failure
left no audit trail.

Add an eventBucket backed by SQLite, insert deduplicated warning events
when persistence mode is disabled, and wire up Events() to query them.

Signed-off-by: Gyuho Lee <gyuhol@nvidia.com>
