### PR TITLE
[LEP-5065] feat(nfs): detect NFS hangs from kmsg and flip node Unhealthy

### DIFF
--- a/components/nfs/component.go
+++ b/components/nfs/component.go
@@ -246,7 +246,15 @@ func (c *component) Check() components.CheckResult {
 			if len(hangEvents) > 0 {
 				var rebootEvents eventstore.Events
 				if c.rebootEventStore != nil {
-					rebootEvents, _ = c.rebootEventStore.GetRebootEvents(c.ctx, cr.ts.Add(-c.lookbackPeriod))
+					var err error
+					rebootEvents, err = c.rebootEventStore.GetRebootEvents(c.ctx, cr.ts.Add(-c.lookbackPeriod))
+					if err != nil {
+						cr.err = err
+						cr.health = apiv1.HealthStateTypeUnhealthy
+						cr.reason = "failed to get reboot events"
+						log.Logger.Warnw(cr.reason, "error", cr.err)
+						return cr
+					}
 					// GetRebootEvents returns events in DESCENDING order
 					// (latest first), but EvaluateSuggestedActions expects
 					// ASCENDING order (oldest first) — see design doc §9 U2.

--- a/components/nfs/component.go
+++ b/components/nfs/component.go
@@ -261,18 +261,23 @@ func (c *component) Check() components.CheckResult {
 					sort.Slice(rebootEvents, func(i, j int) bool {
 						return rebootEvents[i].Time.Before(rebootEvents[j].Time)
 					})
+					if len(rebootEvents) > 0 {
+						hangEvents, hangReason = collectNFSHangEvents(nfsEventsOnOrAfter(evs, rebootEvents[0].Time))
+					}
 				}
-				sa := eventstore.EvaluateSuggestedActions(rebootEvents, hangEvents, 2)
-				if sa != nil {
-					sa.Description = "NFS hang requires immediate reboot; drain may hang on NFS volumes"
-					cr.health = apiv1.HealthStateTypeUnhealthy
-					cr.reason = hangReason
-					cr.suggestedActions = sa
-					return cr
+				if len(hangEvents) > 0 {
+					sa := eventstore.EvaluateSuggestedActions(rebootEvents, hangEvents, 2)
+					if sa != nil {
+						sa.Description = "NFS hang requires immediate reboot; drain may hang on NFS volumes"
+						cr.health = apiv1.HealthStateTypeUnhealthy
+						cr.reason = hangReason
+						cr.suggestedActions = sa
+						return cr
+					}
 				}
-				// sa == nil → a reboot was already observed after the
-				// hang event; fall through to the prober to verify the
-				// mount is currently healthy.
+				// No unresolved post-reboot hang evidence, or sa == nil
+				// because reboot history already resolved the hang; fall
+				// through to the prober for live verification.
 			}
 		}
 	}

--- a/components/nfs/component.go
+++ b/components/nfs/component.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +19,9 @@ import (
 	apiv1 "github.com/leptonai/gpud/api/v1"
 	"github.com/leptonai/gpud/components"
 	"github.com/leptonai/gpud/pkg/disk"
+	"github.com/leptonai/gpud/pkg/eventstore"
+	pkghost "github.com/leptonai/gpud/pkg/host"
+	"github.com/leptonai/gpud/pkg/kmsg"
 	"github.com/leptonai/gpud/pkg/log"
 	pkgnfschecker "github.com/leptonai/gpud/pkg/nfs-checker"
 )
@@ -23,7 +29,16 @@ import (
 // Name is the name of the NFS component.
 const Name = "nfs"
 
+// defaultLookbackPeriod is how far back to query kmsg and reboot history when
+// evaluating NFS hang suggested actions. Bounded by eventstore.DefaultRetention
+// (3 days) — querying further yields no events (design doc §9 U3).
+const defaultLookbackPeriod = 3 * 24 * time.Hour
+
 var _ components.Component = &component{}
+
+type kmsgSyncerCloser interface {
+	Close()
+}
 
 type component struct {
 	ctx    context.Context
@@ -42,12 +57,42 @@ type component struct {
 	checkChecker          func(ctx context.Context, checker pkgnfschecker.Checker) pkgnfschecker.CheckResult
 	cleanChecker          func(checker pkgnfschecker.Checker) error
 
+	// eventBucket stores NFS-related kmsg events for the kmsg-based hang
+	// detection path. Nil when no EventStore is configured (e.g., in unit
+	// tests that exercise only the prober path).
+	eventBucket eventstore.Bucket
+	// kmsgSyncer streams kernel messages into eventBucket; only created when
+	// running as root on Linux.
+	kmsgSyncer kmsgSyncerCloser
+	// rebootEventStore is consulted to decide between REBOOT_SYSTEM and
+	// HARDWARE_INSPECTION when an NFS hang is detected. May be nil.
+	rebootEventStore pkghost.RebootEventStore
+	// lookbackPeriod controls how far back we query events when evaluating
+	// suggested actions.
+	lookbackPeriod time.Duration
+
 	lastMu          sync.RWMutex
 	lastCheckResult *checkResult
 }
 
 // New creates the NFS component.
 func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
+	return newComponent(gpudInstance, runtime.GOOS, os.Geteuid(), kmsg.NewSyncer)
+}
+
+// newComponent is the testable constructor. It accepts the runtime OS, the
+// effective UID, and a kmsg syncer factory so tests can exercise the
+// EventStore wiring without privileged kernel access.
+func newComponent(
+	gpudInstance *components.GPUdInstance,
+	goos string,
+	euid int,
+	newKmsgSyncerFunc func(ctx context.Context, matchFunc kmsg.MatchFunc, eventBucket eventstore.Bucket, opts ...kmsg.OpOption) (*kmsg.Syncer, error),
+) (components.Component, error) {
+	if newKmsgSyncerFunc == nil {
+		newKmsgSyncerFunc = kmsg.NewSyncer
+	}
+
 	cctx, ccancel := context.WithCancel(gpudInstance.RootCtx)
 	c := &component{
 		ctx:    cctx,
@@ -73,6 +118,35 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		cleanChecker: func(checker pkgnfschecker.Checker) error {
 			return checker.Clean()
 		},
+
+		rebootEventStore: gpudInstance.RebootEventStore,
+		lookbackPeriod:   defaultLookbackPeriod,
+	}
+
+	if gpudInstance.EventStore != nil {
+		bucket, err := gpudInstance.EventStore.Bucket(Name)
+		if err != nil {
+			ccancel()
+			return nil, err
+		}
+		c.eventBucket = bucket
+
+		// Only sync kmsg on Linux as root — /dev/kmsg is privileged.
+		if goos == "linux" && euid == 0 {
+			syncer, err := newKmsgSyncerFunc(
+				cctx,
+				Match,
+				c.eventBucket,
+				// Coalesce repeated kmsg lines (e.g., bursty writeback stacks)
+				// within a 5-minute window to keep the event store bounded.
+				kmsg.WithCacheKeyTruncateSeconds(300),
+			)
+			if err != nil {
+				ccancel()
+				return nil, err
+			}
+			c.kmsgSyncer = syncer
+		}
 	}
 
 	return c, nil
@@ -96,13 +170,15 @@ func (c *component) Start() error {
 		defer ticker.Stop()
 
 		for {
+			// Run an initial check immediately so the first health state is
+			// available without waiting one tick interval.
+			_ = c.Check()
+
 			select {
 			case <-c.ctx.Done():
 				return
 			case <-ticker.C:
 			}
-
-			_ = c.Check()
 		}
 	}()
 	return nil
@@ -115,14 +191,28 @@ func (c *component) LastHealthStates() apiv1.HealthStates {
 	return lastCheckResult.HealthStates()
 }
 
-func (c *component) Events(_ context.Context, _ time.Time) (apiv1.Events, error) {
-	return nil, nil
+func (c *component) Events(ctx context.Context, since time.Time) (apiv1.Events, error) {
+	if c.eventBucket == nil {
+		return nil, nil
+	}
+	evs, err := c.eventBucket.Get(ctx, since)
+	if err != nil {
+		return nil, err
+	}
+	return evs.Events(), nil
 }
 
 func (c *component) Close() error {
 	log.Logger.Debugw("closing component")
 
 	c.cancel()
+
+	if c.kmsgSyncer != nil {
+		c.kmsgSyncer.Close()
+	}
+	if c.eventBucket != nil {
+		c.eventBucket.Close()
+	}
 
 	return nil
 }
@@ -139,6 +229,45 @@ func (c *component) Check() components.CheckResult {
 		c.lastCheckResult = cr
 		c.lastMu.Unlock()
 	}()
+
+	// kmsg-based NFS hang detection takes priority over the prober: when the
+	// kernel has already reported writeback hangs / lock-reclaim failures /
+	// unresponsive servers, a probe-issued open()/write() may itself hang
+	// forever, so we surface the suggested action and skip the prober for
+	// this tick. If a reboot has already been observed after the hang
+	// events, EvaluateSuggestedActions returns nil and we fall through to
+	// the prober for live verification (design doc §3.6).
+	if c.eventBucket != nil {
+		evs, err := c.eventBucket.Get(c.ctx, cr.ts.Add(-c.lookbackPeriod))
+		if err != nil {
+			log.Logger.Warnw("failed to query nfs event bucket", "error", err)
+		} else {
+			hangEvents, hangReason := collectNFSHangEvents(evs)
+			if len(hangEvents) > 0 {
+				var rebootEvents eventstore.Events
+				if c.rebootEventStore != nil {
+					rebootEvents, _ = c.rebootEventStore.GetRebootEvents(c.ctx, cr.ts.Add(-c.lookbackPeriod))
+					// GetRebootEvents returns events in DESCENDING order
+					// (latest first), but EvaluateSuggestedActions expects
+					// ASCENDING order (oldest first) — see design doc §9 U2.
+					sort.Slice(rebootEvents, func(i, j int) bool {
+						return rebootEvents[i].Time.Before(rebootEvents[j].Time)
+					})
+				}
+				sa := eventstore.EvaluateSuggestedActions(rebootEvents, hangEvents, 2)
+				if sa != nil {
+					sa.Description = "NFS hang requires immediate reboot; drain may hang on NFS volumes"
+					cr.health = apiv1.HealthStateTypeUnhealthy
+					cr.reason = hangReason
+					cr.suggestedActions = sa
+					return cr
+				}
+				// sa == nil → a reboot was already observed after the
+				// hang event; fall through to the prober to verify the
+				// mount is currently healthy.
+			}
+		}
+	}
 
 	groupConfigs := c.getGroupConfigsFunc()
 	if len(groupConfigs) == 0 {
@@ -275,6 +404,10 @@ type checkResult struct {
 
 	// tracks the healthy evaluation result of the last check
 	health apiv1.HealthStateType
+	// suggestedActions is populated when the kmsg-based hang detection
+	// determines the system needs a reboot or hardware inspection. It is a
+	// pointer so the JSON encoder elides it when unset.
+	suggestedActions *apiv1.SuggestedActions
 	// tracks the reason of the last check
 	reason string
 }
@@ -339,12 +472,13 @@ func (cr *checkResult) HealthStates() apiv1.HealthStates {
 	}
 
 	state := apiv1.HealthState{
-		Time:      metav1.NewTime(cr.ts),
-		Component: Name,
-		Name:      Name,
-		Reason:    cr.reason,
-		Error:     cr.getError(),
-		Health:    cr.health,
+		Time:             metav1.NewTime(cr.ts),
+		Component:        Name,
+		Name:             Name,
+		Reason:           cr.reason,
+		Error:            cr.getError(),
+		Health:           cr.health,
+		SuggestedActions: cr.suggestedActions,
 	}
 
 	return apiv1.HealthStates{state}

--- a/components/nfs/component_test.go
+++ b/components/nfs/component_test.go
@@ -1600,6 +1600,33 @@ func TestCheckKmsgHangAfterReboot(t *testing.T) {
 	assert.Equal(t, "no nfs group configs found", cr.reason)
 }
 
+func TestCheckKmsgHangAfterRebootWithNewFailure(t *testing.T) {
+	now := time.Now().UTC()
+	bucket := &nfsMockEventBucket{
+		events: eventstore.Events{
+			{Name: eventNFSLockReclaimFailed, Time: now.Add(-5 * time.Hour), Message: messageNFSLockReclaimFailed},
+			{Name: eventNFSLockReclaimFailed, Time: now.Add(-1 * time.Hour), Message: messageNFSLockReclaimFailed},
+		},
+	}
+	reboot := &nfsMockRebootEventStore{
+		events: eventstore.Events{
+			{Name: "reboot", Time: now.Add(-3 * time.Hour), Message: "intermediate boot"},
+		},
+	}
+
+	c := newKmsgComponent(bucket, reboot)
+	defer func() { _ = c.Close() }()
+
+	result := c.Check()
+	cr := mustCheckResult(t, result)
+
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.health)
+	assert.Contains(t, cr.reason, "1 lock reclaim failures")
+	require.NotNil(t, cr.suggestedActions)
+	require.Len(t, cr.suggestedActions.RepairActions, 1)
+	assert.Equal(t, apiv1.RepairActionTypeRebootSystem, cr.suggestedActions.RepairActions[0])
+}
+
 // TestCheckNilRebootEventStore: rebootEventStore == nil must be tolerated.
 // With no reboot history, EvaluateSuggestedActions still suggests a reboot.
 func TestCheckNilRebootEventStore(t *testing.T) {

--- a/components/nfs/component_test.go
+++ b/components/nfs/component_test.go
@@ -1622,6 +1622,26 @@ func TestCheckNilRebootEventStore(t *testing.T) {
 	})
 }
 
+func TestCheckKmsgHangRebootStoreError(t *testing.T) {
+	now := time.Now().UTC()
+	rebootErr := errors.New("reboot store unavailable")
+	bucket := &nfsMockEventBucket{
+		events: eventstore.Events{
+			{Name: eventNFSLockReclaimFailed, Time: now.Add(-30 * time.Minute), Message: messageNFSLockReclaimFailed},
+		},
+	}
+	c := newKmsgComponent(bucket, &nfsMockRebootEventStore{err: rebootErr})
+	defer func() { _ = c.Close() }()
+
+	result := c.Check()
+	cr := mustCheckResult(t, result)
+
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.health)
+	assert.ErrorIs(t, cr.err, rebootErr)
+	assert.Equal(t, "failed to get reboot events", cr.reason)
+	assert.Nil(t, cr.suggestedActions)
+}
+
 // TestCheckSkipsProberWhenHangDetected: when a hang is detected the prober
 // path must not run. Use a getGroupConfigsFunc that panics if invoked.
 func TestCheckSkipsProberWhenHangDetected(t *testing.T) {

--- a/components/nfs/component_test.go
+++ b/components/nfs/component_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1397,4 +1399,304 @@ func (m *mockChecker) Check(_ context.Context) pkgnfschecker.CheckResult {
 
 func (m *mockChecker) Clean() error {
 	return nil
+}
+
+// ---------------------------------------------------------------------------
+// kmsg-based hang detection tests
+// ---------------------------------------------------------------------------
+
+// nfsMockEventBucket is a minimal in-memory eventstore.Bucket implementation
+// used to drive the kmsg path. It returns events in DESCENDING order by Time
+// to match the real bucket contract.
+type nfsMockEventBucket struct {
+	mu     sync.Mutex
+	events eventstore.Events
+	getErr error
+}
+
+func (m *nfsMockEventBucket) Name() string { return "nfs-test-bucket" }
+
+func (m *nfsMockEventBucket) Insert(_ context.Context, ev eventstore.Event) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, ev)
+	return nil
+}
+
+func (m *nfsMockEventBucket) Find(_ context.Context, ev eventstore.Event) (*eventstore.Event, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.events {
+		if e.Name == ev.Name && e.Message == ev.Message {
+			out := e
+			return &out, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *nfsMockEventBucket) Get(_ context.Context, since time.Time) (eventstore.Events, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make(eventstore.Events, 0, len(m.events))
+	for _, e := range m.events {
+		if e.Time.After(since) || e.Time.Equal(since) {
+			out = append(out, e)
+		}
+	}
+	// Real bucket returns DESC by Time.
+	sort.Slice(out, func(i, j int) bool { return out[i].Time.After(out[j].Time) })
+	return out, nil
+}
+
+func (m *nfsMockEventBucket) Latest(_ context.Context) (*eventstore.Event, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.events) == 0 {
+		return nil, nil
+	}
+	latest := m.events[0]
+	for _, e := range m.events[1:] {
+		if e.Time.After(latest.Time) {
+			latest = e
+		}
+	}
+	return &latest, nil
+}
+
+func (m *nfsMockEventBucket) Purge(_ context.Context, _ int64) (int, error) { return 0, nil }
+func (m *nfsMockEventBucket) Close()                                        {}
+
+// nfsMockRebootEventStore implements pkghost.RebootEventStore for tests.
+type nfsMockRebootEventStore struct {
+	events eventstore.Events
+	err    error
+}
+
+func (m *nfsMockRebootEventStore) RecordReboot(_ context.Context) error { return nil }
+
+func (m *nfsMockRebootEventStore) GetRebootEvents(_ context.Context, since time.Time) (eventstore.Events, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	out := make(eventstore.Events, 0, len(m.events))
+	for _, e := range m.events {
+		if e.Time.After(since) || e.Time.Equal(since) {
+			out = append(out, e)
+		}
+	}
+	// Real store returns DESC by Time (latest first).
+	sort.Slice(out, func(i, j int) bool { return out[i].Time.After(out[j].Time) })
+	return out, nil
+}
+
+// newKmsgComponent constructs a *component pre-wired with a kmsg event bucket
+// and a configurable reboot event store. The prober path is short-circuited
+// to a no-op by an empty getGroupConfigsFunc.
+func newKmsgComponent(bucket *nfsMockEventBucket, reboot *nfsMockRebootEventStore) *component {
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &component{
+		ctx:    ctx,
+		cancel: cancel,
+
+		machineID: "test-machine",
+
+		getGroupConfigsFunc: func() pkgnfschecker.Configs { return pkgnfschecker.Configs{} },
+
+		eventBucket:    bucket,
+		lookbackPeriod: 24 * time.Hour,
+	}
+	if reboot != nil {
+		c.rebootEventStore = reboot
+	}
+	return c
+}
+
+// TestCheckKmsgHangDetectionUnhealthy: two writeback-hang events + no reboots
+// → suggest REBOOT_SYSTEM.
+func TestCheckKmsgHangDetectionUnhealthy(t *testing.T) {
+	now := time.Now().UTC()
+	bucket := &nfsMockEventBucket{
+		events: eventstore.Events{
+			{Name: eventNFSWritebackHang, Time: now.Add(-5 * time.Hour), Message: messageNFSWritebackHang},
+			{Name: eventNFSWritebackHang, Time: now.Add(-2 * time.Hour), Message: messageNFSWritebackHang},
+		},
+	}
+	c := newKmsgComponent(bucket, &nfsMockRebootEventStore{events: eventstore.Events{}})
+	defer func() { _ = c.Close() }()
+
+	result := c.Check()
+	cr := mustCheckResult(t, result)
+
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.health)
+	assert.Contains(t, cr.reason, "writeback")
+	require.NotNil(t, cr.suggestedActions)
+	require.Len(t, cr.suggestedActions.RepairActions, 1)
+	assert.Equal(t, apiv1.RepairActionTypeRebootSystem, cr.suggestedActions.RepairActions[0])
+	assert.Contains(t, cr.suggestedActions.Description, "drain may hang")
+}
+
+// TestCheckKmsgHangWithRebootLoop (R3-1): two hang events interleaved with two
+// reboots → HARDWARE_INSPECTION because reboots have not resolved the issue.
+func TestCheckKmsgHangWithRebootLoop(t *testing.T) {
+	now := time.Now().UTC()
+	// Hang at T-5h and T-2h.
+	bucket := &nfsMockEventBucket{
+		events: eventstore.Events{
+			{Name: eventNFSWritebackHang, Time: now.Add(-5 * time.Hour), Message: messageNFSWritebackHang},
+			{Name: eventNFSWritebackHang, Time: now.Add(-2 * time.Hour), Message: messageNFSWritebackHang},
+		},
+	}
+	// Reboots at T-6h and T-3h. Note: GetRebootEvents will return them DESC;
+	// the component code re-sorts ASC before calling EvaluateSuggestedActions.
+	reboot := &nfsMockRebootEventStore{
+		events: eventstore.Events{
+			{Name: "reboot", Time: now.Add(-6 * time.Hour), Message: "boot 1"},
+			{Name: "reboot", Time: now.Add(-3 * time.Hour), Message: "boot 2"},
+		},
+	}
+
+	c := newKmsgComponent(bucket, reboot)
+	defer func() { _ = c.Close() }()
+
+	result := c.Check()
+	cr := mustCheckResult(t, result)
+
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.health)
+	require.NotNil(t, cr.suggestedActions, "suggestedActions must be set when hang + reboot loop is detected")
+	require.Len(t, cr.suggestedActions.RepairActions, 1)
+	assert.Equal(t, apiv1.RepairActionTypeHardwareInspection, cr.suggestedActions.RepairActions[0],
+		"two reboot→hang sequences should escalate to hardware inspection")
+}
+
+// TestCheckKmsgHangAfterReboot: one hang event followed by a reboot →
+// EvaluateSuggestedActions returns nil; component falls through to the prober
+// (which has no configs → healthy).
+func TestCheckKmsgHangAfterReboot(t *testing.T) {
+	now := time.Now().UTC()
+	bucket := &nfsMockEventBucket{
+		events: eventstore.Events{
+			{Name: eventNFSWritebackHang, Time: now.Add(-2 * time.Hour), Message: messageNFSWritebackHang},
+		},
+	}
+	reboot := &nfsMockRebootEventStore{
+		events: eventstore.Events{
+			{Name: "reboot", Time: now.Add(-1 * time.Hour), Message: "post-fix boot"},
+		},
+	}
+
+	c := newKmsgComponent(bucket, reboot)
+	defer func() { _ = c.Close() }()
+
+	result := c.Check()
+	cr := mustCheckResult(t, result)
+
+	// Reboot happened AFTER the hang → fall through to prober (no configs).
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, cr.health)
+	assert.Nil(t, cr.suggestedActions, "suggestedActions must be nil after the hang is resolved by a reboot")
+	assert.Equal(t, "no nfs group configs found", cr.reason)
+}
+
+// TestCheckNilRebootEventStore: rebootEventStore == nil must be tolerated.
+// With no reboot history, EvaluateSuggestedActions still suggests a reboot.
+func TestCheckNilRebootEventStore(t *testing.T) {
+	now := time.Now().UTC()
+	bucket := &nfsMockEventBucket{
+		events: eventstore.Events{
+			{Name: eventNFSLockReclaimFailed, Time: now.Add(-30 * time.Minute), Message: messageNFSLockReclaimFailed},
+		},
+	}
+	c := newKmsgComponent(bucket, nil) // explicitly nil
+	defer func() { _ = c.Close() }()
+
+	require.NotPanics(t, func() {
+		result := c.Check()
+		cr := mustCheckResult(t, result)
+		assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.health)
+		require.NotNil(t, cr.suggestedActions)
+		require.Len(t, cr.suggestedActions.RepairActions, 1)
+		assert.Equal(t, apiv1.RepairActionTypeRebootSystem, cr.suggestedActions.RepairActions[0])
+	})
+}
+
+// TestCheckSkipsProberWhenHangDetected: when a hang is detected the prober
+// path must not run. Use a getGroupConfigsFunc that panics if invoked.
+func TestCheckSkipsProberWhenHangDetected(t *testing.T) {
+	now := time.Now().UTC()
+	bucket := &nfsMockEventBucket{
+		events: eventstore.Events{
+			{Name: eventNFSWritebackHang, Time: now.Add(-3 * time.Hour), Message: messageNFSWritebackHang},
+			{Name: eventNFSWritebackHang, Time: now.Add(-1 * time.Hour), Message: messageNFSWritebackHang},
+		},
+	}
+	c := newKmsgComponent(bucket, &nfsMockRebootEventStore{events: eventstore.Events{}})
+	c.getGroupConfigsFunc = func() pkgnfschecker.Configs {
+		panic("prober getGroupConfigsFunc should not be called when hang is detected")
+	}
+	defer func() { _ = c.Close() }()
+
+	require.NotPanics(t, func() {
+		result := c.Check()
+		cr := mustCheckResult(t, result)
+		assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.health)
+		require.NotNil(t, cr.suggestedActions)
+	})
+}
+
+// TestStartImmediateFirstCheck verifies Start() invokes Check() immediately on
+// entry, not after the first ticker interval.
+func TestStartImmediateFirstCheck(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var count int32
+	checked := make(chan struct{}, 1)
+
+	c := &component{
+		ctx:    ctx,
+		cancel: cancel,
+		getGroupConfigsFunc: func() pkgnfschecker.Configs {
+			if atomic.AddInt32(&count, 1) == 1 {
+				// Signal the first check immediately. Use non-blocking send
+				// in case the channel buffer is full.
+				select {
+				case checked <- struct{}{}:
+				default:
+				}
+			}
+			return pkgnfschecker.Configs{}
+		},
+	}
+
+	require.NoError(t, c.Start())
+
+	select {
+	case <-checked:
+		// First Check ran without waiting for the 1-minute ticker.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Check() was not invoked immediately when Start() was called")
+	}
+
+	require.NoError(t, c.Close())
+}
+
+// TestEventsWithBucket exercises the new Events() path when an eventBucket is
+// configured. The legacy TestEvents (nil bucket → nil events) is preserved.
+func TestEventsWithBucket(t *testing.T) {
+	now := time.Now().UTC()
+	bucket := &nfsMockEventBucket{
+		events: eventstore.Events{
+			{Name: eventNFSWritebackHang, Time: now.Add(-1 * time.Hour), Message: messageNFSWritebackHang, Type: "Warning"},
+			{Name: eventNFSServerNotResponding, Time: now.Add(-30 * time.Minute), Message: messageNFSServerNotResponding, Type: "Warning"},
+		},
+	}
+	c := newKmsgComponent(bucket, nil)
+	defer func() { _ = c.Close() }()
+
+	events, err := c.Events(context.Background(), now.Add(-2*time.Hour))
+	require.NoError(t, err)
+	assert.Len(t, events, 2)
 }

