### PR TITLE
fix(containerd): skip dangling-pod check when kubelet read-only port …

### DIFF
--- a/components/containerd/component.go
+++ b/components/containerd/component.go
@@ -18,6 +18,7 @@ import (
 	"github.com/leptonai/gpud/components"
 	componentkubelet "github.com/leptonai/gpud/components/kubelet"
 	"github.com/leptonai/gpud/pkg/log"
+	"github.com/leptonai/gpud/pkg/netutil"
 	nvidianvml "github.com/leptonai/gpud/pkg/nvidia/nvml"
 	"github.com/leptonai/gpud/pkg/systemd"
 )
@@ -299,13 +300,16 @@ func (c *component) Check() components.CheckResult {
 		}
 
 		var danglingCount int
-		cctx, ccancel = context.WithTimeout(c.ctx, 30*time.Second)
-		_, kubeletPods, err := componentkubelet.ListPodsFromKubeletReadOnlyPort(cctx, componentkubelet.DefaultKubeletReadOnlyPort)
-		ccancel()
-		if err != nil {
-			log.Logger.Errorf("error listing pods from kubelet: %v", err)
-		} else {
-			danglingCount = danglingPodCount(cr.Pods, kubeletPods)
+		// skip dangling-pod check if kubelet read-only port is closed
+		if netutil.IsPortOpen(componentkubelet.DefaultKubeletReadOnlyPort) {
+			cctx, ccancel = context.WithTimeout(c.ctx, 30*time.Second)
+			_, kubeletPods, err := componentkubelet.ListPodsFromKubeletReadOnlyPort(cctx, componentkubelet.DefaultKubeletReadOnlyPort)
+			ccancel()
+			if err != nil {
+				log.Logger.Errorf("error listing pods from kubelet: %v", err)
+			} else {
+				danglingCount = danglingPodCount(cr.Pods, kubeletPods)
+			}
 		}
 		switch {
 		case danglingCount > DanglingUnhealthyThreshold:


### PR DESCRIPTION
…is closed

The containerd component unconditionally calls
ListPodsFromKubeletReadOnlyPort against http://localhost:10255 to cross-check sandboxes against kubelet's pod list, producing a recurring connection-refused error log on every node where the kubelet readOnlyPort is disabled (the kubeadm/CIS-hardened default).

Gate the call on netutil.IsPortOpen, matching the pattern the kubelet component already uses (components/kubelet/component.go). When the port is closed the dangling-pod check is skipped (danglingCount stays 0) and the rest of the containerd checks proceed normally.

Example of error:

```May 07 11:58:00 cluster-node-2 gpud[3478]: {"level":"error","ts":"2026-05-07T11:58:00.933Z","caller":"log/log.go:183","msg":"error listing pods from kubelet: Get \"http://localhost:10255/pods\": dial tcp [::1]:10255: connect: connection refused","stacktrace":"github.com/leptonai/gpud/pkg/log.(*gpudLogger).Errorf\n\t/home/runner/work/gpud/gpud/pkg/log/log.go:183\ngithub.com/leptonai/gpud/components/containerd.(*component).Check\n\t/home/runner/work/gpud/gpud/components/containerd/component.go:306\ngithub.com/leptonai/gpud/components/containerd.(*component).Start.func1\n\t/home/runner/work/gpud/gpud/components/containerd/component.go:135"}
May 07 11:59:00 eden1-2 gpud[3478]: {"level":"error","ts":"2026-05-07T11:59:00.935Z","caller":"log/log.go:183","msg":"error listing pods from kubelet: Get \"http://localhost:10255/pods\": dial tcp [::1]:10255: connect: connection refused","stacktrace":"github.com/leptonai/gpud/pkg/log.(*gpudLogger).Errorf\n\t/home/runner/work/gpud/gpud/pkg/log/log.go:183\ngithub.com/leptonai/gpud/components/containerd.(*component).Check\n\t/home/runner/work/gpud/gpud/components/contai
```

With

```
$ gpud --version
gpud version v0.11.4
```

draft reason:

- [ ] And as I'm writing this I haven't tried a binary built with this PR to see that it behaves differently.