### PR TITLE
feat(xid/sxid): allow custom reboot thresholds

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -253,6 +253,14 @@ sudo rm /etc/systemd/system/gpud.service
 					Usage: fmt.Sprintf("set the allowed reboot attempts for XID errors before escalation (defaults to %d)", componentsxid.DefaultRebootThreshold),
 					Value: componentsxid.DefaultRebootThreshold,
 				},
+				&cli.StringFlag{
+					Name:  "xid-reboot-thresholds",
+					Usage: `set per-XID reboot thresholds in JSON, e.g. '{"94":{"rebootThreshold":1000}}'`,
+				},
+				&cli.StringFlag{
+					Name:  "sxid-reboot-thresholds",
+					Usage: `set per-SXID reboot thresholds in JSON, e.g. '{"11004":{"rebootThreshold":7}}'`,
+				},
 				&cli.DurationFlag{
 					Name:  "xid-lookback-period",
 					Usage: "set the lookback period for XID errors",

--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -255,11 +255,11 @@ sudo rm /etc/systemd/system/gpud.service
 				},
 				&cli.StringFlag{
 					Name:  "xid-thresholds",
-					Usage: `set per-XID thresholds in JSON, e.g. '{"94":{"rebootThreshold":1000}}'`,
+					Usage: `set per-XID thresholds in JSON, e.g. '{"overrides":{"94":{"rebootThreshold":1000}}}'`,
 				},
 				&cli.StringFlag{
 					Name:  "sxid-thresholds",
-					Usage: `set per-SXID thresholds in JSON, e.g. '{"11004":{"rebootThreshold":7}}'`,
+					Usage: `set per-SXID thresholds in JSON, e.g. '{"overrides":{"11004":{"rebootThreshold":7}}}'`,
 				},
 				&cli.DurationFlag{
 					Name:  "xid-lookback-period",

--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -254,12 +254,12 @@ sudo rm /etc/systemd/system/gpud.service
 					Value: componentsxid.DefaultRebootThreshold,
 				},
 				&cli.StringFlag{
-					Name:  "xid-reboot-thresholds",
-					Usage: `set per-XID reboot thresholds in JSON, e.g. '{"94":{"rebootThreshold":1000}}'`,
+					Name:  "xid-thresholds",
+					Usage: `set per-XID thresholds in JSON, e.g. '{"94":{"rebootThreshold":1000}}'`,
 				},
 				&cli.StringFlag{
-					Name:  "sxid-reboot-thresholds",
-					Usage: `set per-SXID reboot thresholds in JSON, e.g. '{"11004":{"rebootThreshold":7}}'`,
+					Name:  "sxid-thresholds",
+					Usage: `set per-SXID thresholds in JSON, e.g. '{"11004":{"rebootThreshold":7}}'`,
 				},
 				&cli.DurationFlag{
 					Name:  "xid-lookback-period",

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -142,8 +142,8 @@ func Command(cliContext *cli.Context) error {
 	nvlinkExpectedLinkStates := cliContext.String("nvlink-expected-link-states")
 	nfsCheckerConfigs := cliContext.String("nfs-checker-configs")
 	xidRebootThreshold := cliContext.Int("xid-reboot-threshold")
-	xidRebootThresholds := cliContext.String("xid-reboot-thresholds")
-	sxidRebootThresholds := cliContext.String("sxid-reboot-thresholds")
+	xidThresholds := cliContext.String("xid-thresholds")
+	sxidThresholds := cliContext.String("sxid-thresholds")
 	temperatureMarginThresholdCelsius := cliContext.Int("threshold-celsius-slowdown-margin")
 
 	if len(infinibandExpectedPortStates) > 0 {
@@ -176,43 +176,43 @@ func Command(cliContext *cli.Context) error {
 		log.Logger.Infow("set nfs checker group configs", "groupConfigs", groupConfigs)
 	}
 
-	xidRebootThresholdConfig := componentsxid.GetDefaultRebootThreshold()
-	xidRebootThresholdChanged := false
+	xidThresholdConfig := componentsxid.GetDefaultRebootThreshold()
+	xidThresholdsChanged := false
 	if cliContext.IsSet("xid-reboot-threshold") {
 		if xidRebootThreshold > 0 {
-			xidRebootThresholdConfig.Threshold = xidRebootThreshold
-			xidRebootThresholdChanged = true
+			xidThresholdConfig.Threshold = xidRebootThreshold
+			xidThresholdsChanged = true
 		} else {
 			log.Logger.Warnw("ignoring xid reboot threshold override, value must be positive", "xidRebootThreshold", xidRebootThreshold)
 		}
 	}
-	if strings.TrimSpace(xidRebootThresholds) != "" {
-		overrides, err := parseXIDRebootThresholds(xidRebootThresholds)
+	if strings.TrimSpace(xidThresholds) != "" {
+		overrides, err := parseXIDThresholds(xidThresholds)
 		if err != nil {
 			return err
 		}
-		xidRebootThresholdConfig.ThresholdOverrides = overrides
-		xidRebootThresholdChanged = true
+		xidThresholdConfig.ThresholdOverrides = overrides
+		xidThresholdsChanged = true
 	}
-	if xidRebootThresholdChanged {
-		componentsxid.SetDefaultRebootThreshold(xidRebootThresholdConfig)
-		xidRebootThresholdConfig = componentsxid.GetDefaultRebootThreshold()
+	if xidThresholdsChanged {
+		componentsxid.SetDefaultRebootThreshold(xidThresholdConfig)
+		xidThresholdConfig = componentsxid.GetDefaultRebootThreshold()
 		log.Logger.Infow(
-			"set xid reboot thresholds",
-			"xidRebootThreshold",
-			xidRebootThresholdConfig.Threshold,
-			"xidRebootThresholdOverrides",
-			xidRebootThresholdConfig.ThresholdOverrides,
+			"set xid thresholds",
+			"xidDefaultRebootThreshold",
+			xidThresholdConfig.Threshold,
+			"xidThresholdOverrides",
+			xidThresholdConfig.ThresholdOverrides,
 		)
 	}
 
-	if strings.TrimSpace(sxidRebootThresholds) != "" {
-		overrides, err := parseSXIDRebootThresholds(sxidRebootThresholds)
+	if strings.TrimSpace(sxidThresholds) != "" {
+		overrides, err := parseSXIDThresholds(sxidThresholds)
 		if err != nil {
 			return err
 		}
-		componentssxid.SetDefaultRebootThresholdOverrides(overrides)
-		log.Logger.Infow("set sxid reboot thresholds", "sxidRebootThresholdOverrides", overrides)
+		componentssxid.SetDefaultThresholdOverrides(overrides)
+		log.Logger.Infow("set sxid thresholds", "sxidThresholdOverrides", overrides)
 	}
 
 	if eventsRetentionPeriod > 0 && !cliContext.IsSet("xid-lookback-period") {
@@ -468,47 +468,47 @@ func parseRetentionPeriods(cliContext *cli.Context) (metricsRetentionPeriod, eve
 	return metricsRetentionPeriod, eventsRetentionPeriod
 }
 
-type rebootThresholdOverrideJSON struct {
+type thresholdOverrideJSON struct {
 	RebootThreshold int `json:"rebootThreshold"`
 }
 
-func parseXIDRebootThresholds(raw string) (map[int]componentsxid.RebootThresholdOverride, error) {
-	thresholds, err := parseRebootThresholds(raw, "xid reboot thresholds")
+func parseXIDThresholds(raw string) (map[int]componentsxid.ThresholdOverride, error) {
+	thresholds, err := parseThresholds(raw, "xid thresholds")
 	if err != nil {
 		return nil, err
 	}
 
-	ret := make(map[int]componentsxid.RebootThresholdOverride, len(thresholds))
+	ret := make(map[int]componentsxid.ThresholdOverride, len(thresholds))
 	for xid, threshold := range thresholds {
-		ret[xid] = componentsxid.RebootThresholdOverride{
+		ret[xid] = componentsxid.ThresholdOverride{
 			RebootThreshold: threshold.RebootThreshold,
 		}
 	}
 	return ret, nil
 }
 
-func parseSXIDRebootThresholds(raw string) (map[int]componentssxid.RebootThresholdOverride, error) {
-	thresholds, err := parseRebootThresholds(raw, "sxid reboot thresholds")
+func parseSXIDThresholds(raw string) (map[int]componentssxid.ThresholdOverride, error) {
+	thresholds, err := parseThresholds(raw, "sxid thresholds")
 	if err != nil {
 		return nil, err
 	}
 
-	ret := make(map[int]componentssxid.RebootThresholdOverride, len(thresholds))
+	ret := make(map[int]componentssxid.ThresholdOverride, len(thresholds))
 	for sxid, threshold := range thresholds {
-		ret[sxid] = componentssxid.RebootThresholdOverride{
+		ret[sxid] = componentssxid.ThresholdOverride{
 			RebootThreshold: threshold.RebootThreshold,
 		}
 	}
 	return ret, nil
 }
 
-func parseRebootThresholds(raw string, name string) (map[int]rebootThresholdOverrideJSON, error) {
+func parseThresholds(raw string, name string) (map[int]thresholdOverrideJSON, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return nil, nil
 	}
 
-	var thresholds map[int]rebootThresholdOverrideJSON
+	var thresholds map[int]thresholdOverrideJSON
 	if err := json.Unmarshal([]byte(raw), &thresholds); err != nil {
 		return nil, fmt.Errorf("invalid %s: %w", name, err)
 	}

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -186,13 +186,11 @@ func Command(cliContext *cli.Context) error {
 		}
 	}
 	if strings.TrimSpace(xidThresholds) != "" {
-		xidThresholdConfig := componentsxid.GetDefaultThresholds()
-		overrides, err := parseXIDThresholds(xidThresholds)
+		thresholds, err := parseXIDThresholds(xidThresholds)
 		if err != nil {
 			return err
 		}
-		xidThresholdConfig.ThresholdOverrides = overrides
-		componentsxid.SetDefaultThresholds(xidThresholdConfig)
+		componentsxid.SetDefaultThresholds(thresholds)
 		xidThresholdsChanged = true
 	}
 	if xidThresholdsChanged {
@@ -207,12 +205,12 @@ func Command(cliContext *cli.Context) error {
 	}
 
 	if strings.TrimSpace(sxidThresholds) != "" {
-		overrides, err := parseSXIDThresholds(sxidThresholds)
+		thresholds, err := parseSXIDThresholds(sxidThresholds)
 		if err != nil {
 			return err
 		}
-		componentssxid.SetDefaultThresholdOverrides(overrides)
-		log.Logger.Infow("set sxid thresholds", "sxidThresholdOverrides", overrides)
+		componentssxid.SetDefaultThresholds(thresholds)
+		log.Logger.Infow("set sxid thresholds", "sxidThresholdOverrides", thresholds.ThresholdOverrides)
 	}
 
 	if eventsRetentionPeriod > 0 && !cliContext.IsSet("xid-lookback-period") {
@@ -472,10 +470,10 @@ type thresholdOverrideJSON struct {
 	RebootThreshold int `json:"rebootThreshold"`
 }
 
-func parseXIDThresholds(raw string) (map[int]componentsxid.ThresholdOverride, error) {
+func parseXIDThresholds(raw string) (componentsxid.Thresholds, error) {
 	thresholds, err := parseThresholds(raw, "xid thresholds")
 	if err != nil {
-		return nil, err
+		return componentsxid.Thresholds{}, err
 	}
 
 	ret := make(map[int]componentsxid.ThresholdOverride, len(thresholds))
@@ -484,13 +482,13 @@ func parseXIDThresholds(raw string) (map[int]componentsxid.ThresholdOverride, er
 			RebootThreshold: threshold.RebootThreshold,
 		}
 	}
-	return ret, nil
+	return componentsxid.Thresholds{ThresholdOverrides: ret}, nil
 }
 
-func parseSXIDThresholds(raw string) (map[int]componentssxid.ThresholdOverride, error) {
+func parseSXIDThresholds(raw string) (componentssxid.Thresholds, error) {
 	thresholds, err := parseThresholds(raw, "sxid thresholds")
 	if err != nil {
-		return nil, err
+		return componentssxid.Thresholds{}, err
 	}
 
 	ret := make(map[int]componentssxid.ThresholdOverride, len(thresholds))
@@ -499,7 +497,7 @@ func parseSXIDThresholds(raw string) (map[int]componentssxid.ThresholdOverride, 
 			RebootThreshold: threshold.RebootThreshold,
 		}
 	}
-	return ret, nil
+	return componentssxid.Thresholds{ThresholdOverrides: ret}, nil
 }
 
 func parseThresholds(raw string, name string) (map[int]thresholdOverrideJSON, error) {

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -176,7 +176,7 @@ func Command(cliContext *cli.Context) error {
 		log.Logger.Infow("set nfs checker group configs", "groupConfigs", groupConfigs)
 	}
 
-	xidThresholdConfig := componentsxid.GetDefaultRebootThreshold()
+	xidThresholdConfig := componentsxid.GetDefaultThresholds()
 	xidThresholdsChanged := false
 	if cliContext.IsSet("xid-reboot-threshold") {
 		if xidRebootThreshold > 0 {
@@ -195,8 +195,8 @@ func Command(cliContext *cli.Context) error {
 		xidThresholdsChanged = true
 	}
 	if xidThresholdsChanged {
-		componentsxid.SetDefaultRebootThreshold(xidThresholdConfig)
-		xidThresholdConfig = componentsxid.GetDefaultRebootThreshold()
+		componentsxid.SetDefaultThresholds(xidThresholdConfig)
+		xidThresholdConfig = componentsxid.GetDefaultThresholds()
 		log.Logger.Infow(
 			"set xid thresholds",
 			"xidDefaultRebootThreshold",

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -199,8 +199,8 @@ func Command(cliContext *cli.Context) error {
 			"set xid thresholds",
 			"xidDefaultRebootThreshold",
 			componentsxid.GetDefaultRebootThreshold(),
-			"xidThresholdOverrides",
-			xidThresholdConfig.ThresholdOverrides,
+			"xidOverrides",
+			xidThresholdConfig.Overrides,
 		)
 	}
 
@@ -210,7 +210,7 @@ func Command(cliContext *cli.Context) error {
 			return err
 		}
 		componentssxid.SetDefaultThresholds(thresholds)
-		log.Logger.Infow("set sxid thresholds", "sxidThresholdOverrides", thresholds.ThresholdOverrides)
+		log.Logger.Infow("set sxid thresholds", "sxidOverrides", thresholds.Overrides)
 	}
 
 	if eventsRetentionPeriod > 0 && !cliContext.IsSet("xid-lookback-period") {
@@ -470,6 +470,10 @@ type thresholdOverrideJSON struct {
 	RebootThreshold int `json:"rebootThreshold"`
 }
 
+type thresholdsJSON struct {
+	Overrides map[int]thresholdOverrideJSON `json:"overrides"`
+}
+
 func parseXIDThresholds(raw string) (componentsxid.Thresholds, error) {
 	thresholds, err := parseThresholds(raw, "xid thresholds")
 	if err != nil {
@@ -482,7 +486,7 @@ func parseXIDThresholds(raw string) (componentsxid.Thresholds, error) {
 			RebootThreshold: threshold.RebootThreshold,
 		}
 	}
-	return componentsxid.Thresholds{ThresholdOverrides: ret}, nil
+	return componentsxid.Thresholds{Overrides: ret}, nil
 }
 
 func parseSXIDThresholds(raw string) (componentssxid.Thresholds, error) {
@@ -497,7 +501,7 @@ func parseSXIDThresholds(raw string) (componentssxid.Thresholds, error) {
 			RebootThreshold: threshold.RebootThreshold,
 		}
 	}
-	return componentssxid.Thresholds{ThresholdOverrides: ret}, nil
+	return componentssxid.Thresholds{Overrides: ret}, nil
 }
 
 func parseThresholds(raw string, name string) (map[int]thresholdOverrideJSON, error) {
@@ -506,15 +510,25 @@ func parseThresholds(raw string, name string) (map[int]thresholdOverrideJSON, er
 		return nil, nil
 	}
 
-	var thresholds map[int]thresholdOverrideJSON
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &fields); err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", name, err)
+	}
+	if fields == nil {
+		return nil, fmt.Errorf("invalid %s: expected JSON object", name)
+	}
+	for field := range fields {
+		if field != "overrides" {
+			return nil, fmt.Errorf("invalid %s: unknown field %q", name, field)
+		}
+	}
+
+	var thresholds thresholdsJSON
 	if err := json.Unmarshal([]byte(raw), &thresholds); err != nil {
 		return nil, fmt.Errorf("invalid %s: %w", name, err)
 	}
-	if thresholds == nil {
-		return nil, fmt.Errorf("invalid %s: expected JSON object", name)
-	}
 
-	for id, threshold := range thresholds {
+	for id, threshold := range thresholds.Overrides {
 		if id < 0 {
 			return nil, fmt.Errorf("invalid %s for %d: event ID must be non-negative", name, id)
 		}
@@ -522,7 +536,7 @@ func parseThresholds(raw string, name string) (map[int]thresholdOverrideJSON, er
 			return nil, fmt.Errorf("invalid %s for %d: rebootThreshold must be positive", name, id)
 		}
 	}
-	return thresholds, nil
+	return thresholds.Overrides, nil
 }
 
 func parseInfinibandExcludeDevices(s string) []string {

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -176,31 +176,31 @@ func Command(cliContext *cli.Context) error {
 		log.Logger.Infow("set nfs checker group configs", "groupConfigs", groupConfigs)
 	}
 
-	xidThresholdConfig := componentsxid.GetDefaultThresholds()
 	xidThresholdsChanged := false
 	if cliContext.IsSet("xid-reboot-threshold") {
 		if xidRebootThreshold > 0 {
-			xidThresholdConfig.Threshold = xidRebootThreshold
+			componentsxid.SetDefaultRebootThreshold(xidRebootThreshold)
 			xidThresholdsChanged = true
 		} else {
 			log.Logger.Warnw("ignoring xid reboot threshold override, value must be positive", "xidRebootThreshold", xidRebootThreshold)
 		}
 	}
 	if strings.TrimSpace(xidThresholds) != "" {
+		xidThresholdConfig := componentsxid.GetDefaultThresholds()
 		overrides, err := parseXIDThresholds(xidThresholds)
 		if err != nil {
 			return err
 		}
 		xidThresholdConfig.ThresholdOverrides = overrides
+		componentsxid.SetDefaultThresholds(xidThresholdConfig)
 		xidThresholdsChanged = true
 	}
 	if xidThresholdsChanged {
-		componentsxid.SetDefaultThresholds(xidThresholdConfig)
-		xidThresholdConfig = componentsxid.GetDefaultThresholds()
+		xidThresholdConfig := componentsxid.GetDefaultThresholds()
 		log.Logger.Infow(
 			"set xid thresholds",
 			"xidDefaultRebootThreshold",
-			xidThresholdConfig.Threshold,
+			componentsxid.GetDefaultRebootThreshold(),
 			"xidThresholdOverrides",
 			xidThresholdConfig.ThresholdOverrides,
 		)

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -142,6 +142,8 @@ func Command(cliContext *cli.Context) error {
 	nvlinkExpectedLinkStates := cliContext.String("nvlink-expected-link-states")
 	nfsCheckerConfigs := cliContext.String("nfs-checker-configs")
 	xidRebootThreshold := cliContext.Int("xid-reboot-threshold")
+	xidRebootThresholds := cliContext.String("xid-reboot-thresholds")
+	sxidRebootThresholds := cliContext.String("sxid-reboot-thresholds")
 	temperatureMarginThresholdCelsius := cliContext.Int("threshold-celsius-slowdown-margin")
 
 	if len(infinibandExpectedPortStates) > 0 {
@@ -174,15 +176,43 @@ func Command(cliContext *cli.Context) error {
 		log.Logger.Infow("set nfs checker group configs", "groupConfigs", groupConfigs)
 	}
 
+	xidRebootThresholdConfig := componentsxid.GetDefaultRebootThreshold()
+	xidRebootThresholdChanged := false
 	if cliContext.IsSet("xid-reboot-threshold") {
 		if xidRebootThreshold > 0 {
-			componentsxid.SetDefaultRebootThreshold(componentsxid.RebootThreshold{
-				Threshold: xidRebootThreshold,
-			})
-			log.Logger.Infow("set xid reboot threshold", "xidRebootThreshold", xidRebootThreshold)
+			xidRebootThresholdConfig.Threshold = xidRebootThreshold
+			xidRebootThresholdChanged = true
 		} else {
 			log.Logger.Warnw("ignoring xid reboot threshold override, value must be positive", "xidRebootThreshold", xidRebootThreshold)
 		}
+	}
+	if strings.TrimSpace(xidRebootThresholds) != "" {
+		overrides, err := parseXIDRebootThresholds(xidRebootThresholds)
+		if err != nil {
+			return err
+		}
+		xidRebootThresholdConfig.ThresholdOverrides = overrides
+		xidRebootThresholdChanged = true
+	}
+	if xidRebootThresholdChanged {
+		componentsxid.SetDefaultRebootThreshold(xidRebootThresholdConfig)
+		xidRebootThresholdConfig = componentsxid.GetDefaultRebootThreshold()
+		log.Logger.Infow(
+			"set xid reboot thresholds",
+			"xidRebootThreshold",
+			xidRebootThresholdConfig.Threshold,
+			"xidRebootThresholdOverrides",
+			xidRebootThresholdConfig.ThresholdOverrides,
+		)
+	}
+
+	if strings.TrimSpace(sxidRebootThresholds) != "" {
+		overrides, err := parseSXIDRebootThresholds(sxidRebootThresholds)
+		if err != nil {
+			return err
+		}
+		componentssxid.SetDefaultRebootThresholdOverrides(overrides)
+		log.Logger.Infow("set sxid reboot thresholds", "sxidRebootThresholdOverrides", overrides)
 	}
 
 	if eventsRetentionPeriod > 0 && !cliContext.IsSet("xid-lookback-period") {
@@ -436,6 +466,65 @@ func parseRetentionPeriods(cliContext *cli.Context) (metricsRetentionPeriod, eve
 	}
 
 	return metricsRetentionPeriod, eventsRetentionPeriod
+}
+
+type rebootThresholdOverrideJSON struct {
+	RebootThreshold int `json:"rebootThreshold"`
+}
+
+func parseXIDRebootThresholds(raw string) (map[int]componentsxid.RebootThresholdOverride, error) {
+	thresholds, err := parseRebootThresholds(raw, "xid reboot thresholds")
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make(map[int]componentsxid.RebootThresholdOverride, len(thresholds))
+	for xid, threshold := range thresholds {
+		ret[xid] = componentsxid.RebootThresholdOverride{
+			RebootThreshold: threshold.RebootThreshold,
+		}
+	}
+	return ret, nil
+}
+
+func parseSXIDRebootThresholds(raw string) (map[int]componentssxid.RebootThresholdOverride, error) {
+	thresholds, err := parseRebootThresholds(raw, "sxid reboot thresholds")
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make(map[int]componentssxid.RebootThresholdOverride, len(thresholds))
+	for sxid, threshold := range thresholds {
+		ret[sxid] = componentssxid.RebootThresholdOverride{
+			RebootThreshold: threshold.RebootThreshold,
+		}
+	}
+	return ret, nil
+}
+
+func parseRebootThresholds(raw string, name string) (map[int]rebootThresholdOverrideJSON, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	var thresholds map[int]rebootThresholdOverrideJSON
+	if err := json.Unmarshal([]byte(raw), &thresholds); err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", name, err)
+	}
+	if thresholds == nil {
+		return nil, fmt.Errorf("invalid %s: expected JSON object", name)
+	}
+
+	for id, threshold := range thresholds {
+		if id < 0 {
+			return nil, fmt.Errorf("invalid %s for %d: event ID must be non-negative", name, id)
+		}
+		if threshold.RebootThreshold <= 0 {
+			return nil, fmt.Errorf("invalid %s for %d: rebootThreshold must be positive", name, id)
+		}
+	}
+	return thresholds, nil
 }
 
 func parseInfinibandExcludeDevices(s string) []string {

--- a/cmd/gpud/run/mock_command_exec_test.go
+++ b/cmd/gpud/run/mock_command_exec_test.go
@@ -293,8 +293,8 @@ func TestCommand_SetThresholds(t *testing.T) {
 		stringFlags: map[string]string{
 			"log-level":       "info",
 			"data-dir":        tmpDir,
-			"xid-thresholds":  `{"94":{"rebootThreshold":2000},"95":{"rebootThreshold":3}}`,
-			"sxid-thresholds": `{"11004":{"rebootThreshold":7}}`,
+			"xid-thresholds":  `{"overrides":{"94":{"rebootThreshold":2000},"95":{"rebootThreshold":3}}}`,
+			"sxid-thresholds": `{"overrides":{"11004":{"rebootThreshold":7}}}`,
 		},
 		intFlags: map[string]int{
 			"xid-reboot-threshold": 6,
@@ -325,11 +325,11 @@ func TestCommand_SetThresholds(t *testing.T) {
 
 		xidThresholdConfig := componentsxid.GetDefaultThresholds()
 		assert.Equal(t, 6, componentsxid.GetDefaultRebootThreshold())
-		assert.Equal(t, 2000, xidThresholdConfig.ThresholdOverrides[94].RebootThreshold)
-		assert.Equal(t, 3, xidThresholdConfig.ThresholdOverrides[95].RebootThreshold)
+		assert.Equal(t, 2000, xidThresholdConfig.Overrides[94].RebootThreshold)
+		assert.Equal(t, 3, xidThresholdConfig.Overrides[95].RebootThreshold)
 
 		sxidThresholds := componentssxid.GetDefaultThresholds()
-		assert.Equal(t, 7, sxidThresholds.ThresholdOverrides[11004].RebootThreshold)
+		assert.Equal(t, 7, sxidThresholds.Overrides[11004].RebootThreshold)
 	})
 }
 

--- a/cmd/gpud/run/mock_command_exec_test.go
+++ b/cmd/gpud/run/mock_command_exec_test.go
@@ -63,6 +63,8 @@ func newTestCLIContext(t *testing.T, values cliFlagValues) *cli.Context {
 	set.String("nvlink-expected-link-states", "", "")
 	set.String("nfs-checker-configs", "", "")
 	set.Int("xid-reboot-threshold", 0, "")
+	set.String("xid-reboot-thresholds", "", "")
+	set.String("sxid-reboot-thresholds", "", "")
 	set.Duration("xid-lookback-period", 0, "")
 	set.Duration("sxid-lookback-period", 0, "")
 	set.Int("threshold-celsius-slowdown-margin", 0, "")
@@ -272,6 +274,60 @@ func TestCommand_SetLookbackPeriods(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, newXidLookback, componentsxid.GetLookbackPeriod())
 		assert.Equal(t, newSxidLookback, componentssxid.GetLookbackPeriod())
+	})
+}
+
+func TestCommand_SetRebootThresholds(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	originalXidRebootThreshold := componentsxid.GetDefaultRebootThreshold()
+	originalSxidRebootThresholds := componentssxid.GetDefaultRebootThresholdOverrides()
+	t.Cleanup(func() {
+		componentsxid.SetDefaultRebootThreshold(originalXidRebootThreshold)
+		componentssxid.SetDefaultRebootThresholdOverrides(originalSxidRebootThresholds)
+	})
+
+	ctx := newTestCLIContext(t, cliFlagValues{
+		stringFlags: map[string]string{
+			"log-level":              "info",
+			"data-dir":               tmpDir,
+			"xid-reboot-thresholds":  `{"94":{"rebootThreshold":2000},"95":{"rebootThreshold":3}}`,
+			"sxid-reboot-thresholds": `{"11004":{"rebootThreshold":7}}`,
+		},
+		intFlags: map[string]int{
+			"xid-reboot-threshold": 6,
+		},
+	})
+
+	mockey.PatchConvey("Command sets xid and sxid reboot thresholds", t, func() {
+		mockey.Mock(gpudmanager.New).To(func(dataDir string) (*gpudmanager.Manager, error) {
+			return &gpudmanager.Manager{}, nil
+		}).Build()
+		mockey.Mock((*gpudmanager.Manager).Start).To(func(_ *gpudmanager.Manager, _ context.Context) error {
+			return nil
+		}).Build()
+		mockey.Mock(gpudserver.New).To(func(_ context.Context, _ log.AuditLogger, _ *config.Config, _ *gpudmanager.Manager) (*gpudserver.Server, error) {
+			return &gpudserver.Server{}, nil
+		}).Build()
+		mockey.Mock(gpudserver.HandleSignals).To(func(_ context.Context, _ context.CancelFunc, _ chan os.Signal, _ chan gpudserver.ServerStopper, _ func(context.Context) error) chan struct{} {
+			done := make(chan struct{})
+			close(done)
+			return done
+		}).Build()
+		mockey.Mock(pkgsystemd.SystemctlExists).To(func() bool {
+			return false
+		}).Build()
+
+		err := Command(ctx)
+		require.NoError(t, err)
+
+		xidRebootThreshold := componentsxid.GetDefaultRebootThreshold()
+		assert.Equal(t, 6, xidRebootThreshold.Threshold)
+		assert.Equal(t, 2000, xidRebootThreshold.ThresholdOverrides[94].RebootThreshold)
+		assert.Equal(t, 3, xidRebootThreshold.ThresholdOverrides[95].RebootThreshold)
+
+		sxidRebootThresholds := componentssxid.GetDefaultRebootThresholdOverrides()
+		assert.Equal(t, 7, sxidRebootThresholds[11004].RebootThreshold)
 	})
 }
 

--- a/cmd/gpud/run/mock_command_exec_test.go
+++ b/cmd/gpud/run/mock_command_exec_test.go
@@ -280,10 +280,10 @@ func TestCommand_SetLookbackPeriods(t *testing.T) {
 func TestCommand_SetThresholds(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	originalXidThresholdConfig := componentsxid.GetDefaultRebootThreshold()
+	originalXidThresholdConfig := componentsxid.GetDefaultThresholds()
 	originalSxidThresholds := componentssxid.GetDefaultThresholdOverrides()
 	t.Cleanup(func() {
-		componentsxid.SetDefaultRebootThreshold(originalXidThresholdConfig)
+		componentsxid.SetDefaultThresholds(originalXidThresholdConfig)
 		componentssxid.SetDefaultThresholdOverrides(originalSxidThresholds)
 	})
 
@@ -321,7 +321,7 @@ func TestCommand_SetThresholds(t *testing.T) {
 		err := Command(ctx)
 		require.NoError(t, err)
 
-		xidThresholdConfig := componentsxid.GetDefaultRebootThreshold()
+		xidThresholdConfig := componentsxid.GetDefaultThresholds()
 		assert.Equal(t, 6, xidThresholdConfig.Threshold)
 		assert.Equal(t, 2000, xidThresholdConfig.ThresholdOverrides[94].RebootThreshold)
 		assert.Equal(t, 3, xidThresholdConfig.ThresholdOverrides[95].RebootThreshold)

--- a/cmd/gpud/run/mock_command_exec_test.go
+++ b/cmd/gpud/run/mock_command_exec_test.go
@@ -280,10 +280,12 @@ func TestCommand_SetLookbackPeriods(t *testing.T) {
 func TestCommand_SetThresholds(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	originalXidThresholdConfig := componentsxid.GetDefaultThresholds()
+	originalXidRebootThreshold := componentsxid.GetDefaultRebootThreshold()
+	originalXidThresholds := componentsxid.GetDefaultThresholds()
 	originalSxidThresholds := componentssxid.GetDefaultThresholdOverrides()
 	t.Cleanup(func() {
-		componentsxid.SetDefaultThresholds(originalXidThresholdConfig)
+		componentsxid.SetDefaultRebootThreshold(originalXidRebootThreshold)
+		componentsxid.SetDefaultThresholds(originalXidThresholds)
 		componentssxid.SetDefaultThresholdOverrides(originalSxidThresholds)
 	})
 
@@ -322,7 +324,7 @@ func TestCommand_SetThresholds(t *testing.T) {
 		require.NoError(t, err)
 
 		xidThresholdConfig := componentsxid.GetDefaultThresholds()
-		assert.Equal(t, 6, xidThresholdConfig.Threshold)
+		assert.Equal(t, 6, componentsxid.GetDefaultRebootThreshold())
 		assert.Equal(t, 2000, xidThresholdConfig.ThresholdOverrides[94].RebootThreshold)
 		assert.Equal(t, 3, xidThresholdConfig.ThresholdOverrides[95].RebootThreshold)
 

--- a/cmd/gpud/run/mock_command_exec_test.go
+++ b/cmd/gpud/run/mock_command_exec_test.go
@@ -282,11 +282,11 @@ func TestCommand_SetThresholds(t *testing.T) {
 
 	originalXidRebootThreshold := componentsxid.GetDefaultRebootThreshold()
 	originalXidThresholds := componentsxid.GetDefaultThresholds()
-	originalSxidThresholds := componentssxid.GetDefaultThresholdOverrides()
+	originalSxidThresholds := componentssxid.GetDefaultThresholds()
 	t.Cleanup(func() {
 		componentsxid.SetDefaultRebootThreshold(originalXidRebootThreshold)
 		componentsxid.SetDefaultThresholds(originalXidThresholds)
-		componentssxid.SetDefaultThresholdOverrides(originalSxidThresholds)
+		componentssxid.SetDefaultThresholds(originalSxidThresholds)
 	})
 
 	ctx := newTestCLIContext(t, cliFlagValues{
@@ -328,8 +328,8 @@ func TestCommand_SetThresholds(t *testing.T) {
 		assert.Equal(t, 2000, xidThresholdConfig.ThresholdOverrides[94].RebootThreshold)
 		assert.Equal(t, 3, xidThresholdConfig.ThresholdOverrides[95].RebootThreshold)
 
-		sxidThresholds := componentssxid.GetDefaultThresholdOverrides()
-		assert.Equal(t, 7, sxidThresholds[11004].RebootThreshold)
+		sxidThresholds := componentssxid.GetDefaultThresholds()
+		assert.Equal(t, 7, sxidThresholds.ThresholdOverrides[11004].RebootThreshold)
 	})
 }
 

--- a/cmd/gpud/run/mock_command_exec_test.go
+++ b/cmd/gpud/run/mock_command_exec_test.go
@@ -63,8 +63,8 @@ func newTestCLIContext(t *testing.T, values cliFlagValues) *cli.Context {
 	set.String("nvlink-expected-link-states", "", "")
 	set.String("nfs-checker-configs", "", "")
 	set.Int("xid-reboot-threshold", 0, "")
-	set.String("xid-reboot-thresholds", "", "")
-	set.String("sxid-reboot-thresholds", "", "")
+	set.String("xid-thresholds", "", "")
+	set.String("sxid-thresholds", "", "")
 	set.Duration("xid-lookback-period", 0, "")
 	set.Duration("sxid-lookback-period", 0, "")
 	set.Int("threshold-celsius-slowdown-margin", 0, "")
@@ -277,29 +277,29 @@ func TestCommand_SetLookbackPeriods(t *testing.T) {
 	})
 }
 
-func TestCommand_SetRebootThresholds(t *testing.T) {
+func TestCommand_SetThresholds(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	originalXidRebootThreshold := componentsxid.GetDefaultRebootThreshold()
-	originalSxidRebootThresholds := componentssxid.GetDefaultRebootThresholdOverrides()
+	originalXidThresholdConfig := componentsxid.GetDefaultRebootThreshold()
+	originalSxidThresholds := componentssxid.GetDefaultThresholdOverrides()
 	t.Cleanup(func() {
-		componentsxid.SetDefaultRebootThreshold(originalXidRebootThreshold)
-		componentssxid.SetDefaultRebootThresholdOverrides(originalSxidRebootThresholds)
+		componentsxid.SetDefaultRebootThreshold(originalXidThresholdConfig)
+		componentssxid.SetDefaultThresholdOverrides(originalSxidThresholds)
 	})
 
 	ctx := newTestCLIContext(t, cliFlagValues{
 		stringFlags: map[string]string{
-			"log-level":              "info",
-			"data-dir":               tmpDir,
-			"xid-reboot-thresholds":  `{"94":{"rebootThreshold":2000},"95":{"rebootThreshold":3}}`,
-			"sxid-reboot-thresholds": `{"11004":{"rebootThreshold":7}}`,
+			"log-level":       "info",
+			"data-dir":        tmpDir,
+			"xid-thresholds":  `{"94":{"rebootThreshold":2000},"95":{"rebootThreshold":3}}`,
+			"sxid-thresholds": `{"11004":{"rebootThreshold":7}}`,
 		},
 		intFlags: map[string]int{
 			"xid-reboot-threshold": 6,
 		},
 	})
 
-	mockey.PatchConvey("Command sets xid and sxid reboot thresholds", t, func() {
+	mockey.PatchConvey("Command sets xid and sxid thresholds", t, func() {
 		mockey.Mock(gpudmanager.New).To(func(dataDir string) (*gpudmanager.Manager, error) {
 			return &gpudmanager.Manager{}, nil
 		}).Build()
@@ -321,13 +321,13 @@ func TestCommand_SetRebootThresholds(t *testing.T) {
 		err := Command(ctx)
 		require.NoError(t, err)
 
-		xidRebootThreshold := componentsxid.GetDefaultRebootThreshold()
-		assert.Equal(t, 6, xidRebootThreshold.Threshold)
-		assert.Equal(t, 2000, xidRebootThreshold.ThresholdOverrides[94].RebootThreshold)
-		assert.Equal(t, 3, xidRebootThreshold.ThresholdOverrides[95].RebootThreshold)
+		xidThresholdConfig := componentsxid.GetDefaultRebootThreshold()
+		assert.Equal(t, 6, xidThresholdConfig.Threshold)
+		assert.Equal(t, 2000, xidThresholdConfig.ThresholdOverrides[94].RebootThreshold)
+		assert.Equal(t, 3, xidThresholdConfig.ThresholdOverrides[95].RebootThreshold)
 
-		sxidRebootThresholds := componentssxid.GetDefaultRebootThresholdOverrides()
-		assert.Equal(t, 7, sxidRebootThresholds[11004].RebootThreshold)
+		sxidThresholds := componentssxid.GetDefaultThresholdOverrides()
+		assert.Equal(t, 7, sxidThresholds[11004].RebootThreshold)
 	})
 }
 

--- a/cmd/gpud/run/reboot_thresholds_test.go
+++ b/cmd/gpud/run/reboot_thresholds_test.go
@@ -1,0 +1,26 @@
+package run
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRebootThresholds(t *testing.T) {
+	xidThresholds, err := parseXIDRebootThresholds(`{"94":{"rebootThreshold":1000}}`)
+	require.NoError(t, err)
+	assert.Equal(t, 1000, xidThresholds[94].RebootThreshold)
+
+	sxidThresholds, err := parseSXIDRebootThresholds(`{"11004":{"rebootThreshold":7}}`)
+	require.NoError(t, err)
+	assert.Equal(t, 7, sxidThresholds[11004].RebootThreshold)
+
+	_, err = parseXIDRebootThresholds(`{"94":{"rebootThreshold":0}}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rebootThreshold must be positive")
+
+	_, err = parseSXIDRebootThresholds(`{not-valid-json}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sxid reboot thresholds")
+}

--- a/cmd/gpud/run/thresholds_test.go
+++ b/cmd/gpud/run/thresholds_test.go
@@ -7,20 +7,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseRebootThresholds(t *testing.T) {
-	xidThresholds, err := parseXIDRebootThresholds(`{"94":{"rebootThreshold":1000}}`)
+func TestParseThresholds(t *testing.T) {
+	xidThresholds, err := parseXIDThresholds(`{"94":{"rebootThreshold":1000}}`)
 	require.NoError(t, err)
 	assert.Equal(t, 1000, xidThresholds[94].RebootThreshold)
 
-	sxidThresholds, err := parseSXIDRebootThresholds(`{"11004":{"rebootThreshold":7}}`)
+	sxidThresholds, err := parseSXIDThresholds(`{"11004":{"rebootThreshold":7}}`)
 	require.NoError(t, err)
 	assert.Equal(t, 7, sxidThresholds[11004].RebootThreshold)
 
-	_, err = parseXIDRebootThresholds(`{"94":{"rebootThreshold":0}}`)
+	_, err = parseXIDThresholds(`{"94":{"rebootThreshold":0}}`)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rebootThreshold must be positive")
 
-	_, err = parseSXIDRebootThresholds(`{not-valid-json}`)
+	_, err = parseSXIDThresholds(`{not-valid-json}`)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "sxid reboot thresholds")
+	assert.Contains(t, err.Error(), "sxid thresholds")
 }

--- a/cmd/gpud/run/thresholds_test.go
+++ b/cmd/gpud/run/thresholds_test.go
@@ -8,17 +8,21 @@ import (
 )
 
 func TestParseThresholds(t *testing.T) {
-	xidThresholds, err := parseXIDThresholds(`{"94":{"rebootThreshold":1000}}`)
+	xidThresholds, err := parseXIDThresholds(`{"overrides":{"94":{"rebootThreshold":1000}}}`)
 	require.NoError(t, err)
-	assert.Equal(t, 1000, xidThresholds.ThresholdOverrides[94].RebootThreshold)
+	assert.Equal(t, 1000, xidThresholds.Overrides[94].RebootThreshold)
 
-	sxidThresholds, err := parseSXIDThresholds(`{"11004":{"rebootThreshold":7}}`)
+	sxidThresholds, err := parseSXIDThresholds(`{"overrides":{"11004":{"rebootThreshold":7}}}`)
 	require.NoError(t, err)
-	assert.Equal(t, 7, sxidThresholds.ThresholdOverrides[11004].RebootThreshold)
+	assert.Equal(t, 7, sxidThresholds.Overrides[11004].RebootThreshold)
 
-	_, err = parseXIDThresholds(`{"94":{"rebootThreshold":0}}`)
+	_, err = parseXIDThresholds(`{"overrides":{"94":{"rebootThreshold":0}}}`)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rebootThreshold must be positive")
+
+	_, err = parseXIDThresholds(`{"94":{"rebootThreshold":1000}}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown field "94"`)
 
 	_, err = parseSXIDThresholds(`{not-valid-json}`)
 	require.Error(t, err)

--- a/cmd/gpud/run/thresholds_test.go
+++ b/cmd/gpud/run/thresholds_test.go
@@ -10,11 +10,11 @@ import (
 func TestParseThresholds(t *testing.T) {
 	xidThresholds, err := parseXIDThresholds(`{"94":{"rebootThreshold":1000}}`)
 	require.NoError(t, err)
-	assert.Equal(t, 1000, xidThresholds[94].RebootThreshold)
+	assert.Equal(t, 1000, xidThresholds.ThresholdOverrides[94].RebootThreshold)
 
 	sxidThresholds, err := parseSXIDThresholds(`{"11004":{"rebootThreshold":7}}`)
 	require.NoError(t, err)
-	assert.Equal(t, 7, sxidThresholds[11004].RebootThreshold)
+	assert.Equal(t, 7, sxidThresholds.ThresholdOverrides[11004].RebootThreshold)
 
 	_, err = parseXIDThresholds(`{"94":{"rebootThreshold":0}}`)
 	require.Error(t, err)

--- a/cmd/gpud/scan/command.go
+++ b/cmd/gpud/scan/command.go
@@ -142,7 +142,7 @@ func cmdScan(
 
 	if xidRebootThresholdIsSet {
 		if xidRebootThreshold > 0 {
-			componentsxid.SetDefaultRebootThreshold(componentsxid.RebootThreshold{
+			componentsxid.SetDefaultThresholds(componentsxid.Thresholds{
 				Threshold: xidRebootThreshold,
 			})
 			log.Logger.Infow("set xid reboot threshold", "xidRebootThreshold", xidRebootThreshold)

--- a/cmd/gpud/scan/command.go
+++ b/cmd/gpud/scan/command.go
@@ -142,9 +142,7 @@ func cmdScan(
 
 	if xidRebootThresholdIsSet {
 		if xidRebootThreshold > 0 {
-			componentsxid.SetDefaultThresholds(componentsxid.Thresholds{
-				Threshold: xidRebootThreshold,
-			})
+			componentsxid.SetDefaultRebootThreshold(xidRebootThreshold)
 			log.Logger.Infow("set xid reboot threshold", "xidRebootThreshold", xidRebootThreshold)
 		} else {
 			log.Logger.Warnw("ignoring xid reboot threshold override, value must be positive", "xidRebootThreshold", xidRebootThreshold)

--- a/components/accelerator/nvidia/sxid/health_state.go
+++ b/components/accelerator/nvidia/sxid/health_state.go
@@ -32,12 +32,10 @@ func translateToStateHealth(health int) apiv1.HealthStateType {
 	}
 }
 
-const rebootThreshold = 2
-
 // evolveHealthyState resolves the state of the SXID error component.
 // note: assume events are sorted by time in descending order
 func evolveHealthyState(events eventstore.Events) (ret apiv1.HealthState) {
-	return evolveHealthyStateWithRebootThresholdOverrides(events, rebootThreshold, GetDefaultRebootThresholdOverrides())
+	return evolveHealthyStateWithRebootThresholdOverrides(events, DefaultRebootThreshold, GetDefaultRebootThresholdOverrides())
 }
 
 func evolveHealthyStateWithRebootThresholdOverrides(events eventstore.Events, defaultRebootThreshold int, thresholdOverrides map[int]RebootThresholdOverride) (ret apiv1.HealthState) {

--- a/components/accelerator/nvidia/sxid/health_state.go
+++ b/components/accelerator/nvidia/sxid/health_state.go
@@ -35,13 +35,14 @@ func translateToStateHealth(health int) apiv1.HealthStateType {
 // evolveHealthyState resolves the state of the SXID error component.
 // note: assume events are sorted by time in descending order
 func evolveHealthyState(events eventstore.Events) (ret apiv1.HealthState) {
-	return evolveHealthyStateWithThresholdOverrides(events, DefaultRebootThreshold, GetDefaultThresholdOverrides())
+	return evolveHealthyStateWithThresholds(events, DefaultRebootThreshold, GetDefaultThresholds())
 }
 
-func evolveHealthyStateWithThresholdOverrides(events eventstore.Events, defaultRebootThreshold int, thresholdOverrides map[int]ThresholdOverride) (ret apiv1.HealthState) {
+func evolveHealthyStateWithThresholds(events eventstore.Events, defaultRebootThreshold int, thresholds Thresholds) (ret apiv1.HealthState) {
 	defer func() {
 		log.Logger.Debugf("EvolveHealthyState: %v", ret)
 	}()
+	thresholds = normalizeThresholds(thresholds)
 	var lastSuggestedAction *apiv1.SuggestedActions
 	var lastSXidErr *sxidErrorEventDetail
 	lastHealth := healthStateHealthy
@@ -70,7 +71,7 @@ func evolveHealthyStateWithThresholdOverrides(events eventstore.Events, defaultR
 			lastSXidErr = &currSXidErr
 			if currSXidErr.SuggestedActionsByGPUd != nil && len(currSXidErr.SuggestedActionsByGPUd.RepairActions) > 0 {
 				if currSXidErr.SuggestedActionsByGPUd.RepairActions[0] == apiv1.RepairActionTypeRebootSystem {
-					effectiveRebootThreshold := rebootThresholdForSXID(currSXidErr.SXid, defaultRebootThreshold, thresholdOverrides)
+					effectiveRebootThreshold := rebootThresholdForSXID(currSXidErr.SXid, defaultRebootThreshold, thresholds)
 					if count, ok := sxidRebootMap[currSXidErr.SXid]; !ok {
 						sxidRebootMap[currSXidErr.SXid] = 0
 					} else if count >= effectiveRebootThreshold {

--- a/components/accelerator/nvidia/sxid/health_state.go
+++ b/components/accelerator/nvidia/sxid/health_state.go
@@ -37,6 +37,10 @@ const rebootThreshold = 2
 // evolveHealthyState resolves the state of the SXID error component.
 // note: assume events are sorted by time in descending order
 func evolveHealthyState(events eventstore.Events) (ret apiv1.HealthState) {
+	return evolveHealthyStateWithRebootThresholdOverrides(events, rebootThreshold, GetDefaultRebootThresholdOverrides())
+}
+
+func evolveHealthyStateWithRebootThresholdOverrides(events eventstore.Events, defaultRebootThreshold int, thresholdOverrides map[int]RebootThresholdOverride) (ret apiv1.HealthState) {
 	defer func() {
 		log.Logger.Debugf("EvolveHealthyState: %v", ret)
 	}()
@@ -68,9 +72,10 @@ func evolveHealthyState(events eventstore.Events) (ret apiv1.HealthState) {
 			lastSXidErr = &currSXidErr
 			if currSXidErr.SuggestedActionsByGPUd != nil && len(currSXidErr.SuggestedActionsByGPUd.RepairActions) > 0 {
 				if currSXidErr.SuggestedActionsByGPUd.RepairActions[0] == apiv1.RepairActionTypeRebootSystem {
+					effectiveRebootThreshold := rebootThresholdForSXID(currSXidErr.SXid, defaultRebootThreshold, thresholdOverrides)
 					if count, ok := sxidRebootMap[currSXidErr.SXid]; !ok {
 						sxidRebootMap[currSXidErr.SXid] = 0
-					} else if count >= rebootThreshold {
+					} else if count >= effectiveRebootThreshold {
 						currSXidErr.SuggestedActionsByGPUd.RepairActions[0] = apiv1.RepairActionTypeHardwareInspection
 					}
 				}

--- a/components/accelerator/nvidia/sxid/health_state.go
+++ b/components/accelerator/nvidia/sxid/health_state.go
@@ -35,10 +35,10 @@ func translateToStateHealth(health int) apiv1.HealthStateType {
 // evolveHealthyState resolves the state of the SXID error component.
 // note: assume events are sorted by time in descending order
 func evolveHealthyState(events eventstore.Events) (ret apiv1.HealthState) {
-	return evolveHealthyStateWithRebootThresholdOverrides(events, DefaultRebootThreshold, GetDefaultRebootThresholdOverrides())
+	return evolveHealthyStateWithThresholdOverrides(events, DefaultRebootThreshold, GetDefaultThresholdOverrides())
 }
 
-func evolveHealthyStateWithRebootThresholdOverrides(events eventstore.Events, defaultRebootThreshold int, thresholdOverrides map[int]RebootThresholdOverride) (ret apiv1.HealthState) {
+func evolveHealthyStateWithThresholdOverrides(events eventstore.Events, defaultRebootThreshold int, thresholdOverrides map[int]ThresholdOverride) (ret apiv1.HealthState) {
 	defer func() {
 		log.Logger.Debugf("EvolveHealthyState: %v", ret)
 	}()

--- a/components/accelerator/nvidia/sxid/health_state_test.go
+++ b/components/accelerator/nvidia/sxid/health_state_test.go
@@ -82,6 +82,24 @@ func TestStateUpdateBasedOnEvents(t *testing.T) {
 		assert.Equal(t, apiv1.RepairActionTypeHardwareInspection, state.SuggestedActions.RepairActions[0])
 	})
 
+	t.Run("custom sxid reboot threshold override prevents hardware inspection", func(t *testing.T) {
+		events := eventstore.Events{
+			createSXidEvent(time.Time{}, 94, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
+			{Name: "reboot"},
+			createSXidEvent(time.Time{}, 94, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
+			{Name: "reboot"},
+			createSXidEvent(time.Time{}, 94, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
+		}
+
+		state := evolveHealthyStateWithRebootThresholdOverrides(events, rebootThreshold, map[int]RebootThresholdOverride{
+			94: {RebootThreshold: 1000},
+		})
+		assert.Equal(t, apiv1.HealthStateTypeUnhealthy, state.Health)
+		require.NotNil(t, state.SuggestedActions)
+		require.NotEmpty(t, state.SuggestedActions.RepairActions)
+		assert.Equal(t, apiv1.RepairActionTypeRebootSystem, state.SuggestedActions.RepairActions[0])
+	})
+
 	t.Run("EmptyEvents_ReturnsHealthy", func(t *testing.T) {
 		events := eventstore.Events{}
 		state := evolveHealthyState(events)

--- a/components/accelerator/nvidia/sxid/health_state_test.go
+++ b/components/accelerator/nvidia/sxid/health_state_test.go
@@ -91,7 +91,7 @@ func TestStateUpdateBasedOnEvents(t *testing.T) {
 			createSXidEvent(time.Time{}, 94, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
 		}
 
-		state := evolveHealthyStateWithRebootThresholdOverrides(events, DefaultRebootThreshold, map[int]RebootThresholdOverride{
+		state := evolveHealthyStateWithThresholdOverrides(events, DefaultRebootThreshold, map[int]ThresholdOverride{
 			94: {RebootThreshold: 1000},
 		})
 		assert.Equal(t, apiv1.HealthStateTypeUnhealthy, state.Health)

--- a/components/accelerator/nvidia/sxid/health_state_test.go
+++ b/components/accelerator/nvidia/sxid/health_state_test.go
@@ -91,8 +91,10 @@ func TestStateUpdateBasedOnEvents(t *testing.T) {
 			createSXidEvent(time.Time{}, 94, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
 		}
 
-		state := evolveHealthyStateWithThresholdOverrides(events, DefaultRebootThreshold, map[int]ThresholdOverride{
-			94: {RebootThreshold: 1000},
+		state := evolveHealthyStateWithThresholds(events, DefaultRebootThreshold, Thresholds{
+			ThresholdOverrides: map[int]ThresholdOverride{
+				94: {RebootThreshold: 1000},
+			},
 		})
 		assert.Equal(t, apiv1.HealthStateTypeUnhealthy, state.Health)
 		require.NotNil(t, state.SuggestedActions)

--- a/components/accelerator/nvidia/sxid/health_state_test.go
+++ b/components/accelerator/nvidia/sxid/health_state_test.go
@@ -92,7 +92,7 @@ func TestStateUpdateBasedOnEvents(t *testing.T) {
 		}
 
 		state := evolveHealthyStateWithThresholds(events, DefaultRebootThreshold, Thresholds{
-			ThresholdOverrides: map[int]ThresholdOverride{
+			Overrides: map[int]ThresholdOverride{
 				94: {RebootThreshold: 1000},
 			},
 		})

--- a/components/accelerator/nvidia/sxid/health_state_test.go
+++ b/components/accelerator/nvidia/sxid/health_state_test.go
@@ -91,7 +91,7 @@ func TestStateUpdateBasedOnEvents(t *testing.T) {
 			createSXidEvent(time.Time{}, 94, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
 		}
 
-		state := evolveHealthyStateWithRebootThresholdOverrides(events, rebootThreshold, map[int]RebootThresholdOverride{
+		state := evolveHealthyStateWithRebootThresholdOverrides(events, DefaultRebootThreshold, map[int]RebootThresholdOverride{
 			94: {RebootThreshold: 1000},
 		})
 		assert.Equal(t, apiv1.HealthStateTypeUnhealthy, state.Health)

--- a/components/accelerator/nvidia/sxid/threshold.go
+++ b/components/accelerator/nvidia/sxid/threshold.go
@@ -1,0 +1,57 @@
+package sxid
+
+import (
+	"sync"
+
+	"github.com/leptonai/gpud/pkg/log"
+)
+
+// RebootThresholdOverride configures the reboot threshold for one XID/SXID code.
+type RebootThresholdOverride struct {
+	RebootThreshold int `json:"rebootThreshold"`
+}
+
+var (
+	defaultRebootThresholdOverridesMu sync.RWMutex
+	defaultRebootThresholdOverrides   = map[int]RebootThresholdOverride{}
+)
+
+// GetDefaultRebootThresholdOverrides returns the configured per-SXID reboot thresholds.
+func GetDefaultRebootThresholdOverrides() map[int]RebootThresholdOverride {
+	defaultRebootThresholdOverridesMu.RLock()
+	defer defaultRebootThresholdOverridesMu.RUnlock()
+	return cloneRebootThresholdOverrides(defaultRebootThresholdOverrides)
+}
+
+// SetDefaultRebootThresholdOverrides updates the configured per-SXID reboot thresholds.
+func SetDefaultRebootThresholdOverrides(overrides map[int]RebootThresholdOverride) {
+	overrides = cloneRebootThresholdOverrides(overrides)
+	log.Logger.Infow("setting default sxid reboot threshold overrides", "thresholdOverrides", overrides)
+
+	defaultRebootThresholdOverridesMu.Lock()
+	defer defaultRebootThresholdOverridesMu.Unlock()
+	defaultRebootThresholdOverrides = overrides
+}
+
+func cloneRebootThresholdOverrides(overrides map[int]RebootThresholdOverride) map[int]RebootThresholdOverride {
+	if overrides == nil {
+		return nil
+	}
+	ret := make(map[int]RebootThresholdOverride, len(overrides))
+	for sxid, threshold := range overrides {
+		ret[sxid] = threshold
+	}
+	return ret
+}
+
+func rebootThresholdForSXID(sxid uint64, defaultRebootThreshold int, overrides map[int]RebootThresholdOverride) int {
+	sxidID, ok := intFromUint64(sxid)
+	if !ok {
+		return defaultRebootThreshold
+	}
+
+	if override, ok := overrides[sxidID]; ok && override.RebootThreshold > 0 {
+		return override.RebootThreshold
+	}
+	return defaultRebootThreshold
+}

--- a/components/accelerator/nvidia/sxid/threshold.go
+++ b/components/accelerator/nvidia/sxid/threshold.go
@@ -6,8 +6,8 @@ import (
 	"github.com/leptonai/gpud/pkg/log"
 )
 
-// RebootThresholdOverride configures the reboot threshold for one XID/SXID code.
-type RebootThresholdOverride struct {
+// ThresholdOverride configures threshold overrides for one SXID code.
+type ThresholdOverride struct {
 	RebootThreshold int `json:"rebootThreshold"`
 }
 
@@ -18,44 +18,44 @@ const (
 	// events that happen after a reboot-recoverable SXID, and if the same SXID is
 	// still asking for RebootSystem after this threshold, gpud treats repeated
 	// reboots as insufficient recovery and recommends hardware inspection.
-	// Operators can override individual SXIDs with --sxid-reboot-thresholds.
+	// Operators can override individual SXIDs with --sxid-thresholds.
 	DefaultRebootThreshold = 2
 )
 
 var (
-	defaultRebootThresholdOverridesMu sync.RWMutex
-	defaultRebootThresholdOverrides   = map[int]RebootThresholdOverride{}
+	defaultThresholdOverridesMu sync.RWMutex
+	defaultThresholdOverrides   = map[int]ThresholdOverride{}
 )
 
-// GetDefaultRebootThresholdOverrides returns the configured per-SXID reboot thresholds.
-func GetDefaultRebootThresholdOverrides() map[int]RebootThresholdOverride {
-	defaultRebootThresholdOverridesMu.RLock()
-	defer defaultRebootThresholdOverridesMu.RUnlock()
-	return cloneRebootThresholdOverrides(defaultRebootThresholdOverrides)
+// GetDefaultThresholdOverrides returns the configured per-SXID threshold overrides.
+func GetDefaultThresholdOverrides() map[int]ThresholdOverride {
+	defaultThresholdOverridesMu.RLock()
+	defer defaultThresholdOverridesMu.RUnlock()
+	return cloneThresholdOverrides(defaultThresholdOverrides)
 }
 
-// SetDefaultRebootThresholdOverrides updates the configured per-SXID reboot thresholds.
-func SetDefaultRebootThresholdOverrides(overrides map[int]RebootThresholdOverride) {
-	overrides = cloneRebootThresholdOverrides(overrides)
-	log.Logger.Infow("setting default sxid reboot threshold overrides", "thresholdOverrides", overrides)
+// SetDefaultThresholdOverrides updates the configured per-SXID threshold overrides.
+func SetDefaultThresholdOverrides(overrides map[int]ThresholdOverride) {
+	overrides = cloneThresholdOverrides(overrides)
+	log.Logger.Infow("setting default sxid threshold overrides", "thresholdOverrides", overrides)
 
-	defaultRebootThresholdOverridesMu.Lock()
-	defer defaultRebootThresholdOverridesMu.Unlock()
-	defaultRebootThresholdOverrides = overrides
+	defaultThresholdOverridesMu.Lock()
+	defer defaultThresholdOverridesMu.Unlock()
+	defaultThresholdOverrides = overrides
 }
 
-func cloneRebootThresholdOverrides(overrides map[int]RebootThresholdOverride) map[int]RebootThresholdOverride {
+func cloneThresholdOverrides(overrides map[int]ThresholdOverride) map[int]ThresholdOverride {
 	if overrides == nil {
 		return nil
 	}
-	ret := make(map[int]RebootThresholdOverride, len(overrides))
+	ret := make(map[int]ThresholdOverride, len(overrides))
 	for sxid, threshold := range overrides {
 		ret[sxid] = threshold
 	}
 	return ret
 }
 
-func rebootThresholdForSXID(sxid uint64, defaultRebootThreshold int, overrides map[int]RebootThresholdOverride) int {
+func rebootThresholdForSXID(sxid uint64, defaultRebootThreshold int, overrides map[int]ThresholdOverride) int {
 	sxidID, ok := intFromUint64(sxid)
 	if !ok {
 		return defaultRebootThreshold

--- a/components/accelerator/nvidia/sxid/threshold.go
+++ b/components/accelerator/nvidia/sxid/threshold.go
@@ -8,8 +8,8 @@ import (
 
 // Thresholds configures the SXID reboot threshold policy.
 type Thresholds struct {
-	// ThresholdOverrides configures per-SXID threshold overrides.
-	ThresholdOverrides map[int]ThresholdOverride `json:"thresholdOverrides,omitempty"`
+	// Overrides configures per-SXID threshold overrides.
+	Overrides map[int]ThresholdOverride `json:"overrides,omitempty"`
 }
 
 // ThresholdOverride configures threshold overrides for one SXID code.
@@ -43,7 +43,7 @@ func GetDefaultThresholds() Thresholds {
 // SetDefaultThresholds updates the configured threshold policy for SXID recovery.
 func SetDefaultThresholds(thresholds Thresholds) {
 	thresholds = normalizeThresholds(thresholds)
-	log.Logger.Infow("setting default sxid thresholds", "thresholdOverrides", thresholds.ThresholdOverrides)
+	log.Logger.Infow("setting default sxid thresholds", "overrides", thresholds.Overrides)
 
 	defaultThresholdsMu.Lock()
 	defer defaultThresholdsMu.Unlock()
@@ -51,16 +51,16 @@ func SetDefaultThresholds(thresholds Thresholds) {
 }
 
 func normalizeThresholds(thresholds Thresholds) Thresholds {
-	thresholds.ThresholdOverrides = cloneThresholdOverrides(thresholds.ThresholdOverrides)
+	thresholds.Overrides = cloneOverrides(thresholds.Overrides)
 	return thresholds
 }
 
 func cloneThresholds(thresholds Thresholds) Thresholds {
-	thresholds.ThresholdOverrides = cloneThresholdOverrides(thresholds.ThresholdOverrides)
+	thresholds.Overrides = cloneOverrides(thresholds.Overrides)
 	return thresholds
 }
 
-func cloneThresholdOverrides(overrides map[int]ThresholdOverride) map[int]ThresholdOverride {
+func cloneOverrides(overrides map[int]ThresholdOverride) map[int]ThresholdOverride {
 	if overrides == nil {
 		return nil
 	}
@@ -77,7 +77,7 @@ func rebootThresholdForSXID(sxid uint64, defaultRebootThreshold int, thresholds 
 		return defaultRebootThreshold
 	}
 
-	if override, ok := thresholds.ThresholdOverrides[sxidID]; ok && override.RebootThreshold > 0 {
+	if override, ok := thresholds.Overrides[sxidID]; ok && override.RebootThreshold > 0 {
 		return override.RebootThreshold
 	}
 	return defaultRebootThreshold

--- a/components/accelerator/nvidia/sxid/threshold.go
+++ b/components/accelerator/nvidia/sxid/threshold.go
@@ -11,6 +11,17 @@ type RebootThresholdOverride struct {
 	RebootThreshold int `json:"rebootThreshold"`
 }
 
+const (
+	// DefaultRebootThreshold is the fallback number of reboot events gpud allows
+	// for an SXID before escalating from RebootSystem to HardwareInspection.
+	// During SXID health evaluation, gpud walks the event history, counts reboot
+	// events that happen after a reboot-recoverable SXID, and if the same SXID is
+	// still asking for RebootSystem after this threshold, gpud treats repeated
+	// reboots as insufficient recovery and recommends hardware inspection.
+	// Operators can override individual SXIDs with --sxid-reboot-thresholds.
+	DefaultRebootThreshold = 2
+)
+
 var (
 	defaultRebootThresholdOverridesMu sync.RWMutex
 	defaultRebootThresholdOverrides   = map[int]RebootThresholdOverride{}

--- a/components/accelerator/nvidia/sxid/threshold.go
+++ b/components/accelerator/nvidia/sxid/threshold.go
@@ -6,6 +6,12 @@ import (
 	"github.com/leptonai/gpud/pkg/log"
 )
 
+// Thresholds configures the SXID reboot threshold policy.
+type Thresholds struct {
+	// ThresholdOverrides configures per-SXID threshold overrides.
+	ThresholdOverrides map[int]ThresholdOverride `json:"thresholdOverrides,omitempty"`
+}
+
 // ThresholdOverride configures threshold overrides for one SXID code.
 type ThresholdOverride struct {
 	RebootThreshold int `json:"rebootThreshold"`
@@ -23,25 +29,35 @@ const (
 )
 
 var (
-	defaultThresholdOverridesMu sync.RWMutex
-	defaultThresholdOverrides   = map[int]ThresholdOverride{}
+	defaultThresholdsMu sync.RWMutex
+	defaultThresholds   = Thresholds{}
 )
 
-// GetDefaultThresholdOverrides returns the configured per-SXID threshold overrides.
-func GetDefaultThresholdOverrides() map[int]ThresholdOverride {
-	defaultThresholdOverridesMu.RLock()
-	defer defaultThresholdOverridesMu.RUnlock()
-	return cloneThresholdOverrides(defaultThresholdOverrides)
+// GetDefaultThresholds returns the configured threshold policy for SXID recovery.
+func GetDefaultThresholds() Thresholds {
+	defaultThresholdsMu.RLock()
+	defer defaultThresholdsMu.RUnlock()
+	return cloneThresholds(defaultThresholds)
 }
 
-// SetDefaultThresholdOverrides updates the configured per-SXID threshold overrides.
-func SetDefaultThresholdOverrides(overrides map[int]ThresholdOverride) {
-	overrides = cloneThresholdOverrides(overrides)
-	log.Logger.Infow("setting default sxid threshold overrides", "thresholdOverrides", overrides)
+// SetDefaultThresholds updates the configured threshold policy for SXID recovery.
+func SetDefaultThresholds(thresholds Thresholds) {
+	thresholds = normalizeThresholds(thresholds)
+	log.Logger.Infow("setting default sxid thresholds", "thresholdOverrides", thresholds.ThresholdOverrides)
 
-	defaultThresholdOverridesMu.Lock()
-	defer defaultThresholdOverridesMu.Unlock()
-	defaultThresholdOverrides = overrides
+	defaultThresholdsMu.Lock()
+	defer defaultThresholdsMu.Unlock()
+	defaultThresholds = thresholds
+}
+
+func normalizeThresholds(thresholds Thresholds) Thresholds {
+	thresholds.ThresholdOverrides = cloneThresholdOverrides(thresholds.ThresholdOverrides)
+	return thresholds
+}
+
+func cloneThresholds(thresholds Thresholds) Thresholds {
+	thresholds.ThresholdOverrides = cloneThresholdOverrides(thresholds.ThresholdOverrides)
+	return thresholds
 }
 
 func cloneThresholdOverrides(overrides map[int]ThresholdOverride) map[int]ThresholdOverride {
@@ -55,13 +71,13 @@ func cloneThresholdOverrides(overrides map[int]ThresholdOverride) map[int]Thresh
 	return ret
 }
 
-func rebootThresholdForSXID(sxid uint64, defaultRebootThreshold int, overrides map[int]ThresholdOverride) int {
+func rebootThresholdForSXID(sxid uint64, defaultRebootThreshold int, thresholds Thresholds) int {
 	sxidID, ok := intFromUint64(sxid)
 	if !ok {
 		return defaultRebootThreshold
 	}
 
-	if override, ok := overrides[sxidID]; ok && override.RebootThreshold > 0 {
+	if override, ok := thresholds.ThresholdOverrides[sxidID]; ok && override.RebootThreshold > 0 {
 		return override.RebootThreshold
 	}
 	return defaultRebootThreshold

--- a/components/accelerator/nvidia/sxid/threshold_test.go
+++ b/components/accelerator/nvidia/sxid/threshold_test.go
@@ -16,15 +16,15 @@ func TestDefaultThresholds(t *testing.T) {
 	assert.Equal(t, 2, rebootThresholdForSXID(11005, DefaultRebootThreshold, Thresholds{}))
 
 	thresholds := Thresholds{
-		ThresholdOverrides: map[int]ThresholdOverride{
+		Overrides: map[int]ThresholdOverride{
 			11004: {RebootThreshold: 7},
 		},
 	}
 	SetDefaultThresholds(thresholds)
 
 	updated := GetDefaultThresholds()
-	assert.Equal(t, 7, updated.ThresholdOverrides[11004].RebootThreshold)
+	assert.Equal(t, 7, updated.Overrides[11004].RebootThreshold)
 
-	updated.ThresholdOverrides[11004] = ThresholdOverride{RebootThreshold: 2}
-	assert.Equal(t, 7, GetDefaultThresholds().ThresholdOverrides[11004].RebootThreshold)
+	updated.Overrides[11004] = ThresholdOverride{RebootThreshold: 2}
+	assert.Equal(t, 7, GetDefaultThresholds().Overrides[11004].RebootThreshold)
 }

--- a/components/accelerator/nvidia/sxid/threshold_test.go
+++ b/components/accelerator/nvidia/sxid/threshold_test.go
@@ -1,0 +1,25 @@
+package sxid
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultRebootThresholdOverrides(t *testing.T) {
+	original := GetDefaultRebootThresholdOverrides()
+	t.Cleanup(func() {
+		SetDefaultRebootThresholdOverrides(original)
+	})
+
+	overrides := map[int]RebootThresholdOverride{
+		11004: {RebootThreshold: 7},
+	}
+	SetDefaultRebootThresholdOverrides(overrides)
+
+	updated := GetDefaultRebootThresholdOverrides()
+	assert.Equal(t, 7, updated[11004].RebootThreshold)
+
+	updated[11004] = RebootThresholdOverride{RebootThreshold: 2}
+	assert.Equal(t, 7, GetDefaultRebootThresholdOverrides()[11004].RebootThreshold)
+}

--- a/components/accelerator/nvidia/sxid/threshold_test.go
+++ b/components/accelerator/nvidia/sxid/threshold_test.go
@@ -6,20 +6,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDefaultThresholdOverrides(t *testing.T) {
-	original := GetDefaultThresholdOverrides()
+func TestDefaultThresholds(t *testing.T) {
+	original := GetDefaultThresholds()
 	t.Cleanup(func() {
-		SetDefaultThresholdOverrides(original)
+		SetDefaultThresholds(original)
 	})
 
-	overrides := map[int]ThresholdOverride{
-		11004: {RebootThreshold: 7},
+	thresholds := Thresholds{
+		ThresholdOverrides: map[int]ThresholdOverride{
+			11004: {RebootThreshold: 7},
+		},
 	}
-	SetDefaultThresholdOverrides(overrides)
+	SetDefaultThresholds(thresholds)
 
-	updated := GetDefaultThresholdOverrides()
-	assert.Equal(t, 7, updated[11004].RebootThreshold)
+	updated := GetDefaultThresholds()
+	assert.Equal(t, 7, updated.ThresholdOverrides[11004].RebootThreshold)
 
-	updated[11004] = ThresholdOverride{RebootThreshold: 2}
-	assert.Equal(t, 7, GetDefaultThresholdOverrides()[11004].RebootThreshold)
+	updated.ThresholdOverrides[11004] = ThresholdOverride{RebootThreshold: 2}
+	assert.Equal(t, 7, GetDefaultThresholds().ThresholdOverrides[11004].RebootThreshold)
 }

--- a/components/accelerator/nvidia/sxid/threshold_test.go
+++ b/components/accelerator/nvidia/sxid/threshold_test.go
@@ -6,20 +6,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDefaultRebootThresholdOverrides(t *testing.T) {
-	original := GetDefaultRebootThresholdOverrides()
+func TestDefaultThresholdOverrides(t *testing.T) {
+	original := GetDefaultThresholdOverrides()
 	t.Cleanup(func() {
-		SetDefaultRebootThresholdOverrides(original)
+		SetDefaultThresholdOverrides(original)
 	})
 
-	overrides := map[int]RebootThresholdOverride{
+	overrides := map[int]ThresholdOverride{
 		11004: {RebootThreshold: 7},
 	}
-	SetDefaultRebootThresholdOverrides(overrides)
+	SetDefaultThresholdOverrides(overrides)
 
-	updated := GetDefaultRebootThresholdOverrides()
+	updated := GetDefaultThresholdOverrides()
 	assert.Equal(t, 7, updated[11004].RebootThreshold)
 
-	updated[11004] = RebootThresholdOverride{RebootThreshold: 2}
-	assert.Equal(t, 7, GetDefaultRebootThresholdOverrides()[11004].RebootThreshold)
+	updated[11004] = ThresholdOverride{RebootThreshold: 2}
+	assert.Equal(t, 7, GetDefaultThresholdOverrides()[11004].RebootThreshold)
 }

--- a/components/accelerator/nvidia/sxid/threshold_test.go
+++ b/components/accelerator/nvidia/sxid/threshold_test.go
@@ -12,6 +12,9 @@ func TestDefaultThresholds(t *testing.T) {
 		SetDefaultThresholds(original)
 	})
 
+	assert.Equal(t, 2, DefaultRebootThreshold)
+	assert.Equal(t, 2, rebootThresholdForSXID(11005, DefaultRebootThreshold, Thresholds{}))
+
 	thresholds := Thresholds{
 		ThresholdOverrides: map[int]ThresholdOverride{
 			11004: {RebootThreshold: 7},

--- a/components/accelerator/nvidia/xid/component.go
+++ b/components/accelerator/nvidia/xid/component.go
@@ -601,7 +601,7 @@ func (c *component) updateCurrentState() error {
 	events := mergeEvents(rebootEvents, localEvents)
 
 	c.mu.Lock()
-	c.currState = evolveHealthyState(events, c.devices, rebootThreshold.Threshold)
+	c.currState = evolveHealthyStateWithRebootThreshold(events, c.devices, rebootThreshold)
 	if rebootErr != "" {
 		c.currState.Error = fmt.Sprintf("%s\n%s", rebootErr, c.currState.Error)
 	}

--- a/components/accelerator/nvidia/xid/component.go
+++ b/components/accelerator/nvidia/xid/component.go
@@ -59,7 +59,7 @@ type component struct {
 	devices      map[string]device.Device
 
 	getTimeNowFunc   func() time.Time
-	getThresholdFunc func() RebootThreshold
+	getThresholdFunc func() Thresholds
 
 	rebootEventStore pkghost.RebootEventStore
 	eventBucket      eventstore.Bucket
@@ -86,7 +86,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		getTimeNowFunc: func() time.Time {
 			return time.Now().UTC()
 		},
-		getThresholdFunc: GetDefaultRebootThreshold,
+		getThresholdFunc: GetDefaultThresholds,
 
 		rebootEventStore: gpudInstance.RebootEventStore,
 		extraEventCh:     make(chan *eventstore.Event, 256),
@@ -584,7 +584,7 @@ func (c *component) updateCurrentState() error {
 	}
 
 	now := c.getTimeNowFunc()
-	rebootThreshold := c.getThresholdFunc()
+	thresholds := c.getThresholdFunc()
 
 	var rebootErr string
 	rebootEvents, err := c.rebootEventStore.GetRebootEvents(c.ctx, now.Add(-GetLookbackPeriod()))
@@ -601,7 +601,7 @@ func (c *component) updateCurrentState() error {
 	events := mergeEvents(rebootEvents, localEvents)
 
 	c.mu.Lock()
-	c.currState = evolveHealthyStateWithRebootThreshold(events, c.devices, rebootThreshold)
+	c.currState = evolveHealthyStateWithThresholds(events, c.devices, thresholds)
 	if rebootErr != "" {
 		c.currState.Error = fmt.Sprintf("%s\n%s", rebootErr, c.currState.Error)
 	}

--- a/components/accelerator/nvidia/xid/component.go
+++ b/components/accelerator/nvidia/xid/component.go
@@ -58,8 +58,9 @@ type component struct {
 	nvmlInstance nvidianvml.Instance
 	devices      map[string]device.Device
 
-	getTimeNowFunc   func() time.Time
-	getThresholdFunc func() Thresholds
+	getTimeNowFunc         func() time.Time
+	getRebootThresholdFunc func() int
+	getThresholdFunc       func() Thresholds
 
 	rebootEventStore pkghost.RebootEventStore
 	eventBucket      eventstore.Bucket
@@ -86,7 +87,8 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		getTimeNowFunc: func() time.Time {
 			return time.Now().UTC()
 		},
-		getThresholdFunc: GetDefaultThresholds,
+		getRebootThresholdFunc: GetDefaultRebootThreshold,
+		getThresholdFunc:       GetDefaultThresholds,
 
 		rebootEventStore: gpudInstance.RebootEventStore,
 		extraEventCh:     make(chan *eventstore.Event, 256),
@@ -584,7 +586,14 @@ func (c *component) updateCurrentState() error {
 	}
 
 	now := c.getTimeNowFunc()
-	thresholds := c.getThresholdFunc()
+	rebootThreshold := DefaultRebootThreshold
+	if c.getRebootThresholdFunc != nil {
+		rebootThreshold = c.getRebootThresholdFunc()
+	}
+	thresholds := GetDefaultThresholds()
+	if c.getThresholdFunc != nil {
+		thresholds = c.getThresholdFunc()
+	}
 
 	var rebootErr string
 	rebootEvents, err := c.rebootEventStore.GetRebootEvents(c.ctx, now.Add(-GetLookbackPeriod()))
@@ -601,7 +610,7 @@ func (c *component) updateCurrentState() error {
 	events := mergeEvents(rebootEvents, localEvents)
 
 	c.mu.Lock()
-	c.currState = evolveHealthyStateWithThresholds(events, c.devices, thresholds)
+	c.currState = evolveHealthyStateWithThresholds(events, c.devices, rebootThreshold, thresholds)
 	if rebootErr != "" {
 		c.currState.Error = fmt.Sprintf("%s\n%s", rebootErr, c.currState.Error)
 	}

--- a/components/accelerator/nvidia/xid/component.go
+++ b/components/accelerator/nvidia/xid/component.go
@@ -58,9 +58,8 @@ type component struct {
 	nvmlInstance nvidianvml.Instance
 	devices      map[string]device.Device
 
-	getTimeNowFunc         func() time.Time
-	getRebootThresholdFunc func() int
-	getThresholdFunc       func() Thresholds
+	getTimeNowFunc   func() time.Time
+	getThresholdFunc func() Thresholds
 
 	rebootEventStore pkghost.RebootEventStore
 	eventBucket      eventstore.Bucket
@@ -87,8 +86,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		getTimeNowFunc: func() time.Time {
 			return time.Now().UTC()
 		},
-		getRebootThresholdFunc: GetDefaultRebootThreshold,
-		getThresholdFunc:       GetDefaultThresholds,
+		getThresholdFunc: GetDefaultThresholds,
 
 		rebootEventStore: gpudInstance.RebootEventStore,
 		extraEventCh:     make(chan *eventstore.Event, 256),
@@ -586,10 +584,7 @@ func (c *component) updateCurrentState() error {
 	}
 
 	now := c.getTimeNowFunc()
-	rebootThreshold := DefaultRebootThreshold
-	if c.getRebootThresholdFunc != nil {
-		rebootThreshold = c.getRebootThresholdFunc()
-	}
+	rebootThreshold := GetDefaultRebootThreshold()
 	thresholds := GetDefaultThresholds()
 	if c.getThresholdFunc != nil {
 		thresholds = c.getThresholdFunc()

--- a/components/accelerator/nvidia/xid/component_test.go
+++ b/components/accelerator/nvidia/xid/component_test.go
@@ -386,7 +386,7 @@ func TestXIDComponent_States(t *testing.T) {
 		wantState []apiv1.HealthState
 	}{
 		{
-			// XID 31 has EventTypeWarning in catalog, XID 94 has EventTypeFatal.
+			// XID 31 has EventTypeWarning in catalog, XID 95 has EventTypeFatal.
 			// In real usage, Match() returns the correct EventType from the catalog.
 			name: "xid events with correct event types from catalog",
 			events: eventstore.Events{
@@ -394,14 +394,14 @@ func TestXIDComponent_States(t *testing.T) {
 				createXidEvent(time.Now().Add(-5*24*time.Hour), 31, apiv1.EventTypeWarning, apiv1.RepairActionTypeCheckUserAppAndGPU),
 				// XID 31 is Warning -> stays Healthy
 				createXidEvent(startTime, 31, apiv1.EventTypeWarning, apiv1.RepairActionTypeCheckUserAppAndGPU),
-				// XID 94 is Fatal -> Unhealthy
-				createXidEvent(startTime.Add(5*time.Minute), 94, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
+				// XID 95 is Fatal -> Unhealthy
+				createXidEvent(startTime.Add(5*time.Minute), 95, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
 				{Name: "reboot", Time: startTime.Add(10 * time.Minute)},
-				// XID 94 is Fatal -> Unhealthy
-				createXidEvent(startTime.Add(15*time.Minute), 94, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
+				// XID 95 is Fatal -> Unhealthy
+				createXidEvent(startTime.Add(15*time.Minute), 95, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
 				{Name: "reboot", Time: startTime.Add(20 * time.Minute)},
-				// XID 94 is Fatal -> Unhealthy (3rd occurrence, HardwareInspection)
-				createXidEvent(startTime.Add(25*time.Minute), 94, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
+				// XID 95 is Fatal -> Unhealthy (3rd occurrence, HardwareInspection)
+				createXidEvent(startTime.Add(25*time.Minute), 95, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
 			},
 			wantState: []apiv1.HealthState{
 				{Health: apiv1.HealthStateTypeHealthy, SuggestedActions: &apiv1.SuggestedActions{RepairActions: []apiv1.RepairActionType{apiv1.RepairActionTypeCheckUserAppAndGPU}}},

--- a/components/accelerator/nvidia/xid/health_state.go
+++ b/components/accelerator/nvidia/xid/health_state.go
@@ -55,14 +55,14 @@ func init() {
 // evolveHealthyState resolves the state of the XID error component.
 // note: assume events are sorted by time in descending order
 func evolveHealthyState(events eventstore.Events, devices map[string]device.Device, rebootThreshold int) (ret apiv1.HealthState) {
-	return evolveHealthyStateWithRebootThreshold(events, devices, RebootThreshold{Threshold: rebootThreshold})
+	return evolveHealthyStateWithThresholds(events, devices, Thresholds{Threshold: rebootThreshold})
 }
 
-func evolveHealthyStateWithRebootThreshold(events eventstore.Events, devices map[string]device.Device, rebootThreshold RebootThreshold) (ret apiv1.HealthState) {
+func evolveHealthyStateWithThresholds(events eventstore.Events, devices map[string]device.Device, thresholds Thresholds) (ret apiv1.HealthState) {
 	defer func() {
 		log.Logger.Debugf("EvolveHealthyState: %v", ret)
 	}()
-	rebootThreshold = normalizeRebootThreshold(rebootThreshold)
+	thresholds = normalizeThresholds(thresholds)
 	var lastSuggestedAction *apiv1.SuggestedActions
 	var lastXidErr *xidErrorEventDetail
 	lastHealth := healthStateHealthy
@@ -91,7 +91,7 @@ func evolveHealthyStateWithRebootThreshold(events eventstore.Events, devices map
 			lastXidErr = &currXidErr
 			if currXidErr.SuggestedActionsByGPUd != nil && len(currXidErr.SuggestedActionsByGPUd.RepairActions) > 0 {
 				if currXidErr.SuggestedActionsByGPUd.RepairActions[0] == apiv1.RepairActionTypeRebootSystem {
-					effectiveRebootThreshold := rebootThresholdForXID(currXidErr.Xid, rebootThreshold)
+					effectiveRebootThreshold := rebootThresholdForXID(currXidErr.Xid, thresholds)
 					if count, ok := xidRebootMap[currXidErr.Xid]; !ok {
 						xidRebootMap[currXidErr.Xid] = 0
 					} else if count >= effectiveRebootThreshold {

--- a/components/accelerator/nvidia/xid/health_state.go
+++ b/components/accelerator/nvidia/xid/health_state.go
@@ -55,10 +55,10 @@ func init() {
 // evolveHealthyState resolves the state of the XID error component.
 // note: assume events are sorted by time in descending order
 func evolveHealthyState(events eventstore.Events, devices map[string]device.Device, rebootThreshold int) (ret apiv1.HealthState) {
-	return evolveHealthyStateWithThresholds(events, devices, Thresholds{Threshold: rebootThreshold})
+	return evolveHealthyStateWithThresholds(events, devices, rebootThreshold, GetDefaultThresholds())
 }
 
-func evolveHealthyStateWithThresholds(events eventstore.Events, devices map[string]device.Device, thresholds Thresholds) (ret apiv1.HealthState) {
+func evolveHealthyStateWithThresholds(events eventstore.Events, devices map[string]device.Device, defaultRebootThreshold int, thresholds Thresholds) (ret apiv1.HealthState) {
 	defer func() {
 		log.Logger.Debugf("EvolveHealthyState: %v", ret)
 	}()
@@ -91,7 +91,7 @@ func evolveHealthyStateWithThresholds(events eventstore.Events, devices map[stri
 			lastXidErr = &currXidErr
 			if currXidErr.SuggestedActionsByGPUd != nil && len(currXidErr.SuggestedActionsByGPUd.RepairActions) > 0 {
 				if currXidErr.SuggestedActionsByGPUd.RepairActions[0] == apiv1.RepairActionTypeRebootSystem {
-					effectiveRebootThreshold := rebootThresholdForXID(currXidErr.Xid, thresholds)
+					effectiveRebootThreshold := rebootThresholdForXID(currXidErr.Xid, defaultRebootThreshold, thresholds)
 					if count, ok := xidRebootMap[currXidErr.Xid]; !ok {
 						xidRebootMap[currXidErr.Xid] = 0
 					} else if count >= effectiveRebootThreshold {

--- a/components/accelerator/nvidia/xid/health_state.go
+++ b/components/accelerator/nvidia/xid/health_state.go
@@ -55,9 +55,14 @@ func init() {
 // evolveHealthyState resolves the state of the XID error component.
 // note: assume events are sorted by time in descending order
 func evolveHealthyState(events eventstore.Events, devices map[string]device.Device, rebootThreshold int) (ret apiv1.HealthState) {
+	return evolveHealthyStateWithRebootThreshold(events, devices, RebootThreshold{Threshold: rebootThreshold})
+}
+
+func evolveHealthyStateWithRebootThreshold(events eventstore.Events, devices map[string]device.Device, rebootThreshold RebootThreshold) (ret apiv1.HealthState) {
 	defer func() {
 		log.Logger.Debugf("EvolveHealthyState: %v", ret)
 	}()
+	rebootThreshold = normalizeRebootThreshold(rebootThreshold)
 	var lastSuggestedAction *apiv1.SuggestedActions
 	var lastXidErr *xidErrorEventDetail
 	lastHealth := healthStateHealthy
@@ -86,9 +91,10 @@ func evolveHealthyState(events eventstore.Events, devices map[string]device.Devi
 			lastXidErr = &currXidErr
 			if currXidErr.SuggestedActionsByGPUd != nil && len(currXidErr.SuggestedActionsByGPUd.RepairActions) > 0 {
 				if currXidErr.SuggestedActionsByGPUd.RepairActions[0] == apiv1.RepairActionTypeRebootSystem {
+					effectiveRebootThreshold := rebootThresholdForXID(currXidErr.Xid, rebootThreshold)
 					if count, ok := xidRebootMap[currXidErr.Xid]; !ok {
 						xidRebootMap[currXidErr.Xid] = 0
-					} else if count >= rebootThreshold {
+					} else if count >= effectiveRebootThreshold {
 						currXidErr.SuggestedActionsByGPUd.RepairActions[0] = apiv1.RepairActionTypeHardwareInspection
 					}
 				}

--- a/components/accelerator/nvidia/xid/health_state_test.go
+++ b/components/accelerator/nvidia/xid/health_state_test.go
@@ -121,19 +121,35 @@ func TestStateUpdateBasedOnEvents(t *testing.T) {
 	})
 
 	t.Run("reboot multiple time cannot recover, should be unhealthy", func(t *testing.T) {
-		// XID 94 is EventTypeFatal in the catalog, so we use Fatal here.
+		// XID 95 is EventTypeFatal in the catalog, so we use Fatal here.
 		// In real usage, Match() returns the correct EventType from the catalog.
+		events := eventstore.Events{
+			createXidEvent(time.Time{}, 95, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
+			{Name: "reboot"},
+			createXidEvent(time.Time{}, 95, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
+			{Name: "reboot"},
+			createXidEvent(time.Time{}, 95, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
+			createXidEvent(time.Time{}, 31, apiv1.EventTypeWarning, apiv1.RepairActionTypeCheckUserAppAndGPU),
+		}
+		state := evolveHealthyState(events, nil, DefaultRebootThreshold)
+		assert.Equal(t, apiv1.HealthStateTypeUnhealthy, state.Health)
+		assert.Equal(t, apiv1.RepairActionTypeHardwareInspection, state.SuggestedActions.RepairActions[0])
+	})
+
+	t.Run("xid 94 uses reboot threshold override", func(t *testing.T) {
 		events := eventstore.Events{
 			createXidEvent(time.Time{}, 94, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
 			{Name: "reboot"},
 			createXidEvent(time.Time{}, 94, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
 			{Name: "reboot"},
 			createXidEvent(time.Time{}, 94, apiv1.EventTypeFatal, apiv1.RepairActionTypeRebootSystem),
-			createXidEvent(time.Time{}, 31, apiv1.EventTypeWarning, apiv1.RepairActionTypeCheckUserAppAndGPU),
 		}
+
 		state := evolveHealthyState(events, nil, DefaultRebootThreshold)
 		assert.Equal(t, apiv1.HealthStateTypeUnhealthy, state.Health)
-		assert.Equal(t, apiv1.RepairActionTypeHardwareInspection, state.SuggestedActions.RepairActions[0])
+		require.NotNil(t, state.SuggestedActions)
+		require.NotEmpty(t, state.SuggestedActions.RepairActions)
+		assert.Equal(t, apiv1.RepairActionTypeRebootSystem, state.SuggestedActions.RepairActions[0])
 	})
 
 	// Tests for reboot recovery behavior based on SuggestedActionsByGPUd.

--- a/components/accelerator/nvidia/xid/mock_component_coverage_test.go
+++ b/components/accelerator/nvidia/xid/mock_component_coverage_test.go
@@ -273,9 +273,10 @@ func TestComponent_UpdateCurrentState_RebootErrorBranch_WithMockey(t *testing.T)
 				},
 			},
 		},
-		getTimeNowFunc: func() time.Time { return now },
+		getTimeNowFunc:         func() time.Time { return now },
+		getRebootThresholdFunc: func() int { return 1 },
 		getThresholdFunc: func() Thresholds {
-			return Thresholds{Threshold: 1}
+			return Thresholds{}
 		},
 		devices: map[string]device.Device{},
 	}

--- a/components/accelerator/nvidia/xid/mock_component_coverage_test.go
+++ b/components/accelerator/nvidia/xid/mock_component_coverage_test.go
@@ -273,8 +273,7 @@ func TestComponent_UpdateCurrentState_RebootErrorBranch_WithMockey(t *testing.T)
 				},
 			},
 		},
-		getTimeNowFunc:         func() time.Time { return now },
-		getRebootThresholdFunc: func() int { return 1 },
+		getTimeNowFunc: func() time.Time { return now },
 		getThresholdFunc: func() Thresholds {
 			return Thresholds{}
 		},

--- a/components/accelerator/nvidia/xid/mock_component_coverage_test.go
+++ b/components/accelerator/nvidia/xid/mock_component_coverage_test.go
@@ -274,8 +274,8 @@ func TestComponent_UpdateCurrentState_RebootErrorBranch_WithMockey(t *testing.T)
 			},
 		},
 		getTimeNowFunc: func() time.Time { return now },
-		getThresholdFunc: func() RebootThreshold {
-			return RebootThreshold{Threshold: 1}
+		getThresholdFunc: func() Thresholds {
+			return Thresholds{Threshold: 1}
 		},
 		devices: map[string]device.Device{},
 	}

--- a/components/accelerator/nvidia/xid/mock_xid_test.go
+++ b/components/accelerator/nvidia/xid/mock_xid_test.go
@@ -525,19 +525,27 @@ func TestGetDetail_WithMockey(t *testing.T) {
 func TestThresholds_WithMockey(t *testing.T) {
 	mockey.PatchConvey("Thresholds functions", t, func() {
 		// Get default
-		threshold := GetDefaultThresholds()
-		assert.Equal(t, DefaultRebootThreshold, threshold.Threshold)
+		thresholds := GetDefaultThresholds()
+		assert.Equal(t, DefaultRebootThreshold, GetDefaultRebootThreshold())
+		assert.Equal(t, 1000, thresholds.ThresholdOverrides[94].RebootThreshold)
 
-		// Set new threshold
-		newThreshold := Thresholds{Threshold: 5}
-		SetDefaultThresholds(newThreshold)
+		// Set new global threshold separately from per-XID overrides.
+		SetDefaultRebootThreshold(5)
+		assert.Equal(t, 5, GetDefaultRebootThreshold())
 
-		// Verify it changed
-		threshold = GetDefaultThresholds()
-		assert.Equal(t, 5, threshold.Threshold)
+		// Set new overrides.
+		newThresholds := Thresholds{
+			ThresholdOverrides: map[int]ThresholdOverride{
+				95: {RebootThreshold: 3},
+			},
+		}
+		SetDefaultThresholds(newThresholds)
+		thresholds = GetDefaultThresholds()
+		assert.Equal(t, 3, thresholds.ThresholdOverrides[95].RebootThreshold)
 
 		// Reset to default
-		SetDefaultThresholds(Thresholds{Threshold: DefaultRebootThreshold})
+		SetDefaultRebootThreshold(DefaultRebootThreshold)
+		SetDefaultThresholds(Thresholds{})
 	})
 }
 

--- a/components/accelerator/nvidia/xid/mock_xid_test.go
+++ b/components/accelerator/nvidia/xid/mock_xid_test.go
@@ -527,7 +527,7 @@ func TestThresholds_WithMockey(t *testing.T) {
 		// Get default
 		thresholds := GetDefaultThresholds()
 		assert.Equal(t, DefaultRebootThreshold, GetDefaultRebootThreshold())
-		assert.Equal(t, 1000, thresholds.ThresholdOverrides[94].RebootThreshold)
+		assert.Equal(t, 1000, thresholds.Overrides[94].RebootThreshold)
 
 		// Set new global threshold separately from per-XID overrides.
 		SetDefaultRebootThreshold(5)
@@ -535,13 +535,13 @@ func TestThresholds_WithMockey(t *testing.T) {
 
 		// Set new overrides.
 		newThresholds := Thresholds{
-			ThresholdOverrides: map[int]ThresholdOverride{
+			Overrides: map[int]ThresholdOverride{
 				95: {RebootThreshold: 3},
 			},
 		}
 		SetDefaultThresholds(newThresholds)
 		thresholds = GetDefaultThresholds()
-		assert.Equal(t, 3, thresholds.ThresholdOverrides[95].RebootThreshold)
+		assert.Equal(t, 3, thresholds.Overrides[95].RebootThreshold)
 
 		// Reset to default
 		SetDefaultRebootThreshold(DefaultRebootThreshold)

--- a/components/accelerator/nvidia/xid/mock_xid_test.go
+++ b/components/accelerator/nvidia/xid/mock_xid_test.go
@@ -521,23 +521,23 @@ func TestGetDetail_WithMockey(t *testing.T) {
 	assert.False(t, ok)
 }
 
-// TestRebootThreshold_WithMockey tests the reboot threshold functions.
-func TestRebootThreshold_WithMockey(t *testing.T) {
-	mockey.PatchConvey("RebootThreshold functions", t, func() {
+// TestThresholds_WithMockey tests the threshold configuration functions.
+func TestThresholds_WithMockey(t *testing.T) {
+	mockey.PatchConvey("Thresholds functions", t, func() {
 		// Get default
-		threshold := GetDefaultRebootThreshold()
+		threshold := GetDefaultThresholds()
 		assert.Equal(t, DefaultRebootThreshold, threshold.Threshold)
 
 		// Set new threshold
-		newThreshold := RebootThreshold{Threshold: 5}
-		SetDefaultRebootThreshold(newThreshold)
+		newThreshold := Thresholds{Threshold: 5}
+		SetDefaultThresholds(newThreshold)
 
 		// Verify it changed
-		threshold = GetDefaultRebootThreshold()
+		threshold = GetDefaultThresholds()
 		assert.Equal(t, 5, threshold.Threshold)
 
 		// Reset to default
-		SetDefaultRebootThreshold(RebootThreshold{Threshold: DefaultRebootThreshold})
+		SetDefaultThresholds(Thresholds{Threshold: DefaultRebootThreshold})
 	})
 }
 

--- a/components/accelerator/nvidia/xid/threshold.go
+++ b/components/accelerator/nvidia/xid/threshold.go
@@ -23,6 +23,21 @@ type RebootThresholdOverride struct {
 	RebootThreshold int `json:"rebootThreshold"`
 }
 
+const (
+	// DefaultRebootThreshold is the fallback number of reboot events gpud allows
+	// for an XID before escalating from RebootSystem to HardwareInspection.
+	// During XID health evaluation, gpud walks the event history, counts reboot
+	// events that happen after a reboot-recoverable XID, and if the same XID is
+	// still asking for RebootSystem after this threshold, gpud treats repeated
+	// reboots as insufficient recovery and recommends hardware inspection.
+	// Operators can override this default globally with --xid-reboot-threshold
+	// and can override individual XIDs with --xid-reboot-thresholds or session
+	// updateConfig thresholdOverrides.
+	DefaultRebootThreshold = 2
+	// DefaultLookbackPeriod is the default lookback window for XID events.
+	DefaultLookbackPeriod = eventstore.DefaultRetention
+)
+
 var (
 	// XID 94 is application specific and does NOT warrant system reboot as a
 	// system-level repair signal: NVIDIA's XID catalog classifies it as a
@@ -43,13 +58,6 @@ var (
 
 	defaultLookbackPeriodMu sync.RWMutex
 	defaultLookbackPeriod   = DefaultLookbackPeriod
-)
-
-const (
-	// DefaultRebootThreshold is the default reboot threshold.
-	DefaultRebootThreshold = 2
-	// DefaultLookbackPeriod is the default lookback window for XID events.
-	DefaultLookbackPeriod = eventstore.DefaultRetention
 )
 
 // GetDefaultRebootThreshold returns the configured reboot threshold for XID recovery.

--- a/components/accelerator/nvidia/xid/threshold.go
+++ b/components/accelerator/nvidia/xid/threshold.go
@@ -10,10 +10,6 @@ import (
 
 // Thresholds configures the XID reboot threshold policy.
 type Thresholds struct {
-	// Threshold is the expected number of reboot events within the evaluation window.
-	// If not set, it defaults to 2.
-	Threshold int `json:"threshold"`
-
 	// ThresholdOverrides configures per-XID threshold overrides.
 	ThresholdOverrides map[int]ThresholdOverride `json:"thresholdOverrides,omitempty"`
 }
@@ -30,9 +26,9 @@ const (
 	// events that happen after a reboot-recoverable XID, and if the same XID is
 	// still asking for RebootSystem after this threshold, gpud treats repeated
 	// reboots as insufficient recovery and recommends hardware inspection.
-	// Operators can override this default globally with --xid-reboot-threshold
-	// and can override individual XIDs with --xid-thresholds or session
-	// updateConfig thresholdOverrides.
+	// Operators can override individual XIDs with --xid-thresholds or session
+	// updateConfig thresholdOverrides. The legacy --xid-reboot-threshold flag
+	// can still override this global fallback separately.
 	DefaultRebootThreshold = 2
 	// DefaultLookbackPeriod is the default lookback window for XID events.
 	DefaultLookbackPeriod = eventstore.DefaultRetention
@@ -52,13 +48,34 @@ var (
 
 	defaultThresholdsMu sync.RWMutex
 	defaultThresholds   = Thresholds{
-		Threshold:          DefaultRebootThreshold,
 		ThresholdOverrides: defaultThresholdOverrides,
 	}
+
+	defaultRebootThresholdMu sync.RWMutex
+	defaultRebootThreshold   = DefaultRebootThreshold
 
 	defaultLookbackPeriodMu sync.RWMutex
 	defaultLookbackPeriod   = DefaultLookbackPeriod
 )
+
+// GetDefaultRebootThreshold returns the configured global XID reboot threshold.
+func GetDefaultRebootThreshold() int {
+	defaultRebootThresholdMu.RLock()
+	defer defaultRebootThresholdMu.RUnlock()
+	return defaultRebootThreshold
+}
+
+// SetDefaultRebootThreshold updates the configured global XID reboot threshold.
+func SetDefaultRebootThreshold(threshold int) {
+	if threshold <= 0 {
+		threshold = DefaultRebootThreshold
+	}
+	log.Logger.Infow("setting default xid reboot threshold", "threshold", threshold)
+
+	defaultRebootThresholdMu.Lock()
+	defer defaultRebootThresholdMu.Unlock()
+	defaultRebootThreshold = threshold
+}
 
 // GetDefaultThresholds returns the configured threshold policy for XID recovery.
 func GetDefaultThresholds() Thresholds {
@@ -70,7 +87,7 @@ func GetDefaultThresholds() Thresholds {
 // SetDefaultThresholds updates the configured threshold policy for XID recovery.
 func SetDefaultThresholds(thresholds Thresholds) {
 	thresholds = normalizeThresholds(thresholds)
-	log.Logger.Infow("setting default xid thresholds", "threshold", thresholds.Threshold, "thresholdOverrides", thresholds.ThresholdOverrides)
+	log.Logger.Infow("setting default xid thresholds", "thresholdOverrides", thresholds.ThresholdOverrides)
 
 	defaultThresholdsMu.Lock()
 	defer defaultThresholdsMu.Unlock()
@@ -102,10 +119,10 @@ func cloneThresholdOverrides(overrides map[int]ThresholdOverride) map[int]Thresh
 	return ret
 }
 
-func rebootThresholdForXID(xid uint64, thresholds Thresholds) int {
+func rebootThresholdForXID(xid uint64, defaultRebootThreshold int, thresholds Thresholds) int {
 	xidID, ok := intFromUint64(xid)
 	if !ok {
-		return thresholds.Threshold
+		return defaultRebootThreshold
 	}
 
 	if thresholds.ThresholdOverrides == nil {
@@ -114,7 +131,7 @@ func rebootThresholdForXID(xid uint64, thresholds Thresholds) int {
 	if override, ok := thresholds.ThresholdOverrides[xidID]; ok && override.RebootThreshold > 0 {
 		return override.RebootThreshold
 	}
-	return thresholds.Threshold
+	return defaultRebootThreshold
 }
 
 // GetLookbackPeriod returns the XID event lookback window.

--- a/components/accelerator/nvidia/xid/threshold.go
+++ b/components/accelerator/nvidia/xid/threshold.go
@@ -8,8 +8,8 @@ import (
 	"github.com/leptonai/gpud/pkg/log"
 )
 
-// RebootThreshold configures the expected reboot threshold.
-type RebootThreshold struct {
+// Thresholds configures the XID reboot threshold policy.
+type Thresholds struct {
 	// Threshold is the expected number of reboot events within the evaluation window.
 	// If not set, it defaults to 2.
 	Threshold int `json:"threshold"`
@@ -50,8 +50,8 @@ var (
 		94: {RebootThreshold: 1000},
 	}
 
-	defaultRebootThresholdMu sync.RWMutex
-	defaultRebootThreshold   = RebootThreshold{
+	defaultThresholdsMu sync.RWMutex
+	defaultThresholds   = Thresholds{
 		Threshold:          DefaultRebootThreshold,
 		ThresholdOverrides: defaultThresholdOverrides,
 	}
@@ -60,35 +60,35 @@ var (
 	defaultLookbackPeriod   = DefaultLookbackPeriod
 )
 
-// GetDefaultRebootThreshold returns the configured reboot threshold for XID recovery.
-func GetDefaultRebootThreshold() RebootThreshold {
-	defaultRebootThresholdMu.RLock()
-	defer defaultRebootThresholdMu.RUnlock()
-	return cloneRebootThreshold(defaultRebootThreshold)
+// GetDefaultThresholds returns the configured threshold policy for XID recovery.
+func GetDefaultThresholds() Thresholds {
+	defaultThresholdsMu.RLock()
+	defer defaultThresholdsMu.RUnlock()
+	return cloneThresholds(defaultThresholds)
 }
 
-// SetDefaultRebootThreshold updates the configured reboot threshold for XID recovery.
-func SetDefaultRebootThreshold(threshold RebootThreshold) {
-	threshold = normalizeRebootThreshold(threshold)
-	log.Logger.Infow("setting default reboot threshold", "threshold", threshold.Threshold, "thresholdOverrides", threshold.ThresholdOverrides)
+// SetDefaultThresholds updates the configured threshold policy for XID recovery.
+func SetDefaultThresholds(thresholds Thresholds) {
+	thresholds = normalizeThresholds(thresholds)
+	log.Logger.Infow("setting default xid thresholds", "threshold", thresholds.Threshold, "thresholdOverrides", thresholds.ThresholdOverrides)
 
-	defaultRebootThresholdMu.Lock()
-	defer defaultRebootThresholdMu.Unlock()
-	defaultRebootThreshold = threshold
+	defaultThresholdsMu.Lock()
+	defer defaultThresholdsMu.Unlock()
+	defaultThresholds = thresholds
 }
 
-func normalizeRebootThreshold(threshold RebootThreshold) RebootThreshold {
+func normalizeThresholds(thresholds Thresholds) Thresholds {
 	thresholdOverrides := cloneThresholdOverrides(defaultThresholdOverrides)
-	for xid, override := range threshold.ThresholdOverrides {
+	for xid, override := range thresholds.ThresholdOverrides {
 		thresholdOverrides[xid] = override
 	}
-	threshold.ThresholdOverrides = thresholdOverrides
-	return threshold
+	thresholds.ThresholdOverrides = thresholdOverrides
+	return thresholds
 }
 
-func cloneRebootThreshold(threshold RebootThreshold) RebootThreshold {
-	threshold.ThresholdOverrides = cloneThresholdOverrides(threshold.ThresholdOverrides)
-	return threshold
+func cloneThresholds(thresholds Thresholds) Thresholds {
+	thresholds.ThresholdOverrides = cloneThresholdOverrides(thresholds.ThresholdOverrides)
+	return thresholds
 }
 
 func cloneThresholdOverrides(overrides map[int]ThresholdOverride) map[int]ThresholdOverride {
@@ -102,19 +102,19 @@ func cloneThresholdOverrides(overrides map[int]ThresholdOverride) map[int]Thresh
 	return ret
 }
 
-func rebootThresholdForXID(xid uint64, threshold RebootThreshold) int {
+func rebootThresholdForXID(xid uint64, thresholds Thresholds) int {
 	xidID, ok := intFromUint64(xid)
 	if !ok {
-		return threshold.Threshold
+		return thresholds.Threshold
 	}
 
-	if threshold.ThresholdOverrides == nil {
-		threshold.ThresholdOverrides = defaultThresholdOverrides
+	if thresholds.ThresholdOverrides == nil {
+		thresholds.ThresholdOverrides = defaultThresholdOverrides
 	}
-	if override, ok := threshold.ThresholdOverrides[xidID]; ok && override.RebootThreshold > 0 {
+	if override, ok := thresholds.ThresholdOverrides[xidID]; ok && override.RebootThreshold > 0 {
 		return override.RebootThreshold
 	}
-	return threshold.Threshold
+	return thresholds.Threshold
 }
 
 // GetLookbackPeriod returns the XID event lookback window.

--- a/components/accelerator/nvidia/xid/threshold.go
+++ b/components/accelerator/nvidia/xid/threshold.go
@@ -13,12 +13,32 @@ type RebootThreshold struct {
 	// Threshold is the expected number of reboot events within the evaluation window.
 	// If not set, it defaults to 2.
 	Threshold int `json:"threshold"`
+
+	// ThresholdOverrides configures per-XID reboot thresholds.
+	ThresholdOverrides map[int]RebootThresholdOverride `json:"thresholdOverrides,omitempty"`
+}
+
+// RebootThresholdOverride configures the reboot threshold for one XID/SXID code.
+type RebootThresholdOverride struct {
+	RebootThreshold int `json:"rebootThreshold"`
 }
 
 var (
+	// XID 94 is application specific and does NOT warrant system reboot as a
+	// system-level repair signal: NVIDIA's XID catalog classifies it as a
+	// contained error whose immediate action is restarting the affected app.
+	// Critical ECC paths are still covered separately: XID 92 reports high
+	// single-bit ECC rate, XID 48/95/140 cover uncorrectable or uncontained ECC,
+	// and XID 63/64 plus the remapped-rows component cover row remapping. Keeping
+	// this override narrow avoids masking those critical hardware signals.
+	defaultRebootThresholdOverrides = map[int]RebootThresholdOverride{
+		94: {RebootThreshold: 1000},
+	}
+
 	defaultRebootThresholdMu sync.RWMutex
 	defaultRebootThreshold   = RebootThreshold{
-		Threshold: DefaultRebootThreshold,
+		Threshold:          DefaultRebootThreshold,
+		ThresholdOverrides: defaultRebootThresholdOverrides,
 	}
 
 	defaultLookbackPeriodMu sync.RWMutex
@@ -36,16 +56,57 @@ const (
 func GetDefaultRebootThreshold() RebootThreshold {
 	defaultRebootThresholdMu.RLock()
 	defer defaultRebootThresholdMu.RUnlock()
-	return defaultRebootThreshold
+	return cloneRebootThreshold(defaultRebootThreshold)
 }
 
 // SetDefaultRebootThreshold updates the configured reboot threshold for XID recovery.
 func SetDefaultRebootThreshold(threshold RebootThreshold) {
-	log.Logger.Infow("setting default reboot threshold", "threshold", threshold.Threshold)
+	threshold = normalizeRebootThreshold(threshold)
+	log.Logger.Infow("setting default reboot threshold", "threshold", threshold.Threshold, "thresholdOverrides", threshold.ThresholdOverrides)
 
 	defaultRebootThresholdMu.Lock()
 	defer defaultRebootThresholdMu.Unlock()
 	defaultRebootThreshold = threshold
+}
+
+func normalizeRebootThreshold(threshold RebootThreshold) RebootThreshold {
+	thresholdOverrides := cloneRebootThresholdOverrides(defaultRebootThresholdOverrides)
+	for xid, override := range threshold.ThresholdOverrides {
+		thresholdOverrides[xid] = override
+	}
+	threshold.ThresholdOverrides = thresholdOverrides
+	return threshold
+}
+
+func cloneRebootThreshold(threshold RebootThreshold) RebootThreshold {
+	threshold.ThresholdOverrides = cloneRebootThresholdOverrides(threshold.ThresholdOverrides)
+	return threshold
+}
+
+func cloneRebootThresholdOverrides(overrides map[int]RebootThresholdOverride) map[int]RebootThresholdOverride {
+	if overrides == nil {
+		return nil
+	}
+	ret := make(map[int]RebootThresholdOverride, len(overrides))
+	for xid, threshold := range overrides {
+		ret[xid] = threshold
+	}
+	return ret
+}
+
+func rebootThresholdForXID(xid uint64, threshold RebootThreshold) int {
+	xidID, ok := intFromUint64(xid)
+	if !ok {
+		return threshold.Threshold
+	}
+
+	if threshold.ThresholdOverrides == nil {
+		threshold.ThresholdOverrides = defaultRebootThresholdOverrides
+	}
+	if override, ok := threshold.ThresholdOverrides[xidID]; ok && override.RebootThreshold > 0 {
+		return override.RebootThreshold
+	}
+	return threshold.Threshold
 }
 
 // GetLookbackPeriod returns the XID event lookback window.

--- a/components/accelerator/nvidia/xid/threshold.go
+++ b/components/accelerator/nvidia/xid/threshold.go
@@ -10,8 +10,8 @@ import (
 
 // Thresholds configures the XID reboot threshold policy.
 type Thresholds struct {
-	// ThresholdOverrides configures per-XID threshold overrides.
-	ThresholdOverrides map[int]ThresholdOverride `json:"thresholdOverrides,omitempty"`
+	// Overrides configures per-XID threshold overrides.
+	Overrides map[int]ThresholdOverride `json:"overrides,omitempty"`
 }
 
 // ThresholdOverride configures threshold overrides for one XID code.
@@ -27,7 +27,7 @@ const (
 	// still asking for RebootSystem after this threshold, gpud treats repeated
 	// reboots as insufficient recovery and recommends hardware inspection.
 	// Operators can override individual XIDs with --xid-thresholds or session
-	// updateConfig thresholdOverrides. The legacy --xid-reboot-threshold flag
+	// updateConfig overrides. The legacy --xid-reboot-threshold flag
 	// can still override this global fallback separately.
 	DefaultRebootThreshold = 2
 	// DefaultLookbackPeriod is the default lookback window for XID events.
@@ -42,13 +42,13 @@ var (
 	// single-bit ECC rate, XID 48/95/140 cover uncorrectable or uncontained ECC,
 	// and XID 63/64 plus the remapped-rows component cover row remapping. Keeping
 	// this override narrow avoids masking those critical hardware signals.
-	defaultThresholdOverrides = map[int]ThresholdOverride{
+	defaultOverrides = map[int]ThresholdOverride{
 		94: {RebootThreshold: 1000},
 	}
 
 	defaultThresholdsMu sync.RWMutex
 	defaultThresholds   = Thresholds{
-		ThresholdOverrides: defaultThresholdOverrides,
+		Overrides: defaultOverrides,
 	}
 
 	defaultRebootThresholdMu sync.RWMutex
@@ -87,7 +87,7 @@ func GetDefaultThresholds() Thresholds {
 // SetDefaultThresholds updates the configured threshold policy for XID recovery.
 func SetDefaultThresholds(thresholds Thresholds) {
 	thresholds = normalizeThresholds(thresholds)
-	log.Logger.Infow("setting default xid thresholds", "thresholdOverrides", thresholds.ThresholdOverrides)
+	log.Logger.Infow("setting default xid thresholds", "overrides", thresholds.Overrides)
 
 	defaultThresholdsMu.Lock()
 	defer defaultThresholdsMu.Unlock()
@@ -95,20 +95,20 @@ func SetDefaultThresholds(thresholds Thresholds) {
 }
 
 func normalizeThresholds(thresholds Thresholds) Thresholds {
-	thresholdOverrides := cloneThresholdOverrides(defaultThresholdOverrides)
-	for xid, override := range thresholds.ThresholdOverrides {
-		thresholdOverrides[xid] = override
+	overrides := cloneOverrides(defaultOverrides)
+	for xid, override := range thresholds.Overrides {
+		overrides[xid] = override
 	}
-	thresholds.ThresholdOverrides = thresholdOverrides
+	thresholds.Overrides = overrides
 	return thresholds
 }
 
 func cloneThresholds(thresholds Thresholds) Thresholds {
-	thresholds.ThresholdOverrides = cloneThresholdOverrides(thresholds.ThresholdOverrides)
+	thresholds.Overrides = cloneOverrides(thresholds.Overrides)
 	return thresholds
 }
 
-func cloneThresholdOverrides(overrides map[int]ThresholdOverride) map[int]ThresholdOverride {
+func cloneOverrides(overrides map[int]ThresholdOverride) map[int]ThresholdOverride {
 	if overrides == nil {
 		return nil
 	}
@@ -125,10 +125,10 @@ func rebootThresholdForXID(xid uint64, defaultRebootThreshold int, thresholds Th
 		return defaultRebootThreshold
 	}
 
-	if thresholds.ThresholdOverrides == nil {
-		thresholds.ThresholdOverrides = defaultThresholdOverrides
+	if thresholds.Overrides == nil {
+		thresholds.Overrides = defaultOverrides
 	}
-	if override, ok := thresholds.ThresholdOverrides[xidID]; ok && override.RebootThreshold > 0 {
+	if override, ok := thresholds.Overrides[xidID]; ok && override.RebootThreshold > 0 {
 		return override.RebootThreshold
 	}
 	return defaultRebootThreshold

--- a/components/accelerator/nvidia/xid/threshold.go
+++ b/components/accelerator/nvidia/xid/threshold.go
@@ -14,12 +14,12 @@ type RebootThreshold struct {
 	// If not set, it defaults to 2.
 	Threshold int `json:"threshold"`
 
-	// ThresholdOverrides configures per-XID reboot thresholds.
-	ThresholdOverrides map[int]RebootThresholdOverride `json:"thresholdOverrides,omitempty"`
+	// ThresholdOverrides configures per-XID threshold overrides.
+	ThresholdOverrides map[int]ThresholdOverride `json:"thresholdOverrides,omitempty"`
 }
 
-// RebootThresholdOverride configures the reboot threshold for one XID/SXID code.
-type RebootThresholdOverride struct {
+// ThresholdOverride configures threshold overrides for one XID code.
+type ThresholdOverride struct {
 	RebootThreshold int `json:"rebootThreshold"`
 }
 
@@ -31,7 +31,7 @@ const (
 	// still asking for RebootSystem after this threshold, gpud treats repeated
 	// reboots as insufficient recovery and recommends hardware inspection.
 	// Operators can override this default globally with --xid-reboot-threshold
-	// and can override individual XIDs with --xid-reboot-thresholds or session
+	// and can override individual XIDs with --xid-thresholds or session
 	// updateConfig thresholdOverrides.
 	DefaultRebootThreshold = 2
 	// DefaultLookbackPeriod is the default lookback window for XID events.
@@ -46,14 +46,14 @@ var (
 	// single-bit ECC rate, XID 48/95/140 cover uncorrectable or uncontained ECC,
 	// and XID 63/64 plus the remapped-rows component cover row remapping. Keeping
 	// this override narrow avoids masking those critical hardware signals.
-	defaultRebootThresholdOverrides = map[int]RebootThresholdOverride{
+	defaultThresholdOverrides = map[int]ThresholdOverride{
 		94: {RebootThreshold: 1000},
 	}
 
 	defaultRebootThresholdMu sync.RWMutex
 	defaultRebootThreshold   = RebootThreshold{
 		Threshold:          DefaultRebootThreshold,
-		ThresholdOverrides: defaultRebootThresholdOverrides,
+		ThresholdOverrides: defaultThresholdOverrides,
 	}
 
 	defaultLookbackPeriodMu sync.RWMutex
@@ -78,7 +78,7 @@ func SetDefaultRebootThreshold(threshold RebootThreshold) {
 }
 
 func normalizeRebootThreshold(threshold RebootThreshold) RebootThreshold {
-	thresholdOverrides := cloneRebootThresholdOverrides(defaultRebootThresholdOverrides)
+	thresholdOverrides := cloneThresholdOverrides(defaultThresholdOverrides)
 	for xid, override := range threshold.ThresholdOverrides {
 		thresholdOverrides[xid] = override
 	}
@@ -87,15 +87,15 @@ func normalizeRebootThreshold(threshold RebootThreshold) RebootThreshold {
 }
 
 func cloneRebootThreshold(threshold RebootThreshold) RebootThreshold {
-	threshold.ThresholdOverrides = cloneRebootThresholdOverrides(threshold.ThresholdOverrides)
+	threshold.ThresholdOverrides = cloneThresholdOverrides(threshold.ThresholdOverrides)
 	return threshold
 }
 
-func cloneRebootThresholdOverrides(overrides map[int]RebootThresholdOverride) map[int]RebootThresholdOverride {
+func cloneThresholdOverrides(overrides map[int]ThresholdOverride) map[int]ThresholdOverride {
 	if overrides == nil {
 		return nil
 	}
-	ret := make(map[int]RebootThresholdOverride, len(overrides))
+	ret := make(map[int]ThresholdOverride, len(overrides))
 	for xid, threshold := range overrides {
 		ret[xid] = threshold
 	}
@@ -109,7 +109,7 @@ func rebootThresholdForXID(xid uint64, threshold RebootThreshold) int {
 	}
 
 	if threshold.ThresholdOverrides == nil {
-		threshold.ThresholdOverrides = defaultRebootThresholdOverrides
+		threshold.ThresholdOverrides = defaultThresholdOverrides
 	}
 	if override, ok := threshold.ThresholdOverrides[xidID]; ok && override.RebootThreshold > 0 {
 		return override.RebootThreshold

--- a/components/accelerator/nvidia/xid/threshold_test.go
+++ b/components/accelerator/nvidia/xid/threshold_test.go
@@ -33,7 +33,7 @@ func TestDefaultExpectedPortStates(t *testing.T) {
 func TestRebootThresholdForXID(t *testing.T) {
 	threshold := RebootThreshold{
 		Threshold: DefaultRebootThreshold,
-		ThresholdOverrides: map[int]RebootThresholdOverride{
+		ThresholdOverrides: map[int]ThresholdOverride{
 			94: {RebootThreshold: 1000},
 		},
 	}

--- a/components/accelerator/nvidia/xid/threshold_test.go
+++ b/components/accelerator/nvidia/xid/threshold_test.go
@@ -17,6 +17,7 @@ func TestDefaultThresholds(t *testing.T) {
 	})
 
 	// Test default values
+	assert.Equal(t, 2, DefaultRebootThreshold)
 	assert.Equal(t, DefaultRebootThreshold, GetDefaultRebootThreshold())
 	defaultThresholds := GetDefaultThresholds()
 	assert.Equal(t, 1000, defaultThresholds.ThresholdOverrides[94].RebootThreshold)
@@ -24,6 +25,8 @@ func TestDefaultThresholds(t *testing.T) {
 	// Test setting a global reboot threshold separately from per-XID overrides.
 	SetDefaultRebootThreshold(4)
 	assert.Equal(t, 4, GetDefaultRebootThreshold())
+	SetDefaultRebootThreshold(0)
+	assert.Equal(t, 2, GetDefaultRebootThreshold())
 
 	// Test setting new override values.
 	newThresholds := Thresholds{
@@ -46,7 +49,7 @@ func TestRebootThresholdForXID(t *testing.T) {
 	}
 
 	assert.Equal(t, 1000, rebootThresholdForXID(94, DefaultRebootThreshold, threshold))
-	assert.Equal(t, DefaultRebootThreshold, rebootThresholdForXID(95, DefaultRebootThreshold, threshold))
+	assert.Equal(t, 2, rebootThresholdForXID(95, DefaultRebootThreshold, threshold))
 }
 
 func TestDefaultLookbackPeriod(t *testing.T) {

--- a/components/accelerator/nvidia/xid/threshold_test.go
+++ b/components/accelerator/nvidia/xid/threshold_test.go
@@ -17,6 +17,7 @@ func TestDefaultExpectedPortStates(t *testing.T) {
 	// Test default values
 	defaultRebootThreshold := GetDefaultRebootThreshold()
 	assert.Equal(t, DefaultRebootThreshold, defaultRebootThreshold.Threshold)
+	assert.Equal(t, 1000, defaultRebootThreshold.ThresholdOverrides[94].RebootThreshold)
 
 	// Test setting new values
 	newRebootThreshold := RebootThreshold{
@@ -26,6 +27,19 @@ func TestDefaultExpectedPortStates(t *testing.T) {
 
 	updatedRebootThreshold := GetDefaultRebootThreshold()
 	assert.Equal(t, newRebootThreshold.Threshold, updatedRebootThreshold.Threshold)
+	assert.Equal(t, 1000, updatedRebootThreshold.ThresholdOverrides[94].RebootThreshold)
+}
+
+func TestRebootThresholdForXID(t *testing.T) {
+	threshold := RebootThreshold{
+		Threshold: DefaultRebootThreshold,
+		ThresholdOverrides: map[int]RebootThresholdOverride{
+			94: {RebootThreshold: 1000},
+		},
+	}
+
+	assert.Equal(t, 1000, rebootThresholdForXID(94, threshold))
+	assert.Equal(t, DefaultRebootThreshold, rebootThresholdForXID(95, threshold))
 }
 
 func TestDefaultLookbackPeriod(t *testing.T) {

--- a/components/accelerator/nvidia/xid/threshold_test.go
+++ b/components/accelerator/nvidia/xid/threshold_test.go
@@ -20,7 +20,7 @@ func TestDefaultThresholds(t *testing.T) {
 	assert.Equal(t, 2, DefaultRebootThreshold)
 	assert.Equal(t, DefaultRebootThreshold, GetDefaultRebootThreshold())
 	defaultThresholds := GetDefaultThresholds()
-	assert.Equal(t, 1000, defaultThresholds.ThresholdOverrides[94].RebootThreshold)
+	assert.Equal(t, 1000, defaultThresholds.Overrides[94].RebootThreshold)
 
 	// Test setting a global reboot threshold separately from per-XID overrides.
 	SetDefaultRebootThreshold(4)
@@ -30,20 +30,20 @@ func TestDefaultThresholds(t *testing.T) {
 
 	// Test setting new override values.
 	newThresholds := Thresholds{
-		ThresholdOverrides: map[int]ThresholdOverride{
+		Overrides: map[int]ThresholdOverride{
 			95: {RebootThreshold: 5},
 		},
 	}
 	SetDefaultThresholds(newThresholds)
 
 	updatedThresholds := GetDefaultThresholds()
-	assert.Equal(t, 5, updatedThresholds.ThresholdOverrides[95].RebootThreshold)
-	assert.Equal(t, 1000, updatedThresholds.ThresholdOverrides[94].RebootThreshold)
+	assert.Equal(t, 5, updatedThresholds.Overrides[95].RebootThreshold)
+	assert.Equal(t, 1000, updatedThresholds.Overrides[94].RebootThreshold)
 }
 
 func TestRebootThresholdForXID(t *testing.T) {
 	threshold := Thresholds{
-		ThresholdOverrides: map[int]ThresholdOverride{
+		Overrides: map[int]ThresholdOverride{
 			94: {RebootThreshold: 1000},
 		},
 	}

--- a/components/accelerator/nvidia/xid/threshold_test.go
+++ b/components/accelerator/nvidia/xid/threshold_test.go
@@ -9,37 +9,44 @@ import (
 
 func TestDefaultThresholds(t *testing.T) {
 	// Save original value and restore it after the test to avoid polluting other tests
+	originalRebootThreshold := GetDefaultRebootThreshold()
 	original := GetDefaultThresholds()
 	t.Cleanup(func() {
+		SetDefaultRebootThreshold(originalRebootThreshold)
 		SetDefaultThresholds(original)
 	})
 
 	// Test default values
+	assert.Equal(t, DefaultRebootThreshold, GetDefaultRebootThreshold())
 	defaultThresholds := GetDefaultThresholds()
-	assert.Equal(t, DefaultRebootThreshold, defaultThresholds.Threshold)
 	assert.Equal(t, 1000, defaultThresholds.ThresholdOverrides[94].RebootThreshold)
 
-	// Test setting new values
+	// Test setting a global reboot threshold separately from per-XID overrides.
+	SetDefaultRebootThreshold(4)
+	assert.Equal(t, 4, GetDefaultRebootThreshold())
+
+	// Test setting new override values.
 	newThresholds := Thresholds{
-		Threshold: 4,
+		ThresholdOverrides: map[int]ThresholdOverride{
+			95: {RebootThreshold: 5},
+		},
 	}
 	SetDefaultThresholds(newThresholds)
 
 	updatedThresholds := GetDefaultThresholds()
-	assert.Equal(t, newThresholds.Threshold, updatedThresholds.Threshold)
+	assert.Equal(t, 5, updatedThresholds.ThresholdOverrides[95].RebootThreshold)
 	assert.Equal(t, 1000, updatedThresholds.ThresholdOverrides[94].RebootThreshold)
 }
 
 func TestRebootThresholdForXID(t *testing.T) {
 	threshold := Thresholds{
-		Threshold: DefaultRebootThreshold,
 		ThresholdOverrides: map[int]ThresholdOverride{
 			94: {RebootThreshold: 1000},
 		},
 	}
 
-	assert.Equal(t, 1000, rebootThresholdForXID(94, threshold))
-	assert.Equal(t, DefaultRebootThreshold, rebootThresholdForXID(95, threshold))
+	assert.Equal(t, 1000, rebootThresholdForXID(94, DefaultRebootThreshold, threshold))
+	assert.Equal(t, DefaultRebootThreshold, rebootThresholdForXID(95, DefaultRebootThreshold, threshold))
 }
 
 func TestDefaultLookbackPeriod(t *testing.T) {

--- a/components/accelerator/nvidia/xid/threshold_test.go
+++ b/components/accelerator/nvidia/xid/threshold_test.go
@@ -7,31 +7,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDefaultExpectedPortStates(t *testing.T) {
+func TestDefaultThresholds(t *testing.T) {
 	// Save original value and restore it after the test to avoid polluting other tests
-	original := GetDefaultRebootThreshold()
+	original := GetDefaultThresholds()
 	t.Cleanup(func() {
-		SetDefaultRebootThreshold(original)
+		SetDefaultThresholds(original)
 	})
 
 	// Test default values
-	defaultRebootThreshold := GetDefaultRebootThreshold()
-	assert.Equal(t, DefaultRebootThreshold, defaultRebootThreshold.Threshold)
-	assert.Equal(t, 1000, defaultRebootThreshold.ThresholdOverrides[94].RebootThreshold)
+	defaultThresholds := GetDefaultThresholds()
+	assert.Equal(t, DefaultRebootThreshold, defaultThresholds.Threshold)
+	assert.Equal(t, 1000, defaultThresholds.ThresholdOverrides[94].RebootThreshold)
 
 	// Test setting new values
-	newRebootThreshold := RebootThreshold{
+	newThresholds := Thresholds{
 		Threshold: 4,
 	}
-	SetDefaultRebootThreshold(newRebootThreshold)
+	SetDefaultThresholds(newThresholds)
 
-	updatedRebootThreshold := GetDefaultRebootThreshold()
-	assert.Equal(t, newRebootThreshold.Threshold, updatedRebootThreshold.Threshold)
-	assert.Equal(t, 1000, updatedRebootThreshold.ThresholdOverrides[94].RebootThreshold)
+	updatedThresholds := GetDefaultThresholds()
+	assert.Equal(t, newThresholds.Threshold, updatedThresholds.Threshold)
+	assert.Equal(t, 1000, updatedThresholds.ThresholdOverrides[94].RebootThreshold)
 }
 
 func TestRebootThresholdForXID(t *testing.T) {
-	threshold := RebootThreshold{
+	threshold := Thresholds{
 		Threshold: DefaultRebootThreshold,
 		ThresholdOverrides: map[int]ThresholdOverride{
 			94: {RebootThreshold: 1000},

--- a/pkg/session/mock_session_test.go
+++ b/pkg/session/mock_session_test.go
@@ -1358,16 +1358,12 @@ func TestMockeyProcessUpdateConfig_GPUCounts(t *testing.T) {
 
 func TestMockeyProcessUpdateConfig_XIDConfig(t *testing.T) {
 	mockey.PatchConvey("processUpdateConfig handles valid XID config", t, func() {
-		var receivedRebootThreshold int
 		var receivedThresholds componentsxid.Thresholds
 		s := &Session{
 			setDefaultIbExpectedPortStatesFunc:     func(states componentsnvidiainfinibanditypes.ExpectedPortStates) {},
 			setDefaultNVLinkExpectedLinkStatesFunc: func(states componentsnvidianvlink.ExpectedLinkStates) {},
 			setDefaultGPUCountsFunc:                func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {},
 			setDefaultNFSGroupConfigsFunc:          func(cfgs pkgnfschecker.Configs) {},
-			setDefaultXIDRebootThresholdFunc: func(threshold int) {
-				receivedRebootThreshold = threshold
-			},
 			setDefaultXIDThresholdsFunc: func(thresholds componentsxid.Thresholds) {
 				receivedThresholds = thresholds
 			},
@@ -1375,15 +1371,14 @@ func TestMockeyProcessUpdateConfig_XIDConfig(t *testing.T) {
 		}
 
 		configMap := map[string]string{
-			"accelerator-nvidia-error-xid": `{"threshold": 10}`,
+			"accelerator-nvidia-error-xid": `{"thresholdOverrides":{"94":{"rebootThreshold":1000}}}`,
 		}
 		resp := &Response{}
 
 		s.processUpdateConfig(configMap, resp)
 
 		assert.Empty(t, resp.Error)
-		assert.Equal(t, 10, receivedRebootThreshold)
-		assert.Empty(t, receivedThresholds.ThresholdOverrides)
+		assert.Equal(t, 1000, receivedThresholds.ThresholdOverrides[94].RebootThreshold)
 	})
 }
 

--- a/pkg/session/mock_session_test.go
+++ b/pkg/session/mock_session_test.go
@@ -1371,14 +1371,14 @@ func TestMockeyProcessUpdateConfig_XIDConfig(t *testing.T) {
 		}
 
 		configMap := map[string]string{
-			"accelerator-nvidia-error-xid": `{"thresholdOverrides":{"94":{"rebootThreshold":1000}}}`,
+			"accelerator-nvidia-error-xid": `{"overrides":{"94":{"rebootThreshold":1000}}}`,
 		}
 		resp := &Response{}
 
 		s.processUpdateConfig(configMap, resp)
 
 		assert.Empty(t, resp.Error)
-		assert.Equal(t, 1000, receivedThresholds.ThresholdOverrides[94].RebootThreshold)
+		assert.Equal(t, 1000, receivedThresholds.Overrides[94].RebootThreshold)
 	})
 }
 

--- a/pkg/session/mock_session_test.go
+++ b/pkg/session/mock_session_test.go
@@ -1358,12 +1358,16 @@ func TestMockeyProcessUpdateConfig_GPUCounts(t *testing.T) {
 
 func TestMockeyProcessUpdateConfig_XIDConfig(t *testing.T) {
 	mockey.PatchConvey("processUpdateConfig handles valid XID config", t, func() {
+		var receivedRebootThreshold int
 		var receivedThresholds componentsxid.Thresholds
 		s := &Session{
 			setDefaultIbExpectedPortStatesFunc:     func(states componentsnvidiainfinibanditypes.ExpectedPortStates) {},
 			setDefaultNVLinkExpectedLinkStatesFunc: func(states componentsnvidianvlink.ExpectedLinkStates) {},
 			setDefaultGPUCountsFunc:                func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {},
 			setDefaultNFSGroupConfigsFunc:          func(cfgs pkgnfschecker.Configs) {},
+			setDefaultXIDRebootThresholdFunc: func(threshold int) {
+				receivedRebootThreshold = threshold
+			},
 			setDefaultXIDThresholdsFunc: func(thresholds componentsxid.Thresholds) {
 				receivedThresholds = thresholds
 			},
@@ -1378,7 +1382,8 @@ func TestMockeyProcessUpdateConfig_XIDConfig(t *testing.T) {
 		s.processUpdateConfig(configMap, resp)
 
 		assert.Empty(t, resp.Error)
-		assert.Equal(t, 10, receivedThresholds.Threshold)
+		assert.Equal(t, 10, receivedRebootThreshold)
+		assert.Empty(t, receivedThresholds.ThresholdOverrides)
 	})
 }
 

--- a/pkg/session/mock_session_test.go
+++ b/pkg/session/mock_session_test.go
@@ -1297,7 +1297,7 @@ func TestMockeyProcessUpdateConfig_InfinibandConfig(t *testing.T) {
 			setDefaultNVLinkExpectedLinkStatesFunc: func(states componentsnvidianvlink.ExpectedLinkStates) {},
 			setDefaultGPUCountsFunc:                func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {},
 			setDefaultNFSGroupConfigsFunc:          func(cfgs pkgnfschecker.Configs) {},
-			setDefaultXIDRebootThresholdFunc:       func(threshold componentsxid.RebootThreshold) {},
+			setDefaultXIDThresholdsFunc:            func(threshold componentsxid.Thresholds) {},
 			setDefaultTemperatureThresholdsFunc:    func(thresholds componentstemperature.Thresholds) {},
 		}
 
@@ -1340,7 +1340,7 @@ func TestMockeyProcessUpdateConfig_GPUCounts(t *testing.T) {
 				receivedCounts = counts
 			},
 			setDefaultNFSGroupConfigsFunc:       func(cfgs pkgnfschecker.Configs) {},
-			setDefaultXIDRebootThresholdFunc:    func(threshold componentsxid.RebootThreshold) {},
+			setDefaultXIDThresholdsFunc:         func(threshold componentsxid.Thresholds) {},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {},
 		}
 
@@ -1358,14 +1358,14 @@ func TestMockeyProcessUpdateConfig_GPUCounts(t *testing.T) {
 
 func TestMockeyProcessUpdateConfig_XIDConfig(t *testing.T) {
 	mockey.PatchConvey("processUpdateConfig handles valid XID config", t, func() {
-		var receivedThreshold componentsxid.RebootThreshold
+		var receivedThresholds componentsxid.Thresholds
 		s := &Session{
 			setDefaultIbExpectedPortStatesFunc:     func(states componentsnvidiainfinibanditypes.ExpectedPortStates) {},
 			setDefaultNVLinkExpectedLinkStatesFunc: func(states componentsnvidianvlink.ExpectedLinkStates) {},
 			setDefaultGPUCountsFunc:                func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {},
 			setDefaultNFSGroupConfigsFunc:          func(cfgs pkgnfschecker.Configs) {},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
-				receivedThreshold = threshold
+			setDefaultXIDThresholdsFunc: func(thresholds componentsxid.Thresholds) {
+				receivedThresholds = thresholds
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {},
 		}
@@ -1378,7 +1378,7 @@ func TestMockeyProcessUpdateConfig_XIDConfig(t *testing.T) {
 		s.processUpdateConfig(configMap, resp)
 
 		assert.Empty(t, resp.Error)
-		assert.Equal(t, 10, receivedThreshold.Threshold)
+		assert.Equal(t, 10, receivedThresholds.Threshold)
 	})
 }
 
@@ -1390,7 +1390,7 @@ func TestMockeyProcessUpdateConfig_TemperatureConfig(t *testing.T) {
 			setDefaultNVLinkExpectedLinkStatesFunc: func(states componentsnvidianvlink.ExpectedLinkStates) {},
 			setDefaultGPUCountsFunc:                func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {},
 			setDefaultNFSGroupConfigsFunc:          func(cfgs pkgnfschecker.Configs) {},
-			setDefaultXIDRebootThresholdFunc:       func(threshold componentsxid.RebootThreshold) {},
+			setDefaultXIDThresholdsFunc:            func(threshold componentsxid.Thresholds) {},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				receivedThresholds = thresholds
 			},
@@ -1415,7 +1415,7 @@ func TestMockeyProcessUpdateConfig_NilFuncs(t *testing.T) {
 			setDefaultNVLinkExpectedLinkStatesFunc: nil,
 			setDefaultGPUCountsFunc:                nil,
 			setDefaultNFSGroupConfigsFunc:          nil,
-			setDefaultXIDRebootThresholdFunc:       nil,
+			setDefaultXIDThresholdsFunc:            nil,
 			setDefaultTemperatureThresholdsFunc:    nil,
 		}
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -195,7 +195,6 @@ type Session struct {
 	setDefaultNVLinkExpectedLinkStatesFunc func(states componentsnvidianvlink.ExpectedLinkStates)
 	setDefaultGPUCountsFunc                func(counts componentsnvidiagpucounts.ExpectedGPUCounts)
 	setDefaultNFSGroupConfigsFunc          func(cfgs pkgnfschecker.Configs)
-	setDefaultXIDRebootThresholdFunc       func(threshold int)
 	setDefaultXIDThresholdsFunc            func(thresholds componentsxid.Thresholds)
 	setDefaultTemperatureThresholdsFunc    func(threshold componentstemperature.Thresholds)
 
@@ -304,7 +303,6 @@ func NewSession(ctx context.Context, epLocalGPUdServer string, epControlPlane st
 		setDefaultNVLinkExpectedLinkStatesFunc: componentsnvidianvlink.SetDefaultExpectedLinkStates,
 		setDefaultGPUCountsFunc:                componentsnvidiagpucounts.SetDefaultExpectedGPUCounts,
 		setDefaultNFSGroupConfigsFunc:          componentsnfs.SetDefaultConfigs,
-		setDefaultXIDRebootThresholdFunc:       componentsxid.SetDefaultRebootThreshold,
 		setDefaultXIDThresholdsFunc:            componentsxid.SetDefaultThresholds,
 		setDefaultTemperatureThresholdsFunc:    componentstemperature.SetDefaultMarginThreshold,
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -195,6 +195,7 @@ type Session struct {
 	setDefaultNVLinkExpectedLinkStatesFunc func(states componentsnvidianvlink.ExpectedLinkStates)
 	setDefaultGPUCountsFunc                func(counts componentsnvidiagpucounts.ExpectedGPUCounts)
 	setDefaultNFSGroupConfigsFunc          func(cfgs pkgnfschecker.Configs)
+	setDefaultXIDRebootThresholdFunc       func(threshold int)
 	setDefaultXIDThresholdsFunc            func(thresholds componentsxid.Thresholds)
 	setDefaultTemperatureThresholdsFunc    func(threshold componentstemperature.Thresholds)
 
@@ -303,6 +304,7 @@ func NewSession(ctx context.Context, epLocalGPUdServer string, epControlPlane st
 		setDefaultNVLinkExpectedLinkStatesFunc: componentsnvidianvlink.SetDefaultExpectedLinkStates,
 		setDefaultGPUCountsFunc:                componentsnvidiagpucounts.SetDefaultExpectedGPUCounts,
 		setDefaultNFSGroupConfigsFunc:          componentsnfs.SetDefaultConfigs,
+		setDefaultXIDRebootThresholdFunc:       componentsxid.SetDefaultRebootThreshold,
 		setDefaultXIDThresholdsFunc:            componentsxid.SetDefaultThresholds,
 		setDefaultTemperatureThresholdsFunc:    componentstemperature.SetDefaultMarginThreshold,
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -195,7 +195,7 @@ type Session struct {
 	setDefaultNVLinkExpectedLinkStatesFunc func(states componentsnvidianvlink.ExpectedLinkStates)
 	setDefaultGPUCountsFunc                func(counts componentsnvidiagpucounts.ExpectedGPUCounts)
 	setDefaultNFSGroupConfigsFunc          func(cfgs pkgnfschecker.Configs)
-	setDefaultXIDRebootThresholdFunc       func(threshold componentsxid.RebootThreshold)
+	setDefaultXIDThresholdsFunc            func(thresholds componentsxid.Thresholds)
 	setDefaultTemperatureThresholdsFunc    func(threshold componentstemperature.Thresholds)
 
 	nvmlInstance       nvidianvml.Instance
@@ -303,7 +303,7 @@ func NewSession(ctx context.Context, epLocalGPUdServer string, epControlPlane st
 		setDefaultNVLinkExpectedLinkStatesFunc: componentsnvidianvlink.SetDefaultExpectedLinkStates,
 		setDefaultGPUCountsFunc:                componentsnvidiagpucounts.SetDefaultExpectedGPUCounts,
 		setDefaultNFSGroupConfigsFunc:          componentsnfs.SetDefaultConfigs,
-		setDefaultXIDRebootThresholdFunc:       componentsxid.SetDefaultRebootThreshold,
+		setDefaultXIDThresholdsFunc:            componentsxid.SetDefaultThresholds,
 		setDefaultTemperatureThresholdsFunc:    componentstemperature.SetDefaultMarginThreshold,
 
 		nvmlInstance:       op.nvmlInstance,

--- a/pkg/session/update_config.go
+++ b/pkg/session/update_config.go
@@ -64,14 +64,14 @@ func (s *Session) processUpdateConfig(configMap map[string]string, resp *Respons
 
 		case componentsxid.Name:
 			setComponents[componentName] = struct{}{}
-			var updateCfg componentsxid.RebootThreshold
+			var updateCfg componentsxid.Thresholds
 			if err := json.Unmarshal([]byte(value), &updateCfg); err != nil {
 				log.Logger.Warnw("failed to unmarshal xid config", "error", err)
 				resp.Error = err.Error()
 				return
 			}
-			if s.setDefaultXIDRebootThresholdFunc != nil {
-				s.setDefaultXIDRebootThresholdFunc(updateCfg)
+			if s.setDefaultXIDThresholdsFunc != nil {
+				s.setDefaultXIDThresholdsFunc(updateCfg)
 			}
 
 		case componentstemperature.Name:
@@ -132,9 +132,9 @@ func (s *Session) processUpdateConfig(configMap map[string]string, resp *Respons
 		log.Logger.Infow("falling back to default empty nfs config")
 		s.setDefaultNFSGroupConfigsFunc(pkgnfschecker.Configs{})
 	}
-	if _, ok := setComponents[componentsxid.Name]; !ok && s.setDefaultXIDRebootThresholdFunc != nil {
+	if _, ok := setComponents[componentsxid.Name]; !ok && s.setDefaultXIDThresholdsFunc != nil {
 		log.Logger.Infow("falling back to default xid config")
-		s.setDefaultXIDRebootThresholdFunc(componentsxid.RebootThreshold{Threshold: componentsxid.DefaultRebootThreshold})
+		s.setDefaultXIDThresholdsFunc(componentsxid.Thresholds{Threshold: componentsxid.DefaultRebootThreshold})
 	}
 	if _, ok := setComponents[componentstemperature.Name]; !ok && s.setDefaultTemperatureThresholdsFunc != nil {
 		log.Logger.Infow("falling back to default temperature config")

--- a/pkg/session/update_config.go
+++ b/pkg/session/update_config.go
@@ -16,13 +16,6 @@ import (
 	pkgnfschecker "github.com/leptonai/gpud/pkg/nfs-checker"
 )
 
-type xidUpdateConfig struct {
-	// Threshold is kept for backward compatibility with legacy XID updateConfig
-	// payloads. New per-XID overrides live under ThresholdOverrides.
-	Threshold          *int                                    `json:"threshold,omitempty"`
-	ThresholdOverrides map[int]componentsxid.ThresholdOverride `json:"thresholdOverrides,omitempty"`
-}
-
 func (s *Session) processUpdateConfig(configMap map[string]string, resp *Response) {
 	if len(configMap) == 0 {
 		return
@@ -71,23 +64,14 @@ func (s *Session) processUpdateConfig(configMap map[string]string, resp *Respons
 
 		case componentsxid.Name:
 			setComponents[componentName] = struct{}{}
-			var updateCfg xidUpdateConfig
+			var updateCfg componentsxid.Thresholds
 			if err := json.Unmarshal([]byte(value), &updateCfg); err != nil {
 				log.Logger.Warnw("failed to unmarshal xid config", "error", err)
 				resp.Error = err.Error()
 				return
 			}
-			if s.setDefaultXIDRebootThresholdFunc != nil {
-				if updateCfg.Threshold != nil {
-					s.setDefaultXIDRebootThresholdFunc(*updateCfg.Threshold)
-				} else {
-					s.setDefaultXIDRebootThresholdFunc(componentsxid.DefaultRebootThreshold)
-				}
-			}
 			if s.setDefaultXIDThresholdsFunc != nil {
-				s.setDefaultXIDThresholdsFunc(componentsxid.Thresholds{
-					ThresholdOverrides: updateCfg.ThresholdOverrides,
-				})
+				s.setDefaultXIDThresholdsFunc(updateCfg)
 			}
 
 		case componentstemperature.Name:
@@ -148,14 +132,9 @@ func (s *Session) processUpdateConfig(configMap map[string]string, resp *Respons
 		log.Logger.Infow("falling back to default empty nfs config")
 		s.setDefaultNFSGroupConfigsFunc(pkgnfschecker.Configs{})
 	}
-	if _, ok := setComponents[componentsxid.Name]; !ok {
+	if _, ok := setComponents[componentsxid.Name]; !ok && s.setDefaultXIDThresholdsFunc != nil {
 		log.Logger.Infow("falling back to default xid config")
-		if s.setDefaultXIDRebootThresholdFunc != nil {
-			s.setDefaultXIDRebootThresholdFunc(componentsxid.DefaultRebootThreshold)
-		}
-		if s.setDefaultXIDThresholdsFunc != nil {
-			s.setDefaultXIDThresholdsFunc(componentsxid.Thresholds{})
-		}
+		s.setDefaultXIDThresholdsFunc(componentsxid.Thresholds{})
 	}
 	if _, ok := setComponents[componentstemperature.Name]; !ok && s.setDefaultTemperatureThresholdsFunc != nil {
 		log.Logger.Infow("falling back to default temperature config")

--- a/pkg/session/update_config.go
+++ b/pkg/session/update_config.go
@@ -16,6 +16,13 @@ import (
 	pkgnfschecker "github.com/leptonai/gpud/pkg/nfs-checker"
 )
 
+type xidUpdateConfig struct {
+	// Threshold is kept for backward compatibility with legacy XID updateConfig
+	// payloads. New per-XID overrides live under ThresholdOverrides.
+	Threshold          *int                                    `json:"threshold,omitempty"`
+	ThresholdOverrides map[int]componentsxid.ThresholdOverride `json:"thresholdOverrides,omitempty"`
+}
+
 func (s *Session) processUpdateConfig(configMap map[string]string, resp *Response) {
 	if len(configMap) == 0 {
 		return
@@ -64,14 +71,23 @@ func (s *Session) processUpdateConfig(configMap map[string]string, resp *Respons
 
 		case componentsxid.Name:
 			setComponents[componentName] = struct{}{}
-			var updateCfg componentsxid.Thresholds
+			var updateCfg xidUpdateConfig
 			if err := json.Unmarshal([]byte(value), &updateCfg); err != nil {
 				log.Logger.Warnw("failed to unmarshal xid config", "error", err)
 				resp.Error = err.Error()
 				return
 			}
+			if s.setDefaultXIDRebootThresholdFunc != nil {
+				if updateCfg.Threshold != nil {
+					s.setDefaultXIDRebootThresholdFunc(*updateCfg.Threshold)
+				} else {
+					s.setDefaultXIDRebootThresholdFunc(componentsxid.DefaultRebootThreshold)
+				}
+			}
 			if s.setDefaultXIDThresholdsFunc != nil {
-				s.setDefaultXIDThresholdsFunc(updateCfg)
+				s.setDefaultXIDThresholdsFunc(componentsxid.Thresholds{
+					ThresholdOverrides: updateCfg.ThresholdOverrides,
+				})
 			}
 
 		case componentstemperature.Name:
@@ -132,9 +148,14 @@ func (s *Session) processUpdateConfig(configMap map[string]string, resp *Respons
 		log.Logger.Infow("falling back to default empty nfs config")
 		s.setDefaultNFSGroupConfigsFunc(pkgnfschecker.Configs{})
 	}
-	if _, ok := setComponents[componentsxid.Name]; !ok && s.setDefaultXIDThresholdsFunc != nil {
+	if _, ok := setComponents[componentsxid.Name]; !ok {
 		log.Logger.Infow("falling back to default xid config")
-		s.setDefaultXIDThresholdsFunc(componentsxid.Thresholds{Threshold: componentsxid.DefaultRebootThreshold})
+		if s.setDefaultXIDRebootThresholdFunc != nil {
+			s.setDefaultXIDRebootThresholdFunc(componentsxid.DefaultRebootThreshold)
+		}
+		if s.setDefaultXIDThresholdsFunc != nil {
+			s.setDefaultXIDThresholdsFunc(componentsxid.Thresholds{})
+		}
 	}
 	if _, ok := setComponents[componentstemperature.Name]; !ok && s.setDefaultTemperatureThresholdsFunc != nil {
 		log.Logger.Infow("falling back to default temperature config")

--- a/pkg/session/update_config_test.go
+++ b/pkg/session/update_config_test.go
@@ -94,7 +94,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
-				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
+				assert.Empty(t, threshold.ThresholdOverrides)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				// This gets called with default config due to fallback behavior
@@ -131,7 +131,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
-				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
+				assert.Empty(t, threshold.ThresholdOverrides)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				// This gets called with default config due to fallback behavior
@@ -168,7 +168,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 				assert.Equal(t, 0, counts.Count)
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
-				assert.Equal(t, 10, threshold.Threshold)
+				assert.Empty(t, threshold.ThresholdOverrides)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				// This gets called with default config due to fallback behavior
@@ -206,7 +206,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
-				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
+				assert.Empty(t, threshold.ThresholdOverrides)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				assert.Equal(t, int32(10), thresholds.CelsiusSlowdownMargin)
@@ -404,7 +404,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
-				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
+				assert.Empty(t, threshold.ThresholdOverrides)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				// This gets called with default config due to fallback behavior
@@ -442,7 +442,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior for unsupported components
-				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
+				assert.Empty(t, threshold.ThresholdOverrides)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				// This gets called with default config due to fallback behavior for unsupported components
@@ -498,7 +498,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
-				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
+				assert.Empty(t, threshold.ThresholdOverrides)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				// This gets called with default config due to fallback behavior
@@ -540,7 +540,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
-				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
+				assert.Empty(t, threshold.ThresholdOverrides)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				// This gets called with default config due to fallback behavior
@@ -759,7 +759,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				xidCallCount++
 				// This gets called with default config due to fallback behavior
-				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
+				assert.Empty(t, threshold.ThresholdOverrides)
 			},
 		}
 
@@ -827,7 +827,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				xidCallCount++
-				assert.Equal(t, 10, threshold.Threshold)
+				assert.Empty(t, threshold.ThresholdOverrides)
 			},
 		}
 
@@ -1156,7 +1156,6 @@ func TestProcessUpdateConfig_RealConfigStructures(t *testing.T) {
 	t.Run("xid with real structure", func(t *testing.T) {
 		// Create a real componentsxid.Thresholds structure
 		expectedThresholds := componentsxid.Thresholds{
-			Threshold: 5,
 			ThresholdOverrides: map[int]componentsxid.ThresholdOverride{
 				94: {RebootThreshold: 1000},
 			},
@@ -1181,7 +1180,6 @@ func TestProcessUpdateConfig_RealConfigStructures(t *testing.T) {
 		s.processUpdateConfig(configMap, resp)
 
 		assert.Empty(t, resp.Error)
-		assert.Equal(t, expectedThresholds.Threshold, actualThresholds.Threshold)
 		assert.Equal(t, expectedThresholds.ThresholdOverrides, actualThresholds.ThresholdOverrides)
 	})
 

--- a/pkg/session/update_config_test.go
+++ b/pkg/session/update_config_test.go
@@ -1157,7 +1157,7 @@ func TestProcessUpdateConfig_RealConfigStructures(t *testing.T) {
 		// Create a real componentsxid.RebootThreshold structure
 		expectedThreshold := componentsxid.RebootThreshold{
 			Threshold: 5,
-			ThresholdOverrides: map[int]componentsxid.RebootThresholdOverride{
+			ThresholdOverrides: map[int]componentsxid.ThresholdOverride{
 				94: {RebootThreshold: 1000},
 			},
 		}

--- a/pkg/session/update_config_test.go
+++ b/pkg/session/update_config_test.go
@@ -26,20 +26,20 @@ func TestProcessUpdateConfig(t *testing.T) {
 		setDefaultNVLinkExpectedLinkStatesFunc    func(states componentsnvidianvlink.ExpectedLinkStates)
 		setDefaultNFSGroupConfigsFunc             func(cfgs pkgnfschecker.Configs)
 		setDefaultGPUCountsFunc                   func(counts componentsnvidiagpucounts.ExpectedGPUCounts)
-		setDefaultXIDRebootThresholdFunc          func(threshold componentsxid.RebootThreshold)
+		setDefaultXIDThresholdsFunc               func(threshold componentsxid.Thresholds)
 		setDefaultTemperatureThresholdsFunc       func(thresholds componentstemperature.Thresholds)
 		expectedError                             string
 		expectedIbExpectedPortStatesCalled        bool
 		expectedNVLinkExpectedLinkStatesCalled    bool
 		expectedNFSGroupConfigsCalled             bool
 		expectedGPUCountsCalled                   bool
-		expectedXIDRebootThresholdCalled          bool
+		expectedXIDThresholdsCalled               bool
 		expectedTemperatureThresholdsCalled       bool
 		expectedIbExpectedPortStatesCallCount     int
 		expectedNVLinkExpectedLinkStatesCallCount int
 		expectedNFSGroupConfigsCallCount          int
 		expectedGPUCountsCallCount                int
-		expectedXIDRebootThresholdCallCount       int
+		expectedXIDThresholdsCallCount            int
 		expectedTemperatureThresholdsCallCount    int
 	}{
 		{
@@ -57,8 +57,8 @@ func TestProcessUpdateConfig(t *testing.T) {
 			setDefaultGPUCountsFunc: func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {
 				t.Error("setDefaultGPUCountsFunc should not be called for empty config map")
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
-				t.Error("setDefaultXIDRebootThresholdFunc should not be called for empty config map")
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
+				t.Error("setDefaultXIDThresholdsFunc should not be called for empty config map")
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				t.Error("setDefaultTemperatureThresholdsFunc should not be called for empty config map")
@@ -67,12 +67,12 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedIbExpectedPortStatesCalled:     false,
 			expectedNFSGroupConfigsCalled:          false,
 			expectedGPUCountsCalled:                false,
-			expectedXIDRebootThresholdCalled:       false,
+			expectedXIDThresholdsCalled:            false,
 			expectedTemperatureThresholdsCalled:    false,
 			expectedIbExpectedPortStatesCallCount:  0,
 			expectedNFSGroupConfigsCallCount:       0,
 			expectedGPUCountsCallCount:             0,
-			expectedXIDRebootThresholdCallCount:    0,
+			expectedXIDThresholdsCallCount:         0,
 			expectedTemperatureThresholdsCallCount: 0,
 		},
 		{
@@ -92,7 +92,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 				// This gets called with empty config due to fallback behavior
 				assert.Equal(t, 0, counts.Count)
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
 				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
 			},
@@ -104,12 +104,12 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedIbExpectedPortStatesCalled:     true,
 			expectedNFSGroupConfigsCalled:          true,
 			expectedGPUCountsCalled:                true,
-			expectedXIDRebootThresholdCalled:       true,
+			expectedXIDThresholdsCalled:            true,
 			expectedTemperatureThresholdsCalled:    true,
 			expectedIbExpectedPortStatesCallCount:  1,
 			expectedNFSGroupConfigsCallCount:       1,
 			expectedGPUCountsCallCount:             1,
-			expectedXIDRebootThresholdCallCount:    1,
+			expectedXIDThresholdsCallCount:         1,
 			expectedTemperatureThresholdsCallCount: 1,
 		},
 		{
@@ -129,7 +129,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			setDefaultGPUCountsFunc: func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {
 				assert.Equal(t, 8, counts.Count)
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
 				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
 			},
@@ -141,12 +141,12 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedIbExpectedPortStatesCalled:     true,
 			expectedNFSGroupConfigsCalled:          true,
 			expectedGPUCountsCalled:                true,
-			expectedXIDRebootThresholdCalled:       true,
+			expectedXIDThresholdsCalled:            true,
 			expectedTemperatureThresholdsCalled:    true,
 			expectedIbExpectedPortStatesCallCount:  1,
 			expectedNFSGroupConfigsCallCount:       1,
 			expectedGPUCountsCallCount:             1,
-			expectedXIDRebootThresholdCallCount:    1,
+			expectedXIDThresholdsCallCount:         1,
 			expectedTemperatureThresholdsCallCount: 1,
 		},
 		{
@@ -167,7 +167,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 				// This gets called with empty config due to fallback behavior
 				assert.Equal(t, 0, counts.Count)
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				assert.Equal(t, 10, threshold.Threshold)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
@@ -178,12 +178,12 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedIbExpectedPortStatesCalled:     true,
 			expectedNFSGroupConfigsCalled:          true,
 			expectedGPUCountsCalled:                true,
-			expectedXIDRebootThresholdCalled:       true,
+			expectedXIDThresholdsCalled:            true,
 			expectedTemperatureThresholdsCalled:    true,
 			expectedIbExpectedPortStatesCallCount:  1,
 			expectedNFSGroupConfigsCallCount:       1,
 			expectedGPUCountsCallCount:             1,
-			expectedXIDRebootThresholdCallCount:    1,
+			expectedXIDThresholdsCallCount:         1,
 			expectedTemperatureThresholdsCallCount: 1,
 		},
 		{
@@ -204,7 +204,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 				// This gets called with empty config due to fallback behavior
 				assert.Equal(t, 0, counts.Count)
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
 				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
 			},
@@ -215,12 +215,12 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedIbExpectedPortStatesCalled:     true,
 			expectedNFSGroupConfigsCalled:          true,
 			expectedGPUCountsCalled:                true,
-			expectedXIDRebootThresholdCalled:       true,
+			expectedXIDThresholdsCalled:            true,
 			expectedTemperatureThresholdsCalled:    true,
 			expectedIbExpectedPortStatesCallCount:  1,
 			expectedNFSGroupConfigsCallCount:       1,
 			expectedGPUCountsCallCount:             1,
-			expectedXIDRebootThresholdCallCount:    1,
+			expectedXIDThresholdsCallCount:         1,
 			expectedTemperatureThresholdsCallCount: 1,
 		},
 		{
@@ -237,8 +237,8 @@ func TestProcessUpdateConfig(t *testing.T) {
 			setDefaultGPUCountsFunc: func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {
 				t.Error("setDefaultGPUCountsFunc should not be called for infiniband config")
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
-				t.Error("setDefaultXIDRebootThresholdFunc should not be called for infiniband config")
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
+				t.Error("setDefaultXIDThresholdsFunc should not be called for infiniband config")
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				t.Error("setDefaultTemperatureThresholdsFunc should not be called for infiniband config")
@@ -247,12 +247,12 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedIbExpectedPortStatesCalled:     false,
 			expectedNFSGroupConfigsCalled:          false,
 			expectedGPUCountsCalled:                false,
-			expectedXIDRebootThresholdCalled:       false,
+			expectedXIDThresholdsCalled:            false,
 			expectedTemperatureThresholdsCalled:    false,
 			expectedIbExpectedPortStatesCallCount:  0,
 			expectedNFSGroupConfigsCallCount:       0,
 			expectedGPUCountsCallCount:             0,
-			expectedXIDRebootThresholdCallCount:    0,
+			expectedXIDThresholdsCallCount:         0,
 			expectedTemperatureThresholdsCallCount: 0,
 		},
 		{
@@ -269,8 +269,8 @@ func TestProcessUpdateConfig(t *testing.T) {
 			setDefaultGPUCountsFunc: func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {
 				t.Error("setDefaultGPUCountsFunc should not be called for invalid JSON")
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
-				t.Error("setDefaultXIDRebootThresholdFunc should not be called for gpu counts config")
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
+				t.Error("setDefaultXIDThresholdsFunc should not be called for gpu counts config")
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				t.Error("setDefaultTemperatureThresholdsFunc should not be called for gpu counts config")
@@ -279,12 +279,12 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedIbExpectedPortStatesCalled:     false,
 			expectedNFSGroupConfigsCalled:          false,
 			expectedGPUCountsCalled:                false,
-			expectedXIDRebootThresholdCalled:       false,
+			expectedXIDThresholdsCalled:            false,
 			expectedTemperatureThresholdsCalled:    false,
 			expectedIbExpectedPortStatesCallCount:  0,
 			expectedNFSGroupConfigsCallCount:       0,
 			expectedGPUCountsCallCount:             0,
-			expectedXIDRebootThresholdCallCount:    0,
+			expectedXIDThresholdsCallCount:         0,
 			expectedTemperatureThresholdsCallCount: 0,
 		},
 		{
@@ -301,7 +301,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			setDefaultGPUCountsFunc: func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {
 				t.Error("setDefaultGPUCountsFunc should not be called for xid config")
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				t.Error("setDefaultGPUCountsFunc should not be called for invalid JSON")
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
@@ -311,12 +311,12 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedIbExpectedPortStatesCalled:     false,
 			expectedNFSGroupConfigsCalled:          false,
 			expectedGPUCountsCalled:                false,
-			expectedXIDRebootThresholdCalled:       false,
+			expectedXIDThresholdsCalled:            false,
 			expectedTemperatureThresholdsCalled:    false,
 			expectedIbExpectedPortStatesCallCount:  0,
 			expectedNFSGroupConfigsCallCount:       0,
 			expectedGPUCountsCallCount:             0,
-			expectedXIDRebootThresholdCallCount:    0,
+			expectedXIDThresholdsCallCount:         0,
 			expectedTemperatureThresholdsCallCount: 0,
 		},
 		{
@@ -333,8 +333,8 @@ func TestProcessUpdateConfig(t *testing.T) {
 			setDefaultGPUCountsFunc: func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {
 				t.Error("setDefaultGPUCountsFunc should not be called for temperature config")
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
-				t.Error("setDefaultXIDRebootThresholdFunc should not be called for temperature config")
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
+				t.Error("setDefaultXIDThresholdsFunc should not be called for temperature config")
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				t.Error("setDefaultTemperatureThresholdsFunc should not be called for invalid JSON")
@@ -343,12 +343,12 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedIbExpectedPortStatesCalled:     false,
 			expectedNFSGroupConfigsCalled:          false,
 			expectedGPUCountsCalled:                false,
-			expectedXIDRebootThresholdCalled:       false,
+			expectedXIDThresholdsCalled:            false,
 			expectedTemperatureThresholdsCalled:    false,
 			expectedIbExpectedPortStatesCallCount:  0,
 			expectedNFSGroupConfigsCallCount:       0,
 			expectedGPUCountsCallCount:             0,
-			expectedXIDRebootThresholdCallCount:    0,
+			expectedXIDThresholdsCallCount:         0,
 			expectedTemperatureThresholdsCallCount: 0,
 		},
 		{
@@ -365,8 +365,8 @@ func TestProcessUpdateConfig(t *testing.T) {
 			setDefaultGPUCountsFunc: func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {
 				t.Error("setDefaultGPUCountsFunc should not be called for nfs config")
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
-				t.Error("setDefaultXIDRebootThresholdFunc should not be called for nfs config")
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
+				t.Error("setDefaultXIDThresholdsFunc should not be called for nfs config")
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				t.Error("setDefaultTemperatureThresholdsFunc should not be called for nfs config")
@@ -375,12 +375,12 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedIbExpectedPortStatesCalled:     false,
 			expectedNFSGroupConfigsCalled:          false,
 			expectedGPUCountsCalled:                false,
-			expectedXIDRebootThresholdCalled:       false,
+			expectedXIDThresholdsCalled:            false,
 			expectedTemperatureThresholdsCalled:    false,
 			expectedIbExpectedPortStatesCallCount:  0,
 			expectedNFSGroupConfigsCallCount:       0,
 			expectedGPUCountsCallCount:             0,
-			expectedXIDRebootThresholdCallCount:    0,
+			expectedXIDThresholdsCallCount:         0,
 			expectedTemperatureThresholdsCallCount: 0,
 		},
 		{
@@ -402,7 +402,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 				// This gets called with empty config due to fallback behavior
 				assert.Equal(t, 0, counts.Count)
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
 				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
 			},
@@ -414,12 +414,12 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedIbExpectedPortStatesCalled:     true,
 			expectedNFSGroupConfigsCalled:          true,
 			expectedGPUCountsCalled:                true,
-			expectedXIDRebootThresholdCalled:       true,
+			expectedXIDThresholdsCalled:            true,
 			expectedTemperatureThresholdsCalled:    true,
 			expectedIbExpectedPortStatesCallCount:  1,
 			expectedNFSGroupConfigsCallCount:       1, // function should be called even for invalid configs
 			expectedGPUCountsCallCount:             1,
-			expectedXIDRebootThresholdCallCount:    1,
+			expectedXIDThresholdsCallCount:         1,
 			expectedTemperatureThresholdsCallCount: 1,
 		},
 		{
@@ -440,7 +440,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 				// This gets called with empty config due to fallback behavior for unsupported components
 				assert.Equal(t, 0, counts.Count)
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior for unsupported components
 				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
 			},
@@ -452,12 +452,12 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedIbExpectedPortStatesCalled:     true,
 			expectedNFSGroupConfigsCalled:          true,
 			expectedGPUCountsCalled:                true,
-			expectedXIDRebootThresholdCalled:       true,
+			expectedXIDThresholdsCalled:            true,
 			expectedTemperatureThresholdsCalled:    true,
 			expectedIbExpectedPortStatesCallCount:  1,
 			expectedNFSGroupConfigsCallCount:       1,
 			expectedGPUCountsCallCount:             1,
-			expectedXIDRebootThresholdCallCount:    1,
+			expectedXIDThresholdsCallCount:         1,
 			expectedTemperatureThresholdsCallCount: 1,
 		},
 		{
@@ -468,18 +468,18 @@ func TestProcessUpdateConfig(t *testing.T) {
 			setDefaultIbExpectedPortStatesFunc:     nil,
 			setDefaultNFSGroupConfigsFunc:          nil,
 			setDefaultGPUCountsFunc:                nil,
-			setDefaultXIDRebootThresholdFunc:       nil,
+			setDefaultXIDThresholdsFunc:            nil,
 			setDefaultTemperatureThresholdsFunc:    nil,
 			expectedError:                          "",
 			expectedIbExpectedPortStatesCalled:     false,
 			expectedNFSGroupConfigsCalled:          false,
 			expectedGPUCountsCalled:                false,
-			expectedXIDRebootThresholdCalled:       false,
+			expectedXIDThresholdsCalled:            false,
 			expectedTemperatureThresholdsCalled:    false,
 			expectedIbExpectedPortStatesCallCount:  0,
 			expectedNFSGroupConfigsCallCount:       0,
 			expectedGPUCountsCallCount:             0,
-			expectedXIDRebootThresholdCallCount:    0,
+			expectedXIDThresholdsCallCount:         0,
 			expectedTemperatureThresholdsCallCount: 0,
 		},
 		{
@@ -496,7 +496,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 				// This gets called with empty config due to fallback behavior
 				assert.Len(t, cfgs, 0)
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
 				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
 			},
@@ -509,12 +509,12 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedIbExpectedPortStatesCalled:     true,
 			expectedNFSGroupConfigsCalled:          true,
 			expectedGPUCountsCalled:                false,
-			expectedXIDRebootThresholdCalled:       true,
+			expectedXIDThresholdsCalled:            true,
 			expectedTemperatureThresholdsCalled:    true,
 			expectedIbExpectedPortStatesCallCount:  1,
 			expectedNFSGroupConfigsCallCount:       1,
 			expectedGPUCountsCallCount:             0,
-			expectedXIDRebootThresholdCallCount:    1,
+			expectedXIDThresholdsCallCount:         1,
 			expectedTemperatureThresholdsCallCount: 1,
 		},
 		{
@@ -538,7 +538,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 				// This gets called with empty config due to fallback behavior
 				assert.Equal(t, 0, counts.Count)
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
 				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
 			},
@@ -551,13 +551,13 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedNVLinkExpectedLinkStatesCalled:    true,
 			expectedNFSGroupConfigsCalled:             true,
 			expectedGPUCountsCalled:                   true,
-			expectedXIDRebootThresholdCalled:          true,
+			expectedXIDThresholdsCalled:               true,
 			expectedTemperatureThresholdsCalled:       true,
 			expectedIbExpectedPortStatesCallCount:     1,
 			expectedNVLinkExpectedLinkStatesCallCount: 1,
 			expectedNFSGroupConfigsCallCount:          1,
 			expectedGPUCountsCallCount:                1,
-			expectedXIDRebootThresholdCallCount:       1,
+			expectedXIDThresholdsCallCount:            1,
 			expectedTemperatureThresholdsCallCount:    1,
 		},
 		{
@@ -577,8 +577,8 @@ func TestProcessUpdateConfig(t *testing.T) {
 			setDefaultGPUCountsFunc: func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {
 				t.Error("setDefaultGPUCountsFunc should not be called for nvlink config")
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
-				t.Error("setDefaultXIDRebootThresholdFunc should not be called for nvlink config")
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
+				t.Error("setDefaultXIDThresholdsFunc should not be called for nvlink config")
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				t.Error("setDefaultTemperatureThresholdsFunc should not be called for nvlink config")
@@ -588,13 +588,13 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedNVLinkExpectedLinkStatesCalled:    false,
 			expectedNFSGroupConfigsCalled:             false,
 			expectedGPUCountsCalled:                   false,
-			expectedXIDRebootThresholdCalled:          false,
+			expectedXIDThresholdsCalled:               false,
 			expectedTemperatureThresholdsCalled:       false,
 			expectedIbExpectedPortStatesCallCount:     0,
 			expectedNVLinkExpectedLinkStatesCallCount: 0,
 			expectedNFSGroupConfigsCallCount:          0,
 			expectedGPUCountsCallCount:                0,
-			expectedXIDRebootThresholdCallCount:       0,
+			expectedXIDThresholdsCallCount:            0,
 			expectedTemperatureThresholdsCallCount:    0,
 		},
 	}
@@ -648,10 +648,10 @@ func TestProcessUpdateConfig(t *testing.T) {
 						tt.setDefaultGPUCountsFunc(counts)
 					}
 				},
-				setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
+				setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 					xidCallCount++
-					if tt.setDefaultXIDRebootThresholdFunc != nil {
-						tt.setDefaultXIDRebootThresholdFunc(threshold)
+					if tt.setDefaultXIDThresholdsFunc != nil {
+						tt.setDefaultXIDThresholdsFunc(threshold)
 					}
 				},
 				setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
@@ -675,8 +675,8 @@ func TestProcessUpdateConfig(t *testing.T) {
 			if tt.setDefaultGPUCountsFunc == nil {
 				s.setDefaultGPUCountsFunc = nil
 			}
-			if tt.setDefaultXIDRebootThresholdFunc == nil {
-				s.setDefaultXIDRebootThresholdFunc = nil
+			if tt.setDefaultXIDThresholdsFunc == nil {
+				s.setDefaultXIDThresholdsFunc = nil
 			}
 			if tt.setDefaultTemperatureThresholdsFunc == nil {
 				s.setDefaultTemperatureThresholdsFunc = nil
@@ -714,7 +714,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			assert.Equal(t, tt.expectedNVLinkExpectedLinkStatesCallCount, nvlinkCallCount, "Unexpected NVLink function call count")
 			assert.Equal(t, tt.expectedNFSGroupConfigsCallCount, nfsCallCount, "Unexpected NFS function call count")
 			assert.Equal(t, tt.expectedGPUCountsCallCount, gpuCallCount, "Unexpected GPU counts function call count")
-			assert.Equal(t, tt.expectedXIDRebootThresholdCallCount, xidCallCount, "Unexpected XID reboot threshold function call count")
+			assert.Equal(t, tt.expectedXIDThresholdsCallCount, xidCallCount, "Unexpected XID thresholds function call count")
 			assert.Equal(t, tt.expectedTemperatureThresholdsCallCount, tempCallCount, "Unexpected temperature threshold function call count")
 		})
 	}
@@ -756,7 +756,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 				// This gets called with empty config due to fallback behavior
 				assert.Equal(t, 0, counts.Count)
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				xidCallCount++
 				// This gets called with default config due to fallback behavior
 				assert.Equal(t, componentsxid.DefaultRebootThreshold, threshold.Threshold)
@@ -788,7 +788,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 		assert.Equal(t, 1, nvlinkCallCount, "Unexpected NVLink function call count")
 		assert.Equal(t, 1, nfsCallCount, "Unexpected NFS function call count")
 		assert.Equal(t, 1, gpuCallCount, "Unexpected GPU counts function call count")
-		assert.Equal(t, 1, xidCallCount, "Unexpected XID reboot threshold function call count")
+		assert.Equal(t, 1, xidCallCount, "Unexpected XID thresholds function call count")
 	})
 
 	t.Run("multiple valid configs", func(t *testing.T) {
@@ -825,7 +825,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 				gpuCallCount++
 				assert.Equal(t, 16, counts.Count)
 			},
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
+			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				xidCallCount++
 				assert.Equal(t, 10, threshold.Threshold)
 			},
@@ -859,7 +859,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 		assert.Equal(t, 1, nvlinkCallCount, "Unexpected NVLink function call count")
 		assert.Equal(t, 1, nfsCallCount, "Unexpected NFS function call count")
 		assert.Equal(t, 1, gpuCallCount, "Unexpected GPU counts function call count")
-		assert.Equal(t, 1, xidCallCount, "Unexpected XID reboot threshold function call count")
+		assert.Equal(t, 1, xidCallCount, "Unexpected XID thresholds function call count")
 	})
 }
 
@@ -958,7 +958,7 @@ func TestProcessUpdateConfig_JSONUnmarshalEdgeCases(t *testing.T) {
 				setDefaultIbExpectedPortStatesFunc: func(states componentsnvidiainfinibanditypes.ExpectedPortStates) {},
 				setDefaultNFSGroupConfigsFunc:      func(cfgs pkgnfschecker.Configs) {},
 				setDefaultGPUCountsFunc:            func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {},
-				setDefaultXIDRebootThresholdFunc:   func(threshold componentsxid.RebootThreshold) {},
+				setDefaultXIDThresholdsFunc:        func(threshold componentsxid.Thresholds) {},
 			}
 
 			configMap := map[string]string{
@@ -1154,8 +1154,8 @@ func TestProcessUpdateConfig_RealConfigStructures(t *testing.T) {
 	})
 
 	t.Run("xid with real structure", func(t *testing.T) {
-		// Create a real componentsxid.RebootThreshold structure
-		expectedThreshold := componentsxid.RebootThreshold{
+		// Create a real componentsxid.Thresholds structure
+		expectedThresholds := componentsxid.Thresholds{
 			Threshold: 5,
 			ThresholdOverrides: map[int]componentsxid.ThresholdOverride{
 				94: {RebootThreshold: 1000},
@@ -1163,13 +1163,13 @@ func TestProcessUpdateConfig_RealConfigStructures(t *testing.T) {
 		}
 
 		// Marshal it to JSON
-		configBytes, err := json.Marshal(expectedThreshold)
+		configBytes, err := json.Marshal(expectedThresholds)
 		assert.NoError(t, err)
 
-		var actualThreshold componentsxid.RebootThreshold
+		var actualThresholds componentsxid.Thresholds
 		s := &Session{
-			setDefaultXIDRebootThresholdFunc: func(threshold componentsxid.RebootThreshold) {
-				actualThreshold = threshold
+			setDefaultXIDThresholdsFunc: func(thresholds componentsxid.Thresholds) {
+				actualThresholds = thresholds
 			},
 		}
 
@@ -1181,8 +1181,8 @@ func TestProcessUpdateConfig_RealConfigStructures(t *testing.T) {
 		s.processUpdateConfig(configMap, resp)
 
 		assert.Empty(t, resp.Error)
-		assert.Equal(t, expectedThreshold.Threshold, actualThreshold.Threshold)
-		assert.Equal(t, expectedThreshold.ThresholdOverrides, actualThreshold.ThresholdOverrides)
+		assert.Equal(t, expectedThresholds.Threshold, actualThresholds.Threshold)
+		assert.Equal(t, expectedThresholds.ThresholdOverrides, actualThresholds.ThresholdOverrides)
 	})
 
 	t.Run("temperature with real structure", func(t *testing.T) {

--- a/pkg/session/update_config_test.go
+++ b/pkg/session/update_config_test.go
@@ -1157,6 +1157,9 @@ func TestProcessUpdateConfig_RealConfigStructures(t *testing.T) {
 		// Create a real componentsxid.RebootThreshold structure
 		expectedThreshold := componentsxid.RebootThreshold{
 			Threshold: 5,
+			ThresholdOverrides: map[int]componentsxid.RebootThresholdOverride{
+				94: {RebootThreshold: 1000},
+			},
 		}
 
 		// Marshal it to JSON
@@ -1179,6 +1182,7 @@ func TestProcessUpdateConfig_RealConfigStructures(t *testing.T) {
 
 		assert.Empty(t, resp.Error)
 		assert.Equal(t, expectedThreshold.Threshold, actualThreshold.Threshold)
+		assert.Equal(t, expectedThreshold.ThresholdOverrides, actualThreshold.ThresholdOverrides)
 	})
 
 	t.Run("temperature with real structure", func(t *testing.T) {

--- a/pkg/session/update_config_test.go
+++ b/pkg/session/update_config_test.go
@@ -152,7 +152,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 		{
 			name: "valid xid config",
 			configMap: map[string]string{
-				"accelerator-nvidia-error-xid": `{"threshold": 10}`,
+				"accelerator-nvidia-error-xid": `{"thresholdOverrides":{"94":{"rebootThreshold":1000}}}`,
 			},
 			setDefaultIbExpectedPortStatesFunc: func(states componentsnvidiainfinibanditypes.ExpectedPortStates) {
 				// This gets called with empty config due to fallback behavior
@@ -168,7 +168,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 				assert.Equal(t, 0, counts.Count)
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
-				assert.Empty(t, threshold.ThresholdOverrides)
+				assert.Equal(t, 1000, threshold.ThresholdOverrides[94].RebootThreshold)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				// This gets called with default config due to fallback behavior
@@ -290,7 +290,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 		{
 			name: "invalid xid config - malformed JSON",
 			configMap: map[string]string{
-				"accelerator-nvidia-error-xid": `{"threshold":}`,
+				"accelerator-nvidia-error-xid": `{"thresholdOverrides":}`,
 			},
 			setDefaultIbExpectedPortStatesFunc: func(states componentsnvidiainfinibanditypes.ExpectedPortStates) {
 				t.Error("setDefaultIbExpectedPortStatesFunc should not be called for xid config")
@@ -827,7 +827,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				xidCallCount++
-				assert.Empty(t, threshold.ThresholdOverrides)
+				assert.Equal(t, 1000, threshold.ThresholdOverrides[94].RebootThreshold)
 			},
 		}
 
@@ -835,7 +835,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			"accelerator-nvidia-infiniband": `{"at_least_ports": 4, "at_least_rate": 200}`,
 			"nfs":                           `[{"volume_path": "` + tempDir + `", "file_contents": "multi-content", "ttl_to_delete": "10m", "num_expected_files": 5}]`,
 			"accelerator-nvidia-gpu-counts": `{"count": 16}`,
-			"accelerator-nvidia-error-xid":  `{"threshold": 10}`,
+			"accelerator-nvidia-error-xid":  `{"thresholdOverrides":{"94":{"rebootThreshold":1000}}}`,
 		}
 
 		resp := &Response{}
@@ -947,7 +947,7 @@ func TestProcessUpdateConfig_JSONUnmarshalEdgeCases(t *testing.T) {
 		{
 			name:          "xid - invalid field type",
 			componentName: "accelerator-nvidia-error-xid",
-			configValue:   `{"threshold": "invalid"}`,
+			configValue:   `{"thresholdOverrides": "invalid"}`,
 			expectedError: "cannot unmarshal string into Go struct field",
 		},
 	}

--- a/pkg/session/update_config_test.go
+++ b/pkg/session/update_config_test.go
@@ -94,7 +94,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
-				assert.Empty(t, threshold.ThresholdOverrides)
+				assert.Empty(t, threshold.Overrides)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				// This gets called with default config due to fallback behavior
@@ -131,7 +131,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
-				assert.Empty(t, threshold.ThresholdOverrides)
+				assert.Empty(t, threshold.Overrides)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				// This gets called with default config due to fallback behavior
@@ -152,7 +152,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 		{
 			name: "valid xid config",
 			configMap: map[string]string{
-				"accelerator-nvidia-error-xid": `{"thresholdOverrides":{"94":{"rebootThreshold":1000}}}`,
+				"accelerator-nvidia-error-xid": `{"overrides":{"94":{"rebootThreshold":1000}}}`,
 			},
 			setDefaultIbExpectedPortStatesFunc: func(states componentsnvidiainfinibanditypes.ExpectedPortStates) {
 				// This gets called with empty config due to fallback behavior
@@ -168,7 +168,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 				assert.Equal(t, 0, counts.Count)
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
-				assert.Equal(t, 1000, threshold.ThresholdOverrides[94].RebootThreshold)
+				assert.Equal(t, 1000, threshold.Overrides[94].RebootThreshold)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				// This gets called with default config due to fallback behavior
@@ -206,7 +206,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
-				assert.Empty(t, threshold.ThresholdOverrides)
+				assert.Empty(t, threshold.Overrides)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				assert.Equal(t, int32(10), thresholds.CelsiusSlowdownMargin)
@@ -290,7 +290,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 		{
 			name: "invalid xid config - malformed JSON",
 			configMap: map[string]string{
-				"accelerator-nvidia-error-xid": `{"thresholdOverrides":}`,
+				"accelerator-nvidia-error-xid": `{"overrides":}`,
 			},
 			setDefaultIbExpectedPortStatesFunc: func(states componentsnvidiainfinibanditypes.ExpectedPortStates) {
 				t.Error("setDefaultIbExpectedPortStatesFunc should not be called for xid config")
@@ -404,7 +404,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
-				assert.Empty(t, threshold.ThresholdOverrides)
+				assert.Empty(t, threshold.Overrides)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				// This gets called with default config due to fallback behavior
@@ -442,7 +442,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior for unsupported components
-				assert.Empty(t, threshold.ThresholdOverrides)
+				assert.Empty(t, threshold.Overrides)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				// This gets called with default config due to fallback behavior for unsupported components
@@ -498,7 +498,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
-				assert.Empty(t, threshold.ThresholdOverrides)
+				assert.Empty(t, threshold.Overrides)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				// This gets called with default config due to fallback behavior
@@ -540,7 +540,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				// This gets called with default config due to fallback behavior
-				assert.Empty(t, threshold.ThresholdOverrides)
+				assert.Empty(t, threshold.Overrides)
 			},
 			setDefaultTemperatureThresholdsFunc: func(thresholds componentstemperature.Thresholds) {
 				// This gets called with default config due to fallback behavior
@@ -759,7 +759,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				xidCallCount++
 				// This gets called with default config due to fallback behavior
-				assert.Empty(t, threshold.ThresholdOverrides)
+				assert.Empty(t, threshold.Overrides)
 			},
 		}
 
@@ -827,7 +827,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			},
 			setDefaultXIDThresholdsFunc: func(threshold componentsxid.Thresholds) {
 				xidCallCount++
-				assert.Equal(t, 1000, threshold.ThresholdOverrides[94].RebootThreshold)
+				assert.Equal(t, 1000, threshold.Overrides[94].RebootThreshold)
 			},
 		}
 
@@ -835,7 +835,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			"accelerator-nvidia-infiniband": `{"at_least_ports": 4, "at_least_rate": 200}`,
 			"nfs":                           `[{"volume_path": "` + tempDir + `", "file_contents": "multi-content", "ttl_to_delete": "10m", "num_expected_files": 5}]`,
 			"accelerator-nvidia-gpu-counts": `{"count": 16}`,
-			"accelerator-nvidia-error-xid":  `{"thresholdOverrides":{"94":{"rebootThreshold":1000}}}`,
+			"accelerator-nvidia-error-xid":  `{"overrides":{"94":{"rebootThreshold":1000}}}`,
 		}
 
 		resp := &Response{}
@@ -947,7 +947,7 @@ func TestProcessUpdateConfig_JSONUnmarshalEdgeCases(t *testing.T) {
 		{
 			name:          "xid - invalid field type",
 			componentName: "accelerator-nvidia-error-xid",
-			configValue:   `{"thresholdOverrides": "invalid"}`,
+			configValue:   `{"overrides": "invalid"}`,
 			expectedError: "cannot unmarshal string into Go struct field",
 		},
 	}
@@ -1156,7 +1156,7 @@ func TestProcessUpdateConfig_RealConfigStructures(t *testing.T) {
 	t.Run("xid with real structure", func(t *testing.T) {
 		// Create a real componentsxid.Thresholds structure
 		expectedThresholds := componentsxid.Thresholds{
-			ThresholdOverrides: map[int]componentsxid.ThresholdOverride{
+			Overrides: map[int]componentsxid.ThresholdOverride{
 				94: {RebootThreshold: 1000},
 			},
 		}
@@ -1180,7 +1180,7 @@ func TestProcessUpdateConfig_RealConfigStructures(t *testing.T) {
 		s.processUpdateConfig(configMap, resp)
 
 		assert.Empty(t, resp.Error)
-		assert.Equal(t, expectedThresholds.ThresholdOverrides, actualThresholds.ThresholdOverrides)
+		assert.Equal(t, expectedThresholds.Overrides, actualThresholds.Overrides)
 	})
 
 	t.Run("temperature with real structure", func(t *testing.T) {


### PR DESCRIPTION
Add per-XID and per-SXID reboot threshold maps for gpud run.

```bash
gpud run \
--xid-thresholds '{"94":{"rebootThreshold":1000}}' \
--sxid-thresholds '{"11004":{"rebootThreshold":7}}'
```