--- a/components/nfs/hang_evaluator.go
+++ b/components/nfs/hang_evaluator.go
@@ -138,3 +138,15 @@ func nfsServerFromEventMessage(message string) string {
 	}
 	return ""
 }
+
+// nfsEventsOnOrAfter returns events whose timestamps are on or after since,
+// matching eventstore.EvaluateSuggestedActions' treatment of equal timestamps.
+func nfsEventsOnOrAfter(events eventstore.Events, since time.Time) eventstore.Events {
+	filtered := make(eventstore.Events, 0, len(events))
+	for _, ev := range events {
+		if !ev.Time.Before(since) {
+			filtered = append(filtered, ev)
+		}
+	}
+	return filtered
+}

--- a/components/nfs/hang_evaluator.go
+++ b/components/nfs/hang_evaluator.go
@@ -14,8 +14,8 @@ import (
 //
 // Rules:
 //   - nfs_lock_reclaim_failed: any single occurrence counts.
-//   - nfs_server_not_responding: counts only when no later nfs_server_ok
-//     cancels it out (compare the latest of each kind).
+//   - nfs_server_not_responding: counts per server only when it happened after
+//     that server's latest nfs_server_ok.
 //   - nfs_writeback_hang: counts only when there are ≥ 2 occurrences in the
 //     input window.
 //
@@ -28,10 +28,9 @@ import (
 // so the caller can decide whether to fall back to the prober.
 func collectNFSHangEvents(events eventstore.Events) (hang eventstore.Events, reason string) {
 	var (
-		lockReclaim   eventstore.Events
-		notResponding eventstore.Events
-		ok            eventstore.Events
-		writeback     eventstore.Events
+		lockReclaim    eventstore.Events
+		serverResponse = make(map[string]*nfsServerResponseEvents)
+		writeback      eventstore.Events
 	)
 
 	for _, ev := range events {
@@ -39,9 +38,11 @@ func collectNFSHangEvents(events eventstore.Events) (hang eventstore.Events, rea
 		case eventNFSLockReclaimFailed:
 			lockReclaim = append(lockReclaim, ev)
 		case eventNFSServerNotResponding:
-			notResponding = append(notResponding, ev)
+			response := getNFSServerResponseEvents(serverResponse, ev)
+			response.notResponding = append(response.notResponding, ev)
 		case eventNFSServerOK:
-			ok = append(ok, ev)
+			response := getNFSServerResponseEvents(serverResponse, ev)
+			response.ok = append(response.ok, ev)
 		case eventNFSWritebackHang:
 			writeback = append(writeback, ev)
 		}
@@ -55,21 +56,32 @@ func collectNFSHangEvents(events eventstore.Events) (hang eventstore.Events, rea
 		reasonParts = append(reasonParts, fmt.Sprintf("%d lock reclaim failures", len(lockReclaim)))
 	}
 
-	// Rule A: server not responding — only counts if not cancelled by a
-	// later "OK". Compare the latest of each.
-	if len(notResponding) > 0 {
-		latestNR := latestTime(notResponding)
-		cancelled := false
-		if len(ok) > 0 {
-			latestOK := latestTime(ok)
-			if latestOK.After(latestNR) {
-				cancelled = true
+	// Rule A: server not responding — evaluate each server independently and
+	// keep only events that happened after that server's latest "OK".
+	notRespondingCount := 0
+	for _, response := range serverResponse {
+		if len(response.notResponding) == 0 {
+			continue
+		}
+
+		unresolved := response.notResponding
+		if len(response.ok) > 0 {
+			latestOK := latestTime(response.ok)
+			unresolved = nil
+			for _, ev := range response.notResponding {
+				if ev.Time.After(latestOK) {
+					unresolved = append(unresolved, ev)
+				}
 			}
 		}
-		if !cancelled {
-			hang = append(hang, notResponding...)
-			reasonParts = append(reasonParts, fmt.Sprintf("%d NFS server not-responding events", len(notResponding)))
+
+		if len(unresolved) > 0 {
+			hang = append(hang, unresolved...)
+			notRespondingCount += len(unresolved)
 		}
+	}
+	if notRespondingCount > 0 {
+		reasonParts = append(reasonParts, fmt.Sprintf("%d NFS server not-responding events", notRespondingCount))
 	}
 
 	// Rule C: writeback stack hints — require ≥ 2 occurrences.
@@ -100,4 +112,29 @@ func latestTime(events eventstore.Events) time.Time {
 		}
 	}
 	return t
+}
+
+type nfsServerResponseEvents struct {
+	notResponding eventstore.Events
+	ok            eventstore.Events
+}
+
+func getNFSServerResponseEvents(responses map[string]*nfsServerResponseEvents, ev eventstore.Event) *nfsServerResponseEvents {
+	server := nfsServerFromEventMessage(ev.Message)
+	if responses[server] == nil {
+		responses[server] = &nfsServerResponseEvents{}
+	}
+	return responses[server]
+}
+
+func nfsServerFromEventMessage(message string) string {
+	for _, prefix := range []string{
+		messageNFSServerNotResponding + ": ",
+		messageNFSServerOK + ": ",
+	} {
+		if server := strings.TrimPrefix(message, prefix); server != message {
+			return server
+		}
+	}
+	return ""
 }

--- a/components/nfs/hang_evaluator.go
+++ b/components/nfs/hang_evaluator.go
@@ -1,0 +1,103 @@
+package nfs
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/leptonai/gpud/pkg/eventstore"
+)
+
+// collectNFSHangEvents applies the conjunctive evidence rules (design doc
+// §3.2.2) to filter true hang events out of raw kmsg events.
+//
+// Rules:
+//   - nfs_lock_reclaim_failed: any single occurrence counts.
+//   - nfs_server_not_responding: counts only when no later nfs_server_ok
+//     cancels it out (compare the latest of each kind).
+//   - nfs_writeback_hang: counts only when there are ≥ 2 occurrences in the
+//     input window.
+//
+// The input events come from Bucket.Get (descending by Time). The function
+// does not assume any particular order — internally it inspects each event
+// independently. The returned hang slice is sorted ascending by Time so it
+// can be fed directly into eventstore.EvaluateSuggestedActions (which
+// expects ascending order per design doc §9 U2). The reason is a
+// human-readable summary; when no hang is detected, ("", nil) is returned
+// so the caller can decide whether to fall back to the prober.
+func collectNFSHangEvents(events eventstore.Events) (hang eventstore.Events, reason string) {
+	var (
+		lockReclaim   eventstore.Events
+		notResponding eventstore.Events
+		ok            eventstore.Events
+		writeback     eventstore.Events
+	)
+
+	for _, ev := range events {
+		switch ev.Name {
+		case eventNFSLockReclaimFailed:
+			lockReclaim = append(lockReclaim, ev)
+		case eventNFSServerNotResponding:
+			notResponding = append(notResponding, ev)
+		case eventNFSServerOK:
+			ok = append(ok, ev)
+		case eventNFSWritebackHang:
+			writeback = append(writeback, ev)
+		}
+	}
+
+	var reasonParts []string
+
+	// Rule B: lock reclaim — any single occurrence is a hang.
+	if len(lockReclaim) > 0 {
+		hang = append(hang, lockReclaim...)
+		reasonParts = append(reasonParts, fmt.Sprintf("%d lock reclaim failures", len(lockReclaim)))
+	}
+
+	// Rule A: server not responding — only counts if not cancelled by a
+	// later "OK". Compare the latest of each.
+	if len(notResponding) > 0 {
+		latestNR := latestTime(notResponding)
+		cancelled := false
+		if len(ok) > 0 {
+			latestOK := latestTime(ok)
+			if latestOK.After(latestNR) {
+				cancelled = true
+			}
+		}
+		if !cancelled {
+			hang = append(hang, notResponding...)
+			reasonParts = append(reasonParts, fmt.Sprintf("%d NFS server not-responding events", len(notResponding)))
+		}
+	}
+
+	// Rule C: writeback stack hints — require ≥ 2 occurrences.
+	if len(writeback) >= 2 {
+		hang = append(hang, writeback...)
+		reasonParts = append(reasonParts, fmt.Sprintf("%d NFS writeback stack hints", len(writeback)))
+	}
+
+	if len(hang) == 0 {
+		return nil, ""
+	}
+
+	sort.Slice(hang, func(i, j int) bool {
+		return hang[i].Time.Before(hang[j].Time)
+	})
+
+	reason = "NFS hang detected: " + strings.Join(reasonParts, "; ")
+	return hang, reason
+}
+
+// latestTime returns the maximum Time across the given events. The slice
+// must be non-empty.
+func latestTime(events eventstore.Events) time.Time {
+	t := events[0].Time
+	for _, ev := range events[1:] {
+		if ev.Time.After(t) {
+			t = ev.Time
+		}
+	}
+	return t
+}

--- a/components/nfs/hang_evaluator_test.go
+++ b/components/nfs/hang_evaluator_test.go
@@ -1,0 +1,157 @@
+package nfs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/leptonai/gpud/pkg/eventstore"
+)
+
+func TestCollectNFSHangEvents(t *testing.T) {
+	now := time.Now()
+
+	mk := func(name string, t time.Time) eventstore.Event {
+		return eventstore.Event{
+			Component: "nfs",
+			Time:      t,
+			Name:      name,
+			Type:      "Warning",
+			Message:   name,
+		}
+	}
+
+	tests := []struct {
+		name               string
+		events             eventstore.Events
+		wantHangCount      int
+		wantReasonEmpty    bool
+		wantReasonContains []string
+	}{
+		{
+			name:            "empty input → no hang",
+			events:          nil,
+			wantHangCount:   0,
+			wantReasonEmpty: true,
+		},
+		{
+			name: "single lock reclaim → 1 hang",
+			events: eventstore.Events{
+				mk(eventNFSLockReclaimFailed, now.Add(-10*time.Minute)),
+			},
+			wantHangCount:      1,
+			wantReasonContains: []string{"NFS hang detected", "1 lock reclaim failures"},
+		},
+		{
+			name: "single not_responding with no ok → 1 hang",
+			events: eventstore.Events{
+				mk(eventNFSServerNotResponding, now.Add(-30*time.Minute)),
+			},
+			wantHangCount:      1,
+			wantReasonContains: []string{"1 NFS server not-responding events"},
+		},
+		{
+			name: "not_responding cancelled by later ok → 0 hang",
+			events: eventstore.Events{
+				// Descending order, as Bucket.Get would return.
+				mk(eventNFSServerOK, now.Add(-30*time.Minute)),
+				mk(eventNFSServerNotResponding, now.Add(-1*time.Hour)),
+			},
+			wantHangCount:   0,
+			wantReasonEmpty: true,
+		},
+		{
+			name: "not_responding later than ok → 1 hang",
+			events: eventstore.Events{
+				mk(eventNFSServerNotResponding, now.Add(-30*time.Minute)),
+				mk(eventNFSServerOK, now.Add(-1*time.Hour)),
+			},
+			wantHangCount:      1,
+			wantReasonContains: []string{"1 NFS server not-responding events"},
+		},
+		{
+			name: "single writeback below threshold → 0 hang",
+			events: eventstore.Events{
+				mk(eventNFSWritebackHang, now.Add(-5*time.Minute)),
+			},
+			wantHangCount:   0,
+			wantReasonEmpty: true,
+		},
+		{
+			name: "two writeback events → 2 hang",
+			events: eventstore.Events{
+				mk(eventNFSWritebackHang, now.Add(-3*time.Minute)),
+				mk(eventNFSWritebackHang, now.Add(-10*time.Minute)),
+			},
+			wantHangCount:      2,
+			wantReasonContains: []string{"2 NFS writeback stack hints"},
+		},
+		{
+			name: "1 lock_reclaim + 1 writeback → only lock_reclaim counts",
+			events: eventstore.Events{
+				mk(eventNFSLockReclaimFailed, now.Add(-5*time.Minute)),
+				mk(eventNFSWritebackHang, now.Add(-10*time.Minute)),
+			},
+			wantHangCount:      1,
+			wantReasonContains: []string{"1 lock reclaim failures"},
+		},
+		{
+			name: "mixed all three rules → 6 hang, three reason segments",
+			events: eventstore.Events{
+				mk(eventNFSWritebackHang, now.Add(-1*time.Minute)),
+				mk(eventNFSWritebackHang, now.Add(-2*time.Minute)),
+				mk(eventNFSWritebackHang, now.Add(-3*time.Minute)),
+				mk(eventNFSLockReclaimFailed, now.Add(-4*time.Minute)),
+				mk(eventNFSServerNotResponding, now.Add(-5*time.Minute)),
+				mk(eventNFSServerNotResponding, now.Add(-6*time.Minute)),
+			},
+			wantHangCount: 6,
+			wantReasonContains: []string{
+				"1 lock reclaim failures",
+				"2 NFS server not-responding events",
+				"3 NFS writeback stack hints",
+				";",
+			},
+		},
+		{
+			name: "descending input yields ascending output",
+			events: eventstore.Events{
+				mk(eventNFSWritebackHang, now.Add(-1*time.Minute)),
+				mk(eventNFSWritebackHang, now.Add(-5*time.Minute)),
+				mk(eventNFSLockReclaimFailed, now.Add(-10*time.Minute)),
+			},
+			wantHangCount:      3,
+			wantReasonContains: []string{"1 lock reclaim failures", "2 NFS writeback stack hints"},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			hang, reason := collectNFSHangEvents(tc.events)
+
+			assert.Equal(t, tc.wantHangCount, len(hang), "hang count mismatch")
+
+			if tc.wantReasonEmpty {
+				assert.Empty(t, reason, "expected empty reason")
+				assert.Nil(t, hang, "expected nil hang slice when no hang detected")
+			} else {
+				for _, sub := range tc.wantReasonContains {
+					assert.Contains(t, reason, sub, "reason missing substring %q", sub)
+				}
+			}
+
+			// Ascending-order invariant (design doc §9 U2).
+			for i := 0; i+1 < len(hang); i++ {
+				cur := hang[i].Time
+				next := hang[i+1].Time
+				assert.True(t,
+					cur.Before(next) || cur.Equal(next),
+					"hang[%d].Time (%v) is after hang[%d].Time (%v); expected ascending order",
+					i, cur, i+1, next,
+				)
+			}
+		})
+	}
+}

--- a/components/nfs/hang_evaluator_test.go
+++ b/components/nfs/hang_evaluator_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/leptonai/gpud/pkg/eventstore"
 )
@@ -154,4 +155,32 @@ func TestCollectNFSHangEvents(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCollectNFSHangEventsServerOKIsPerServerAndPerCycle(t *testing.T) {
+	now := time.Now()
+	mk := func(name string, ts time.Time, message string) eventstore.Event {
+		return eventstore.Event{
+			Component: "nfs",
+			Time:      ts,
+			Name:      name,
+			Type:      "Warning",
+			Message:   message,
+		}
+	}
+
+	hang, reason := collectNFSHangEvents(eventstore.Events{
+		// A later OK from server-b must not cancel server-a.
+		mk(eventNFSServerOK, now.Add(-10*time.Minute), messageNFSServerOK+": server-b"),
+		// This is the currently unresolved server-a event.
+		mk(eventNFSServerNotResponding, now.Add(-20*time.Minute), messageNFSServerNotResponding+": server-a"),
+		// This older OK resolves only earlier server-a failures.
+		mk(eventNFSServerOK, now.Add(-30*time.Minute), messageNFSServerOK+": server-a"),
+		// This stale server-a event should not be carried into suggested actions.
+		mk(eventNFSServerNotResponding, now.Add(-40*time.Minute), messageNFSServerNotResponding+": server-a"),
+	})
+
+	require.Len(t, hang, 1)
+	assert.Equal(t, messageNFSServerNotResponding+": server-a", hang[0].Message)
+	assert.Contains(t, reason, "1 NFS server not-responding events")
 }

--- a/components/nfs/hang_evaluator_test.go
+++ b/components/nfs/hang_evaluator_test.go
@@ -53,7 +53,7 @@ func TestCollectNFSHangEvents(t *testing.T) {
 			wantReasonContains: []string{"1 NFS server not-responding events"},
 		},
 		{
-			name: "not_responding cancelled by later ok → 0 hang",
+			name: "not_responding canceled by later ok → 0 hang",
 			events: eventstore.Events{
 				// Descending order, as Bucket.Get would return.
 				mk(eventNFSServerOK, now.Add(-30*time.Minute)),

--- a/components/nfs/kmsg_matcher.go
+++ b/components/nfs/kmsg_matcher.go
@@ -1,0 +1,101 @@
+package nfs
+
+import "regexp"
+
+const (
+	// Rule A (main-line): Linux NFS client signals the server is hung or the
+	// network is broken.
+	// e.g.,
+	// nfs: server 7.247.192.16 not responding, timed out
+	eventNFSServerNotResponding   = "nfs_server_not_responding"
+	regexNFSServerNotResponding   = `nfs: server [^ ]+ not responding`
+	messageNFSServerNotResponding = "NFS server not responding"
+
+	// Recovery signal, paired with eventNFSServerNotResponding to cancel out
+	// transient network blips.
+	// e.g.,
+	// nfs: server 7.247.192.16 OK
+	eventNFSServerOK   = "nfs_server_ok"
+	regexNFSServerOK   = `nfs: server [^ ]+ OK`
+	messageNFSServerOK = "NFS server recovered"
+
+	// Rule B: NFS lock state manager failed to reclaim state from server.
+	// e.g.,
+	// nfs4_reclaim_open_state: Lock reclaim failed!
+	eventNFSLockReclaimFailed   = "nfs_lock_reclaim_failed"
+	regexNFSLockReclaimFailed   = `nfs4_reclaim_open_state: Lock reclaim failed`
+	messageNFSLockReclaimFailed = "NFS lock reclaim failed (state manager unable to recover)"
+
+	// Rule C: NFS writeback path is stuck spinning in the kernel — fingerprint
+	// of the 2026-05-15 nsc-svg-slurm-1-gpu-136 NFS hang. When softlockup /
+	// hung_task / panic dumps a stack, lines like the following appear:
+	//   nfs_lock_and_join_requests+0x61/0x2b0 [nfs]
+	//   nfs_wb_all+0x2c/0x190 [nfs]
+	//   nfs_page_async_flush+0x24/0x290 [nfs]
+	//   nfs_writepages_callback+0x31/0x60 [nfs]
+	//
+	// Stack frames typically have a leading space; pkg/kmsg preserves it
+	// (strings.SplitN(line, ";", 2), no trim). The regex therefore anchors on
+	// either the start of the line or a whitespace boundary, so we don't match
+	// substrings of unrelated symbols.
+	eventNFSWritebackHang   = "nfs_writeback_hang"
+	regexNFSWritebackHang   = `(^|\s)(nfs_lock_and_join_requests|nfs_wb_all|nfs_page_async_flush|nfs_writepages_callback)\+0x[0-9a-f]+`
+	messageNFSWritebackHang = "NFS client stuck in kernel writeback path"
+)
+
+var (
+	compiledNFSServerNotResponding = regexp.MustCompile(regexNFSServerNotResponding)
+	compiledNFSServerOK            = regexp.MustCompile(regexNFSServerOK)
+	compiledNFSLockReclaimFailed   = regexp.MustCompile(regexNFSLockReclaimFailed)
+	compiledNFSWritebackHang       = regexp.MustCompile(regexNFSWritebackHang)
+)
+
+// HasNFSServerNotResponding reports whether the line indicates an NFS server
+// became unresponsive.
+func HasNFSServerNotResponding(line string) bool {
+	return compiledNFSServerNotResponding.MatchString(line)
+}
+
+// HasNFSServerOK reports whether the line indicates an NFS server recovered.
+func HasNFSServerOK(line string) bool {
+	return compiledNFSServerOK.MatchString(line)
+}
+
+// HasNFSLockReclaimFailed reports whether the line indicates NFS lock reclaim
+// (state manager recovery) failed.
+func HasNFSLockReclaimFailed(line string) bool {
+	return compiledNFSLockReclaimFailed.MatchString(line)
+}
+
+// HasNFSWritebackHang reports whether the line is a kernel stack frame
+// indicating the NFS writeback path is stuck.
+func HasNFSWritebackHang(line string) bool {
+	return compiledNFSWritebackHang.MatchString(line)
+}
+
+// Match returns the first NFS hang related kernel-message match for the given
+// log line. It is a kmsg.MatchFunc.
+func Match(line string) (eventName string, message string) {
+	for _, m := range getMatches() {
+		if m.check(line) {
+			return m.eventName, m.message
+		}
+	}
+	return "", ""
+}
+
+type match struct {
+	check     func(string) bool
+	eventName string
+	regex     string
+	message   string
+}
+
+func getMatches() []match {
+	return []match{
+		{check: HasNFSServerNotResponding, eventName: eventNFSServerNotResponding, regex: regexNFSServerNotResponding, message: messageNFSServerNotResponding},
+		{check: HasNFSServerOK, eventName: eventNFSServerOK, regex: regexNFSServerOK, message: messageNFSServerOK},
+		{check: HasNFSLockReclaimFailed, eventName: eventNFSLockReclaimFailed, regex: regexNFSLockReclaimFailed, message: messageNFSLockReclaimFailed},
+		{check: HasNFSWritebackHang, eventName: eventNFSWritebackHang, regex: regexNFSWritebackHang, message: messageNFSWritebackHang},
+	}
+}

--- a/components/nfs/kmsg_matcher.go
+++ b/components/nfs/kmsg_matcher.go
@@ -8,7 +8,7 @@ const (
 	// e.g.,
 	// nfs: server 7.247.192.16 not responding, timed out
 	eventNFSServerNotResponding   = "nfs_server_not_responding"
-	regexNFSServerNotResponding   = `nfs: server [^ ]+ not responding`
+	regexNFSServerNotResponding   = `nfs: server ([^ ]+) not responding`
 	messageNFSServerNotResponding = "NFS server not responding"
 
 	// Recovery signal, paired with eventNFSServerNotResponding to cancel out
@@ -16,7 +16,7 @@ const (
 	// e.g.,
 	// nfs: server 7.247.192.16 OK
 	eventNFSServerOK   = "nfs_server_ok"
-	regexNFSServerOK   = `nfs: server [^ ]+ OK`
+	regexNFSServerOK   = `nfs: server ([^ ]+) OK`
 	messageNFSServerOK = "NFS server recovered"
 
 	// Rule B: NFS lock state manager failed to reclaim state from server.
@@ -78,7 +78,7 @@ func HasNFSWritebackHang(line string) bool {
 func Match(line string) (eventName string, message string) {
 	for _, m := range getMatches() {
 		if m.check(line) {
-			return m.eventName, m.message
+			return m.eventName, m.getMessage(line)
 		}
 	}
 	return "", ""
@@ -89,13 +89,45 @@ type match struct {
 	eventName string
 	regex     string
 	message   string
+	messageFn func(string) string
 }
 
 func getMatches() []match {
 	return []match{
-		{check: HasNFSServerNotResponding, eventName: eventNFSServerNotResponding, regex: regexNFSServerNotResponding, message: messageNFSServerNotResponding},
-		{check: HasNFSServerOK, eventName: eventNFSServerOK, regex: regexNFSServerOK, message: messageNFSServerOK},
+		{
+			check:     HasNFSServerNotResponding,
+			eventName: eventNFSServerNotResponding,
+			regex:     regexNFSServerNotResponding,
+			message:   messageNFSServerNotResponding,
+			messageFn: func(line string) string {
+				return messageWithNFSServer(messageNFSServerNotResponding, line, compiledNFSServerNotResponding)
+			},
+		},
+		{
+			check:     HasNFSServerOK,
+			eventName: eventNFSServerOK,
+			regex:     regexNFSServerOK,
+			message:   messageNFSServerOK,
+			messageFn: func(line string) string {
+				return messageWithNFSServer(messageNFSServerOK, line, compiledNFSServerOK)
+			},
+		},
 		{check: HasNFSLockReclaimFailed, eventName: eventNFSLockReclaimFailed, regex: regexNFSLockReclaimFailed, message: messageNFSLockReclaimFailed},
 		{check: HasNFSWritebackHang, eventName: eventNFSWritebackHang, regex: regexNFSWritebackHang, message: messageNFSWritebackHang},
 	}
+}
+
+func (m match) getMessage(line string) string {
+	if m.messageFn != nil {
+		return m.messageFn(line)
+	}
+	return m.message
+}
+
+func messageWithNFSServer(baseMessage string, line string, re *regexp.Regexp) string {
+	matches := re.FindStringSubmatch(line)
+	if len(matches) < 2 {
+		return baseMessage
+	}
+	return baseMessage + ": " + matches[1]
 }

--- a/components/nfs/kmsg_matcher_test.go
+++ b/components/nfs/kmsg_matcher_test.go
@@ -18,19 +18,19 @@ func TestMatch(t *testing.T) {
 			name:          "server not responding, timed out",
 			line:          "nfs: server 7.247.192.16 not responding, timed out",
 			wantEventName: eventNFSServerNotResponding,
-			wantMessage:   messageNFSServerNotResponding,
+			wantMessage:   messageNFSServerNotResponding + ": 7.247.192.16",
 		},
 		{
 			name:          "server not responding, still trying",
 			line:          "nfs: server nfs-prod-01.example.com not responding, still trying",
 			wantEventName: eventNFSServerNotResponding,
-			wantMessage:   messageNFSServerNotResponding,
+			wantMessage:   messageNFSServerNotResponding + ": nfs-prod-01.example.com",
 		},
 		{
 			name:          "server not responding with kernel timestamp prefix",
 			line:          "kernel: nfs: server 10.0.0.5 not responding, timed out",
 			wantEventName: eventNFSServerNotResponding,
-			wantMessage:   messageNFSServerNotResponding,
+			wantMessage:   messageNFSServerNotResponding + ": 10.0.0.5",
 		},
 
 		// ── Rule A pair: server OK ──
@@ -38,13 +38,13 @@ func TestMatch(t *testing.T) {
 			name:          "server OK",
 			line:          "nfs: server 7.247.192.16 OK",
 			wantEventName: eventNFSServerOK,
-			wantMessage:   messageNFSServerOK,
+			wantMessage:   messageNFSServerOK + ": 7.247.192.16",
 		},
 		{
 			name:          "server OK with hostname",
 			line:          "nfs: server nfs-prod-01.example.com OK",
 			wantEventName: eventNFSServerOK,
-			wantMessage:   messageNFSServerOK,
+			wantMessage:   messageNFSServerOK + ": nfs-prod-01.example.com",
 		},
 
 		// ── Rule B: lock reclaim failed ──

--- a/components/nfs/kmsg_matcher_test.go
+++ b/components/nfs/kmsg_matcher_test.go
@@ -1,0 +1,144 @@
+package nfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatch(t *testing.T) {
+	tests := []struct {
+		name          string
+		line          string
+		wantEventName string
+		wantMessage   string
+	}{
+		// ── Rule A: server not responding ──
+		{
+			name:          "server not responding, timed out",
+			line:          "nfs: server 7.247.192.16 not responding, timed out",
+			wantEventName: eventNFSServerNotResponding,
+			wantMessage:   messageNFSServerNotResponding,
+		},
+		{
+			name:          "server not responding, still trying",
+			line:          "nfs: server nfs-prod-01.example.com not responding, still trying",
+			wantEventName: eventNFSServerNotResponding,
+			wantMessage:   messageNFSServerNotResponding,
+		},
+		{
+			name:          "server not responding with kernel timestamp prefix",
+			line:          "kernel: nfs: server 10.0.0.5 not responding, timed out",
+			wantEventName: eventNFSServerNotResponding,
+			wantMessage:   messageNFSServerNotResponding,
+		},
+
+		// ── Rule A pair: server OK ──
+		{
+			name:          "server OK",
+			line:          "nfs: server 7.247.192.16 OK",
+			wantEventName: eventNFSServerOK,
+			wantMessage:   messageNFSServerOK,
+		},
+		{
+			name:          "server OK with hostname",
+			line:          "nfs: server nfs-prod-01.example.com OK",
+			wantEventName: eventNFSServerOK,
+			wantMessage:   messageNFSServerOK,
+		},
+
+		// ── Rule B: lock reclaim failed ──
+		{
+			name:          "lock reclaim failed",
+			line:          "nfs4_reclaim_open_state: Lock reclaim failed!",
+			wantEventName: eventNFSLockReclaimFailed,
+			wantMessage:   messageNFSLockReclaimFailed,
+		},
+		{
+			name:          "lock reclaim failed without exclamation",
+			line:          "nfs4_reclaim_open_state: Lock reclaim failed",
+			wantEventName: eventNFSLockReclaimFailed,
+			wantMessage:   messageNFSLockReclaimFailed,
+		},
+
+		// ── Rule C: writeback hang stack frames ──
+		// All real dmesg stack-trace lines start with a leading space, which
+		// pkg/kmsg's parser preserves. These cases enforce that the regex
+		// boundary anchor accepts leading whitespace.
+		{
+			name:          "writeback hang nfs_lock_and_join_requests with leading space",
+			line:          " nfs_lock_and_join_requests+0x61/0x2b0 [nfs]",
+			wantEventName: eventNFSWritebackHang,
+			wantMessage:   messageNFSWritebackHang,
+		},
+		{
+			name:          "writeback hang nfs_wb_all with leading space",
+			line:          " nfs_wb_all+0x2c/0x190 [nfs]",
+			wantEventName: eventNFSWritebackHang,
+			wantMessage:   messageNFSWritebackHang,
+		},
+		{
+			name:          "writeback hang nfs_page_async_flush with leading space",
+			line:          " nfs_page_async_flush+0x24/0x290 [nfs]",
+			wantEventName: eventNFSWritebackHang,
+			wantMessage:   messageNFSWritebackHang,
+		},
+		{
+			name:          "writeback hang nfs_writepages_callback with tab indent",
+			line:          "\tnfs_writepages_callback+0x31/0x60 [nfs]",
+			wantEventName: eventNFSWritebackHang,
+			wantMessage:   messageNFSWritebackHang,
+		},
+		{
+			name:          "writeback hang at line start (no leading whitespace)",
+			line:          "nfs_lock_and_join_requests+0x61/0x2b0 [nfs]",
+			wantEventName: eventNFSWritebackHang,
+			wantMessage:   messageNFSWritebackHang,
+		},
+
+		// ── Negative cases ──
+		{
+			name:          "negative: server starting is not not-responding",
+			line:          "nfs: server 7.247.192.16 starting",
+			wantEventName: "",
+			wantMessage:   "",
+		},
+		{
+			name:          "negative: unrelated lock message",
+			line:          "some other syscall lock contention detected",
+			wantEventName: "",
+			wantMessage:   "",
+		},
+		{
+			name:          "negative: similar but unrelated nfs symbol",
+			line:          " nfs_xxx_other+0x12/0x340 [nfs]",
+			wantEventName: "",
+			wantMessage:   "",
+		},
+		{
+			name:          "negative: writeback symbol as substring of larger token",
+			line:          " prefix_nfs_lock_and_join_requests+0x61/0x2b0 [nfs]",
+			wantEventName: "",
+			wantMessage:   "",
+		},
+		{
+			name:          "negative: empty line",
+			line:          "",
+			wantEventName: "",
+			wantMessage:   "",
+		},
+		{
+			name:          "negative: nfs mount info",
+			line:          "NFS: Registering the id_resolver key type",
+			wantEventName: "",
+			wantMessage:   "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotEventName, gotMessage := Match(tt.line)
+			assert.Equal(t, tt.wantEventName, gotEventName, "Match() eventName")
+			assert.Equal(t, tt.wantMessage, gotMessage, "Match() message")
+		})
+	}
+}


### PR DESCRIPTION
  ## Summary

  Adds a kmsg-based detection path to the `nfs` component that catches NFS
  hangs the existing read/write prober cannot — specifically the case where
  the NFS client kernel module is spinning on its own writeback locks while
  kubelet's main thread keeps reporting Ready.

  When a hang is detected, the component flips to `Unhealthy` with a
  `SuggestedActions{REBOOT_SYSTEM}`, which lets cluster-operator's
  auto-fixer cordon and reboot the node automatically. Repeated hangs
  across reboots are upgraded to `HARDWARE_INSPECTION` via the existing
  `eventstore.EvaluateSuggestedActions` machinery, so this does not
  introduce a reboot loop.

  ## Motivation

  A worker node ran for 3.5 days in a state where:

  - kubelet's main goroutine kept writing logs and reporting heartbeats
    (node `Ready=True`)
  - one CPU core was 100% pinned inside `nfs_lock_and_join_requests` →
    `_raw_spin_lock`, triggered by a user-issued `mksquashfs` writing a
    large file to `/nfs/home`
  - any goroutine touching the filesystem (kubelet's pod admit / volume
    mount / cAdvisor) blocked forever
  - new pods could be scheduled to the node but never admitted

  dmesg reported `watchdog: BUG: soft lockup` every ~28 seconds from the
  first 26-second stuck event onward, but nothing was listening for it.
  The current `components/cpu` matcher already recognises `soft lockup`
  text but only records it as an event — it never affects health state.

  This change makes that signal actionable, scoped to NFS so the
  generic `soft lockup` semantics in `components/cpu` are unchanged.

  ## What's in this PR

  Two commits, each independently buildable and testable:

  1. **`feat(nfs): add kmsg matcher and hang evaluator for NFS hang detection`**
     Pure additions, no wiring:
     - `kmsg_matcher.go`: four NFS-specific regexes (server not responding,
       server OK recovery, lock reclaim failed, NFS writeback functions
       in stack traces) + a `Match` function for `kmsg.Syncer`.
     - `hang_evaluator.go`: `collectNFSHangEvents()` applies conjunction
       rules — lock-reclaim failed counts unconditionally, "not responding"
       is cancelled by a later "OK", writeback stack hints require ≥ 2
       occurrences in the lookback window (which, combined with the
       300-second dedup, means ≥ 5 minutes of sustained hang and filters
       out one-shot sysrq dumps).

  2. **`feat(nfs): wire kmsg-based hang detection into component health`**
     Hooks the detector into the component:
     - New fields `eventBucket`, `kmsgSyncer`, `rebootEventStore`,
       `lookbackPeriod` (3 days, aligned with `eventstore.DefaultRetention`).
     - `newComponent()` testable inner constructor; `kmsg.Syncer` started
       on `linux + euid==0 + EventStore!=nil` with
       `WithCacheKeyTruncateSeconds(300)`.
     - `Check()` evaluates kmsg events before the prober. If a hang is
       present, query reboot history, sort ascending (see note below),
       and let `EvaluateSuggestedActions` decide whether to suggest
       reboot or hardware inspection. If a reboot already happened after
       the hang, fall through to the prober for live re-check rather than
       reporting stale state.
     - `Start()` now runs `Check()` immediately on the first iteration
       instead of waiting one tick, matching `components/disk`.
     - `Close()` shuts the syncer before the bucket.
     - `Events()` returns bucket contents instead of `nil`.
     - `checkResult.suggestedActions` surfaced through `HealthStates()`.

  ## Notable design points

  - **Ordering quirk**: `Bucket.Get` and `RebootEventStore.GetRebootEvents`
    both return events in **descending** order (latest first), but
    `eventstore.EvaluateSuggestedActions` expects **ascending** input
    (see `pkg/eventstore/suggested_actions_test.go` case 4 where
    `failureEvents[0]` is the earliest). This PR sorts ascending before
    calling. `components/disk` happens to pass the descending slice
    directly — that may be a latent issue worth addressing in a separate
    PR but is out of scope here.
  - **Lookback = 3 days** (not longer), because `EventStore` doesn't support
    per-bucket retention overrides and the global default is 3 days. Within
    this window we get accurate reboot-vs-hang ordering; beyond it we'd
    just be reading nothing.
  - **kmsg `Message` preserves leading whitespace** (parsed by
    `strings.SplitN(line, ";", 2)` in `pkg/kmsg/watcher.go`), so the
    writeback regex uses `(^|\s)…` to tolerate the leading space typical
    of kernel stack trace lines.

  ## Testing

  ```text
  go test ./components/nfs/ -short -race -count=1
  ok  github.com/leptonai/gpud/components/nfs  1.7s

  56 tests pass (all pre-existing + 25 newly added across matcher,
  evaluator, and component layers). Highlights:

  - Reboot-loop guard: TestCheckKmsgHangWithRebootLoop — two hangs
  with two interleaved reboots upgrades to HARDWARE_INSPECTION.
  - No-loop safety: TestCheckKmsgHangAfterReboot — hang followed by
  a later reboot returns nil from EvaluateSuggestedActions and falls
  through to the prober.
  - Robustness: TestCheckNilRebootEventStore — nil reboot store
  does not panic.
  - Probe skip: TestCheckSkipsProberWhenHangDetected — confirms the
  kmsg path returns before a probe is issued on a known-hung mount.
  - Cold-start latency: TestStartImmediateFirstCheck — Start()
  runs Check() before the first ticker fire (also fixes pre-existing
  behaviour where the first health state would only appear after a
  full minute).

  Risk & limitations

  - Repeated sysrq within 5 minutes could trigger a false positive
  (two writeback stack hints needed). This is a controlled human
  action and the resulting cordon is a safe side-effect.
  - gpud's own probe goroutines are still vulnerable to NFS hangs
  that occur mid-execution: the existing 5-second ctx.WithTimeout
  cannot cancel an in-kernel NFS syscall. This PR mitigates by
  skipping new probes on known-hung mounts but does not rescue
  already-stuck goroutines. Pre-existing; out of scope.
  - components/cpu is intentionally untouched: its existing
  soft lockup matcher still only writes events and does not affect
  health, since the generic CPU lockup signal is too noisy to act on
  unconditionally.

  Manual verification on a real node

  # 1. Inject "server not responding" (no OK to cancel) -> Unhealthy within 60s
  echo 'nfs: server 192.168.1.100 not responding, timed out' | sudo tee /dev/kmsg
  sleep 65
  curl -sk https://localhost:15132/v1/states | jq '.[] | select(.name=="nfs")'

  # 2. Single writeback stack hint -> still Healthy (below threshold)
  echo ' nfs_lock_and_join_requests+0x61/0x2b0 [nfs]' | sudo tee /dev/kmsg
  sleep 65

  # 3. Second writeback hint 5+ minutes later (defeats dedup) -> Unhealthy
  sleep 305
  echo ' nfs_lock_and_join_requests+0x82/0x2b0 [nfs]' | sudo tee /dev/kmsg
  sleep 65
  # Expect: .health == "Unhealthy"
  #         .suggested_actions.repair_actions == ["REBOOT_SYSTEM"]
  #         .suggested_actions.description == "NFS hang requires immediate reboot; drain may hang on NFS volumes"