### PR TITLE
feat(disk, helm, docker): host-namespace disk inspection for containerized gpud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ custom-gcl
 
 /gpud
 
+
+# Private helm values overlay (nvcr.io image + pull secret) -- internal only
+deployments/helm/gpud/values-nvcr.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -137,6 +137,17 @@ RUN echo "# APT Package Sources" > /apt-sources/APT_SOURCES.txt && \
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-${OS_NAME}${OS_VERSION}
 WORKDIR /
 
+# OCI image metadata. Mirrors the Helm chart's Chart.yaml/README so registries
+# (e.g. nvcr.io) surface the same description, source, and license for the image.
+# ref. https://github.com/opencontainers/image-spec/blob/main/annotations.md
+LABEL org.opencontainers.image.title="gpud" \
+      org.opencontainers.image.description="GPUd automates monitoring, diagnostics, and issue identification for GPUs" \
+      org.opencontainers.image.source="https://github.com/leptonai/gpud" \
+      org.opencontainers.image.url="https://github.com/leptonai/gpud" \
+      org.opencontainers.image.documentation="https://github.com/leptonai/gpud" \
+      org.opencontainers.image.vendor="leptonai" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
 # Install required runtime dependencies not included in the NVIDIA CUDA runtime image.
 # NOTE: gnupg is installed temporarily for Docker GPG key verification, then purged
 # to address CVE-2025-68973 (out-of-bounds write in GnuPG armor_filter before 2.4.9)
@@ -161,6 +172,9 @@ RUN apt-get update && \
   # Remove gnupg and related packages to address CVE-2025-68973
   # These are only needed for GPG key verification during build, not at runtime
   apt-get purge -y --auto-remove gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm dirmngr && \
