### PR TITLE
fix(pkg/log): incorrect caller in log wrapper

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -72,7 +72,7 @@ func CreateLoggerWithConfig(config *zap.Config) *gpudLogger {
 		config = DefaultLoggerConfig()
 	}
 
-	l, err := config.Build()
+	l, err := config.Build(zap.AddCallerSkip(1))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
### What changed
- zap.AddCallerSkip(1) to `CreateLoggerWithConfig` to prevent the caller field from pointing to 'log/log.go'
- Left `CreateLoggerWithLumberjack` unchanged, caller-free behavior for file logging

### Why
When building and running the application locally using the default console logger, all log entries incorrectly point to `log/log.go`, making it impossible to trace code

```
make all
./bin/gpud run
```

Before
<img width="1085" height="340" alt="Screenshot 2026-06-17 at 2 12 10 AM" src="https://github.com/user-attachments/assets/97bb67ce-24b6-4072-8584-b3e842afb2de" />
After
<img width="1078" height="511" alt="Screenshot 2026-06-17 at 2 13 42 AM" src="https://github.com/user-attachments/assets/048b42da-5e0c-4f23-b97b-a8ae7fc5d9e4" />

This happens because `gpudLogger` wraps the underlying `zap.SugaredLogger`