### PR TITLE
feat(nvidia/processes): tolerate transient process query errors (requires 5 consecutive failures for "Unhealthy")

### DIFF
--- a/components/accelerator/nvidia/processes/component.go
+++ b/components/accelerator/nvidia/processes/component.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -163,13 +164,21 @@ func (c *component) Check() components.CheckResult {
 	}
 
 	devs := c.nvmlInstance.Devices()
-	for uuid, dev := range devs {
+	uuids := make([]string, 0, len(devs))
+	for uuid := range devs {
+		uuids = append(uuids, uuid)
+	}
+	sort.Strings(uuids)
+
+	var genericErr error
+	var genericErrUUID string
+	for _, uuid := range uuids {
+		dev := devs[uuid]
 		procs, err := c.getProcessesFunc(uuid, dev)
 		if err != nil {
-			cr.err = err
-
 			if errors.Is(err, nvmlerrors.ErrGPURequiresReset) {
 				c.recordGetProcessesError(false)
+				cr.err = err
 				cr.health = apiv1.HealthStateTypeUnhealthy
 				cr.reason = nvmlerrors.ErrGPURequiresReset.Error()
 				cr.suggestedActions = &apiv1.SuggestedActions{
@@ -184,6 +193,7 @@ func (c *component) Check() components.CheckResult {
 
 			if errors.Is(err, nvmlerrors.ErrGPULost) {
 				c.recordGetProcessesError(false)
+				cr.err = err
 				cr.health = apiv1.HealthStateTypeUnhealthy
 				cr.reason = nvmlerrors.ErrGPULost.Error()
 				cr.suggestedActions = &apiv1.SuggestedActions{
@@ -196,27 +206,37 @@ func (c *component) Check() components.CheckResult {
 				return cr
 			}
 
-			consecutive := c.recordGetProcessesError(true)
-			if consecutive < getProcessesErrorConsecutiveThreshold {
-				cr.health = apiv1.HealthStateTypeHealthy
-				cr.reason = fmt.Sprintf(
-					"error getting processes (detected %d/%d consecutive checks)",
-					consecutive,
-					getProcessesErrorConsecutiveThreshold,
-				)
-				log.Logger.Warnw(cr.reason, "uuid", uuid, "error", err)
-				return cr
+			if genericErr == nil {
+				genericErr = err
+				genericErrUUID = uuid
 			}
-
-			cr.health = apiv1.HealthStateTypeUnhealthy
-			cr.reason = fmt.Sprintf("error getting processes (failed continuously for %d checks)", getProcessesErrorConsecutiveThreshold)
-			log.Logger.Warnw(cr.reason, "uuid", uuid, "error", err)
-			return cr
+			log.Logger.Warnw("error getting processes", "uuid", uuid, "error", err)
+			continue
 		}
 
 		cr.Processes = append(cr.Processes, procs)
 
 		metricRunningProcesses.With(prometheus.Labels{"uuid": uuid}).Set(float64(len(procs.RunningProcesses)))
+	}
+
+	if genericErr != nil {
+		cr.err = genericErr
+		consecutive := c.recordGetProcessesError(true)
+		if consecutive < getProcessesErrorConsecutiveThreshold {
+			cr.health = apiv1.HealthStateTypeHealthy
+			cr.reason = fmt.Sprintf(
+				"error getting processes (detected %d/%d consecutive checks)",
+				consecutive,
+				getProcessesErrorConsecutiveThreshold,
+			)
+			log.Logger.Warnw(cr.reason, "uuid", genericErrUUID, "error", genericErr)
+			return cr
+		}
+
+		cr.health = apiv1.HealthStateTypeUnhealthy
+		cr.reason = fmt.Sprintf("error getting processes (failed continuously for %d checks)", getProcessesErrorConsecutiveThreshold)
+		log.Logger.Warnw(cr.reason, "uuid", genericErrUUID, "error", genericErr)
+		return cr
 	}
 
 	c.recordGetProcessesError(false)

--- a/components/accelerator/nvidia/processes/component.go
+++ b/components/accelerator/nvidia/processes/component.go
@@ -212,7 +212,8 @@ func (c *component) Check() components.CheckResult {
 			}
 			log.Logger.Warnw("error getting processes", "uuid", uuid, "error", err)
 			// Keep scanning other GPUs so a transient query error on one GPU does
-			// not hide a later GPU lost/reset error in the same component check.
+			// not hide a later GPU lost/reset error in the same component check;
+			// the consecutive counter is evaluated only after this full scan.
 			continue
 		}
 
@@ -243,6 +244,8 @@ func (c *component) Check() components.CheckResult {
 		return cr
 	}
 
+	// A clean full scan resets the counter, so generic process-query errors must
+	// be uninterrupted across checks before this component becomes unhealthy.
 	c.recordGetProcessesError(false)
 	cr.health = apiv1.HealthStateTypeHealthy
 	cr.reason = fmt.Sprintf("all %d GPU(s) were checked, no process issue found", len(devs))

--- a/components/accelerator/nvidia/processes/component.go
+++ b/components/accelerator/nvidia/processes/component.go
@@ -211,6 +211,8 @@ func (c *component) Check() components.CheckResult {
 				genericErrUUID = uuid
 			}
 			log.Logger.Warnw("error getting processes", "uuid", uuid, "error", err)
+			// Keep scanning other GPUs so a transient query error on one GPU does
+			// not hide a later GPU lost/reset error in the same component check.
 			continue
 		}
 
@@ -221,6 +223,8 @@ func (c *component) Check() components.CheckResult {
 
 	if genericErr != nil {
 		cr.err = genericErr
+		// Count one generic process-query failure per complete component check,
+		// regardless of how many GPUs returned that generic error.
 		consecutive := c.recordGetProcessesError(true)
 		if consecutive < getProcessesErrorConsecutiveThreshold {
 			cr.health = apiv1.HealthStateTypeHealthy

--- a/components/accelerator/nvidia/processes/component.go
+++ b/components/accelerator/nvidia/processes/component.go
@@ -22,8 +22,12 @@ import (
 	"github.com/leptonai/gpud/pkg/nvidia/nvml/device"
 )
 
-// Name is the component name for NVIDIA GPU process monitoring.
-const Name = "accelerator-nvidia-processes"
+const (
+	// Name is the component name for NVIDIA GPU process monitoring.
+	Name = "accelerator-nvidia-processes"
+
+	getProcessesErrorConsecutiveThreshold = 5
+)
 
 var _ components.Component = &component{}
 
@@ -35,6 +39,9 @@ type component struct {
 
 	nvmlInstance     nvidianvml.Instance
 	getProcessesFunc func(uuid string, dev device.Device) (Processes, error)
+
+	getProcessesErrorMu    sync.Mutex
+	getProcessesErrorCount int
 
 	lastMu          sync.RWMutex
 	lastCheckResult *checkResult
@@ -123,11 +130,13 @@ func (c *component) Check() components.CheckResult {
 	}()
 
 	if c.nvmlInstance == nil {
+		c.recordGetProcessesError(false)
 		cr.health = apiv1.HealthStateTypeHealthy
 		cr.reason = "NVIDIA NVML instance is nil"
 		return cr
 	}
 	if !c.nvmlInstance.NVMLExists() {
+		c.recordGetProcessesError(false)
 		cr.health = apiv1.HealthStateTypeHealthy
 		cr.reason = "NVIDIA NVML library is not loaded"
 		return cr
@@ -136,6 +145,7 @@ func (c *component) Check() components.CheckResult {
 	// This handles cases like "error getting device handle for index 'N': Unknown Error"
 	// which corresponds to nvidia-smi showing "Unable to determine the device handle for GPU".
 	if err := c.nvmlInstance.InitError(); err != nil {
+		c.recordGetProcessesError(false)
 		cr.health = apiv1.HealthStateTypeUnhealthy
 		cr.reason = fmt.Sprintf("NVML initialization error: %v", err)
 		cr.suggestedActions = &apiv1.SuggestedActions{
@@ -146,6 +156,7 @@ func (c *component) Check() components.CheckResult {
 		return cr
 	}
 	if c.nvmlInstance.ProductName() == "" {
+		c.recordGetProcessesError(false)
 		cr.health = apiv1.HealthStateTypeHealthy
 		cr.reason = "NVIDIA NVML is loaded but GPU is not detected (missing product name)"
 		return cr
@@ -156,10 +167,10 @@ func (c *component) Check() components.CheckResult {
 		procs, err := c.getProcessesFunc(uuid, dev)
 		if err != nil {
 			cr.err = err
-			cr.health = apiv1.HealthStateTypeUnhealthy
-			cr.reason = "error getting processes"
 
 			if errors.Is(err, nvmlerrors.ErrGPURequiresReset) {
+				c.recordGetProcessesError(false)
+				cr.health = apiv1.HealthStateTypeUnhealthy
 				cr.reason = nvmlerrors.ErrGPURequiresReset.Error()
 				cr.suggestedActions = &apiv1.SuggestedActions{
 					Description: nvmlerrors.ErrGPURequiresReset.Error(),
@@ -167,9 +178,13 @@ func (c *component) Check() components.CheckResult {
 						apiv1.RepairActionTypeRebootSystem,
 					},
 				}
+				log.Logger.Warnw(cr.reason, "uuid", uuid, "error", err)
+				return cr
 			}
 
 			if errors.Is(err, nvmlerrors.ErrGPULost) {
+				c.recordGetProcessesError(false)
+				cr.health = apiv1.HealthStateTypeUnhealthy
 				cr.reason = nvmlerrors.ErrGPULost.Error()
 				cr.suggestedActions = &apiv1.SuggestedActions{
 					Description: nvmlerrors.ErrGPULost.Error(),
@@ -177,9 +192,25 @@ func (c *component) Check() components.CheckResult {
 						apiv1.RepairActionTypeRebootSystem,
 					},
 				}
+				log.Logger.Warnw(cr.reason, "uuid", uuid, "error", err)
+				return cr
 			}
 
-			log.Logger.Warnw(cr.reason, "error", err)
+			consecutive := c.recordGetProcessesError(true)
+			if consecutive < getProcessesErrorConsecutiveThreshold {
+				cr.health = apiv1.HealthStateTypeHealthy
+				cr.reason = fmt.Sprintf(
+					"error getting processes (detected %d/%d consecutive checks)",
+					consecutive,
+					getProcessesErrorConsecutiveThreshold,
+				)
+				log.Logger.Warnw(cr.reason, "uuid", uuid, "error", err)
+				return cr
+			}
+
+			cr.health = apiv1.HealthStateTypeUnhealthy
+			cr.reason = fmt.Sprintf("error getting processes (failed continuously for %d checks)", getProcessesErrorConsecutiveThreshold)
+			log.Logger.Warnw(cr.reason, "uuid", uuid, "error", err)
 			return cr
 		}
 
@@ -188,10 +219,24 @@ func (c *component) Check() components.CheckResult {
 		metricRunningProcesses.With(prometheus.Labels{"uuid": uuid}).Set(float64(len(procs.RunningProcesses)))
 	}
 
+	c.recordGetProcessesError(false)
 	cr.health = apiv1.HealthStateTypeHealthy
 	cr.reason = fmt.Sprintf("all %d GPU(s) were checked, no process issue found", len(devs))
 
 	return cr
+}
+
+func (c *component) recordGetProcessesError(failed bool) int {
+	c.getProcessesErrorMu.Lock()
+	defer c.getProcessesErrorMu.Unlock()
+
+	if !failed {
+		c.getProcessesErrorCount = 0
+		return 0
+	}
+
+	c.getProcessesErrorCount++
+	return c.getProcessesErrorCount
 }
 
 var _ components.CheckResult = &checkResult{}

--- a/components/accelerator/nvidia/processes/component_test.go
+++ b/components/accelerator/nvidia/processes/component_test.go
@@ -3,6 +3,7 @@ package processes
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -279,7 +280,21 @@ func TestCheckError(t *testing.T) {
 		return Processes{}, testErr
 	}
 
-	// Run Check
+	for i := 1; i < getProcessesErrorConsecutiveThreshold; i++ {
+		result := c.Check()
+
+		data, ok := result.(*checkResult)
+		require.True(t, ok)
+		assert.Equal(t, apiv1.HealthStateTypeHealthy, data.health)
+		assert.Equal(t, testErr, data.err)
+		assert.Equal(
+			t,
+			fmt.Sprintf("error getting processes (detected %d/%d consecutive checks)", i, getProcessesErrorConsecutiveThreshold),
+			data.reason,
+		)
+	}
+
+	// Run Check enough times to cross the consecutive failure threshold.
 	result := c.Check()
 
 	// Verify result is correct
@@ -287,6 +302,69 @@ func TestCheckError(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, data.health)
 	assert.Equal(t, testErr, data.err)
+	assert.Equal(
+		t,
+		fmt.Sprintf("error getting processes (failed continuously for %d checks)", getProcessesErrorConsecutiveThreshold),
+		data.reason,
+	)
+}
+
+func TestCheckErrorCounterResetsAfterSuccess(t *testing.T) {
+	ctx := context.Background()
+
+	mockDev1 := createMockDevice("gpu-uuid-1", nil)
+	mockDevices := map[string]device.Device{
+		"gpu-uuid-1": mockDev1,
+	}
+	mockInstance := &mockNVMLInstance{
+		nvmlExists: true,
+		devicesFunc: func() map[string]device.Device {
+			return mockDevices
+		},
+	}
+
+	gpudInstance := &components.GPUdInstance{
+		RootCtx:      ctx,
+		NVMLInstance: mockInstance,
+	}
+
+	comp, err := New(gpudInstance)
+	assert.NoError(t, err)
+
+	c := mustComponent(t, comp)
+
+	testErr := errors.New("test error")
+	shouldFail := true
+	c.getProcessesFunc = func(uuid string, _ device.Device) (Processes, error) {
+		if shouldFail {
+			return Processes{}, testErr
+		}
+		return Processes{UUID: uuid}, nil
+	}
+
+	for i := 1; i <= 2; i++ {
+		data := c.Check().(*checkResult)
+		assert.Equal(t, apiv1.HealthStateTypeHealthy, data.health)
+		assert.Equal(
+			t,
+			fmt.Sprintf("error getting processes (detected %d/%d consecutive checks)", i, getProcessesErrorConsecutiveThreshold),
+			data.reason,
+		)
+	}
+
+	shouldFail = false
+	data := c.Check().(*checkResult)
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, data.health)
+	assert.Equal(t, "all 1 GPU(s) were checked, no process issue found", data.reason)
+
+	shouldFail = true
+	data = c.Check().(*checkResult)
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, data.health)
+	assert.Equal(
+		t,
+		fmt.Sprintf("error getting processes (detected 1/%d consecutive checks)", getProcessesErrorConsecutiveThreshold),
+		data.reason,
+	)
 }
 
 func TestLastHealthStates(t *testing.T) {

--- a/components/accelerator/nvidia/processes/component_test.go
+++ b/components/accelerator/nvidia/processes/component_test.go
@@ -367,6 +367,57 @@ func TestCheckErrorCounterResetsAfterSuccess(t *testing.T) {
 	)
 }
 
+func TestCheckGenericProcessErrorDoesNotMaskLaterCriticalError(t *testing.T) {
+	ctx := context.Background()
+
+	mockDev1 := createMockDevice("gpu-uuid-1", nil)
+	mockDev2 := createMockDevice("gpu-uuid-2", nil)
+	mockDevices := map[string]device.Device{
+		"gpu-uuid-1": mockDev1,
+		"gpu-uuid-2": mockDev2,
+	}
+	mockInstance := &mockNVMLInstance{
+		nvmlExists: true,
+		devicesFunc: func() map[string]device.Device {
+			return mockDevices
+		},
+	}
+
+	gpudInstance := &components.GPUdInstance{
+		RootCtx:      ctx,
+		NVMLInstance: mockInstance,
+	}
+
+	comp, err := New(gpudInstance)
+	require.NoError(t, err)
+
+	c := mustComponent(t, comp)
+
+	testErr := errors.New("transient process query error")
+	var checkedUUIDs []string
+	c.getProcessesFunc = func(uuid string, _ device.Device) (Processes, error) {
+		checkedUUIDs = append(checkedUUIDs, uuid)
+		switch uuid {
+		case "gpu-uuid-1":
+			return Processes{}, testErr
+		case "gpu-uuid-2":
+			return Processes{}, nvmlerrors.ErrGPULost
+		default:
+			require.Failf(t, "unexpected GPU UUID", "uuid=%s", uuid)
+			return Processes{}, nil
+		}
+	}
+
+	result := c.Check()
+
+	data, ok := result.(*checkResult)
+	require.True(t, ok)
+	assert.Equal(t, []string{"gpu-uuid-1", "gpu-uuid-2"}, checkedUUIDs)
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, data.health)
+	assert.True(t, errors.Is(data.err, nvmlerrors.ErrGPULost), "error should be nvmlerrors.ErrGPULost")
+	assert.Equal(t, nvmlerrors.ErrGPULost.Error(), data.reason)
+}
+
 func TestLastHealthStates(t *testing.T) {
 	ctx := context.Background()
 	mockInstance := &mockNVMLInstance{nvmlExists: true}

--- a/pkg/process/utils_test.go
+++ b/pkg/process/utils_test.go
@@ -90,12 +90,23 @@ func newTestProcess(command string, args ...string) (*testProcess, error) {
 		return nil, err
 	}
 
+	return p, nil
+}
+
+func waitForTestProcess(t *testing.T, p *testProcess) {
+	t.Helper()
+
 	go func() {
-		waitCh <- cmd.Wait()
-		close(waitCh)
+		p.waitCh <- p.cmd.Wait()
+		close(p.waitCh)
 	}()
 
-	return p, nil
+	select {
+	case err := <-p.Wait():
+		require.NoError(t, err)
+	case <-time.After(1 * time.Second):
+		require.FailNow(t, "timeout waiting for command")
+	}
 }
 
 func TestReadAll(t *testing.T) {
@@ -138,6 +149,8 @@ func TestReadAll(t *testing.T) {
 	t.Run("basic echo command", func(t *testing.T) {
 		p, err := newTestProcess("echo", "hello world")
 		require.NoError(t, err)
+		defer waitForTestProcess(t, p)
+
 		output := ""
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)


### PR DESCRIPTION
> accelerator-nvidia-processes/accelerator-nvidia-processes unhealthy: error getting processes

can be transient. Thus requires 5 consecutive failure.