### PR TITLE
feat(session): support configurable reboot commands

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -200,6 +200,11 @@ sudo rm /etc/systemd/system/gpud.service
 					Usage: "specifies the exit code to exit with when auto updating (set -1 to disable exit code)",
 				},
 				cli.StringFlag{
+					Name:  "reboot-commands",
+					Usage: "bash script to run when the control plane sends a reboot request (leave empty to use the built-in sudo reboot behavior)",
+					Value: "",
+				},
+				cli.StringFlag{
 					Name:  "version-file",
 					Usage: "specifies the version file to use for auto update (leave empty to disable auto update)",
 					Value: pkgupdate.DefaultVersionFile,

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -129,6 +129,7 @@ func Command(cliContext *cli.Context) error {
 
 	enableAutoUpdate := cliContext.Bool("enable-auto-update")
 	autoUpdateExitCode := cliContext.Int("auto-update-exit-code")
+	rebootCommands := cliContext.String("reboot-commands")
 	versionFile := cliContext.String("version-file")
 	versionFileSet := cliContext.IsSet("version-file")
 	pluginSpecsFile := cliContext.String("plugin-specs-file")
@@ -337,6 +338,7 @@ func Command(cliContext *cli.Context) error {
 
 	cfg.EnableAutoUpdate = enableAutoUpdate
 	cfg.AutoUpdateExitCode = autoUpdateExitCode
+	cfg.RebootCommands = rebootCommands
 	if !versionFileSet {
 		versionFile = config.VersionFilePath(cfg.DataDir)
 	}

--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -44,6 +44,8 @@ spec:
       # Consumers should reach GPUd via each node's IP/port (e.g. https://<node-ip>:15132).
       hostNetwork: true
       # Required for the driver to inspect processes on the host (e.g. via /proc).
+      # Also required by the chart-default reboot command: nsenter targets host PID 1
+      # so gpud can request a node reboot from inside the container.
       hostPID: true
       restartPolicy: Always
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
@@ -221,6 +223,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           # Privileged access is required for hardware inspection and low-level system access.
+          # The default rebootCommands script also needs the privileges to enter host namespaces
+          # and ask the host init system to reboot the node.
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           command:
@@ -295,14 +299,29 @@ spec:
               set -- "$@" --auto-update-exit-code={{ .Values.gpud.autoUpdateExitCode }}
 
               # Log the command for debugging, then exec to replace shell with gpud.
+              # Keep the multi-line reboot script out of the startup log; gpud logs it
+              # when a reboot request actually schedules and executes it.
+              start_log_args="$*"
+
+              # The chart default sets a host-namespace reboot script. Users can
+              # set gpud.rebootCommands="" to preserve gpud's built-in sudo reboot path.
+              if [ -n "${GPUD_REBOOT_COMMANDS:-}" ]; then
+                start_log_args="$start_log_args --reboot-commands=<set>"
+                set -- "$@" --reboot-commands="$GPUD_REBOOT_COMMANDS"
+              fi
+
               # Using exec ensures gpud receives signals directly (important for graceful shutdown).
-              echo "Starting: /usr/local/bin/gpud $*"
+              echo "Starting: /usr/local/bin/gpud $start_log_args"
               exec /usr/local/bin/gpud "$@"
 {{- end }}
 
           env:
             - name: GPUD_NO_USAGE_STATS
               value: {{ not .Values.gpud.telemetry.enabled | quote }}
+            {{- if .Values.gpud.rebootCommands }}
+            - name: GPUD_REBOOT_COMMANDS
+              value: {{ .Values.gpud.rebootCommands | quote }}
+            {{- end }}
 
           {{- if .Values.service.enabled }}
           ports:

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -36,6 +36,31 @@ gpud:
   # set -1 to disable exit code
   autoUpdateExitCode: -1
 
+  # Bash script passed to "gpud run --reboot-commands".
+  # Empty keeps gpud's built-in reboot behavior, which runs "sudo reboot" after
+  # a 10-second delay. The Helm chart sets this by default because gpud runs
+  # inside a container here; asking the container to reboot itself is not enough.
+  #
+  # The script enters the host namespaces and host root through PID 1 before
+  # calling systemd/reboot, so the reboot request targets the node, not the
+  # container. This depends on the pod settings below:
+  # - hostPID=true lets nsenter target the host's PID 1.
+  # - securityContext.privileged=true grants the namespace and reboot capabilities.
+  # - securityContext.runAsUser=0 runs gpud and nsenter as root.
+  rebootCommands: |
+    set -o errexit
+    set -o nounset
+
+    if command -v nsenter >/dev/null 2>&1; then
+      if nsenter --target 1 --mount --uts --ipc --net --pid --cgroup --root --wd=/ -- /usr/bin/systemctl reboot; then
+        exit 0
+      fi
+      nsenter --target 1 --mount --uts --ipc --net --pid --cgroup --root --wd=/ -- /sbin/reboot
+      exit 0
+    fi
+
+    sudo reboot
+
   # Mount /dev/mem for deep hardware inspection and memory diagnostics (e.g., PCIe config space).
   # Defaults to false for maximum compatibility across platforms (addresses issue #1144).
   # Set to true if you need deep memory inspection and your environment supports /dev/mem.
@@ -111,8 +136,15 @@ updateStrategy:
 # Container-level security context.
 securityContext:
   # WARNING: This chart requires privileged access to the host node.
+  # The default rebootCommands script enters the host namespaces with nsenter and must
+  # have CAP_SYS_ADMIN/CAP_SYS_BOOT, which privileged mode provides.
   privileged: true
+  # Required so gpud can use the built-in reboot path when rebootCommands is empty
+  # and so the chart default rebootCommands script can enter host namespaces as root.
   runAsUser: 0
+  # Keep this explicit because the chart intentionally runs host-level tooling.
+  # Setting this false can break nsenter-based reboot commands.
+  allowPrivilegeEscalation: true
 
 # Pod-level security context.
 podSecurityContext: {}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,6 +49,10 @@ type Config struct {
 	// Set -1 to disable the auto update by exit code.
 	AutoUpdateExitCode int `json:"auto_update_exit_code"`
 
+	// RebootCommands is a bash script to run when the control plane sends a reboot session request.
+	// Empty preserves the built-in "sudo reboot" path.
+	RebootCommands string `json:"reboot_commands,omitempty"`
+
 	// VersionFile is the file that contains the target version.
 	// If empty, the version file is not used.
 	VersionFile string `json:"version_file"`

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -58,6 +58,7 @@ func DefaultConfig(ctx context.Context, opts ...OpOption) (*Config, error) {
 		},
 		FailureInjector: options.FailureInjector,
 		DBInMemory:      options.DBInMemory,
+		RebootCommands:  options.RebootCommands,
 
 		SessionToken:     options.SessionToken,
 		SessionMachineID: options.SessionMachineID,

--- a/pkg/config/default_test.go
+++ b/pkg/config/default_test.go
@@ -27,6 +27,7 @@ func TestDefaultConfig(t *testing.T) {
 		assert.False(t, cfg.Pprof)
 		assert.True(t, cfg.EnableAutoUpdate)
 		assert.NotEmpty(t, cfg.DataDir)
+		assert.Empty(t, cfg.RebootCommands)
 
 		// We can't reliably test State path since it depends on environment
 		assert.NotEmpty(t, cfg.State, "State path should be set")
@@ -53,6 +54,15 @@ func TestDefaultConfig(t *testing.T) {
 
 		_, err = os.Stat(customDir)
 		assert.NoError(t, err)
+	})
+
+	t.Run("with reboot command", func(t *testing.T) {
+		rebootCommands := "echo reboot"
+
+		cfg, err := DefaultConfig(ctx, WithRebootCommands(rebootCommands))
+		require.NoError(t, err)
+
+		assert.Equal(t, rebootCommands, cfg.RebootCommands)
 	})
 }
 

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -14,6 +14,10 @@ type Op struct {
 	DataDir    string
 	DBInMemory bool
 
+	// RebootCommands is an optional bash script used for control-plane reboot requests.
+	// Empty keeps the default host reboot implementation.
+	RebootCommands string
+
 	// SessionToken is the session token for db-in-memory mode.
 	// When DBInMemory is true and this is set, the server will seed
 	// this token into the in-memory database.
@@ -87,6 +91,14 @@ func WithDataDir(dataDir string) OpOption {
 func WithDBInMemory(b bool) OpOption {
 	return func(op *Op) {
 		op.DBInMemory = b
+	}
+}
+
+// WithRebootCommands sets the bash script to run for control-plane reboot requests.
+// Empty keeps the default host reboot implementation.
+func WithRebootCommands(commands string) OpOption {
+	return func(op *Op) {
+		op.RebootCommands = commands
 	}
 }
 

--- a/pkg/config/options_test.go
+++ b/pkg/config/options_test.go
@@ -187,6 +187,34 @@ func TestWithDBInMemory(t *testing.T) {
 	}
 }
 
+func TestWithRebootCommands(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		expected string
+	}{
+		{
+			name:     "empty reboot command",
+			command:  "",
+			expected: "",
+		},
+		{
+			name:     "custom reboot command",
+			command:  "nsenter --target 1 --mount -- /usr/bin/systemctl reboot",
+			expected: "nsenter --target 1 --mount -- /usr/bin/systemctl reboot",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op := &Op{}
+			option := WithRebootCommands(tt.command)
+			option(op)
+			assert.Equal(t, tt.expected, op.RebootCommands)
+		})
+	}
+}
+
 func TestWithDataDir(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -90,6 +90,7 @@ type Server struct {
 
 	enableAutoUpdate        bool
 	autoUpdateExitCode      int
+	rebootCommands          string
 	skipSessionUpdateConfig bool
 
 	pluginSpecsFile string
@@ -247,6 +248,7 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *lepconfig.Con
 
 		enableAutoUpdate:        config.EnableAutoUpdate,
 		autoUpdateExitCode:      config.AutoUpdateExitCode,
+		rebootCommands:          config.RebootCommands,
 		skipSessionUpdateConfig: config.SkipSessionUpdateConfig,
 
 		pluginSpecsFile: config.PluginSpecsFile,
@@ -599,6 +601,7 @@ func (s *Server) updateToken(ctx context.Context, metricsStore pkgmetrics.Store,
 			session.WithPipeInterval(3*time.Second),
 			session.WithEnableAutoUpdate(s.enableAutoUpdate),
 			session.WithAutoUpdateExitCode(s.autoUpdateExitCode),
+			session.WithRebootCommands(s.rebootCommands),
 			session.WithSkipUpdateConfig(s.skipSessionUpdateConfig),
 			session.WithComponentsRegistry(s.componentsRegistry),
 			session.WithDataDir(s.dataDir),
@@ -663,6 +666,7 @@ func (s *Server) updateToken(ctx context.Context, metricsStore pkgmetrics.Store,
 				session.WithPipeInterval(3*time.Second),
 				session.WithEnableAutoUpdate(s.enableAutoUpdate),
 				session.WithAutoUpdateExitCode(s.autoUpdateExitCode),
+				session.WithRebootCommands(s.rebootCommands),
 				session.WithSkipUpdateConfig(s.skipSessionUpdateConfig),
 				session.WithComponentsRegistry(s.componentsRegistry),
 				session.WithDataDir(s.dataDir),

--- a/pkg/session/mock_session_test.go
+++ b/pkg/session/mock_session_test.go
@@ -104,6 +104,15 @@ func TestMockeyOpOption_WithAutoUpdateExitCode(t *testing.T) {
 	})
 }
 
+func TestMockeyOpOption_WithRebootCommands(t *testing.T) {
+	mockey.PatchConvey("WithRebootCommands sets reboot commands on Op", t, func() {
+		op := &Op{}
+		opt := WithRebootCommands("echo reboot")
+		opt(op)
+		assert.Equal(t, "echo reboot", op.rebootCommands)
+	})
+}
+
 func TestMockeyOpOption_WithDataDir(t *testing.T) {
 	mockey.PatchConvey("WithDataDir sets data directory on Op", t, func() {
 		op := &Op{}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -43,6 +43,7 @@ type Op struct {
 	pipeInterval        time.Duration
 	enableAutoUpdate    bool
 	autoUpdateExitCode  int
+	rebootCommands      string
 	skipUpdateConfig    bool
 	componentsRegistry  components.Registry
 	dataDir             string
@@ -98,6 +99,14 @@ func WithPipeInterval(t time.Duration) OpOption {
 func WithEnableAutoUpdate(enableAutoUpdate bool) OpOption {
 	return func(op *Op) {
 		op.enableAutoUpdate = enableAutoUpdate
+	}
+}
+
+// WithRebootCommands configures the bash script to run for session reboot requests.
+// Empty keeps the built-in host reboot path.
+func WithRebootCommands(commands string) OpOption {
+	return func(op *Op) {
+		op.rebootCommands = commands
 	}
 }
 
@@ -212,6 +221,7 @@ type Session struct {
 
 	enableAutoUpdate   bool
 	autoUpdateExitCode int
+	rebootCommands     string
 
 	savePluginSpecsFunc func(context.Context, pkgcustomplugins.Specs) (bool, error)
 	faultInjector       pkgfaultinjector.Injector
@@ -247,6 +257,10 @@ type Session struct {
 	// checkServerHealthFunc checks server health
 	// In production: s.checkServerHealth, in tests: can be mocked
 	checkServerHealthFunc func(ctx context.Context, jar *cookiejar.Jar, token string) error
+
+	// runRebootCommandsFunc runs the configured reboot script.
+	// In production: defaultRebootCommands or configured reboot script runner, in tests: can be mocked.
+	runRebootCommandsFunc func(ctx context.Context) error
 }
 
 type closeOnce struct {
@@ -325,6 +339,7 @@ func NewSession(ctx context.Context, epLocalGPUdServer string, epControlPlane st
 
 		enableAutoUpdate:   op.enableAutoUpdate,
 		autoUpdateExitCode: op.autoUpdateExitCode,
+		rebootCommands:     op.rebootCommands,
 	}
 
 	s.timeAfterFunc = time.After
@@ -333,6 +348,7 @@ func NewSession(ctx context.Context, epLocalGPUdServer string, epControlPlane st
 	s.startReaderFunc = s.startReader
 	s.startWriterFunc = s.startWriter
 	s.checkServerHealthFunc = s.checkServerHealth
+	s.configureRebootCommands(op.rebootCommands)
 
 	s.reader = make(chan Body, 20)
 	s.writer = make(chan Body, 20)

--- a/pkg/session/session_process_request.go
+++ b/pkg/session/session_process_request.go
@@ -235,6 +235,7 @@ func runConfiguredRebootCommands(ctx context.Context, commands string) error {
 		proc,
 		process.WithReadStdout(),
 		process.WithReadStderr(),
+		process.WithWaitForCmd(),
 		process.WithProcessLine(func(line string) {
 			log.Logger.Infow("configured reboot commands output", "line", line)
 		}),

--- a/pkg/session/session_process_request.go
+++ b/pkg/session/session_process_request.go
@@ -4,9 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
+	"time"
 
 	pkghost "github.com/leptonai/gpud/pkg/host"
 	"github.com/leptonai/gpud/pkg/log"
+	"github.com/leptonai/gpud/pkg/process"
+)
+
+const (
+	rebootDelaySeconds = 10
+	rebootDelay        = rebootDelaySeconds * time.Second
 )
 
 // processRequest handles all request processing logic
@@ -17,7 +25,7 @@ func (s *Session) processRequest(ctx context.Context, reqID string, payload Requ
 	switch payload.Method {
 	case "reboot":
 		// To inform the control plane that the reboot request has been processed, reboot after 10 seconds.
-		err := pkghost.Reboot(s.ctx, pkghost.WithDelaySeconds(10))
+		err := s.runRebootCommands(s.ctx)
 		if err != nil {
 			log.Logger.Warnw("failed to trigger reboot machine", "error", err)
 			response.Error = err.Error()
@@ -137,6 +145,100 @@ func (s *Session) processRequest(ctx context.Context, reqID string, payload Requ
 	}
 
 	return false // Request is handled synchronously
+}
+
+func (s *Session) configureRebootCommands(commands string) {
+	rebootCommands := strings.TrimSpace(commands)
+	s.rebootCommands = rebootCommands
+	if rebootCommands == "" {
+		s.runRebootCommandsFunc = defaultRebootCommands
+		return
+	}
+
+	s.runRebootCommandsFunc = func(ctx context.Context) error {
+		return s.triggerConfiguredRebootCommands(ctx, rebootCommands, rebootDelay)
+	}
+}
+
+func (s *Session) runRebootCommands(ctx context.Context) error {
+	if s.runRebootCommandsFunc == nil {
+		s.configureRebootCommands(s.rebootCommands)
+	}
+	return s.runRebootCommandsFunc(ctx)
+}
+
+func defaultRebootCommands(ctx context.Context) error {
+	return pkghost.Reboot(ctx, pkghost.WithDelaySeconds(rebootDelaySeconds))
+}
+
+func (s *Session) triggerConfiguredRebootCommands(ctx context.Context, commands string, delay time.Duration) error {
+	if delay <= 0 {
+		log.Logger.Infow("executing configured reboot commands", "commands", commands)
+		return runConfiguredRebootCommands(ctx, commands)
+	}
+
+	timeAfter := s.timeAfterFunc
+	if timeAfter == nil {
+		timeAfter = time.After
+	}
+
+	go func() {
+		select {
+		case <-timeAfter(delay):
+			log.Logger.Infow(
+				"delay expired, executing configured reboot commands",
+				"delaySeconds", int(delay.Seconds()),
+				"commands", commands,
+			)
+		case <-ctx.Done():
+			log.Logger.Warnw("context done, aborting configured reboot commands", "commands", commands)
+			return
+		}
+
+		if err := runConfiguredRebootCommands(ctx, commands); err != nil {
+			log.Logger.Warnw("configured reboot commands failed", "commands", commands, "error", err)
+			return
+		}
+
+		// This normally should not print if the reboot command successfully takes the host down.
+		log.Logger.Infow("configured reboot commands completed", "commands", commands)
+	}()
+
+	log.Logger.Infow(
+		"triggering configured reboot commands after delay",
+		"delaySeconds", int(delay.Seconds()),
+		"commands", commands,
+	)
+	return nil
+}
+
+func runConfiguredRebootCommands(ctx context.Context, commands string) error {
+	proc, err := process.New(
+		process.WithBashScriptContentsToRun(commands),
+		process.WithRunBashInline(),
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := proc.Start(ctx); err != nil {
+		return err
+	}
+	defer func() {
+		if err := proc.Close(ctx); err != nil {
+			log.Logger.Warnw("failed to close configured reboot commands", "error", err)
+		}
+	}()
+
+	return process.Read(
+		ctx,
+		proc,
+		process.WithReadStdout(),
+		process.WithReadStderr(),
+		process.WithProcessLine(func(line string) {
+			log.Logger.Infow("configured reboot commands output", "line", line)
+		}),
+	)
 }
 
 // processRequestAsync runs entirely in a background goroutine.

--- a/pkg/session/session_process_request_test.go
+++ b/pkg/session/session_process_request_test.go
@@ -667,3 +667,9 @@ func TestRunConfiguredRebootCommandsReturnsStartError(t *testing.T) {
 
 	require.Error(t, err)
 }
+
+func TestRunConfiguredRebootCommandsReturnsExitError(t *testing.T) {
+	err := runConfiguredRebootCommands(context.Background(), "echo configured-reboot-failed; exit 7")
+
+	require.Error(t, err)
+}

--- a/pkg/session/session_process_request_test.go
+++ b/pkg/session/session_process_request_test.go
@@ -2,6 +2,9 @@ package session
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -38,6 +41,35 @@ func TestSession_processRequest(t *testing.T) {
 		// When not running as root, we expect an error
 		if response.Error != "" {
 			assert.Contains(t, response.Error, "sudo/root", "Expected permission error when not running as root")
+		}
+	})
+
+	t.Run("reboot method uses selected reboot function", func(t *testing.T) {
+		called := make(chan struct{}, 1)
+		session := &Session{
+			ctx: context.Background(),
+			runRebootCommandsFunc: func(context.Context) error {
+				called <- struct{}{}
+				return nil
+			},
+		}
+		response := &Response{}
+		restartExitCode := -1
+
+		payload := Request{
+			Method: "reboot",
+		}
+
+		handledAsync := session.processRequest(context.Background(), "test-req", payload, response, &restartExitCode)
+
+		assert.False(t, handledAsync, "reboot should be handled synchronously")
+		assert.Equal(t, -1, restartExitCode, "restart exit code should not change")
+		assert.Empty(t, response.Error)
+
+		select {
+		case <-called:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for selected reboot function")
 		}
 	})
 
@@ -489,4 +521,149 @@ func TestSession_sendResponse(t *testing.T) {
 			// No response might be sent if marshal actually fails
 		}
 	})
+}
+
+func TestSession_configureRebootCommands(t *testing.T) {
+	t.Run("empty command uses default reboot runner", func(t *testing.T) {
+		session := &Session{}
+		session.configureRebootCommands("")
+
+		assert.Empty(t, session.rebootCommands)
+		assert.NotNil(t, session.runRebootCommandsFunc)
+	})
+
+	t.Run("non-empty command trims and installs configured runner", func(t *testing.T) {
+		session := &Session{}
+		session.configureRebootCommands("  echo configured-reboot  ")
+
+		assert.Equal(t, "echo configured-reboot", session.rebootCommands)
+		assert.NotNil(t, session.runRebootCommandsFunc)
+	})
+}
+
+func TestSession_runRebootCommandsWithConfiguredCommands(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "lazy-configured-reboot")
+	script := fmt.Sprintf("printf lazy-configured-reboot > %q", outputPath)
+	session := &Session{
+		ctx:            context.Background(),
+		rebootCommands: script,
+		timeAfterFunc: func(time.Duration) <-chan time.Time {
+			ch := make(chan time.Time, 1)
+			ch <- time.Now()
+			return ch
+		},
+	}
+
+	require.NoError(t, session.runRebootCommands(context.Background()))
+
+	require.Eventually(t, func() bool {
+		got, err := os.ReadFile(outputPath)
+		return err == nil && string(got) == "lazy-configured-reboot"
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestSession_triggerConfiguredRebootCommands(t *testing.T) {
+	t.Run("immediate execution returns command errors", func(t *testing.T) {
+		session := &Session{}
+
+		err := session.triggerConfiguredRebootCommands(context.Background(), "", 0)
+
+		require.Error(t, err)
+	})
+
+	t.Run("delayed execution runs after timer", func(t *testing.T) {
+		outputPath := filepath.Join(t.TempDir(), "delayed-configured-reboot")
+		script := fmt.Sprintf("printf delayed-configured-reboot > %q", outputPath)
+		session := &Session{
+			timeAfterFunc: func(time.Duration) <-chan time.Time {
+				ch := make(chan time.Time, 1)
+				ch <- time.Now()
+				return ch
+			},
+		}
+
+		require.NoError(t, session.triggerConfiguredRebootCommands(context.Background(), script, time.Second))
+
+		require.Eventually(t, func() bool {
+			got, err := os.ReadFile(outputPath)
+			return err == nil && string(got) == "delayed-configured-reboot"
+		}, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("delayed execution uses default timer", func(t *testing.T) {
+		outputPath := filepath.Join(t.TempDir(), "default-timer-configured-reboot")
+		script := fmt.Sprintf("printf default-timer-configured-reboot > %q", outputPath)
+		session := &Session{}
+
+		require.NoError(t, session.triggerConfiguredRebootCommands(context.Background(), script, time.Millisecond))
+
+		require.Eventually(t, func() bool {
+			got, err := os.ReadFile(outputPath)
+			return err == nil && string(got) == "default-timer-configured-reboot"
+		}, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("delayed execution runs script body before nonzero exit", func(t *testing.T) {
+		outputPath := filepath.Join(t.TempDir(), "delayed-configured-reboot-failure")
+		script := fmt.Sprintf("printf delayed-configured-reboot-failure > %q; exit 7", outputPath)
+		session := &Session{
+			timeAfterFunc: func(time.Duration) <-chan time.Time {
+				ch := make(chan time.Time, 1)
+				ch <- time.Now()
+				return ch
+			},
+		}
+
+		require.NoError(t, session.triggerConfiguredRebootCommands(context.Background(), script, time.Second))
+
+		require.Eventually(t, func() bool {
+			got, err := os.ReadFile(outputPath)
+			return err == nil && string(got) == "delayed-configured-reboot-failure"
+		}, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("delayed execution logs runner errors", func(t *testing.T) {
+		session := &Session{
+			timeAfterFunc: func(time.Duration) <-chan time.Time {
+				ch := make(chan time.Time, 1)
+				ch <- time.Now()
+				return ch
+			},
+		}
+
+		require.NoError(t, session.triggerConfiguredRebootCommands(context.Background(), "", time.Second))
+		time.Sleep(10 * time.Millisecond)
+	})
+
+	t.Run("context cancellation aborts delayed execution", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		session := &Session{
+			timeAfterFunc: func(time.Duration) <-chan time.Time {
+				return make(chan time.Time)
+			},
+		}
+
+		require.NoError(t, session.triggerConfiguredRebootCommands(ctx, "echo should-not-run", time.Second))
+	})
+}
+
+func TestRunConfiguredRebootCommands(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "configured-reboot")
+	script := fmt.Sprintf("echo configured-reboot; printf configured-reboot > %q", outputPath)
+
+	require.NoError(t, runConfiguredRebootCommands(context.Background(), script))
+
+	got, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Equal(t, "configured-reboot", string(got))
+}
+
+func TestRunConfiguredRebootCommandsReturnsStartError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := runConfiguredRebootCommands(ctx, "sleep 1")
+
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Summary
- add gpud run --reboot-commands and thread RebootCommands through config, server, and session setup
- preserve the default pkghost.Reboot(ctx, WithDelaySeconds(10)) behavior when the flag is empty
- make the Helm DaemonSet opt into host-namespace reboot via nsenter with documented hostPID/privileged/root requirements

## Validation
- go test -vet=off ./pkg/config ./pkg/session -run 'Test(DefaultConfig|WithRebootCommands|Session_processRequest|Session_configureRebootCommands|Session_runRebootCommandsWithConfiguredCommands|Session_triggerConfiguredRebootCommands|RunConfiguredRebootCommands|MockeyOpOption_WithRebootCommands)' -count=1
- go test -run '^$' ./pkg/config ./pkg/session ./pkg/server ./cmd/gpud/command ./cmd/gpud/run -count=1
- go vet ./pkg/config ./pkg/session ./pkg/server ./cmd/gpud/command ./cmd/gpud/run
- helm template gpud deployments/helm/gpud --namespace gpud --show-only templates/daemonset.yaml
- git diff --check

## Notes
- A broader local go test over the touched packages without the repository's mockey gcflags hit existing full-suite mockey/runtime-test behavior; GitHub Actions tests-unit is the authoritative full unit signal for the PR.