### PR TITLE
fix(gcp): report zone as provider region

### DIFF
--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -10,7 +10,7 @@ import (
 const Name = "gcp"
 
 func New() providers.Detector {
-	return providers.New(Name, detectProvider, imds.FetchPublicIPv4, nil, nil, imds.FetchInstanceID)
+	return providers.NewWithRegion(Name, detectProvider, imds.FetchPublicIPv4, nil, imds.FetchRegion, nil, imds.FetchInstanceID)
 }
 
 func detectProvider(ctx context.Context) (string, error) {

--- a/pkg/providers/gcp/imds/imds.go
+++ b/pkg/providers/gcp/imds/imds.go
@@ -88,6 +88,22 @@ func extractZoneFromPath(zonePath string) string {
 	return parts[len(parts)-1]
 }
 
+// FetchRegion fetches the Google Cloud instance region using IMDS.
+//
+// GCP IMDS does not expose a dedicated region key; it only exposes the zone
+// (e.g. "us-east5-c"). The full zone string is returned so the login request
+// reflects the precise instance location instead of falling back to the DERP
+// latency-based region.
+func FetchRegion(ctx context.Context) (string, error) {
+	return fetchRegion(ctx, imdsMetadataURL)
+}
+
+// fetchRegion retrieves the Google Cloud instance region from the specified
+// path using IMDS, returning the full zone string.
+func fetchRegion(ctx context.Context, metadataURL string) (string, error) {
+	return fetchAvailabilityZone(ctx, metadataURL)
+}
+
 // FetchPublicIPv4 fetches Google Cloud instance public IPv4 using IMDS.
 func FetchPublicIPv4(ctx context.Context) (string, error) {
 	return fetchPublicIPv4(ctx, imdsMetadataURL)

--- a/pkg/providers/gcp/imds/imds_test.go
+++ b/pkg/providers/gcp/imds/imds_test.go
@@ -143,6 +143,57 @@ func TestFetchAvailabilityZone(t *testing.T) {
 	}
 }
 
+func TestFetchRegion(t *testing.T) {
+	tests := []struct {
+		name           string
+		mockHandler    func(w http.ResponseWriter, r *http.Request)
+		expectedRegion string
+		expectedError  string
+	}{
+		{
+			name: "successful region fetch returns full zone",
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodGet, r.Method)
+				require.Equal(t, metadataFlavorGoogle, r.Header.Get(headerMetadataFlavor))
+				require.True(t, strings.HasSuffix(r.URL.Path, "/instance/zone"), "Path should end with /instance/zone")
+				w.WriteHeader(http.StatusOK)
+				_, err := w.Write([]byte("projects/980931390107/zones/us-east5-a"))
+				require.NoError(t, err)
+			},
+			expectedRegion: "us-east5-a",
+		},
+		{
+			name: "region fetch failure",
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, err := w.Write([]byte("Not found"))
+				require.NoError(t, err)
+			},
+			expectedError: "failed to fetch metadata: received status code 404",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			server := httptest.NewServer(http.HandlerFunc(tc.mockHandler))
+			defer server.Close()
+
+			region, err := fetchRegion(ctx, server.URL)
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedError)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedRegion, region)
+			}
+		})
+	}
+}
+
 func TestFetchPublicIPv4(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/providers/gcp/imds/mock_imds_public_test.go
+++ b/pkg/providers/gcp/imds/mock_imds_public_test.go
@@ -34,6 +34,19 @@ func TestFetchAvailabilityZone_Public_WithMockey(t *testing.T) {
 	})
 }
 
+func TestFetchRegion_Public_WithMockey(t *testing.T) {
+	mockey.PatchConvey("FetchRegion forwards default URL", t, func() {
+		mockey.Mock(fetchRegion).To(func(ctx context.Context, metadataURL string) (string, error) {
+			require.Equal(t, imdsMetadataURL, metadataURL)
+			return "us-east5-a", nil
+		}).Build()
+
+		got, err := FetchRegion(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "us-east5-a", got)
+	})
+}
+
 func TestFetchPublicIPv4_Public_WithMockey(t *testing.T) {
 	mockey.PatchConvey("FetchPublicIPv4 forwards default URL", t, func() {
 		mockey.Mock(fetchPublicIPv4).To(func(ctx context.Context, metadataURL string) (string, error) {

--- a/pkg/providers/gcp/mock_gcp_test.go
+++ b/pkg/providers/gcp/mock_gcp_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/require"
 
+	"github.com/leptonai/gpud/pkg/providers"
 	"github.com/leptonai/gpud/pkg/providers/gcp/imds"
 )
 
@@ -28,6 +29,24 @@ func TestNewAndDetectProvider_WithMockey(t *testing.T) {
 		zone, err := detectProvider(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, Name, zone)
+	})
+}
+
+func TestNewImplementsRegionDetector_WithMockey(t *testing.T) {
+	mockey.PatchConvey("New returns a RegionDetector reporting the zone-based region", t, func() {
+		mockey.Mock(imds.FetchRegion).To(func(ctx context.Context) (string, error) {
+			return "us-east5-a", nil
+		}).Build()
+
+		detector := New()
+		require.NotNil(t, detector)
+
+		regionDetector, ok := detector.(providers.RegionDetector)
+		require.True(t, ok, "gcp detector should implement providers.RegionDetector")
+
+		region, err := regionDetector.Region(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "us-east5-a", region)
 	})
 }
 


### PR DESCRIPTION
## Summary

Fix GCP provider region detection so GPUd registration reports the instance's GCP zone, for example `us-east5-a`, instead of leaving the provider region empty and falling back to the DERP latency-derived region such as `us-east-1`.

## Root Cause

GCP provider detection previously used `providers.New`, so it did not implement `providers.RegionDetector`. The login path only prefers provider location when `providers.Info.Region` is populated; otherwise it falls back to the latency-based machine location.

## Changes

- Wire GCP through `providers.NewWithRegion`.
- Add `imds.FetchRegion` for GCP backed by `/instance/zone`, returning the full zone string.
- Add focused tests for the IMDS fetch path and GCP detector `RegionDetector` behavior.

## Validation

- `codegraph init -i && codegraph sync`
- `go test -gcflags='all=-N -l' ./pkg/providers/... ./pkg/machine-info`
- `git diff --check`

Note: a broader local `go test -gcflags='all=-N -l' ./...` run failed in unrelated environment-sensitive packages on this macOS host: `pkg/host` expects `/etc/os-release`, and `pkg/process` has a self-process check failure.