### PR TITLE
accelerator-nvidia-processes: no such process

### DIFF
--- a/pkg/nvidia/errors/error.go
+++ b/pkg/nvidia/errors/error.go
@@ -126,10 +126,14 @@ func IsNotFoundError(ret nvml.Return) bool {
 	return isNotFoundError(ret, nvml.ErrorString)
 }
 
+// IsNoSuchFileOrDirectoryError returns true if the referenced file or process no longer exists.
+// Also matches ESRCH, which procfs returns for /proc/<pid>/* of a just-exited process.
 func IsNoSuchFileOrDirectoryError(err error) bool {
 	if err == nil {
 		return false
 	}
 	s := strings.ToLower(err.Error())
-	return strings.Contains(s, "not found") || strings.Contains(s, "no such file or directory")
+	return strings.Contains(s, "not found") ||
+		strings.Contains(s, "no such file or directory") ||
+		strings.Contains(s, "no such process")
 }

--- a/pkg/nvidia/errors/error_test.go
+++ b/pkg/nvidia/errors/error_test.go
@@ -655,6 +655,11 @@ func TestIsNoSuchFileOrDirectoryError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "no such process (ESRCH)",
+			err:      errors.New("open /proc/2748003/environ: no such process"),
+			expected: true,
+		},
+		{
 			name:     "different error",
 			err:      errors.New("permission denied"),
 			expected: false,


### PR DESCRIPTION
Closes #1238

  - error.go — IsNoSuchFileOrDirectoryError now also matches "no such process" (ESRCH), so the procfs race in Environ()/Status()/CmdlineSlice()/CreateTime()/NewProcess() skips the vanished PID instead of bubbling up to flip accelerator-nvidia-processes Unhealthy. Two-line comment matches existing style.


I was able to reproduce this on v0.11.4 with the script below.
With the patch I was unable to (with 64 workers).

```bash
#!/usr/bin/env bash
# Reproduce gpud's accelerator-nvidia-processes ESRCH race.
#
# Background:
#   gpud calls nvmlDeviceGetComputeRunningProcesses() to get a list of CUDA-active
#   PIDs, then opens /proc/<pid>/environ etc. for each one. If a PID exits between
#   those two steps, the kernel returns errno ESRCH ("no such process") rather
#   than ENOENT. v0.11.4's IsNoSuchFileOrDirectoryError doesn't match ESRCH, so
#   the component flips to Unhealthy and NHC drains the node.
#
# Strategy:
#   Spawn many tiny CUDA processes in parallel. Each creates a CUDA context (so
#   it appears in NVML's process list) and exits immediately. Sustained churn
#   maximises the chance that a PID is in the dying/reaped state during gpud's
#   per-minute check tick.
#
# Usage (run on the GPU host with gpud 0.11.4 installed):
#   sudo systemctl status gpud           # confirm gpud is running
#   bash /tmp/reproduce-gpud-esrch.sh    # in one shell
#   # in another shell, watch logs:
#   sudo journalctl -u gpud -f | grep -E 'error getting processes|no such process|accelerator-nvidia-processes'
#
# Tunables (env vars or flags):
#   DURATION  total runtime in seconds (default 600 = 10 minutes, ~10 gpud ticks)
#   WORKERS   parallel spawner loops    (default 32)

set -euo pipefail

DURATION=${DURATION:-600}
WORKERS=${WORKERS:-32}

while [[ $# -gt 0 ]]; do
  case "$1" in
    --duration) DURATION="$2"; shift 2 ;;
    --workers)  WORKERS="$2";  shift 2 ;;
    -h|--help)  sed -n '2,30p' "$0"; exit 0 ;;
    *) echo "unknown arg: $1" >&2; exit 2 ;;
  esac
done

if ! command -v python3 >/dev/null; then
  echo "python3 not found; install python3 or adapt this script to use a compiled CUDA binary." >&2
  exit 1
fi

if ! ldconfig -p | grep -q libcuda.so; then
  echo "libcuda.so not found in ldconfig cache; ensure the NVIDIA driver is installed." >&2
  exit 1
fi

# Tiny worker: cuInit + cuCtxCreate + cuMemAlloc, then exit immediately.
# Uses ctypes so we don't need torch/pycuda. Each invocation lives ~50-200 ms.
WORKER=$(cat <<'PY'
import ctypes, sys
cuda = ctypes.CDLL("libcuda.so.1")
cuda.cuInit.argtypes = [ctypes.c_uint]
cuda.cuInit.restype  = ctypes.c_int
ctx = ctypes.c_void_p()
cuda.cuCtxCreate_v2.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_uint, ctypes.c_int]
cuda.cuCtxCreate_v2.restype  = ctypes.c_int
mem = ctypes.c_void_p()
cuda.cuMemAlloc_v2.argtypes  = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]
cuda.cuMemAlloc_v2.restype   = ctypes.c_int
if cuda.cuInit(0) != 0:
    sys.exit(0)
# pick GPU 0; change the third arg to spread across GPUs if you want
if cuda.cuCtxCreate_v2(ctypes.byref(ctx), 0, 0) != 0:
    sys.exit(0)
cuda.cuMemAlloc_v2(ctypes.byref(mem), ctypes.c_size_t(1024))
# fall through -> process exit tears down the context
PY
)

cat <<EOF
Spawning short-lived CUDA processes:
  duration : ${DURATION}s
  workers  : ${WORKERS}

Watch gpud logs in another terminal:
  sudo journalctl -u gpud -f | grep -E 'error getting processes|no such process|accelerator-nvidia-processes'

Or poll status:
  watch -n 5 'gpud status accelerator-nvidia-processes 2>&1 | head -30'

Press Ctrl-C to stop early.
EOF

trap 'echo; echo "Stopping workers..."; kill 0; exit 0' INT TERM

end=$(( $(date +%s) + DURATION ))
for _ in $(seq 1 "$WORKERS"); do
  (
    while (( $(date +%s) < end )); do
      python3 -c "$WORKER" >/dev/null 2>&1 || true
    done
  ) &
done

wait
echo "Done."
echo "Search the gpud journal for hits:"
echo "  sudo journalctl -u gpud --since '${DURATION} seconds ago' | grep -c 'no such process' || true"
```