+  # util-linux provides findmnt, which the disk component shells out to.
+  command -v findmnt >/dev/null && \
+  findmnt --version >/dev/null && \
   rm -rf /var/lib/apt/lists/*
 
 # Copy the gpud binary

--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -205,6 +205,26 @@ sudo rm /etc/systemd/system/gpud.service
 					Value: "",
 				},
 				cli.StringFlag{
+					Name:  "findmnt-commands",
+					Usage: "command prefix used to invoke findmnt for the disk component (e.g. 'nsenter --target 1 --mount -- findmnt' to read host mounts from inside a container); leave empty to locate and run findmnt directly",
+					Value: "",
+				},
+				cli.StringFlag{
+					Name:  "lsblk-commands",
+					Usage: "command prefix used to invoke lsblk for the disk component (e.g. 'nsenter --target 1 --mount -- lsblk' to read host block devices from inside a container); leave empty to locate and run lsblk directly",
+					Value: "",
+				},
+				cli.StringFlag{
+					Name:  "blockdev-usage-commands",
+					Usage: "command prefix used to collect block device usage for the disk component (e.g. 'nsenter --target 1 --mount -- df' to read host disk usage from inside a container); leave empty to use the built-in gopsutil/statfs behavior",
+					Value: "",
+				},
+				cli.StringFlag{
+					Name:  "containerd-service-active-commands",
+					Usage: "command used to check whether the containerd service is active (e.g. 'nsenter --target 1 --mount -- systemctl is-active containerd' to query the host service manager from inside a container; exit code 0 means active); leave empty to use the built-in systemd check",
+					Value: "",
+				},
+				cli.StringFlag{
 					Name:  "version-file",
 					Usage: "specifies the version file to use for auto update (leave empty to disable auto update)",
 					Value: pkgupdate.DefaultVersionFile,

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -130,6 +130,10 @@ func Command(cliContext *cli.Context) error {
 	enableAutoUpdate := cliContext.Bool("enable-auto-update")
 	autoUpdateExitCode := cliContext.Int("auto-update-exit-code")
 	rebootCommands := cliContext.String("reboot-commands")
+	findmntCommands := cliContext.String("findmnt-commands")
+	lsblkCommands := cliContext.String("lsblk-commands")
+	blockdevUsageCommands := cliContext.String("blockdev-usage-commands")
+	containerdServiceActiveCommands := cliContext.String("containerd-service-active-commands")
 	versionFile := cliContext.String("version-file")
 	versionFileSet := cliContext.IsSet("version-file")
 	pluginSpecsFile := cliContext.String("plugin-specs-file")
@@ -339,6 +343,10 @@ func Command(cliContext *cli.Context) error {
 	cfg.EnableAutoUpdate = enableAutoUpdate
 	cfg.AutoUpdateExitCode = autoUpdateExitCode
 	cfg.RebootCommands = rebootCommands
+	cfg.FindmntCommands = findmntCommands
+	cfg.LsblkCommands = lsblkCommands
+	cfg.BlockdevUsageCommands = blockdevUsageCommands
+	cfg.ContainerdServiceActiveCommands = containerdServiceActiveCommands
 	if !versionFileSet {
 		versionFile = config.VersionFilePath(cfg.DataDir)
 	}

--- a/components/containerd/component.go
+++ b/components/containerd/component.go
@@ -109,7 +109,16 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		checkDependencyInstalledFunc: checkContainerdInstalled,
 		checkSocketExistsFunc:        checkSocketExistsFunc,
 		checkContainerdRunningFunc:   CheckContainerdRunning,
-		checkServiceActiveFunc: func(_ context.Context) (bool, error) {
+		// checkServiceActiveFunc defaults to the in-namespace systemd.IsActive
+		// check. When ContainerdServiceActiveCommands is set (e.g. wrapping
+		// "systemctl is-active containerd" with nsenter), the check runs against
+		// the host's service manager instead -- required when gpud runs inside a
+		// container, where the container's own systemd does not manage containerd.
+		// Empty preserves the legacy behavior byte-for-byte.
+		checkServiceActiveFunc: func(ctx context.Context) (bool, error) {
+			if gpudInstance.ContainerdServiceActiveCommands != "" {
+				return CheckServiceActiveWithCommand(ctx, gpudInstance.ContainerdServiceActiveCommands)
+			}
 			return systemd.IsActive("containerd")
 		},
 		getContainerdUptimeFunc: func() (*time.Duration, error) {

--- a/components/containerd/cri.go
+++ b/components/containerd/cri.go
@@ -249,6 +249,27 @@ func CheckContainerdRunning(ctx context.Context) bool {
 	return false
 }
 
+// CheckServiceActiveWithCommand runs the given command and reports whether the
+// containerd service is active based on its exit code (0 = active). It overrides
+// the default in-namespace systemd.IsActive check, e.g. by wrapping
+// "systemctl is-active containerd" with nsenter so the check queries the host's
+// service manager from inside a container. A non-zero exit means "not active"
+// (not an error); only a failure to execute the command itself returns an error.
+func CheckServiceActiveWithCommand(ctx context.Context, command string) (bool, error) {
+	// #nosec G204 -- command is an operator-provided override (same trust model as reboot-commands).
+	out, err := exec.CommandContext(ctx, "bash", "-c", command).CombinedOutput()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			log.Logger.Debugw("containerd service-active command reported inactive",
+				"command", command, "exitCode", exitErr.ExitCode(), "output", string(out))
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to run containerd service-active command %q: %w", command, err)
+	}
+	return true, nil
+}
+
 // GetVersion gets the version of the containerd runtime.
 func GetVersion(ctx context.Context, endpoint string) (string, error) {
 	conn, err := connect(ctx, endpoint)

--- a/components/containerd/cri_test.go
+++ b/components/containerd/cri_test.go
@@ -802,3 +802,22 @@ func TestIsErrUnimplemented(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckServiceActiveWithCommand(t *testing.T) {
+	ctx := context.Background()
+
+	// exit code 0 => active
+	active, err := CheckServiceActiveWithCommand(ctx, "true")
+	require.NoError(t, err)
+	assert.True(t, active, "expected active=true for exit-0 command")
+
+	// emulates "systemctl is-active containerd" returning active
+	active, err = CheckServiceActiveWithCommand(ctx, "echo active")
+	require.NoError(t, err)
+	assert.True(t, active, "expected active=true for 'echo active'")
+
+	// non-zero exit => inactive, but NOT an error (mirrors systemctl exit 3)
+	active, err = CheckServiceActiveWithCommand(ctx, "false")
+	require.NoError(t, err, "non-zero exit should not be an error")
+	assert.False(t, active, "expected active=false for exit-non-zero command")
+}

--- a/components/disk/component.go
+++ b/components/disk/component.go
@@ -141,17 +141,26 @@ func newComponent(
 		getExt4PartitionsFunc: func(ctx context.Context) (disk.Partitions, error) {
 			timeoutCtx, cancel := context.WithTimeout(ctx, getPartitionsTimeout)
 			defer cancel()
-			return disk.GetPartitions(timeoutCtx, disk.WithFstype(disk.DefaultExt4FsTypeFunc), disk.WithMountPoint(disk.DefaultMountPointFunc))
+			// WithBlockdevUsageCommand is empty by default (legacy gopsutil + statfs
+			// path); when configured it runs the override (e.g. nsenter df) so usage
+			// is read from the host mount namespace. The getPartitionsTimeout context
+			// bounds the command, so a hung filesystem cannot block indefinitely.
+			return disk.GetPartitions(timeoutCtx, disk.WithFstype(disk.DefaultExt4FsTypeFunc), disk.WithMountPoint(disk.DefaultMountPointFunc), disk.WithBlockdevUsageCommand(gpudInstance.BlockdevUsageCommands))
 		},
 		getNFSPartitionsFunc: func(ctx context.Context) (disk.Partitions, error) {
 			// statfs on nfs can incur network I/O or impact disk I/O performance
 			// do not track usage for nfs partitions
 			timeoutCtx, cancel := context.WithTimeout(ctx, getPartitionsTimeout)
 			defer cancel()
-			return disk.GetPartitions(timeoutCtx, disk.WithFstype(disk.DefaultNFSFsTypeFunc), disk.WithMountPoint(disk.DefaultMountPointFunc))
+			return disk.GetPartitions(timeoutCtx, disk.WithFstype(disk.DefaultNFSFsTypeFunc), disk.WithMountPoint(disk.DefaultMountPointFunc), disk.WithBlockdevUsageCommand(gpudInstance.BlockdevUsageCommands))
 		},
 
-		findMntFunc: disk.FindMnt,
+		// findMntFunc defaults to the legacy in-namespace findmnt when
+		// FindmntCommands is empty (FindMntWithCommand(ctx, target, "") == FindMnt),
+		// and runs the override (e.g. nsenter findmnt) when configured.
+		findMntFunc: func(ctx context.Context, target string) (*disk.FindMntOutput, error) {
+			return disk.FindMntWithCommand(ctx, target, gpudInstance.FindmntCommands)
+		},
 
 		// Initialize file operation function field with real implementation
 		statWithTimeoutFunc: pkgfile.StatWithTimeout,
@@ -167,11 +176,17 @@ func newComponent(
 		c.getBlockDevicesFunc = func(ctx context.Context) (disk.BlockDevices, error) {
 			timeoutCtx, cancel := context.WithTimeout(ctx, getBlockDevicesTimeout)
 			defer cancel()
+			// WithLsblkCommand/WithFindmntCommand are empty by default (legacy
+			// in-namespace lsblk + findmnt back-fill); when configured they run the
+			// overrides (e.g. nsenter lsblk/findmnt) so block devices and fstypes
+			// are read from the host mount namespace.
 			return disk.GetBlockDevicesWithLsblk(
 				timeoutCtx,
 				disk.WithFstype(disk.DefaultFsTypeFunc),
 				disk.WithDeviceType(disk.DefaultDeviceTypeFunc),
 				disk.WithMountPoint(disk.DefaultMountPointFunc),
+				disk.WithLsblkCommand(gpudInstance.LsblkCommands),
+				disk.WithFindmntCommand(gpudInstance.FindmntCommands),
 			)
 		}
 	}
@@ -576,12 +591,17 @@ func (c *component) Check() components.CheckResult {
 		// e.g.,
 		// "unexpected end of JSON input"
 		prevFailed := false
-		for range 5 {
+		findMntSucceeded := false
+		for attempt := range 5 {
 			cctx, ccancel := context.WithTimeout(c.ctx, time.Minute)
 			mntOut, err := c.findMntFunc(cctx, target)
 			ccancel()
 			if err != nil {
-				log.Logger.Errorw("failed to find mnt", "error", err)
+				// findmnt is occasionally flaky and returns empty output, which
+				// parses as "unexpected end of JSON input". This is transient, so
+				// warn and retry; only a fully-exhausted retry budget (handled
+				// after the loop) is a real error.
+				log.Logger.Warnw("failed to find mnt, will retry", "target", target, "attempt", attempt+1, "error", err)
 
 				select {
 				case <-c.ctx.Done():
@@ -600,9 +620,13 @@ func (c *component) Check() components.CheckResult {
 			}
 			cr.MountTargetUsages[target] = *mntOut
 			if prevFailed {
-				log.Logger.Infow("successfully ran findmnt after retries")
+				log.Logger.Infow("successfully ran findmnt after retries", "target", target)
 			}
+			findMntSucceeded = true
 			break
+		}
+		if !findMntSucceeded {
+			log.Logger.Errorw("failed to find mnt after retries", "target", target)
 		}
 	}
 

--- a/components/registry.go
+++ b/components/registry.go
@@ -43,6 +43,33 @@ type GPUdInstance struct {
 	MountPoints  []string
 	MountTargets []string
 
+	// FindmntCommands overrides how the disk component invokes "findmnt".
+	// Empty (the default) preserves the legacy behavior of locating "findmnt" on
+	// PATH and running it in the current namespace. When set (e.g.
+	// "nsenter --target 1 --mount -- findmnt"), the command runs in the host
+	// mount namespace so it reports the host's mounts instead of the container's.
+	FindmntCommands string
+
+	// LsblkCommands overrides how the disk component invokes "lsblk".
+	// Empty (the default) preserves the legacy behavior. When set (e.g.
+	// "nsenter --target 1 --mount -- lsblk"), the command runs in the host mount
+	// namespace.
+	LsblkCommands string
+
+	// BlockdevUsageCommands overrides how the disk component collects partition
+	// usage. Empty (the default) preserves the legacy behavior of enumerating
+	// mounts via gopsutil and measuring usage via the statfs syscall. When set
+	// (e.g. "nsenter --target 1 --mount -- df"), partitions and usage are read
+	// from that command's output in the host mount namespace.
+	BlockdevUsageCommands string
+
+	// ContainerdServiceActiveCommands overrides how the containerd component
+	// checks whether the containerd service is active. Empty (the default)
+	// preserves the legacy in-namespace systemd.IsActive behavior. When set (e.g.
+	// "nsenter --target 1 --mount -- systemctl is-active containerd"), the command
+	// runs against the host's service manager; exit code 0 means active.
+	ContainerdServiceActiveCommands string
+
 	FailureInjector *FailureInjector
 }
 

--- a/deployments/helm/gpud/.helmignore
+++ b/deployments/helm/gpud/.helmignore
@@ -21,3 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
+
+# Private values overlay -- internal only
+values-nvcr.yaml

--- a/deployments/helm/gpud/Chart.yaml
+++ b/deployments/helm/gpud/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: gpud
 description: GPUd Helm chart for Kubernetes
 type: application
-version: 0.10.0
-appVersion: "v0.10.0"
+version: 0.12.2
+appVersion: "0.12.2"
 icon: https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png

--- a/deployments/helm/gpud/README.md
+++ b/deployments/helm/gpud/README.md
@@ -38,6 +38,185 @@ helm install my-gpud <YOUR_REPO_NAME>/gpud \
   --namespace gpud -f my-values.yaml
 ```
 
+### Reboot Support Inside DaemonSet Pods
+
+The chart passes `gpud.rebootCommands` to `gpud run --reboot-commands`. By
+default, it uses `nsenter` to enter the host namespaces through PID 1 and ask
+the host init system to reboot the node. This is the path needed when GPUd runs
+inside a privileged DaemonSet pod rather than directly as a host systemd
+service.
+
+The default reboot path depends on these chart defaults:
+
+- `hostPID: true`
+- `securityContext.privileged: true`
+- `securityContext.runAsUser: 0`
+- `securityContext.allowPrivilegeEscalation: true`
+
+Use a values file for multi-line reboot commands:
+
+```yaml
+gpud:
+  rebootCommands: |
+    set -o errexit
+    set -o nounset
+
+    if command -v nsenter >/dev/null 2>&1; then
+      if nsenter --target 1 --mount --uts --ipc --net --pid --cgroup --root --wd=/ -- /usr/bin/systemctl reboot; then
+        exit 0
+      fi
+      nsenter --target 1 --mount --uts --ipc --net --pid --cgroup --root --wd=/ -- /sbin/reboot
+      exit 0
+    fi
+
+    sudo reboot
+```
+
+Set `gpud.rebootCommands: ""` to keep GPUd's built-in reboot behavior instead.
+If `gpud.commandOverride` is set, the default startup wrapper is bypassed, so
+include `--reboot-commands` in the override when node reboot support is needed.
+
+### Disk Inspection Inside DaemonSet Pods
+
+The disk component shells out to `findmnt` and `lsblk` and measures filesystem
+usage via `statfs`. Run from inside a container, these report the container's
+overlay rootfs instead of the node's real disks (the root disk and any data
+disks). The chart therefore wraps each of them with `nsenter --target 1 --mount`
+by default so they run in the host's mount namespace:
+
+```yaml
+gpud:
+  findmntCommands: "nsenter --target 1 --mount -- findmnt"
+  lsblkCommands: "nsenter --target 1 --mount -- lsblk"
+  blockdevUsageCommands: "nsenter --target 1 --mount -- df"
+```
+
+These map to `gpud run --findmnt-commands`, `--lsblk-commands`, and
+`--blockdev-usage-commands`. The value is the invocation prefix; GPUd appends the
+flags it controls (for example `findmnt --target ... --json --df`, or
+`df -T -B1 -P`). They depend on the same chart defaults as `rebootCommands`
+(`hostPID: true`, `securityContext.privileged: true`, `runAsUser: 0`).
+
+Set any of these to `""` to keep GPUd's built-in in-namespace behavior, which is
+appropriate when GPUd runs directly on the host (e.g. as a systemd service) or in
+a non-privileged pod. As with reboot, if `gpud.commandOverride` is set the
+default startup wrapper is bypassed, so include these flags in the override when
+host disk inspection is needed.
+
+### Containerd Monitoring Inside DaemonSet Pods
+
+The containerd component checks the host's containerd socket and CRI endpoint,
+reads `/etc/containerd/config.toml` to verify the NVIDIA runtime is configured,
+and checks whether the containerd systemd service is active. Run from inside a
+container, the socket/config are not visible and the systemd check only sees the
+container's own service manager. The chart addresses both:
+
+```yaml
+gpud:
+  # Bind-mount the host's containerd dirs (default true):
+  #   /run/containerd (read-write)  -> socket + CRI endpoint
+  #   /etc/containerd (read-only)   -> config.toml NVIDIA-runtime check
+  # Both use hostPath DirectoryOrCreate, so the pod still starts without containerd.
+  mountContainerd: true
+
+  # Check whether the host's containerd service is active (exit code 0 = active),
+  # mapped to "gpud run --containerd-service-active-commands".
+  containerdServiceActiveCommands: "nsenter --target 1 --mount -- systemctl is-active containerd"
+```
+
+Set `gpud.mountContainerd: false` and `gpud.containerdServiceActiveCommands: ""`
+on nodes that do not run containerd (e.g. docker or cri-o only).
+
+### Session Token from a Secret
+
+By default the chart reads the session token from a node label (via
+`nodeLabelExporter`). To read it from an existing Kubernetes Secret instead, set
+`gpud.tokenSecret`; the token is injected as the `TOKEN` env via `secretKeyRef`
+and takes priority over any token label:
+
+```yaml
+gpud:
+  tokenSecret:
+    name: gpud-token   # existing Secret in the release namespace
+    key: TOKEN
+```
+
+### BYOK Worker Cluster Example
+
+For a BYOK worker cluster using a private NVCR image, create the image pull
+secret and the gpud session-token secret in the release namespace:
+
+```bash
+source ~/nvapi.sh
+NAMESPACE=default
+
+# Image pull secret for the private NGC image.
+kubectl create secret docker-registry nvcr-staging-pull \
+  --docker-server=nvcr.io \
+  --docker-username='$oauthtoken' \
+  --docker-password="$NVAPI_KEY" \
+  --namespace "$NAMESPACE"
+
+# gpud session token (read by gpud.tokenSecret below).
+kubectl create secret generic gpud-token \
+  --from-literal=TOKEN="<YOUR_GPUD_SESSION_TOKEN>" \
+  --namespace "$NAMESPACE"
+```
+
+Then install or upgrade with a values file like this (a full BYOK overlay):
+
+```yaml
+image:
+  repository: nvcr.io/nvstaging/dgx-cloud-lepton/gpud
+  tag: 0.12.2   # no "v" prefix from 0.12.2 onward
+
+imagePullSecrets:
+  - name: nvcr-staging-pull
+
+gpud:
+  endpoint: gpud-manager-dev02.dev02.dgxc-lepton-dev.nvidia.com
+  # Session token from the gpud-token Secret created above.
+  tokenSecret:
+    name: gpud-token
+    key: TOKEN
+  # The node also exposes /dev/mem on this platform.
+  mountHostDevMem: true
+  # reboot / disk (findmnt,lsblk,df) / containerd command overrides and the
+  # containerd socket+config mounts are chart defaults (nsenter wrappers).
+
+# Pass the per-node platform machine ID from the node label to
+# "gpud run --machine-id", so GPUd rejoins as the SAME machine after a pod
+# replacement, node reboot, or reimage (even if /etc/machine-id changes).
+nodeLabelExporter:
+  enabled: true
+  labelKeys:
+    machineId: lepton.ai/machine-id
+
+# Schedule only on the intended GPU worker nodes.
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node.lepton.ai/dedicated-node-group-id
+              operator: Exists
+            - key: lepton.ai/machine-id
+              operator: Exists
+```
+
+Install or upgrade with that values file in the same namespace:
+
+```bash
+helm upgrade --install gpud <YOUR_REPO_NAME>/gpud \
+  --namespace "$NAMESPACE" \
+  -f byok-values.yaml
+```
+
+This makes a `helm install` a drop-in replacement for a hand-written GPUd
+DaemonSet: the machine ID is preserved (node label + the persisted
+`/var/lib/gpud` hostPath), the token comes from the Secret, and the disk and
+containerd components report the node's real state via the nsenter wrappers.
+
 ## Uninstalling the Chart
 
 To uninstall the `my-gpud` release:

--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -149,6 +149,26 @@ spec:
           hostPath:
             path: /var/lib/kubelet
             type: DirectoryOrCreate
+
+        {{- if .Values.gpud.mountContainerd }}
+        # Host containerd runtime directory (holds containerd.sock).
+        # Required by: components/containerd (stat the socket and reach the CRI
+        # endpoint at unix:///run/containerd/containerd.sock).
+        # DirectoryOrCreate so the pod still starts on nodes without containerd.
+        # Disable via gpud.mountContainerd=false on nodes without containerd.
+        - name: host-run-containerd
+          hostPath:
+            path: /run/containerd
+            type: DirectoryOrCreate
+
+        # Host containerd config directory (holds config.toml).
+        # Required by: components/containerd (read /etc/containerd/config.toml to
+        # verify the NVIDIA runtime is configured). Mounted read-only.
+        - name: host-etc-containerd
+          hostPath:
+            path: /etc/containerd
+            type: DirectoryOrCreate
+        {{- end }}
       {{- if .Values.extraVolumes }}
       {{- toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
@@ -175,6 +195,11 @@ spec:
           # Needs a shell-capable image; distroless kubectl images lack /bin/sh so the script would fail.
           image: "{{ .Values.nodeLabelExporter.image.repository }}:{{ .Values.nodeLabelExporter.image.tag }}"
           imagePullPolicy: {{ .Values.nodeLabelExporter.image.pullPolicy }}
+          # Run as root: the label file is written to the root-owned /var/lib/gpud
+          # hostPath (gpud runs as root and owns it). The kubectl image otherwise
+          # defaults to a non-root UID and cannot write there.
+          securityContext:
+            runAsUser: 0
           command:
             - /bin/sh
             - -ec
@@ -287,7 +312,21 @@ spec:
                 set -- "$@" --endpoint="$ENDPOINT"
               fi
 
-              # Token and machine-id are only added if present (from node labels)
+              # A token Secret (gpud.tokenSecret) is injected as GPUD_TOKEN and
+              # takes priority over any token node label. This supports clusters
+              # that store the gpud session token in a Secret rather than a label.
+              if [ -n "${GPUD_TOKEN:-}" ]; then
+                TOKEN="$GPUD_TOKEN"
+              fi
+
+              # Token vs machine-id are intentionally sourced differently:
+              #   --token: a SHARED, cluster/node-group enrollment credential
+              #     ("may I join?"). Every node uses the same token (from the
+              #     gpud.tokenSecret Secret, or a token label). It does NOT
+              #     identify the machine.
+              #   --machine-id: the UNIQUE per-node identity ("who am I?"), read
+              #     from each node's machine-id label. Passing it keeps the node
+              #     registered as the SAME machine across restarts/replacement.
               if [ -n "$TOKEN" ]; then
                 set -- "$@" --token="$TOKEN"
               fi
@@ -310,6 +349,27 @@ spec:
                 set -- "$@" --reboot-commands="$GPUD_REBOOT_COMMANDS"
               fi
 
+              # The chart default wraps the disk component's host tools with
+              # nsenter so they read the node's disks instead of the container's
+              # overlay. Users can set the corresponding gpud.*Commands value to
+              # "" to preserve gpud's built-in in-namespace behavior.
+              if [ -n "${GPUD_FINDMNT_COMMANDS:-}" ]; then
+                start_log_args="$start_log_args --findmnt-commands=<set>"
+                set -- "$@" --findmnt-commands="$GPUD_FINDMNT_COMMANDS"
+              fi
+              if [ -n "${GPUD_LSBLK_COMMANDS:-}" ]; then
+                start_log_args="$start_log_args --lsblk-commands=<set>"
+                set -- "$@" --lsblk-commands="$GPUD_LSBLK_COMMANDS"
+              fi
+              if [ -n "${GPUD_BLOCKDEV_USAGE_COMMANDS:-}" ]; then
+                start_log_args="$start_log_args --blockdev-usage-commands=<set>"
+                set -- "$@" --blockdev-usage-commands="$GPUD_BLOCKDEV_USAGE_COMMANDS"
+              fi
+              if [ -n "${GPUD_CONTAINERD_SERVICE_ACTIVE_COMMANDS:-}" ]; then
+                start_log_args="$start_log_args --containerd-service-active-commands=<set>"
+                set -- "$@" --containerd-service-active-commands="$GPUD_CONTAINERD_SERVICE_ACTIVE_COMMANDS"
+              fi
+
               # Using exec ensures gpud receives signals directly (important for graceful shutdown).
               echo "Starting: /usr/local/bin/gpud $start_log_args"
               exec /usr/local/bin/gpud "$@"
@@ -318,9 +378,34 @@ spec:
           env:
             - name: GPUD_NO_USAGE_STATS
               value: {{ not .Values.gpud.telemetry.enabled | quote }}
+            {{- if .Values.gpud.tokenSecret.name }}
+            # Session token sourced from an existing Secret (takes priority over a
+            # token node label). Consumed by the startup script as $GPUD_TOKEN.
+            - name: GPUD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.gpud.tokenSecret.name | quote }}
+                  key: {{ .Values.gpud.tokenSecret.key | quote }}
+            {{- end }}
             {{- if .Values.gpud.rebootCommands }}
             - name: GPUD_REBOOT_COMMANDS
               value: {{ .Values.gpud.rebootCommands | quote }}
+            {{- end }}
+            {{- if .Values.gpud.findmntCommands }}
+            - name: GPUD_FINDMNT_COMMANDS
+              value: {{ .Values.gpud.findmntCommands | quote }}
+            {{- end }}
+            {{- if .Values.gpud.lsblkCommands }}
+            - name: GPUD_LSBLK_COMMANDS
+              value: {{ .Values.gpud.lsblkCommands | quote }}
+            {{- end }}
+            {{- if .Values.gpud.blockdevUsageCommands }}
+            - name: GPUD_BLOCKDEV_USAGE_COMMANDS
+              value: {{ .Values.gpud.blockdevUsageCommands | quote }}
+            {{- end }}
+            {{- if .Values.gpud.containerdServiceActiveCommands }}
+            - name: GPUD_CONTAINERD_SERVICE_ACTIVE_COMMANDS
+              value: {{ .Values.gpud.containerdServiceActiveCommands | quote }}
             {{- end }}
 
           {{- if .Values.service.enabled }}
@@ -397,6 +482,20 @@ spec:
             - name: host-kubelet-vol
               mountPath: /var/lib/kubelet
               readOnly: true
+
+            {{- if .Values.gpud.mountContainerd }}
+            # Host containerd socket directory for containerd monitoring.
+            # Mounted at the same path gpud expects (/run/containerd/containerd.sock).
+            # Not read-only: connecting to the CRI unix socket requires write access.
+            - name: host-run-containerd
+              mountPath: /run/containerd
+
+            # Host containerd config for the NVIDIA-runtime check (read-only).
+            # Mounted at the same path gpud reads (/etc/containerd/config.toml).
+            - name: host-etc-containerd
+              mountPath: /etc/containerd
+              readOnly: true
+            {{- end }}
           {{- if .Values.extraVolumeMounts }}
           {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
@@ -409,6 +508,11 @@ spec:
           # Needs a shell-capable image; distroless kubectl images lack /bin/sh so the looped script would fail.
           image: "{{ .Values.nodeLabelExporter.image.repository }}:{{ .Values.nodeLabelExporter.image.tag }}"
           imagePullPolicy: {{ .Values.nodeLabelExporter.image.pullPolicy }}
+          # Run as root: the label file is written to the root-owned /var/lib/gpud
+          # hostPath (gpud runs as root and owns it). The kubectl image otherwise
+          # defaults to a non-root UID and cannot write there.
+          securityContext:
+            runAsUser: 0
           command:
             - /bin/sh
             - -ec

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -29,12 +29,37 @@ gpud:
   # The endpoint for the control plane.
   endpoint: "gpud-manager-prod01.dgxc-lepton.nvidia.com"
 
+  # Optional: read the gpud session token from an existing Secret instead of a
+  # node label. When name is set, the token is injected as the TOKEN env via
+  # secretKeyRef and takes priority over any token node label. Leave name empty
+  # to rely on the node label (nodeLabelExporter) or no token.
+  #
+  # TOKEN MODEL: this is a SHARED, cluster/node-group-level enrollment credential.
+  # Every gpud pod in the DaemonSet reads the SAME Secret, so all machines
+  # authenticate to the control plane with the SAME token. Machines are NOT told
+  # apart by the token -- they are distinguished by their unique per-node
+  # machine ID (see nodeLabelExporter.labelKeys.machineId below). In short:
+  #   - token      = "may I join this workspace?"  (shared across all nodes)
+  #   - machine ID = "which machine am I?"         (unique per node)
+  # For per-machine tokens instead (e.g. to revoke a single node), leave this
+  # empty and put a distinct token in each node's label via nodeLabelExporter.
+  tokenSecret:
+    name: ""
+    key: "TOKEN"
+
   # Enable auto update of gpud.
   enableAutoUpdate: false
 
   # The exit code to use when auto-updating.
   # set -1 to disable exit code
   autoUpdateExitCode: -1
+
+  # --- Host command overrides ---
+  # The settings in this block (rebootCommands and the disk findmntCommands /
+  # lsblkCommands / blockdevUsageCommands) wrap host tools with nsenter so they
+  # run in the host's namespaces instead of the container's. They share the same
+  # requirements: hostPID=true, securityContext.privileged=true, runAsUser=0.
+  # Set any of them to "" to fall back to gpud's built-in in-namespace behavior.
 
   # Bash script passed to "gpud run --reboot-commands".
   # Empty keeps gpud's built-in reboot behavior, which runs "sudo reboot" after
@@ -61,6 +86,47 @@ gpud:
 
     sudo reboot
 
+  # Command prefixes the disk component uses to inspect the host's disks.
+  #
+  # gpud runs inside a container here, so "findmnt"/"lsblk"/statfs executed in the
+  # container's mount namespace report the container's overlay rootfs instead of
+  # the node's real filesystems (e.g. the root disk and any data disks). The chart
+  # therefore wraps these tools with "nsenter --target 1 --mount --" by default so
+  # they run in the host's mount namespace and report the node's disks. gpud
+  # appends the flags it controls (e.g. findmnt --target ... --json --df).
+  #
+  # This depends on the same pod settings as rebootCommands above:
+  # - hostPID=true lets nsenter target the host's PID 1.
+  # - securityContext.privileged=true grants the namespace-entering capability.
+  # - securityContext.runAsUser=0 runs gpud and nsenter as root.
+  #
+  # Set any of these to "" to disable the override and use gpud's built-in
+  # in-namespace behavior (appropriate for non-privileged or bare-metal setups).
+  findmntCommands: "nsenter --target 1 --mount -- findmnt"
+  lsblkCommands: "nsenter --target 1 --mount -- lsblk"
+  blockdevUsageCommands: "nsenter --target 1 --mount -- df"
+
+  # Command used by the containerd component to check whether the containerd
+  # service is active. gpud runs inside a container here, so the container's own
+  # systemd does not manage containerd; the chart wraps "systemctl is-active
+  # containerd" with nsenter so the check queries the host's service manager
+  # (exit code 0 means active). Requires the host containerd mounts below
+  # (mountContainerd) plus the same hostPID/privileged settings as above.
+  # Set to "" to use gpud's built-in in-namespace systemd check.
+  containerdServiceActiveCommands: "nsenter --target 1 --mount -- systemctl is-active containerd"
+
+  # Mount the host containerd directories so the containerd component can monitor
+  # the node's containerd when gpud runs inside a container:
+  #   - /run/containerd (read-write): stat the socket and reach the CRI endpoint
+  #     at unix:///run/containerd/containerd.sock.
+  #   - /etc/containerd (read-only): read config.toml to verify the NVIDIA runtime
+  #     is configured. Without this, gpud sees only the container image's stub
+  #     config and falsely reports the NVIDIA runtime as missing.
+  # Both use hostPath type DirectoryOrCreate, so the pod still starts on nodes
+  # without containerd (the component then reports containerd as not installed).
+  # Set to false on nodes that do not run containerd (e.g. docker/cri-o only).
+  mountContainerd: true
+
   # Mount /dev/mem for deep hardware inspection and memory diagnostics (e.g., PCIe config space).
   # Defaults to false for maximum compatibility across platforms (addresses issue #1144).
   # Set to true if you need deep memory inspection and your environment supports /dev/mem.
@@ -86,6 +152,9 @@ gpud:
   mountHostProc: true
 
   # Override the default command for the gpud container.
+  # If set, the chart's default startup wrapper is bypassed; include any gpud
+  # flags you still need there, including --reboot-commands and the disk
+  # --findmnt-commands/--lsblk-commands/--blockdev-usage-commands when applicable.
   commandOverride: []
 
 # Reference to one or more secrets to be used for pulling images from private registries.
@@ -206,13 +275,26 @@ nodeLabelExporter:
   image:
     # Use a shell-capable kubectl image. Distroless kubectl images (registry.k8s.io/kubectl)
     # do not include /bin/sh, but our init/sidecar scripts rely on a POSIX shell.
-    # Hosted on public ECR to avoid Docker Hub rate limits.
-    repository: public.ecr.aws/bitnami/kubectl
-    tag: v1.34.0
+    # NOTE: Bitnami removed their public ECR mirror (public.ecr.aws/bitnami) in 2025,
+    # so we use the Docker Hub bitnami/kubectl image. Override if you mirror it
+    # elsewhere or hit Docker Hub rate limits.
+    repository: docker.io/bitnami/kubectl
+    tag: latest
     pullPolicy: IfNotPresent
   # File written on the host (via the shared /var/lib/gpud volume).
   outputFile: /var/lib/gpud/node-labels.env
   # Label keys to look for in the node labels.
+  # For BYOK worker clusters, set machineId to the label that stores the
+  # platform machine ID (for example, lepton.ai/machine-id) so gpud rejoins
+  # with the same machine ID even if the host /etc/machine-id changes.
+  #
+  # machineId is the UNIQUE per-node identity ("which machine am I?"): each node
+  # carries its own value, and passing it to "gpud run --machine-id" is what
+  # keeps a node registered as the SAME machine across pod restarts, DaemonSet
+  # replacement, or node reimage. (The token, by contrast, is shared across all
+  # nodes -- see gpud.tokenSecret. token = "may I join?", machineId = "who am I?".)
+  # endpoint/token here are optional label-based alternatives to gpud.endpoint and
+  # gpud.tokenSecret; leave them unmatched to use those values instead.
   labelKeys:
     endpoint: gpud.dgxc.lepton.ai/endpoint
     token: gpud.dgxc.lepton.ai/token

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,6 +53,33 @@ type Config struct {
 	// Empty preserves the built-in "sudo reboot" path.
 	RebootCommands string `json:"reboot_commands,omitempty"`
 
+	// FindmntCommands overrides how the disk component invokes "findmnt".
+	// Empty preserves the legacy behavior of locating "findmnt" on PATH and
+	// running it in the current namespace. When set (e.g.
+	// "nsenter --target 1 --mount -- findmnt"), it runs in the host mount
+	// namespace so the disk component reports the host's mounts.
+	FindmntCommands string `json:"findmnt_commands,omitempty"`
+
+	// LsblkCommands overrides how the disk component invokes "lsblk".
+	// Empty preserves the legacy behavior. When set (e.g.
+	// "nsenter --target 1 --mount -- lsblk"), it runs in the host mount namespace.
+	LsblkCommands string `json:"lsblk_commands,omitempty"`
+
+	// BlockdevUsageCommands overrides how the disk component collects partition
+	// usage. Empty preserves the legacy behavior of enumerating mounts via
+	// gopsutil and measuring usage via the statfs syscall. When set (e.g.
+	// "nsenter --target 1 --mount -- df"), partitions and usage are read from
+	// that command's output in the host mount namespace.
+	BlockdevUsageCommands string `json:"blockdev_usage_commands,omitempty"`
+
+	// ContainerdServiceActiveCommands overrides how the containerd component checks
+	// whether the containerd service is active. Empty preserves the legacy
+	// behavior of calling systemd directly (systemd.IsActive), which only sees the
+	// container's own service manager. When set (e.g.
+	// "nsenter --target 1 --mount -- systemctl is-active containerd"), the command
+	// runs against the host's service manager; exit code 0 means active.
+	ContainerdServiceActiveCommands string `json:"containerd_service_active_commands,omitempty"`
+
 	// VersionFile is the file that contains the target version.
 	// If empty, the version file is not used.
 	VersionFile string `json:"version_file"`

--- a/pkg/config/default.go
+++ b/pkg/config/default.go
@@ -60,6 +60,12 @@ func DefaultConfig(ctx context.Context, opts ...OpOption) (*Config, error) {
 		DBInMemory:      options.DBInMemory,
 		RebootCommands:  options.RebootCommands,
 
+		FindmntCommands:       options.FindmntCommands,
+		LsblkCommands:         options.LsblkCommands,
+		BlockdevUsageCommands: options.BlockdevUsageCommands,
+
+		ContainerdServiceActiveCommands: options.ContainerdServiceActiveCommands,
+
 		SessionToken:     options.SessionToken,
 		SessionMachineID: options.SessionMachineID,
 		SessionEndpoint:  options.SessionEndpoint,

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -18,6 +18,23 @@ type Op struct {
 	// Empty keeps the default host reboot implementation.
 	RebootCommands string
 
+	// FindmntCommands optionally overrides how the disk component invokes "findmnt".
+	// Empty keeps the legacy in-namespace behavior.
+	FindmntCommands string
+
+	// LsblkCommands optionally overrides how the disk component invokes "lsblk".
+	// Empty keeps the legacy in-namespace behavior.
+	LsblkCommands string
+
+	// BlockdevUsageCommands optionally overrides how the disk component collects
+	// partition usage. Empty keeps the legacy gopsutil + statfs behavior.
+	BlockdevUsageCommands string
+
+	// ContainerdServiceActiveCommands optionally overrides how the containerd
+	// component checks whether the containerd service is active. Empty keeps the
+	// legacy in-namespace systemd.IsActive behavior.
+	ContainerdServiceActiveCommands string
+
 	// SessionToken is the session token for db-in-memory mode.
 	// When DBInMemory is true and this is set, the server will seed
 	// this token into the in-memory database.
@@ -99,6 +116,39 @@ func WithDBInMemory(b bool) OpOption {
 func WithRebootCommands(commands string) OpOption {
 	return func(op *Op) {
 		op.RebootCommands = commands
+	}
+}
+
+// WithFindmntCommands overrides how the disk component invokes "findmnt".
+// Empty keeps the legacy in-namespace behavior.
+func WithFindmntCommands(commands string) OpOption {
+	return func(op *Op) {
+		op.FindmntCommands = commands
+	}
+}
+
+// WithLsblkCommands overrides how the disk component invokes "lsblk".
+// Empty keeps the legacy in-namespace behavior.
+func WithLsblkCommands(commands string) OpOption {
+	return func(op *Op) {
+		op.LsblkCommands = commands
+	}
+}
+
+// WithBlockdevUsageCommands overrides how the disk component collects partition
+// usage. Empty keeps the legacy gopsutil + statfs behavior.
+func WithBlockdevUsageCommands(commands string) OpOption {
+	return func(op *Op) {
+		op.BlockdevUsageCommands = commands
+	}
+}
+
+// WithContainerdServiceActiveCommands overrides how the containerd component
+// checks whether the containerd service is active. Empty keeps the legacy
+// in-namespace systemd.IsActive behavior.
+func WithContainerdServiceActiveCommands(commands string) OpOption {
+	return func(op *Op) {
+		op.ContainerdServiceActiveCommands = commands
 	}
 }
 

--- a/pkg/disk/df_test.go
+++ b/pkg/disk/df_test.go
@@ -1,0 +1,199 @@
+package disk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunDfCommandExecutes is a regression test for the blockdev-usage override:
+// runDfCommand must Start() the process before reading it. A missing Start()
+// previously surfaced at runtime as "failed to read df output: process not
+// started", failing the disk component's ext4 partitions check. Using "echo"
+// keeps the test portable (no dependency on df flag support).
+func TestRunDfCommandExecutes(t *testing.T) {
+	out, err := runDfCommand(context.Background(), "echo disk-ok")
+	require.NoError(t, err)
+	assert.Contains(t, out, "disk-ok")
+}
+
+func TestParseDfOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		want    Partitions
+		wantErr bool
+	}{
+		{
+			name:   "empty output",
+			output: "",
+			want:   Partitions{},
+		},
+		{
+			name: "typical df -T -B1 -P output",
+			output: `Filesystem     Type 1B-blocks         Used     Available Capacity Mounted on
+/dev/root      ext4 133003395072 36369936384   96616681472      28% /
+/dev/sdb1      ext4 3063790665728      32768 2908082184192       1% /mnt`,
+			want: Partitions{
+				{
+					Device:     "/dev/root",
+					Fstype:     "ext4",
+					MountPoint: "/",
+					Mounted:    true,
+					Usage: &Usage{
+						TotalBytes: 133003395072,
+						FreeBytes:  96616681472,
+						UsedBytes:  36369936384,
+					},
+				},
+				{
+					Device:     "/dev/sdb1",
+					Fstype:     "ext4",
+					MountPoint: "/mnt",
+					Mounted:    true,
+					Usage: &Usage{
+						TotalBytes: 3063790665728,
+						FreeBytes:  2908082184192,
+						UsedBytes:  32768,
+					},
+				},
+			},
+		},
+		{
+			name: "mount point with spaces is preserved",
+			output: `Filesystem Type 1B-blocks Used Available Capacity Mounted on
+/dev/sdc1 ext4 1000 100 900 10% /mnt/my disk`,
+			want: Partitions{
+				{
+					Device:     "/dev/sdc1",
+					Fstype:     "ext4",
+					MountPoint: "/mnt/my disk",
+					Mounted:    true,
+					Usage:      &Usage{TotalBytes: 1000, FreeBytes: 900, UsedBytes: 100},
+				},
+			},
+		},
+		{
+			name: "non-numeric and short lines are skipped defensively",
+			output: `Filesystem Type 1B-blocks Used Available Capacity Mounted on
+df: /broken: Permission denied
+overlay overlay - - - - /
+/dev/root ext4 1000 100 900 10% /
+short line`,
+			want: Partitions{
+				{
+					Device:     "/dev/root",
+					Fstype:     "ext4",
+					MountPoint: "/",
+					Mounted:    true,
+					Usage:      &Usage{TotalBytes: 1000, FreeBytes: 900, UsedBytes: 100},
+				},
+			},
+		},
+		{
+			name: "blank lines are ignored",
+			output: `
+Filesystem Type 1B-blocks Used Available Capacity Mounted on
+
+/dev/root ext4 1000 100 900 10% /
+`,
+			want: Partitions{
+				{
+					Device:     "/dev/root",
+					Fstype:     "ext4",
+					MountPoint: "/",
+					Mounted:    true,
+					Usage:      &Usage{TotalBytes: 1000, FreeBytes: 900, UsedBytes: 100},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDfOutput(tt.output)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFilterDfPartitions(t *testing.T) {
+	parsed := Partitions{
+		{Device: "/dev/root", Fstype: "ext4", MountPoint: "/", Usage: &Usage{TotalBytes: 1000}},
+		{Device: "overlay", Fstype: "overlay", MountPoint: "/", Usage: &Usage{TotalBytes: 9999}},
+		{Device: "/dev/sdb1", Fstype: "ext4", MountPoint: "/mnt", Usage: &Usage{TotalBytes: 5000}},
+		{Device: "nfsserver:/exp", Fstype: "nfs4", MountPoint: "/nfs", Usage: &Usage{TotalBytes: 7000}},
+	}
+
+	t.Run("ext4 filter keeps only ext4 and sorts by total desc", func(t *testing.T) {
+		op := &Op{}
+		require.NoError(t, op.applyOpts([]OpOption{WithFstype(DefaultExt4FsTypeFunc), WithMountPoint(DefaultMountPointFunc)}))
+
+		got := filterDfPartitions(parsed, op)
+		require.Len(t, got, 2)
+		// sorted descending by total bytes: /mnt (5000) before / (1000)
+		assert.Equal(t, "/mnt", got[0].MountPoint)
+		assert.Equal(t, "/", got[1].MountPoint)
+		for _, p := range got {
+			assert.True(t, p.Mounted, "df partition should be marked mounted")
+			require.NotNil(t, p.Usage)
+		}
+	})
+
+	t.Run("skipUsage leaves usage nil", func(t *testing.T) {
+		op := &Op{}
+		require.NoError(t, op.applyOpts([]OpOption{WithFstype(DefaultExt4FsTypeFunc), WithMountPoint(DefaultMountPointFunc), WithSkipUsage()}))
+
+		got := filterDfPartitions(parsed, op)
+		for _, p := range got {
+			assert.Nil(t, p.Usage, "expected usage to be nil with WithSkipUsage")
+		}
+	})
+
+	t.Run("nfs filter keeps only nfs", func(t *testing.T) {
+		op := &Op{}
+		require.NoError(t, op.applyOpts([]OpOption{WithFstype(DefaultNFSFsTypeFunc), WithMountPoint(DefaultMountPointFunc)}))
+
+		got := filterDfPartitions(parsed, op)
+		require.Len(t, got, 1)
+		assert.Equal(t, "nfs4", got[0].Fstype)
+	})
+}
+
+// TestDiskCommandOptionsDefaultEmpty asserts the backward-compatibility
+// invariant: with no override options, the command fields are empty, which makes
+// FindMnt/lsblk/GetPartitions take the legacy in-namespace code paths.
+func TestDiskCommandOptionsDefaultEmpty(t *testing.T) {
+	op := &Op{}
+	require.NoError(t, op.applyOpts(nil))
+	assert.Empty(t, op.findmntCommand)
+	assert.Empty(t, op.lsblkCommand)
+	assert.Empty(t, op.blockdevUsageCommand)
+}
+
+func TestDiskCommandOptionsSet(t *testing.T) {
+	op := &Op{}
+	err := op.applyOpts([]OpOption{
+		WithFindmntCommand("nsenter --target 1 --mount -- findmnt"),
+		WithLsblkCommand("nsenter --target 1 --mount -- lsblk"),
+		WithBlockdevUsageCommand("nsenter --target 1 --mount -- df"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "nsenter --target 1 --mount -- findmnt", op.findmntCommand)
+	assert.Equal(t, "nsenter --target 1 --mount -- lsblk", op.lsblkCommand)
+	assert.Equal(t, "nsenter --target 1 --mount -- df", op.blockdevUsageCommand)
+}
+
+// TestFindMntCommandWithOverrideBase verifies the command builder uses the
+// override invocation prefix verbatim and still appends the flags gpud controls.
+func TestFindMntCommandWithOverrideBase(t *testing.T) {
+	got := findMntCommand("nsenter --target 1 --mount -- findmnt", "/var/lib/kubelet")
+	assert.Equal(t, "nsenter --target 1 --mount -- findmnt --target /var/lib/kubelet --json --df", got)
+}

--- a/pkg/disk/disk_partition_usage.go
+++ b/pkg/disk/disk_partition_usage.go
@@ -19,12 +19,21 @@ import (
 
 	pkgfile "github.com/leptonai/gpud/pkg/file"
 	"github.com/leptonai/gpud/pkg/log"
+	"github.com/leptonai/gpud/pkg/process"
 )
 
 func GetPartitions(ctx context.Context, opts ...OpOption) (Partitions, error) {
 	op := &Op{}
 	if err := op.applyOpts(opts); err != nil {
 		return nil, err
+	}
+
+	// When a usage command override is configured (e.g.
+	// "nsenter --target 1 --mount -- df"), collect partitions and usage from that
+	// command's output so the measurement runs in the host mount namespace.
+	// Empty (the default) preserves the legacy gopsutil + statfs path below.
+	if op.blockdevUsageCommand != "" {
+		return getPartitionsWithDf(ctx, op)
 	}
 
 	partitions, err := disk.PartitionsWithContext(ctx, true)
@@ -186,4 +195,180 @@ type Usage struct {
 	TotalBytes uint64 `json:"total_bytes"`
 	FreeBytes  uint64 `json:"free_bytes"`
 	UsedBytes  uint64 `json:"used_bytes"`
+}
+
+// dfFlags are the flags gpud appends to the configured blockdev usage command.
+//   - "-T" adds a filesystem Type column (needed for fstype filtering).
+//   - "-B1" reports sizes in bytes (so no unit parsing is required).
+//   - "-P" forces the portable POSIX format: exactly one line per filesystem,
+//     which keeps the output stable and machine-parseable.
+const dfFlags = "-T -B1 -P"
+
+// getPartitionsWithDf collects partitions and usage by running the configured
+// blockdev usage command (e.g. "nsenter --target 1 --mount -- df") instead of
+// enumerating mounts via gopsutil (/proc/self/mountinfo) and measuring usage via
+// the statfs syscall. This lets the disk component report the host's filesystems
+// and their usage when gpud runs inside a container.
+//
+// It applies the same fstype/mount-point filters and the same descending
+// total-bytes ordering as the legacy GetPartitions path, so downstream consumers
+// see a consistent shape regardless of which collection path produced it.
+//
+// Note: usage here comes from df's "Available" column (space usable by
+// unprivileged processes), which can be slightly smaller than the statfs-based
+// FreeBytes (which includes filesystem-reserved blocks). This only applies when
+// the override is explicitly configured; the default path is unchanged.
+func getPartitionsWithDf(ctx context.Context, op *Op) (Partitions, error) {
+	output, err := runDfCommand(ctx, op.blockdevUsageCommand)
+	if err != nil {
+		return nil, err
+	}
+
+	parsed, err := parseDfOutput(output)
+	if err != nil {
+		return nil, err
+	}
+
+	return filterDfPartitions(parsed, op), nil
+}
+
+// filterDfPartitions applies the same fstype/mount-point filters, mounted/usage
+// semantics, and descending total-bytes ordering as the legacy GetPartitions
+// path to partitions parsed from "df" output. It is separated from command
+// execution so it can be unit tested without running df.
+func filterDfPartitions(parsed Partitions, op *Op) Partitions {
+	ps := make(Partitions, 0, len(parsed))
+	for _, p := range parsed {
+		if !op.matchFuncFstype(p.Fstype) {
+			log.Logger.Debugw("skipping partition due to mismatch fstype", "fstype", p.Fstype, "device", p.Device, "mountPoint", p.MountPoint)
+			continue
+		}
+		if !op.matchFuncMountPoint(p.MountPoint) {
+			log.Logger.Debugw("skipping partition due to missing mount point", "fstype", p.Fstype, "device", p.Device, "mountPoint", p.MountPoint)
+			continue
+		}
+
+		part := Partition{
+			Device:     p.Device,
+			Fstype:     p.Fstype,
+			MountPoint: p.MountPoint,
+			// df only lists currently mounted filesystems.
+			Mounted: true,
+		}
+		// Mirror the legacy path's WithSkipUsage semantics: when usage is
+		// skipped, leave Partition.Usage nil.
+		if !op.skipUsage {
+			part.Usage = p.Usage
+		}
+
+		ps = append(ps, part)
+	}
+
+	// sort in descending order of total bytes (identical to GetPartitions).
+	sort.Slice(ps, func(i, j int) bool {
+		if ps[j].Usage == nil {
+			return true
+		}
+		if ps[i].Usage == nil {
+			return false
+		}
+		return ps[i].Usage.TotalBytes > ps[j].Usage.TotalBytes
+	})
+
+	return ps
+}
+
+// runDfCommand runs "<command> -T -B1 -P" and returns its stdout. The command is
+// the configured invocation prefix (gpud appends dfFlags). Only stdout is read,
+// since df may emit non-fatal warnings (e.g. permission denied on a mount) to
+// stderr that must not contaminate the parsed table.
+func runDfCommand(ctx context.Context, command string) (string, error) {
+	p, err := process.New(
+		process.WithCommand(command+" "+dfFlags),
+		process.WithRunAsBashScript(),
+		process.WithRunBashInline(),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	if err := p.Start(ctx); err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := p.Close(ctx); err != nil {
+			log.Logger.Warnw("failed to abort command", "err", err)
+		}
+	}()
+
+	lines := make([]string, 0)
+	if err := process.Read(
+		ctx,
+		p,
+		process.WithReadStdout(),
+		process.WithProcessLine(func(line string) {
+			lines = append(lines, line)
+		}),
+		process.WithWaitForCmd(),
+	); err != nil {
+		return "", fmt.Errorf("failed to read df output: %w (output: %s)", err, strings.Join(lines, "\n"))
+	}
+
+	return strings.Join(lines, "\n"), nil
+}
+
+// parseDfOutput parses the output of "df -T -B1 -P". Expected columns per data
+// row (POSIX format, sizes already in bytes):
+//
+//	Filesystem  Type  1B-blocks  Used  Available  Capacity  Mounted-on
+//
+// The mount point (last column) may legitimately contain spaces, so everything
+// from the 7th field onward is joined back into the mount point. Rows that do
+// not parse as data rows (the header, blank lines, or stray non-numeric lines)
+// are skipped defensively rather than failing the whole collection.
+func parseDfOutput(output string) (Partitions, error) {
+	parts := make(Partitions, 0)
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 7 {
+			log.Logger.Debugw("skipping df line with too few fields", "line", line)
+			continue
+		}
+
+		// Skip the header row ("Filesystem Type 1B-blocks Used Available ...").
+		if fields[0] == "Filesystem" {
+			continue
+		}
+
+		totalBytes, errTotal := strconv.ParseUint(fields[2], 10, 64)
+		usedBytes, errUsed := strconv.ParseUint(fields[3], 10, 64)
+		availBytes, errAvail := strconv.ParseUint(fields[4], 10, 64)
+		if errTotal != nil || errUsed != nil || errAvail != nil {
+			// Not a numeric data row (e.g. a stray warning); skip defensively.
+			log.Logger.Debugw("skipping df line with non-numeric size columns", "line", line)
+			continue
+		}
+
+		// fields[5] is the capacity percentage (e.g. "27%"); not needed.
+		mountPoint := strings.Join(fields[6:], " ")
+
+		parts = append(parts, Partition{
+			Device:     fields[0],
+			Fstype:     fields[1],
+			MountPoint: mountPoint,
+			Mounted:    true,
+			Usage: &Usage{
+				TotalBytes: totalBytes,
+				FreeBytes:  availBytes,
+				UsedBytes:  usedBytes,
+			},
+		})
+	}
+
+	return parts, nil
 }

--- a/pkg/disk/findmnt.go
+++ b/pkg/disk/findmnt.go
@@ -15,14 +15,38 @@ import (
 )
 
 // Runs "findmnt --target [TARGET] --json --df" and parses the output.
+//
+// FindMnt locates "findmnt" on PATH and runs it in the current (e.g. container)
+// mount namespace. Inside a container the root is typically an overlay (a pseudo
+// filesystem that --df filters out), so on its own this reports the container's
+// view. Use FindMntWithCommand to override the invocation (e.g. wrap with
+// "nsenter --target 1 --mount -- findmnt") so it reports the host's real mounts.
 func FindMnt(ctx context.Context, target string) (*FindMntOutput, error) {
-	findmntPath, err := file.LocateExecutable("findmnt")
-	if err != nil {
-		return nil, err
+	return FindMntWithCommand(ctx, target, "")
+}
+
+// FindMntWithCommand behaves like FindMnt but uses the given command override as
+// the findmnt invocation prefix instead of locating "findmnt" on PATH.
+//
+// An empty command falls back to the default behavior (locate "findmnt"), so
+// FindMntWithCommand(ctx, target, "") is byte-for-byte identical to
+// FindMnt(ctx, target). gpud always appends the flags it controls
+// (--target, --json, --df).
+func FindMntWithCommand(ctx context.Context, target string, command string) (*FindMntOutput, error) {
+	// Empty command preserves the legacy behavior: locate "findmnt" on PATH and
+	// run it directly. A non-empty override is used verbatim as the command
+	// prefix (gpud still appends the flags it controls below).
+	findmntCmd := command
+	if findmntCmd == "" {
+		findmntPath, err := file.LocateExecutable("findmnt")
+		if err != nil {
+			return nil, err
+		}
+		findmntCmd = findmntPath
 	}
 
 	p, err := process.New(
-		process.WithCommand(fmt.Sprintf("%s --target %s --json --df", findmntPath, target)),
+		process.WithCommand(findMntCommand(findmntCmd, target)),
 		process.WithRunAsBashScript(),
 		process.WithRunBashInline(),
 	)
@@ -59,6 +83,10 @@ func FindMnt(ctx context.Context, target string) (*FindMntOutput, error) {
 	}
 	out.Target = target
 	return out, nil
+}
+
+func findMntCommand(findmntPath, target string) string {
+	return fmt.Sprintf("%s --target %s --json --df", findmntPath, target)
 }
 
 // Represents the output of the command

--- a/pkg/disk/findmnt_test.go
+++ b/pkg/disk/findmnt_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseFindMntOutput(t *testing.T) {
@@ -66,4 +68,9 @@ func TestExtractMntSources(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFindMntCommand(t *testing.T) {
+	got := findMntCommand("/usr/bin/findmnt", "/")
+	assert.Equal(t, "/usr/bin/findmnt --target / --json --df", got)
 }

--- a/pkg/disk/lsblk.go
+++ b/pkg/disk/lsblk.go
@@ -63,10 +63,25 @@ type BlockDevice struct {
 // Receives device path. If device is empty string, info about all devices will be collected
 // Returns slice of BlockDevice structs or error if something went wrong
 func GetBlockDevicesWithLsblk(ctx context.Context, opts ...OpOption) (BlockDevices, error) {
+	op := &Op{}
+	if err := op.applyOpts(opts); err != nil {
+		return nil, err
+	}
+
+	// Empty lsblkCommand/findmntCommand preserve the legacy behavior: locate the
+	// binaries on PATH and run them directly in the current namespace. The
+	// closures below are byte-for-byte equivalent to passing getLsblkBinPathAndVersion
+	// and FindMnt directly when both overrides are empty.
 	return getBlockDevicesWithLsblk(ctx, getBlockDevicesDeps{
-		getLsblkBinPathAndVersion: getLsblkBinPathAndVersion,
-		executeLsblkCommand:       executeLsblkCommand,
-		findMnt:                   FindMnt,
+		getLsblkBinPathAndVersion: func(ctx context.Context) (string, string, error) {
+			return getLsblkBinPathAndVersionWithCommand(ctx, op.lsblkCommand)
+		},
+		executeLsblkCommand: executeLsblkCommand,
+		// Thread the findmnt override so the fstype back-fill (used when lsblk
+		// omits fstype) also runs in the configured (e.g. host) mount namespace.
+		findMnt: func(ctx context.Context, target string) (*FindMntOutput, error) {
+			return FindMntWithCommand(ctx, target, op.findmntCommand)
+		},
 	}, opts...)
 }
 
@@ -189,9 +204,21 @@ func executeLsblkCommand(ctx context.Context, lsblkBin string, flags string) ([]
 
 // getLsblkBinPathAndVersion returns the "lsblk" executable path and the output of "lsblk --version".
 func getLsblkBinPathAndVersion(ctx context.Context) (string, string, error) {
-	lsblkBin, err := file.LocateExecutable("lsblk")
-	if err != nil {
-		return "", "", err
+	return getLsblkBinPathAndVersionWithCommand(ctx, "")
+}
+
+// getLsblkBinPathAndVersionWithCommand is like getLsblkBinPathAndVersion but uses
+// the given command override as the lsblk invocation prefix instead of locating
+// "lsblk" on PATH. An empty command falls back to locating "lsblk", so it is
+// byte-for-byte identical to getLsblkBinPathAndVersion in that case.
+func getLsblkBinPathAndVersionWithCommand(ctx context.Context, command string) (string, string, error) {
+	lsblkBin := command
+	if lsblkBin == "" {
+		var err error
+		lsblkBin, err = file.LocateExecutable("lsblk")
+		if err != nil {
+			return "", "", err
+		}
 	}
 
 	p, err := process.New(

--- a/pkg/disk/options.go
+++ b/pkg/disk/options.go
@@ -11,6 +11,28 @@ type Op struct {
 	matchFuncMountPoint MatchFunc
 	skipUsage           bool
 	statTimeout         time.Duration
+
+	// findmntCommand overrides how the "findmnt" binary is invoked.
+	// Empty preserves the default behavior of locating "findmnt" on PATH and
+	// running it directly in the current namespace. When set, it is used as the
+	// command prefix (e.g. "nsenter --target 1 --mount -- findmnt") and gpud
+	// appends the flags it controls (--target, --json, --df).
+	findmntCommand string
+
+	// lsblkCommand overrides how the "lsblk" binary is invoked.
+	// Empty preserves the default behavior of locating "lsblk" on PATH and
+	// running it directly in the current namespace. When set, it is used as the
+	// command prefix (e.g. "nsenter --target 1 --mount -- lsblk") and gpud
+	// appends the flags it controls.
+	lsblkCommand string
+
+	// blockdevUsageCommand overrides how block device usage/partitions are
+	// collected. Empty preserves the default behavior of enumerating mounts via
+	// gopsutil (/proc/self/mountinfo) and measuring usage via the statfs syscall.
+	// When set, it is used as the command prefix (e.g.
+	// "nsenter --target 1 --mount -- df") and gpud appends the flags it controls
+	// (-T -B1 -P) to collect partitions and usage from its output.
+	blockdevUsageCommand string
 }
 
 type MatchFunc func(fs string) bool
@@ -76,6 +98,40 @@ func WithSkipUsage() OpOption {
 func WithStatTimeout(timeout time.Duration) OpOption {
 	return func(op *Op) {
 		op.statTimeout = timeout
+	}
+}
+
+// WithFindmntCommand overrides how the "findmnt" binary is invoked.
+// Empty (the default) preserves the legacy behavior of locating "findmnt" on
+// PATH and running it directly. When set, the value is used as the command
+// prefix (e.g. "nsenter --target 1 --mount -- findmnt") so the command can run
+// in the host mount namespace; gpud still appends the flags it controls.
+func WithFindmntCommand(command string) OpOption {
+	return func(op *Op) {
+		op.findmntCommand = command
+	}
+}
+
+// WithLsblkCommand overrides how the "lsblk" binary is invoked.
+// Empty (the default) preserves the legacy behavior of locating "lsblk" on PATH
+// and running it directly. When set, the value is used as the command prefix
+// (e.g. "nsenter --target 1 --mount -- lsblk") so the command can run in the
+// host mount namespace; gpud still appends the flags it controls.
+func WithLsblkCommand(command string) OpOption {
+	return func(op *Op) {
+		op.lsblkCommand = command
+	}
+}
+
+// WithBlockdevUsageCommand overrides how block device partitions and usage are
+// collected. Empty (the default) preserves the legacy behavior of enumerating
+// mounts via gopsutil and measuring usage via the statfs syscall. When set, the
+// value is used as the command prefix (e.g. "nsenter --target 1 --mount -- df")
+// so the measurement can run in the host mount namespace; gpud appends the flags
+// it controls (-T -B1 -P) and parses the output.
+func WithBlockdevUsageCommand(command string) OpOption {
+	return func(op *Op) {
+		op.blockdevUsageCommand = command
 	}
 }
 

--- a/pkg/machine-info/machine_info.go
+++ b/pkg/machine-info/machine_info.go
@@ -4,6 +4,7 @@ package machineinfo
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"runtime"
 	"sort"
@@ -105,6 +106,19 @@ func GetMachineInfo(nvmlInstance nvidianvml.Instance) (*apiv1.MachineInfo, error
 	return info, nil
 }
 
+// uint64ToInt64Capped converts a uint64 to int64, capping at math.MaxInt64.
+// A bare int64(v) conversion wraps values above math.MaxInt64 to negative
+// numbers; capping keeps disk sizes/usage non-negative and monotonic. Real disk
+// sizes never legitimately exceed ~9.2 EB, so the cap is a safety bound rather
+// than an expected case. (Also satisfies CodeQL's incorrect-integer-conversion
+// check by bounding the value before the conversion.)
+func uint64ToInt64Capped(v uint64) int64 {
+	if v > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(v)
+}
+
 // GetSystemResourceRootVolumeTotal returns the system root disk resource of the machine
 // for the total disk size, using the type defined in "corev1.ResourceName"
 // in https://pkg.go.dev/k8s.io/api/core/v1#ResourceName.
@@ -119,7 +133,7 @@ func GetSystemResourceRootVolumeTotal() (string, error) {
 		return "", fmt.Errorf("failed to get disk usage: %w", err)
 	}
 
-	qty := resource.NewQuantity(int64(usage.TotalBytes), resource.DecimalSI)
+	qty := resource.NewQuantity(uint64ToInt64Capped(usage.TotalBytes), resource.DecimalSI)
 	return qty.String(), nil
 }
 
@@ -432,8 +446,8 @@ func GetMachineDiskInfo(ctx context.Context) (*apiv1.MachineDiskInfo, error) {
 		rs = append(rs, apiv1.MachineDiskDevice{
 			Name:       bd.Name,
 			Type:       bd.Type,
-			Size:       int64(bd.Size),
-			Used:       int64(bd.FSUsed),
+			Size:       uint64ToInt64Capped(bd.Size),
+			Used:       uint64ToInt64Capped(bd.FSUsed),
 			Rota:       bd.Rota,
 			Serial:     bd.Serial,
 			WWN:        bd.WWN,
@@ -468,8 +482,8 @@ func GetMachineDiskInfo(ctx context.Context) (*apiv1.MachineDiskInfo, error) {
 				FSType:     part.Fstype,
 			}
 			if part.Usage != nil {
-				dev.Size = int64(part.Usage.TotalBytes)
-				dev.Used = int64(part.Usage.UsedBytes)
+				dev.Size = uint64ToInt64Capped(part.Usage.TotalBytes)
+				dev.Used = uint64ToInt64Capped(part.Usage.UsedBytes)
 			}
 			rs = append(rs, dev)
 		}

--- a/pkg/machine-info/machine_info_test.go
+++ b/pkg/machine-info/machine_info_test.go
@@ -3,6 +3,7 @@ package machineinfo
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"runtime"
 	"strconv"
@@ -510,4 +511,25 @@ func TestGetMachineDiskInfo_FilterProviderSpecificPaths(t *testing.T) {
 	}
 
 	t.Logf("Verified %d block devices have no provider-specific mount points", len(info.BlockDevices))
+}
+
+func TestUint64ToInt64Capped(t *testing.T) {
+	tests := []struct {
+		name string
+		in   uint64
+		want int64
+	}{
+		{"zero", 0, 0},
+		{"small", 1024, 1024},
+		{"max int64", math.MaxInt64, math.MaxInt64},
+		{"max int64 plus one is capped", uint64(math.MaxInt64) + 1, math.MaxInt64},
+		{"max uint64 is capped", math.MaxUint64, math.MaxInt64},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := uint64ToInt64Capped(tt.in)
+			assert.Equal(t, tt.want, got)
+			assert.GreaterOrEqual(t, got, int64(0), "result must never be negative")
+		})
+	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -305,6 +305,12 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *lepconfig.Con
 		MountPoints:  []string{"/"},
 		MountTargets: []string{"/var/lib/kubelet"},
 
+		FindmntCommands:       config.FindmntCommands,
+		LsblkCommands:         config.LsblkCommands,
+		BlockdevUsageCommands: config.BlockdevUsageCommands,
+
+		ContainerdServiceActiveCommands: config.ContainerdServiceActiveCommands,
+
 		FailureInjector: config.FailureInjector,
 	}
 	if s.gpudInstance.MachineID == "" {


### PR DESCRIPTION
## Summary

Make the GPUd disk component report the **node's real disks** when GPUd runs inside a container (e.g. a privileged DaemonSet), and replace the prior overlay-root workaround with a proper, configurable fix.

## Problem

Inside a container, the disk component's host tools run in the **container's** mount namespace, so they describe the container's overlay rootfs instead of the node:

- `findmnt --target / --json --df` returns nothing (overlay is a pseudo filesystem that `--df` filters out) and **exits 1**, failing the disk check.
- `lsblk` misses the node's data disks and reports empty fstypes.
- `statfs(path)` falls through to the overlay — e.g. reporting **124G for a 2.8T** data disk.

## Change

Add configurable command overrides so the disk component can run its host tools in the **host mount namespace** (via `nsenter`), mirroring the existing `--reboot-commands` pattern.

**`gpud run` flags (new):** `--findmnt-commands`, `--lsblk-commands`, `--blockdev-usage-commands`
Plumbed `cmd/gpud` → `pkg/config` → `pkg/server` → `GPUdInstance` → disk component → `pkg/disk`.

**`pkg/disk`:**
- `FindMntWithCommand` and an `lsblk` command override (run the configured invocation prefix; GPUd appends the flags it controls).
- A `df`-based partitions/usage path (`df -T -B1 -P`) that replaces gopsutil enumeration + `statfs` when the override is set.

**Helm chart:**
- New `gpud.findmntCommands` / `gpud.lsblkCommands` / `gpud.blockdevUsageCommands` values, defaulted to `nsenter --target 1 --mount -- {findmnt,lsblk,df}` and wired into the DaemonSet startup (env + flags), gated like `rebootCommands`.
- Document DaemonSet **reboot** and **disk inspection** configuration in the chart README; bump chart to **v0.12.2**; note the BYOK machine-id node label.

**Docker:** keep a runtime-stage guard verifying `findmnt` is present in the image.

## Backward compatibility (strict invariant)

When a flag is **unset** (the default), every code path falls through to the **exact legacy behavior** — locate `findmnt`/`lsblk` on `PATH` and run them directly, enumerate via gopsutil, and measure usage via `statfs`. Behavior on bare-metal / host GPUd is unchanged. Helm renders **no** disk env/flags when a value is empty.

## Revert of the `--all` band-aid

This branch previously added `findmnt --df --all` to force the container overlay into `--df` output. With the host-namespace fix, `findmnt --target X --json --df` (matching `main`) works on real filesystems, and `--all` only masked the container-overlay case with **misleading data** (`overlay` instead of `/dev/sda1 ext4`). The default `findmnt` command is restored to `main`'s.

## Tests

- `pkg/disk` unit tests: `df` output parser, partition filtering, option setters, command builders, and the **empty-flag == legacy-path** invariant.
- Validated on a live BYOK (AKS) cluster: `nsenter`-wrapped `findmnt`/`lsblk`/`df` report the node's real ext4 root and 2.8T data disk; `df -T -B1 -P` column order matches the parser.
- `go build` / `go vet` clean; touched-package tests pass; `helm lint` and `helm template` (default + empty-override) verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
