### PR TITLE
[LEP-5117] fix(server, session): report invalid GPUd tokens as auth failures

### DIFF
--- a/pkg/server/mock_server_coverage_test.go
+++ b/pkg/server/mock_server_coverage_test.go
@@ -297,6 +297,55 @@ func TestUpdateToken_PipeReadAndSessionRecreateBranches_WithMockey(t *testing.T)
 	})
 }
 
+func TestUpdateToken_PipeReadErrorDoesNotReuseInitialToken(t *testing.T) {
+	mockey.PatchConvey("updateToken does not recreate a session from a stale token after pipe read error", t, func() {
+		s := &Server{
+			machineID:         "machine-1",
+			epLocalGPUdServer: "https://local",
+			epControlPlane:    "https://control",
+			fifoPath:          "/tmp/gpud-fifo-test",
+			gpudInstance:      &components.GPUdInstance{},
+		}
+		userToken := &UserToken{}
+
+		_, w, err := os.Pipe()
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+
+		mockey.Mock(pkgmetadata.ReadToken).To(func(_ context.Context, _ *sql.DB) (string, error) {
+			return "db-token", nil
+		}).Build()
+		mockey.Mock(os.Stat).To(func(_ string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist
+		}).Build()
+		mockey.Mock(syscall.Mkfifo).To(func(_ string, _ uint32) error {
+			return nil
+		}).Build()
+
+		openCalls := 0
+		mockey.Mock(os.OpenFile).To(func(_ string, _ int, _ os.FileMode) (*os.File, error) {
+			openCalls++
+			if openCalls == 1 {
+				return w, nil
+			}
+			return nil, errors.New("open failed")
+		}).Build()
+
+		var tokens []string
+		mockey.Mock(pkgsession.NewSession).To(func(_ context.Context, _, _, token string, _ ...pkgsession.OpOption) (*pkgsession.Session, error) {
+			tokens = append(tokens, token)
+			return nil, errors.New("session create failed")
+		}).Build()
+
+		mockey.Mock(time.Sleep).To(func(_ time.Duration) {}).Build()
+
+		s.updateToken(context.Background(), nil, userToken)
+
+		require.Len(t, tokens, 1)
+		assert.Equal(t, "db-token", tokens[0])
+	})
+}
+
 func TestUpdateToken_PipeReadErrorAndStatErrorBranches_WithMockey(t *testing.T) {
 	t.Run("pipe read error", func(t *testing.T) {
 		mockey.PatchConvey("updateToken handles pipe read error path", t, func() {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -640,16 +640,21 @@ func (s *Server) updateToken(ctx context.Context, metricsStore pkgmetrics.Store,
 			return
 		}
 		buffer := make([]byte, 1024)
+		pipeToken := ""
 		if n, err := pipe.Read(buffer); err != nil {
 			log.Logger.Errorf("error reading pipe: %v", err)
 		} else {
-			userToken = string(buffer[:n])
+			pipeToken = string(buffer[:n])
 		}
 
 		if err := pipe.Close(); err != nil {
 			log.Logger.Errorf("error closing pipe: %v", err)
 		}
-		if userToken != "" {
+		if pipeToken != "" {
+			// WHY: userToken may still hold the startup DB token; after a FIFO
+			// read error, recreating the session with that stale value would
+			// hide the actual failed token handoff.
+			userToken = pipeToken
 			token.mu.Lock()
 			token.userToken = userToken
 			token.mu.Unlock()

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -543,17 +543,9 @@ func (s *Session) startReader(ctx context.Context, readerExit chan any, jar *coo
 	if resp.StatusCode != http.StatusOK {
 		log.Logger.Warnw("session reader: request resp not ok -- retrying", "status", resp.Status, "statusCode", resp.StatusCode)
 
-		// Persist authentication-related failures to session_states so "gpud status" surfaces them.
-		// The server returns 401/403 for auth errors, but may also return 500 with
-		// "failed to validate token" when the token is invalid (server-side bug).
 		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusInternalServerError {
 			bodyBytes, _ := io.ReadAll(resp.Body)
-			body := string(bodyBytes)
-			if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized || strings.Contains(body, "failed to validate token") {
-				message := fmt.Sprintf("HTTP %d: %s", resp.StatusCode, body)
-				if len(message) > 500 {
-					message = message[:500]
-				}
+			if message, ok := loginFailureStatusMessage(resp.StatusCode, string(bodyBytes)); ok {
 				s.persistLoginStatus(ctx, false, message)
 			}
 		}
@@ -578,6 +570,48 @@ type healthCheckHTTPError struct {
 
 func (e *healthCheckHTTPError) Error() string {
 	return fmt.Sprintf("server health check failed: HTTP %d: %s", e.statusCode, e.body)
+}
+
+const tokenValidationFailureMessage = "failed to validate token"
+
+func loginFailureStatusMessage(statusCode int, body string) (string, bool) {
+	switch statusCode {
+	case http.StatusForbidden, http.StatusUnauthorized:
+	case http.StatusInternalServerError:
+		if !strings.Contains(body, tokenValidationFailureMessage) {
+			return "", false
+		}
+
+		// WHY: some gpud-manager deployments wrap invalid-token validation as
+		// HTTP 500/InternalFailure. `gpud status` is operator-facing, so report
+		// the authentication cause instead of making a bad token look like a
+		// control-plane outage.
+		statusCode = http.StatusUnauthorized
+		body = invalidTokenStatusBody(body)
+	default:
+		return "", false
+	}
+
+	message := fmt.Sprintf("HTTP %d: %s", statusCode, body)
+	if len(message) > 500 {
+		message = message[:500]
+	}
+	return message, true
+}
+
+func invalidTokenStatusBody(body string) string {
+	payload := make(map[string]any)
+	if err := json.Unmarshal([]byte(body), &payload); err == nil {
+		payload["code"] = "InvalidToken"
+		if _, ok := payload["message"]; !ok {
+			payload["message"] = tokenValidationFailureMessage
+		}
+		if normalized, err := json.Marshal(payload); err == nil {
+			return string(normalized)
+		}
+	}
+
+	return `{"code":"InvalidToken","message":"failed to validate token"}`
 }
 
 func (s *Session) checkServerHealth(ctx context.Context, jar *cookiejar.Jar, token string) error {

--- a/pkg/session/session_keepalive.go
+++ b/pkg/session/session_keepalive.go
@@ -3,10 +3,7 @@ package session
 import (
 	"context"
 	"errors"
-	"fmt"
-	"net/http"
 	"net/http/cookiejar"
-	"strings"
 	"time"
 
 	"github.com/leptonai/gpud/pkg/log"
@@ -81,8 +78,8 @@ func (s *Session) keepAlive() {
 				// "failed to validate token" when the token is invalid.
 				var httpErr *healthCheckHTTPError
 				if errors.As(err, &httpErr) {
-					if httpErr.statusCode == http.StatusForbidden || httpErr.statusCode == http.StatusUnauthorized || strings.Contains(httpErr.body, "failed to validate token") {
-						s.persistLoginStatus(ctx, false, fmt.Sprintf("HTTP %d: %s", httpErr.statusCode, httpErr.body))
+					if message, ok := loginFailureStatusMessage(httpErr.statusCode, httpErr.body); ok {
+						s.persistLoginStatus(ctx, false, message)
 					}
 				}
 

--- a/pkg/session/session_keepalive_health_check_test.go
+++ b/pkg/session/session_keepalive_health_check_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/cookiejar"
+	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -103,8 +105,8 @@ func TestKeepAliveHealthCheck403PersistsFailure(t *testing.T) {
 
 // TestKeepAliveHealthCheck500TokenValidationPersistsFailure verifies that when
 // checkServerHealth returns an HTTP 500 error with "failed to validate token" body,
-// the keepAlive loop persists the failure to session_states. The control plane may
-// return 500 instead of 403 for auth failures (server-side bug).
+// the keepAlive loop persists an authentication failure to session_states. The
+// control plane may return 500 instead of 401/403 for auth failures (server-side bug).
 func TestKeepAliveHealthCheck500TokenValidationPersistsFailure(t *testing.T) {
 	tmpDir := t.TempDir()
 
@@ -172,8 +174,111 @@ func TestKeepAliveHealthCheck500TokenValidationPersistsFailure(t *testing.T) {
 	require.NotNil(t, state, "Expected session state to be persisted for 500 with token validation failure")
 
 	assert.False(t, state.Success, "Session state should indicate failure")
-	assert.Contains(t, state.Message, "HTTP 500")
+	assert.Contains(t, state.Message, "HTTP 401")
+	assert.Contains(t, state.Message, "InvalidToken")
 	assert.Contains(t, state.Message, "failed to validate token")
+	assert.NotContains(t, state.Message, "HTTP 500")
+	assert.NotContains(t, state.Message, "InternalFailure")
+}
+
+func TestStartReader500TokenValidationPersistsAuthenticationFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	stateFile := tmpDir + "/gpud.state"
+	dbSetup, err := sqlite.Open(stateFile)
+	require.NoError(t, err)
+	require.NoError(t, sessionstates.CreateTable(context.Background(), dbSetup))
+	require.NoError(t, dbSetup.Close())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "read", r.Header.Get("X-GPUD-Session-Type"))
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"code":"InternalFailure","message":"failed to validate token"}`))
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	s := &Session{
+		ctx:            ctx,
+		dataDir:        tmpDir,
+		epControlPlane: server.URL,
+		machineID:      "machine-id",
+		token:          "bad-token",
+		closer:         &closeOnce{closer: make(chan any)},
+	}
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+
+	readerExit := make(chan any)
+	s.startReader(ctx, readerExit, jar)
+
+	dbRO, err := sqlite.Open(stateFile, sqlite.WithReadOnly(true))
+	require.NoError(t, err)
+	defer func() { _ = dbRO.Close() }()
+
+	state, err := sessionstates.ReadLast(context.Background(), dbRO)
+	require.NoError(t, err)
+	require.NotNil(t, state, "Expected session state to be persisted for reader auth failure")
+
+	assert.False(t, state.Success)
+	assert.Contains(t, state.Message, "HTTP 401")
+	assert.Contains(t, state.Message, "InvalidToken")
+	assert.Contains(t, state.Message, "failed to validate token")
+	assert.NotContains(t, state.Message, "HTTP 500")
+	assert.NotContains(t, state.Message, "InternalFailure")
+}
+
+func TestLoginFailureStatusMessage(t *testing.T) {
+	t.Run("preserves forbidden auth failure", func(t *testing.T) {
+		message, ok := loginFailureStatusMessage(http.StatusForbidden, `{"code":"Unauthorized","message":"failed to validate token"}`)
+		require.True(t, ok)
+		assert.Contains(t, message, "HTTP 403")
+		assert.Contains(t, message, "Unauthorized")
+		assert.Contains(t, message, "failed to validate token")
+	})
+
+	t.Run("normalizes internal failure token validation body", func(t *testing.T) {
+		message, ok := loginFailureStatusMessage(http.StatusInternalServerError, `{"code":"InternalFailure","message":"failed to validate token"}`)
+		require.True(t, ok)
+		assert.Contains(t, message, "HTTP 401")
+		assert.Contains(t, message, "InvalidToken")
+		assert.Contains(t, message, "failed to validate token")
+		assert.NotContains(t, message, "InternalFailure")
+	})
+
+	t.Run("normalizes non-json token validation body", func(t *testing.T) {
+		message, ok := loginFailureStatusMessage(http.StatusInternalServerError, "failed to validate token")
+		require.True(t, ok)
+		assert.Equal(t, `HTTP 401: {"code":"InvalidToken","message":"failed to validate token"}`, message)
+	})
+
+	t.Run("adds missing message when normalizing json body", func(t *testing.T) {
+		message, ok := loginFailureStatusMessage(http.StatusInternalServerError, `{"code":"InternalFailure","detail":"failed to validate token"}`)
+		require.True(t, ok)
+		assert.Contains(t, message, "HTTP 401")
+		assert.Contains(t, message, "InvalidToken")
+		assert.Contains(t, message, `"message":"failed to validate token"`)
+		assert.Contains(t, message, `"detail":"failed to validate token"`)
+	})
+
+	t.Run("does not persist unrelated internal failure", func(t *testing.T) {
+		_, ok := loginFailureStatusMessage(http.StatusInternalServerError, `{"code":"InternalFailure","message":"database unavailable"}`)
+		assert.False(t, ok)
+	})
+
+	t.Run("does not persist unrelated status", func(t *testing.T) {
+		_, ok := loginFailureStatusMessage(http.StatusTeapot, `{"code":"Teapot","message":"failed to validate token"}`)
+		assert.False(t, ok)
+	})
+
+	t.Run("truncates long messages", func(t *testing.T) {
+		body := `{"code":"InternalFailure","message":"failed to validate token ` + strings.Repeat("x", 600) + `"}`
+		message, ok := loginFailureStatusMessage(http.StatusInternalServerError, body)
+		require.True(t, ok)
+		assert.Len(t, message, 500)
+		assert.Contains(t, message, "HTTP 401")
+	})
 }
 
 // TestKeepAliveHealthCheckNon403DoesNotPersist verifies that non-403 health check


### PR DESCRIPTION
## Summary
- Normalize gpud-manager 500/InternalFailure token-validation responses before persisting login/session status.
- Keep generic HTTP 500 responses transient/unpersisted so `gpud status` does not misclassify control-plane outages as auth failures.
- Fix a secondary FIFO token handoff edge where a pipe read error could reuse an older DB token.

## Root Cause
LEP-5117 reproduces by storing an invalid session token, restarting gpud, and checking `gpud status`. On restart, `Session.keepAlive` calls the control-plane health check before opening reader/writer streams. Some gpud-manager deployments can return `HTTP 500 {"code":"InternalFailure","message":"failed to validate token"}` for invalid-token validation. GPUd persisted that literal 500 into `session_states`, so `gpud status` reported an internal failure instead of an authentication failure.

Control-plane context checked in `~/leptonai/lepton/gpud-manager`: `server/internal/auth.ValidateToken` returns 401 for recognized token errors, but can still return 500/InternalFailure with `failed to validate token` for other validator errors. GPUd status is operator-facing, so it now normalizes that known body to `HTTP 401 {"code":"InvalidToken","message":"failed to validate token"}` while leaving unrelated 500s alone.

## Fix
- Add a shared session-status formatter used by both keepalive health checks and reader non-OK responses.
- Preserve real 401/403 responses as-is.
- Convert only 500 responses containing `failed to validate token` into an auth-class status message.
- Add tests for the Jira health-check path and reader path.
- Add a small FIFO read-error guard with an inline WHY comment so stale startup DB tokens are not reused after failed FIFO reads.

## Validation
- `codegraph init -i && codegraph sync`
- `git diff --check`
- `go test -count=1 -gcflags="all=-N -l" ./pkg/session -run 'TestLoginFailureStatusMessage|TestKeepAliveHealthCheck|TestStartReader500TokenValidation|TestHealthCheckHTTPError'`
- `go test -count=1 -gcflags="all=-N -l" ./pkg/server -run 'TestUpdateToken_PipeRead'`
- `go test -count=1 -gcflags="all=-N -l" ./pkg/session ./pkg/server`
- `go test -count=1 -coverprofile=/private/tmp/gpud-session.cover -gcflags="all=-N -l" ./pkg/session -run 'TestLoginFailureStatusMessage|TestKeepAliveHealthCheck|TestStartReader500TokenValidation|TestHealthCheckHTTPError'`
- `go tool cover -func=/private/tmp/gpud-session.cover`
- `go test -race -count=1 -gcflags="all=-N -l -d=checkptr=0" ./pkg/session -run 'TestLoginFailureStatusMessage|TestKeepAliveHealthCheck|TestStartReader500TokenValidation|TestHealthCheckHTTPError'`
- `go test -race -count=1 -gcflags="all=-N -l -d=checkptr=0" ./pkg/server -run 'TestUpdateToken_PipeRead'`
- `go vet -v ./pkg/session ./pkg/server`
