### PR TITLE
feat(login, helm): re-register on machine-id change and refresh session token

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -103,14 +103,14 @@ nohup sudo gpud run &>> <your log file path> &
 				cli.BoolFlag{
 					Name:   "machine-id-overwrite",
 					Hidden: true,
-					Usage:  "(optional) when --machine-id differs from the persisted machine id, discard the persisted login identity (machine id + session token) and re-register as the NEW machine instead of failing. Health/system state (reboot history, events) is preserved. Use for the container/DaemonSet pattern where a node can be deleted from its node group and rejoined with a new machine object.",
+					Usage:  "(optional) when --machine-id differs from the persisted machine id, discard the persisted login identity (machine id + session token) and check in with the requested machine instead of failing. Health/system state (reboot history, events) is preserved. Use for the container/DaemonSet pattern where a node can be deleted from its node group and rejoined with a new machine object.",
 				},
 				// TODO: once validated in production, make session-token refresh the default
 				// behavior (always re-login on start) and remove this flag.
 				cli.BoolFlag{
 					Name:   "refresh-session-token",
 					Hidden: true,
-					Usage:  "(optional) on every start, re-run login to re-fetch the session token from the control plane instead of reusing the persisted one (skips the 'machine id already assigned' fast path). Use for the container/DaemonSet pattern so a restarted node always gets a current session token; the persisted token can otherwise go stale after a server-side session reset or a workspace token rotation.",
+					Usage:  "(optional) on every start, re-run login to re-fetch the current session token from the control plane instead of reusing the persisted one (skips the 'machine id already assigned' fast path). Use for the container/DaemonSet pattern after a workspace token rotation.",
 				},
 				cli.StringFlag{
 					Name:  "node-group",
@@ -183,14 +183,14 @@ sudo rm /etc/systemd/system/gpud.service
 				&cli.BoolFlag{
 					Name:   "machine-id-overwrite",
 					Hidden: true,
-					Usage:  "(optional) when --machine-id differs from the persisted machine id, discard the persisted login identity (machine id + session token) and re-register as the NEW machine instead of failing. Health/system state (reboot history, events) is preserved. Use for the container/DaemonSet pattern where a node can be deleted from its node group and rejoined with a new machine object.",
+					Usage:  "(optional) when --machine-id differs from the persisted machine id, discard the persisted login identity (machine id + session token) and check in with the requested machine instead of failing. Health/system state (reboot history, events) is preserved. Use for the container/DaemonSet pattern where a node can be deleted from its node group and rejoined with a new machine object.",
 				},
 				// TODO: once validated in production, make session-token refresh the default
 				// behavior (always re-login on start) and remove this flag.
 				&cli.BoolFlag{
 					Name:   "refresh-session-token",
 					Hidden: true,
-					Usage:  "(optional) on every start, re-run login to re-fetch the session token from the control plane instead of reusing the persisted one (skips the 'machine id already assigned' fast path). Use for the container/DaemonSet pattern so a restarted node always gets a current session token; the persisted token can otherwise go stale after a server-side session reset or a workspace token rotation.",
+					Usage:  "(optional) on every start, re-run login to re-fetch the current session token from the control plane instead of reusing the persisted one (skips the 'machine id already assigned' fast path). Use for the container/DaemonSet pattern after a workspace token rotation.",
 				},
 				&cli.StringFlag{
 					Name:   "token",

--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -98,7 +98,19 @@ nohup sudo gpud run &>> <your log file path> &
 				cli.StringFlag{
 					Name:   "machine-id",
 					Hidden: true,
-					Usage:  "(optional) for override default machine id",
+					Usage:  "(optional) machine id to register/run as. If it matches the machine id already persisted in the state DB, login is skipped (reused across reboots). If it DIFFERS from the persisted one, login fails unless --machine-id-overwrite is set -- this prevents silently retargeting an already-registered node.",
+				},
+				cli.BoolFlag{
+					Name:   "machine-id-overwrite",
+					Hidden: true,
+					Usage:  "(optional) when --machine-id differs from the persisted machine id, discard the persisted login identity (machine id + session token) and re-register as the NEW machine instead of failing. Health/system state (reboot history, events) is preserved. Use for the container/DaemonSet pattern where a node can be deleted from its node group and rejoined with a new machine object.",
+				},
+				// TODO: once validated in production, make session-token refresh the default
+				// behavior (always re-login on start) and remove this flag.
+				cli.BoolFlag{
+					Name:   "refresh-session-token",
+					Hidden: true,
+					Usage:  "(optional) on every start, re-run login to re-fetch the session token from the control plane instead of reusing the persisted one (skips the 'machine id already assigned' fast path). Use for the container/DaemonSet pattern so a restarted node always gets a current session token; the persisted token can otherwise go stale after a server-side session reset or a workspace token rotation.",
 				},
 				cli.StringFlag{
 					Name:  "node-group",
@@ -166,7 +178,19 @@ sudo rm /etc/systemd/system/gpud.service
 				&cli.StringFlag{
 					Name:   "machine-id",
 					Hidden: true,
-					Usage:  "(optional) for override default machine id",
+					Usage:  "(optional) machine id to register/run as. If it matches the machine id already persisted in the state DB, login is skipped (reused across reboots). If it DIFFERS from the persisted one, login fails unless --machine-id-overwrite is set -- this prevents silently retargeting an already-registered node.",
+				},
+				&cli.BoolFlag{
+					Name:   "machine-id-overwrite",
+					Hidden: true,
+					Usage:  "(optional) when --machine-id differs from the persisted machine id, discard the persisted login identity (machine id + session token) and re-register as the NEW machine instead of failing. Health/system state (reboot history, events) is preserved. Use for the container/DaemonSet pattern where a node can be deleted from its node group and rejoined with a new machine object.",
+				},
+				// TODO: once validated in production, make session-token refresh the default
+				// behavior (always re-login on start) and remove this flag.
+				&cli.BoolFlag{
+					Name:   "refresh-session-token",
+					Hidden: true,
+					Usage:  "(optional) on every start, re-run login to re-fetch the session token from the control plane instead of reusing the persisted one (skips the 'machine id already assigned' fast path). Use for the container/DaemonSet pattern so a restarted node always gets a current session token; the persisted token can otherwise go stale after a server-side session reset or a workspace token rotation.",
 				},
 				&cli.StringFlag{
 					Name:   "token",

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -80,7 +80,7 @@ func Command(cliContext *cli.Context) error {
 	controlPlaneLoginRegistrationToken := cliContext.String("token")
 
 	machineIDForOverride := cliContext.String("machine-id")
-	machineIDOverwrite := cliContext.Bool("machine-id-overwrite")
+	shouldOverwriteMachineID := cliContext.Bool("machine-id-overwrite")
 	refreshSessionToken := cliContext.Bool("refresh-session-token")
 	controlPlaneLoginSucceeded := false
 
@@ -98,7 +98,7 @@ func Command(cliContext *cli.Context) error {
 			Token:               controlPlaneLoginRegistrationToken,
 			Endpoint:            controlPlaneEndpoint,
 			MachineID:           machineIDForOverride,
-			MachineIDOverwrite:  machineIDOverwrite,
+			MachineIDOverwrite:  shouldOverwriteMachineID,
 			RefreshSessionToken: refreshSessionToken,
 			DataDir:             dataDir,
 
@@ -381,7 +381,7 @@ func Command(cliContext *cli.Context) error {
 		mctx, mcancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer mcancel()
 
-		if err := persistMetadataOverrides(mctx, cfg.State, controlPlaneEndpoint, machineIDForOverride, machineIDOverwrite, controlPlaneLoginSucceeded); err != nil {
+		if err := persistMetadataOverrides(mctx, cfg.State, controlPlaneEndpoint, machineIDForOverride, shouldOverwriteMachineID, controlPlaneLoginSucceeded); err != nil {
 			return err
 		}
 	}

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -80,6 +80,8 @@ func Command(cliContext *cli.Context) error {
 	controlPlaneLoginRegistrationToken := cliContext.String("token")
 
 	machineIDForOverride := cliContext.String("machine-id")
+	machineIDOverwrite := cliContext.Bool("machine-id-overwrite")
+	refreshSessionToken := cliContext.Bool("refresh-session-token")
 
 	// Note: login.Login() ALWAYS writes to the persistent state file (via dataDir),
 	// regardless of --db-in-memory flag. The login package doesn't know about in-memory mode.
@@ -92,10 +94,12 @@ func Command(cliContext *cli.Context) error {
 		defer loginCancel()
 
 		loginCfg := login.LoginConfig{
-			Token:     controlPlaneLoginRegistrationToken,
-			Endpoint:  controlPlaneEndpoint,
-			MachineID: machineIDForOverride,
-			DataDir:   dataDir,
+			Token:               controlPlaneLoginRegistrationToken,
+			Endpoint:            controlPlaneEndpoint,
+			MachineID:           machineIDForOverride,
+			MachineIDOverwrite:  machineIDOverwrite,
+			RefreshSessionToken: refreshSessionToken,
+			DataDir:             dataDir,
 
 			GPUCount: gpuCountStr,
 		}
@@ -399,10 +403,27 @@ func Command(cliContext *cli.Context) error {
 		// NOT the registration token
 
 		if machineIDForOverride != "" {
-			if err := pkgmetadata.SetMetadata(mctx, dbRW, pkgmetadata.MetadataKeyMachineID, machineIDForOverride); err != nil {
-				return fmt.Errorf("failed to set machine-id metadata: %w", err)
+			// Mirror login.Login's reconciliation for the override path (e.g. when
+			// login was skipped or not performed): only REPLACE a differing persisted
+			// machine id when --machine-id-overwrite is set; otherwise fail rather
+			// than silently retarget the node. (When login.Login already re-registered
+			// as the new machine, the persisted id matches here and this is a no-op.)
+			prevMachineID, rerr := pkgmetadata.ReadMetadata(mctx, dbRW, pkgmetadata.MetadataKeyMachineID)
+			if rerr != nil {
+				return fmt.Errorf("failed to read persisted machine-id: %w", rerr)
 			}
-			log.Logger.Infow("overriding machine id from flag", "machineID", machineIDForOverride)
+			if prevMachineID != "" && prevMachineID != machineIDForOverride && !machineIDOverwrite {
+				return fmt.Errorf("persisted machine ID %q differs from --machine-id %q; pass --machine-id-overwrite to replace it", prevMachineID, machineIDForOverride)
+			}
+			if prevMachineID != machineIDForOverride {
+				if prevMachineID != "" {
+					log.Logger.Warnw("!!! MACHINE ID OVERWRITE !!! replacing persisted machine id from flag", "old", prevMachineID, "new", machineIDForOverride)
+				}
+				if err := pkgmetadata.SetMetadata(mctx, dbRW, pkgmetadata.MetadataKeyMachineID, machineIDForOverride); err != nil {
+					return fmt.Errorf("failed to set machine-id metadata: %w", err)
+				}
+				log.Logger.Infow("overriding machine id from flag", "machineID", machineIDForOverride)
+			}
 		}
 	}
 

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -82,6 +82,7 @@ func Command(cliContext *cli.Context) error {
 	machineIDForOverride := cliContext.String("machine-id")
 	machineIDOverwrite := cliContext.Bool("machine-id-overwrite")
 	refreshSessionToken := cliContext.Bool("refresh-session-token")
+	controlPlaneLoginSucceeded := false
 
 	// Note: login.Login() ALWAYS writes to the persistent state file (via dataDir),
 	// regardless of --db-in-memory flag. The login package doesn't know about in-memory mode.
@@ -108,6 +109,7 @@ func Command(cliContext *cli.Context) error {
 		if lerr := login.Login(loginCtx, loginCfg); lerr != nil {
 			return lerr
 		}
+		controlPlaneLoginSucceeded = true
 		log.Logger.Infow("successfully logged in in gpud run")
 
 		if err := recordLoginSuccessState(loginCtx, dataDir); err != nil {
@@ -379,51 +381,8 @@ func Command(cliContext *cli.Context) error {
 		mctx, mcancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer mcancel()
 
-		dbRW, err := pkgsqlite.Open(cfg.State)
-		if err != nil {
-			return fmt.Errorf("failed to open state for metadata overrides: %w", err)
-		}
-		defer func() {
-			_ = dbRW.Close()
-		}()
-
-		if err := pkgmetadata.CreateTableMetadata(mctx, dbRW); err != nil {
-			return fmt.Errorf("failed to ensure metadata table: %w", err)
-		}
-
-		if controlPlaneEndpoint != "" {
-			if err := pkgmetadata.SetMetadata(mctx, dbRW, pkgmetadata.MetadataKeyEndpoint, controlPlaneEndpoint); err != nil {
-				return fmt.Errorf("failed to set endpoint metadata: %w", err)
-			}
-			log.Logger.Infow("overriding endpoint from flag", "endpoint", controlPlaneEndpoint)
-		}
-
-		// DO NOT overwrite "pkgmetadata.MetadataKeyToken"
-		// because successful login operation will persist the session token in the metadata
-		// NOT the registration token
-
-		if machineIDForOverride != "" {
-			// Mirror login.Login's reconciliation for the override path (e.g. when
-			// login was skipped or not performed): only REPLACE a differing persisted
-			// machine id when --machine-id-overwrite is set; otherwise fail rather
-			// than silently retarget the node. (When login.Login already re-registered
-			// as the new machine, the persisted id matches here and this is a no-op.)
-			prevMachineID, rerr := pkgmetadata.ReadMetadata(mctx, dbRW, pkgmetadata.MetadataKeyMachineID)
-			if rerr != nil {
-				return fmt.Errorf("failed to read persisted machine-id: %w", rerr)
-			}
-			if prevMachineID != "" && prevMachineID != machineIDForOverride && !machineIDOverwrite {
-				return fmt.Errorf("persisted machine ID %q differs from --machine-id %q; pass --machine-id-overwrite to replace it", prevMachineID, machineIDForOverride)
-			}
-			if prevMachineID != machineIDForOverride {
-				if prevMachineID != "" {
-					log.Logger.Warnw("!!! MACHINE ID OVERWRITE !!! replacing persisted machine id from flag", "old", prevMachineID, "new", machineIDForOverride)
-				}
-				if err := pkgmetadata.SetMetadata(mctx, dbRW, pkgmetadata.MetadataKeyMachineID, machineIDForOverride); err != nil {
-					return fmt.Errorf("failed to set machine-id metadata: %w", err)
-				}
-				log.Logger.Infow("overriding machine id from flag", "machineID", machineIDForOverride)
-			}
+		if err := persistMetadataOverrides(mctx, cfg.State, controlPlaneEndpoint, machineIDForOverride, machineIDOverwrite, controlPlaneLoginSucceeded); err != nil {
+			return err
 		}
 	}
 
@@ -474,6 +433,66 @@ func Command(cliContext *cli.Context) error {
 	log.Logger.Infow("successfully booted", "tookSeconds", time.Since(start).Seconds())
 	<-done
 
+	return nil
+}
+
+func validateMachineIDOverride(prevMachineID, requestedMachineID string, overwrite, controlPlaneLoginSucceeded bool) error {
+	if prevMachineID == "" || prevMachineID == requestedMachineID {
+		return nil
+	}
+	if !overwrite {
+		return fmt.Errorf("persisted machine ID %q differs from --machine-id %q; pass --machine-id-overwrite to replace it", prevMachineID, requestedMachineID)
+	}
+	if !controlPlaneLoginSucceeded {
+		return fmt.Errorf("cannot overwrite persisted machine ID %q with --machine-id %q without a successful control-plane login; pass --token so gpud can check in to the requested machine", prevMachineID, requestedMachineID)
+	}
+	return nil
+}
+
+func persistMetadataOverrides(ctx context.Context, stateFile, controlPlaneEndpoint, machineIDForOverride string, machineIDOverwrite, controlPlaneLoginSucceeded bool) error {
+	dbRW, err := pkgsqlite.Open(stateFile)
+	if err != nil {
+		return fmt.Errorf("failed to open state for metadata overrides: %w", err)
+	}
+	defer func() {
+		_ = dbRW.Close()
+	}()
+
+	if err := pkgmetadata.CreateTableMetadata(ctx, dbRW); err != nil {
+		return fmt.Errorf("failed to ensure metadata table: %w", err)
+	}
+
+	if controlPlaneEndpoint != "" {
+		if err := pkgmetadata.SetMetadata(ctx, dbRW, pkgmetadata.MetadataKeyEndpoint, controlPlaneEndpoint); err != nil {
+			return fmt.Errorf("failed to set endpoint metadata: %w", err)
+		}
+		log.Logger.Infow("overriding endpoint from flag", "endpoint", controlPlaneEndpoint)
+	}
+
+	if machineIDForOverride == "" {
+		return nil
+	}
+
+	prevMachineID, err := pkgmetadata.ReadMetadata(ctx, dbRW, pkgmetadata.MetadataKeyMachineID)
+	if err != nil {
+		return fmt.Errorf("failed to read persisted machine-id: %w", err)
+	}
+	if err := validateMachineIDOverride(prevMachineID, machineIDForOverride, machineIDOverwrite, controlPlaneLoginSucceeded); err != nil {
+		return err
+	}
+
+	// A successful control-plane login persists the machine ID returned by the
+	// control plane. Do not overwrite that authoritative result with the CLI
+	// value. The no-login path keeps the historical behavior of recording an
+	// initial machine-id override locally.
+	if prevMachineID == machineIDForOverride || controlPlaneLoginSucceeded {
+		return nil
+	}
+
+	if err := pkgmetadata.SetMetadata(ctx, dbRW, pkgmetadata.MetadataKeyMachineID, machineIDForOverride); err != nil {
+		return fmt.Errorf("failed to set machine-id metadata: %w", err)
+	}
+	log.Logger.Infow("overriding machine id from flag", "machineID", machineIDForOverride)
 	return nil
 }
 

--- a/cmd/gpud/run/command_test.go
+++ b/cmd/gpud/run/command_test.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"context"
 	"flag"
 	"testing"
 	"time"
@@ -10,6 +11,8 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/leptonai/gpud/pkg/config"
+	pkgmetadata "github.com/leptonai/gpud/pkg/metadata"
+	pkgsqlite "github.com/leptonai/gpud/pkg/sqlite"
 )
 
 func TestParseInfinibandExcludeDevices(t *testing.T) {
@@ -125,6 +128,113 @@ func TestParseRetentionPeriods(t *testing.T) {
 			metrics, events := parseRetentionPeriods(ctx)
 			assert.Equal(t, tt.expectMetrics, metrics)
 			assert.Equal(t, tt.expectEvents, events)
+		})
+	}
+}
+
+func TestPersistMetadataOverrides(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                       string
+		persistedMachineID         string
+		persistedToken             string
+		controlPlaneEndpoint       string
+		requestedMachineID         string
+		machineIDOverwrite         bool
+		controlPlaneLoginSucceeded bool
+		wantMachineID              string
+		wantToken                  string
+		wantEndpoint               string
+		errContains                string
+	}{
+		{
+			name:                 "endpoint override without machine id is persisted",
+			controlPlaneEndpoint: "gpud-manager.example.com",
+			wantEndpoint:         "gpud-manager.example.com",
+		},
+		{
+			name:               "initial machine id without login is allowed",
+			requestedMachineID: "new-machine-id",
+			wantMachineID:      "new-machine-id",
+		},
+		{
+			name:               "matching machine id without login is allowed",
+			persistedMachineID: "machine-id",
+			persistedToken:     "session-token",
+			requestedMachineID: "machine-id",
+			wantMachineID:      "machine-id",
+			wantToken:          "session-token",
+		},
+		{
+			name:               "mismatch without overwrite is rejected",
+			persistedMachineID: "old-machine-id",
+			persistedToken:     "old-session-token",
+			requestedMachineID: "new-machine-id",
+			wantMachineID:      "old-machine-id",
+			wantToken:          "old-session-token",
+			errContains:        "pass --machine-id-overwrite",
+		},
+		{
+			name:               "mismatch without a successful login is rejected",
+			persistedMachineID: "old-machine-id",
+			persistedToken:     "old-session-token",
+			requestedMachineID: "new-machine-id",
+			machineIDOverwrite: true,
+			wantMachineID:      "old-machine-id",
+			wantToken:          "old-session-token",
+			errContains:        "pass --token",
+		},
+		{
+			name:                       "successful login keeps control plane machine id",
+			persistedMachineID:         "manager-machine-id",
+			persistedToken:             "fresh-session-token",
+			requestedMachineID:         "requested-machine-id",
+			machineIDOverwrite:         true,
+			controlPlaneLoginSucceeded: true,
+			wantMachineID:              "manager-machine-id",
+			wantToken:                  "fresh-session-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			stateFile := config.StateFilePath(t.TempDir())
+			dbRW, err := pkgsqlite.Open(stateFile)
+			require.NoError(t, err)
+			require.NoError(t, pkgmetadata.CreateTableMetadata(ctx, dbRW))
+			if tt.persistedMachineID != "" {
+				require.NoError(t, pkgmetadata.SetMetadata(ctx, dbRW, pkgmetadata.MetadataKeyMachineID, tt.persistedMachineID))
+			}
+			if tt.persistedToken != "" {
+				require.NoError(t, pkgmetadata.SetMetadata(ctx, dbRW, pkgmetadata.MetadataKeyToken, tt.persistedToken))
+			}
+			require.NoError(t, dbRW.Close())
+
+			err = persistMetadataOverrides(ctx, stateFile, tt.controlPlaneEndpoint, tt.requestedMachineID, tt.machineIDOverwrite, tt.controlPlaneLoginSucceeded)
+			if tt.errContains == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			}
+
+			dbRO, err := pkgsqlite.Open(stateFile, pkgsqlite.WithReadOnly(true))
+			require.NoError(t, err)
+			defer func() { _ = dbRO.Close() }()
+
+			machineID, err := pkgmetadata.ReadMachineID(ctx, dbRO)
+			require.NoError(t, err)
+			token, err := pkgmetadata.ReadToken(ctx, dbRO)
+			require.NoError(t, err)
+			endpoint, err := pkgmetadata.ReadMetadata(ctx, dbRO, pkgmetadata.MetadataKeyEndpoint)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMachineID, machineID)
+			assert.Equal(t, tt.wantToken, token)
+			assert.Equal(t, tt.wantEndpoint, endpoint)
 		})
 	}
 }

--- a/cmd/gpud/run/metadata_overrides_test.go
+++ b/cmd/gpud/run/metadata_overrides_test.go
@@ -1,0 +1,99 @@
+package run
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmetadata "github.com/leptonai/gpud/pkg/metadata"
+	pkgsqlite "github.com/leptonai/gpud/pkg/sqlite"
+)
+
+func TestPersistMetadataOverridesErrors(t *testing.T) {
+	t.Run("state open", func(t *testing.T) {
+		mockey.PatchConvey("metadata override state open error", t, func() {
+			mockey.Mock(pkgsqlite.Open).To(func(string, ...pkgsqlite.OpOption) (*sql.DB, error) {
+				return nil, errors.New("open failed")
+			}).Build()
+
+			err := persistMetadataOverrides(context.Background(), "/tmp/state.db", "", "machine-id", false, false)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to open state for metadata overrides")
+		})
+	})
+
+	t.Run("metadata table", func(t *testing.T) {
+		mockey.PatchConvey("metadata override table error", t, func() {
+			mockey.Mock(pkgsqlite.Open).To(func(string, ...pkgsqlite.OpOption) (*sql.DB, error) {
+				return &sql.DB{}, nil
+			}).Build()
+			mockey.Mock((*sql.DB).Close).To(func(*sql.DB) error { return nil }).Build()
+			mockey.Mock(pkgmetadata.CreateTableMetadata).To(func(context.Context, *sql.DB) error {
+				return errors.New("create table failed")
+			}).Build()
+
+			err := persistMetadataOverrides(context.Background(), "/tmp/state.db", "", "machine-id", false, false)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to ensure metadata table")
+		})
+	})
+
+	t.Run("endpoint write", func(t *testing.T) {
+		mockey.PatchConvey("metadata override endpoint write error", t, func() {
+			mockey.Mock(pkgsqlite.Open).To(func(string, ...pkgsqlite.OpOption) (*sql.DB, error) {
+				return &sql.DB{}, nil
+			}).Build()
+			mockey.Mock((*sql.DB).Close).To(func(*sql.DB) error { return nil }).Build()
+			mockey.Mock(pkgmetadata.CreateTableMetadata).To(func(context.Context, *sql.DB) error { return nil }).Build()
+			mockey.Mock(pkgmetadata.SetMetadata).To(func(context.Context, *sql.DB, string, string) error {
+				return errors.New("endpoint write failed")
+			}).Build()
+
+			err := persistMetadataOverrides(context.Background(), "/tmp/state.db", "endpoint", "", false, false)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to set endpoint metadata")
+		})
+	})
+
+	t.Run("machine id read", func(t *testing.T) {
+		mockey.PatchConvey("metadata override machine id read error", t, func() {
+			mockey.Mock(pkgsqlite.Open).To(func(string, ...pkgsqlite.OpOption) (*sql.DB, error) {
+				return &sql.DB{}, nil
+			}).Build()
+			mockey.Mock((*sql.DB).Close).To(func(*sql.DB) error { return nil }).Build()
+			mockey.Mock(pkgmetadata.CreateTableMetadata).To(func(context.Context, *sql.DB) error { return nil }).Build()
+			mockey.Mock(pkgmetadata.ReadMetadata).To(func(context.Context, *sql.DB, string) (string, error) {
+				return "", errors.New("machine id read failed")
+			}).Build()
+
+			err := persistMetadataOverrides(context.Background(), "/tmp/state.db", "", "machine-id", false, false)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to read persisted machine-id")
+		})
+	})
+
+	t.Run("machine id write", func(t *testing.T) {
+		mockey.PatchConvey("metadata override machine id write error", t, func() {
+			mockey.Mock(pkgsqlite.Open).To(func(string, ...pkgsqlite.OpOption) (*sql.DB, error) {
+				return &sql.DB{}, nil
+			}).Build()
+			mockey.Mock((*sql.DB).Close).To(func(*sql.DB) error { return nil }).Build()
+			mockey.Mock(pkgmetadata.CreateTableMetadata).To(func(context.Context, *sql.DB) error { return nil }).Build()
+			mockey.Mock(pkgmetadata.ReadMetadata).To(func(context.Context, *sql.DB, string) (string, error) {
+				return "", nil
+			}).Build()
+			mockey.Mock(pkgmetadata.SetMetadata).To(func(context.Context, *sql.DB, string, string) error {
+				return errors.New("machine id write failed")
+			}).Build()
+
+			err := persistMetadataOverrides(context.Background(), "/tmp/state.db", "", "machine-id", false, false)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to set machine-id metadata")
+		})
+	})
+}

--- a/cmd/gpud/run/mock_command_exec_test.go
+++ b/cmd/gpud/run/mock_command_exec_test.go
@@ -46,6 +46,8 @@ func newTestCLIContext(t *testing.T, values cliFlagValues) *cli.Context {
 	set.String("endpoint", "", "")
 	set.String("token", "", "")
 	set.String("machine-id", "", "")
+	set.Bool("machine-id-overwrite", false, "")
+	set.Bool("refresh-session-token", false, "")
 	set.String("listen-address", "", "")
 	set.Bool("pprof", false, "")
 	set.Duration("metrics-retention-period", 0, "")
@@ -127,6 +129,8 @@ func TestCommand_SuccessPath(t *testing.T) {
 			"gpu-product-name": "H100-SXM",
 		},
 		boolFlags: map[string]bool{
+			"machine-id-overwrite":          true,
+			"refresh-session-token":         true,
 			"pprof":                         true,
 			"enable-auto-update":            true,
 			"skip-session-update-config":    true,
@@ -147,7 +151,9 @@ func TestCommand_SuccessPath(t *testing.T) {
 	mockey.PatchConvey("Command success path", t, func() {
 		var receivedCfg *config.Config
 
+		var receivedLoginCfg login.LoginConfig
 		mockey.Mock(login.Login).To(func(ctx context.Context, cfg login.LoginConfig) error {
+			receivedLoginCfg = cfg
 			return nil
 		}).Build()
 		mockey.Mock(recordLoginSuccessState).To(func(ctx context.Context, dataDir string) error {
@@ -178,6 +184,8 @@ func TestCommand_SuccessPath(t *testing.T) {
 		err := Command(ctx)
 		require.NoError(t, err)
 		require.NotNil(t, receivedCfg)
+		assert.True(t, receivedLoginCfg.MachineIDOverwrite)
+		assert.True(t, receivedLoginCfg.RefreshSessionToken)
 		assert.Equal(t, 5*time.Minute, receivedCfg.MetricsRetentionPeriod.Duration)
 		assert.Equal(t, 14*24*time.Hour, receivedCfg.EventsRetentionPeriod.Duration)
 	})

--- a/cmd/gpud/up/command.go
+++ b/cmd/gpud/up/command.go
@@ -69,11 +69,13 @@ func Command(cliContext *cli.Context) (retErr error) {
 		defer loginCancel()
 
 		loginCfg := login.LoginConfig{
-			Token:     token,
-			Endpoint:  cliContext.String("endpoint"),
-			MachineID: cliContext.String("machine-id"),
-			NodeGroup: cliContext.String("node-group"),
-			DataDir:   dataDir,
+			Token:               token,
+			Endpoint:            cliContext.String("endpoint"),
+			MachineID:           cliContext.String("machine-id"),
+			MachineIDOverwrite:  cliContext.Bool("machine-id-overwrite"),
+			RefreshSessionToken: cliContext.Bool("refresh-session-token"),
+			NodeGroup:           cliContext.String("node-group"),
+			DataDir:             dataDir,
 
 			GPUCount:   gpuCountStr,
 			NodeLabels: nodeLabels,

--- a/cmd/gpud/up/mock_command_additional_test.go
+++ b/cmd/gpud/up/mock_command_additional_test.go
@@ -40,6 +40,8 @@ func newMockeyCLIContext(t *testing.T, args []string) *cli.Context {
 	_ = flags.String("token", "", "")
 	_ = flags.String("endpoint", "", "")
 	_ = flags.String("machine-id", "", "")
+	_ = flags.Bool("machine-id-overwrite", false, "")
+	_ = flags.Bool("refresh-session-token", false, "")
 	_ = flags.String("node-group", "", "")
 	_ = flags.String("node-labels", "", "")
 	_ = flags.String("gpu-count", "", "")
@@ -179,6 +181,8 @@ func TestCommand_WithAllFlags(t *testing.T) {
 			"--token", "test-token",
 			"--endpoint", "https://api.example.com",
 			"--machine-id", "machine-123",
+			"--machine-id-overwrite",
+			"--refresh-session-token",
 			"--node-group", "gpu-nodes",
 			"--node-labels", `{"team":"ml","rack":"r42"}`,
 			"--gpu-count", "8",
@@ -193,6 +197,8 @@ func TestCommand_WithAllFlags(t *testing.T) {
 		assert.Equal(t, "test-token", loginCfgCapture.Token)
 		assert.Equal(t, "https://api.example.com", loginCfgCapture.Endpoint)
 		assert.Equal(t, "machine-123", loginCfgCapture.MachineID)
+		assert.True(t, loginCfgCapture.MachineIDOverwrite)
+		assert.True(t, loginCfgCapture.RefreshSessionToken)
 		assert.Equal(t, "gpu-nodes", loginCfgCapture.NodeGroup)
 		assert.Equal(t, map[string]string{"team": "ml", "rack": "r42"}, loginCfgCapture.NodeLabels)
 		assert.Equal(t, "8", loginCfgCapture.GPUCount)

--- a/deployments/helm/gpud/README.md
+++ b/deployments/helm/gpud/README.md
@@ -129,10 +129,10 @@ on nodes that do not run containerd (e.g. docker or cri-o only).
 
 ### Session Token from a Secret
 
-By default the chart reads the session token from a node label (via
-`nodeLabelExporter`). To read it from an existing Kubernetes Secret instead, set
-`gpud.tokenSecret`; the token is injected as the `TOKEN` env via `secretKeyRef`
-and takes priority over any token label:
+When `nodeLabelExporter.enabled=true`, the chart's init container can read the
+session token from a node label. To read it from an existing Kubernetes Secret
+instead, set `gpud.tokenSecret`; the token is injected as the `TOKEN` env via
+`secretKeyRef` and takes priority over any token label:
 
 ```yaml
 gpud:
@@ -187,6 +187,8 @@ gpud:
 # Pass the per-node platform machine ID from the node label to
 # "gpud run --machine-id", so GPUd rejoins as the SAME machine after a pod
 # replacement, node reboot, or reimage (even if /etc/machine-id changes).
+# This is intentionally init-only: gpud reads the file once at startup, so a
+# sidecar update could not reconfigure the already-running process.
 nodeLabelExporter:
   enabled: true
   labelKeys:

--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -334,6 +334,22 @@ spec:
                 set -- "$@" --machine-id="$MID"
               fi
 
+              # When the node's machine-id label changes (the node was deleted from
+              # its node group and rejoined, binding a NEW machine object), the
+              # persisted /var/lib/gpud identity is stale. --machine-id-overwrite
+              # tells gpud to discard that stale identity and re-register as the new
+              # machine instead of failing. Reboot/health state is preserved.
+              if [ "${GPUD_MACHINE_ID_OVERWRITE:-}" = "true" ]; then
+                set -- "$@" --machine-id-overwrite
+              fi
+
+              # Pods restart often; the cached /var/lib/gpud session token can be stale
+              # (server-side session reset, workspace token rotation). --refresh-session-token
+              # forces a fresh login on start so we always re-fetch a current token.
+              if [ "${GPUD_REFRESH_SESSION_TOKEN:-}" = "true" ]; then
+                set -- "$@" --refresh-session-token
+              fi
+
               set -- "$@" --enable-auto-update={{ .Values.gpud.enableAutoUpdate }}
               set -- "$@" --auto-update-exit-code={{ .Values.gpud.autoUpdateExitCode }}
 
@@ -386,6 +402,18 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.gpud.tokenSecret.name | quote }}
                   key: {{ .Values.gpud.tokenSecret.key | quote }}
+            {{- end }}
+            {{- if .Values.gpud.machineIdOverwrite }}
+            # Allow a changed machine-id label to re-register the node (see the
+            # startup script). Consumed as $GPUD_MACHINE_ID_OVERWRITE.
+            - name: GPUD_MACHINE_ID_OVERWRITE
+              value: "true"
+            {{- end }}
+            {{- if .Values.gpud.refreshSessionToken }}
+            # Always re-fetch the session token on start (see the startup script).
+            # Consumed as $GPUD_REFRESH_SESSION_TOKEN.
+            - name: GPUD_REFRESH_SESSION_TOKEN
+              value: "true"
             {{- end }}
             {{- if .Values.gpud.rebootCommands }}
             - name: GPUD_REBOOT_COMMANDS

--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -117,7 +117,7 @@ spec:
         {{- end }}
 
         # GPUd's persistent data directory for state, cache, and configuration
-        # Used for storing GPUd runtime data, labels from nodeLabelExporter, etc.
+        # Used for storing GPUd runtime data and labels fetched by node-label-init.
         - name: lib-gpud
           hostPath:
             path: /var/lib/gpud
@@ -180,15 +180,18 @@ spec:
       # --- Containers ---
       # --- OPTIONAL: Init Containers ---
       # This section is entirely OPTIONAL and only renders when:
-      # 1. nodeLabelExporter.enabled=true (for Kubernetes node label reading), OR
+      # 1. nodeLabelExporter.enabled=true (for init-only Kubernetes node-label reading), OR
       # 2. Custom initContainers are specified in values.yaml
-      # By default, nodeLabelExporter.enabled=false, so no init containers are created.
+      # By default, nodeLabelExporter.enabled=false, so no label init container is created.
       {{- if or .Values.nodeLabelExporter.enabled .Values.initContainers }}
       initContainers:
         {{- if .Values.nodeLabelExporter.enabled }}
         # OPTIONAL: Node Label Reader Init Container
-        # This init container fetches Kubernetes node labels ONCE before gpud starts.
-        # It writes labels to a file that gpud reads for endpoint/token/machine-id configuration.
+        # WHY init instead of a polling sidecar: gpud reads this file only while
+        # building its startup command, so updates after exec cannot reconfigure
+        # the running process. Fetching once before startup is therefore sufficient.
+        # This init container retries until it atomically writes fresh node labels,
+        # preventing gpud from starting with a missing or stale machine identity.
         # Enable with: nodeLabelExporter.enabled=true
         # Requires RBAC: nodeLabelExporter.rbac.create=true (creates ClusterRole for node read access)
         - name: node-label-init
@@ -214,17 +217,24 @@ spec:
               tmp_file="${OUTPUT_FILE}.tmp"
               mkdir -p "$(dirname "${OUTPUT_FILE}")"
 
-              # Fetch node labels once before main container starts
-              # Safe implementation: uses atomic move to prevent partial reads by consumers.
-              if kubectl get node "${NODE_NAME}" \
-                -o go-template='{{`{{range $k,$v := .metadata.labels}}{{printf "%s=%s\n" $k $v}}{{end}}`}}' \
-                > "${tmp_file}"; then
-                mv "${tmp_file}" "${OUTPUT_FILE}"
-                echo "Successfully wrote node labels to ${OUTPUT_FILE}"
-              else
-                echo "Warning: Failed to fetch node labels, file will be created by sidecar"
+              # gpud consumes this file once at startup. Retry here rather than
+              # relying on a sidecar: a sidecar could update the file later, but
+              # cannot make the already-running gpud process reload it.
+              while true; do
+                if kubectl get node "${NODE_NAME}" \
+                  -o go-template='{{`{{range $k,$v := .metadata.labels}}{{printf "%s=%s\n" $k $v}}{{end}}`}}' \
+                  > "${tmp_file}"; then
+                  # Atomic move prevents the main container from ever reading a
+                  # partially written label file.
+                  mv "${tmp_file}" "${OUTPUT_FILE}"
+                  echo "Successfully wrote node labels to ${OUTPUT_FILE}"
+                  break
+                fi
+
                 rm -f "${tmp_file}"
-              fi
+                echo "Waiting to fetch node labels for ${NODE_NAME}; retrying in 5 seconds"
+                sleep 5
+              done
           env:
             - name: NODE_NAME
               valueFrom:
@@ -232,6 +242,9 @@ spec:
                   fieldPath: spec.nodeName
             - name: OUTPUT_FILE
               value: {{ .Values.nodeLabelExporter.outputFile | quote }}
+          {{- with .Values.nodeLabelExporter.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: lib-gpud
               mountPath: /var/lib/gpud
@@ -271,8 +284,8 @@ spec:
               if ( set -o pipefail ) 2>/dev/null; then set -o pipefail; fi
 
               # --- OPTIONAL: Read configuration from Kubernetes node labels ---
-              # If nodeLabelExporter sidecar is enabled, it writes node labels to this file.
-              # This allows dynamic configuration of endpoint/token/machine-id from K8s labels.
+              # When nodeLabelExporter is enabled, node-label-init writes node labels to this file.
+              # This supplies endpoint/token/machine-id configuration for this gpud start.
               LABEL_FILE="{{ .Values.nodeLabelExporter.outputFile }}"
 
               # Label keys can be overridden via environment variables (useful for testing)
@@ -527,59 +540,3 @@ spec:
           {{- if .Values.extraVolumeMounts }}
           {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
-        {{- if .Values.nodeLabelExporter.enabled }}
-        # OPTIONAL: Node Label Exporter Sidecar
-        # This sidecar periodically syncs Kubernetes node labels to a file for gpud consumption.
-        # Runs alongside the main gpud container and updates labels at the configured interval.
-        # Enable with: nodeLabelExporter.enabled=true
-        - name: node-label-exporter
-          # Needs a shell-capable image; distroless kubectl images lack /bin/sh so the looped script would fail.
-          image: "{{ .Values.nodeLabelExporter.image.repository }}:{{ .Values.nodeLabelExporter.image.tag }}"
-          imagePullPolicy: {{ .Values.nodeLabelExporter.image.pullPolicy }}
-          # Run as root: the label file is written to the root-owned /var/lib/gpud
-          # hostPath (gpud runs as root and owns it). The kubectl image otherwise
-          # defaults to a non-root UID and cannot write there.
-          securityContext:
-            runAsUser: 0
-          command:
-            - /bin/sh
-            - -ec
-            - |
-              set -o errexit
-              set -o nounset
-              # pipefail not supported in dash (Ubuntu's /bin/sh).
-              # POSIX special builtins (like `set`) cause the shell to exit on failure
-              # even in `|| true` constructs. A subshell safely isolates the test.
-              if ( set -o pipefail ) 2>/dev/null; then set -o pipefail; fi
-
-              tmp_file="${OUTPUT_FILE}.tmp"
-              mkdir -p "$(dirname "${OUTPUT_FILE}")"
-
-              while true; do
-                if kubectl get node "${NODE_NAME}" \
-                  -o go-template='{{`{{range $k,$v := .metadata.labels}}{{printf "%s=%s\n" $k $v}}{{end}}`}}' \
-                  > "${tmp_file}"; then
-                  mv "${tmp_file}" "${OUTPUT_FILE}"
-                else
-                  rm -f "${tmp_file}"
-                fi
-                sleep "${UPDATE_INTERVAL}"
-              done
-          env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: OUTPUT_FILE
-              value: {{ .Values.nodeLabelExporter.outputFile | quote }}
-            - name: UPDATE_INTERVAL
-              value: {{ int .Values.nodeLabelExporter.updateIntervalSeconds | quote }}
-          {{- with .Values.nodeLabelExporter.extraEnv }}
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - name: lib-gpud
-              mountPath: /var/lib/gpud
-          resources:
-            {{- toYaml .Values.nodeLabelExporter.resources | nindent 12 }}
-        {{- end }}

--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -337,15 +337,15 @@ spec:
               # When the node's machine-id label changes (the node was deleted from
               # its node group and rejoined, binding a NEW machine object), the
               # persisted /var/lib/gpud identity is stale. --machine-id-overwrite
-              # tells gpud to discard that stale identity and re-register as the new
-              # machine instead of failing. Reboot/health state is preserved.
+              # tells gpud to discard that stale identity and check in with the
+              # requested machine instead of failing. Reboot/health state is preserved.
               if [ "${GPUD_MACHINE_ID_OVERWRITE:-}" = "true" ]; then
                 set -- "$@" --machine-id-overwrite
               fi
 
               # Pods restart often; the cached /var/lib/gpud session token can be stale
-              # (server-side session reset, workspace token rotation). --refresh-session-token
-              # forces a fresh login on start so we always re-fetch a current token.
+              # (for example, after workspace token rotation). --refresh-session-token
+              # forces a fresh login on start so we re-fetch the current token.
               if [ "${GPUD_REFRESH_SESSION_TOKEN:-}" = "true" ]; then
                 set -- "$@" --refresh-session-token
               fi
@@ -404,7 +404,7 @@ spec:
                   key: {{ .Values.gpud.tokenSecret.key | quote }}
             {{- end }}
             {{- if .Values.gpud.machineIdOverwrite }}
-            # Allow a changed machine-id label to re-register the node (see the
+            # Allow a changed machine-id label to check in the node (see the
             # startup script). Consumed as $GPUD_MACHINE_ID_OVERWRITE.
             - name: GPUD_MACHINE_ID_OVERWRITE
               value: "true"

--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -287,6 +287,7 @@ spec:
               # When nodeLabelExporter is enabled, node-label-init writes node labels to this file.
               # This supplies endpoint/token/machine-id configuration for this gpud start.
               LABEL_FILE="{{ .Values.nodeLabelExporter.outputFile }}"
+              NODE_LABEL_EXPORTER_ENABLED="{{ .Values.nodeLabelExporter.enabled }}"
 
               # Label keys can be overridden via environment variables (useful for testing)
               EP_LABEL_KEY="${GPUD_ENDPOINT_LABEL_KEY:-{{ .Values.nodeLabelExporter.labelKeys.endpoint }}}"
@@ -298,7 +299,11 @@ spec:
               TOKEN=""
               MID=""
 
-              if [ -f "$LABEL_FILE" ]; then
+              # /var/lib/gpud is a hostPath and can retain node-labels.env from a
+              # previous chart release. Honor that file only when this feature is
+              # enabled, so disabling nodeLabelExporter means no stale label can
+              # silently override the configured endpoint, token, or machine ID.
+              if [ "$NODE_LABEL_EXPORTER_ENABLED" = "true" ] && [ -f "$LABEL_FILE" ]; then
                 # Parse label file using awk with index() for EXACT string matching:
                 # - index($0, key"=") == 1: Line must START with "key=" (prevents partial matches)
                 # - substr($0, length(key)+2): Extract everything AFTER the "=" sign

--- a/deployments/helm/gpud/templates/rbac.yaml
+++ b/deployments/helm/gpud/templates/rbac.yaml
@@ -8,7 +8,9 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
+    # node-label-init performs only "kubectl get node $NODE_NAME" before gpud
+    # starts; list/watch were needed by the removed polling sidecar.
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -308,7 +308,8 @@ nodeLabelExporter:
   # arguments, so a sidecar updating it later cannot reload the running process.
   # A successful label read is intentionally a startup prerequisite when enabled:
   # the init container retries until it has written a fresh, complete snapshot.
-  # When disabled, no label init container is rendered and gpud starts normally.
+  # When disabled, no label init container is rendered, gpud starts normally,
+  # and any stale host-mounted node-labels.env from an earlier release is ignored.
   # Requires RBAC permissions - set nodeLabelExporter.rbac.create=true.
   enabled: false
   image:

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -300,17 +300,20 @@ extraVolumes: []
 # Extra volume mounts for the pod.
 extraVolumeMounts: []
 
-# Helper sidecar that syncs Kubernetes node labels into a host-mounted file
-# for consumption by gpud or other host-level processes.
+# Optional, init-only Kubernetes node-label reader for gpud configuration.
 nodeLabelExporter:
-  # OPTIONAL: Enable to read Kubernetes node labels for gpud configuration.
-  # When enabled, creates an init container and sidecar that fetch node labels
-  # and write them to a file for gpud to read endpoint/token/machine-id values.
-  # Requires RBAC permissions - set nodeLabelExporter.rbac.create=true
+  # When enabled, creates an init container that fetches node labels before gpud
+  # starts and writes them to a file for endpoint/token/machine-id configuration.
+  # WHY no sidecar: gpud reads this file only while constructing its startup
+  # arguments, so a sidecar updating it later cannot reload the running process.
+  # A successful label read is intentionally a startup prerequisite when enabled:
+  # the init container retries until it has written a fresh, complete snapshot.
+  # When disabled, no label init container is rendered and gpud starts normally.
+  # Requires RBAC permissions - set nodeLabelExporter.rbac.create=true.
   enabled: false
   image:
     # Use a shell-capable kubectl image. Distroless kubectl images (registry.k8s.io/kubectl)
-    # do not include /bin/sh, but our init/sidecar scripts rely on a POSIX shell.
+    # do not include /bin/sh, but the init script relies on a POSIX shell.
     # NOTE: Bitnami removed their public ECR mirror (public.ecr.aws/bitnami) in 2025,
     # so we use the Docker Hub bitnami/kubectl image. Override if you mirror it
     # elsewhere or hit Docker Hub rate limits.
@@ -335,9 +338,7 @@ nodeLabelExporter:
     endpoint: gpud.dgxc.lepton.ai/endpoint
     token: gpud.dgxc.lepton.ai/token
     machineId: gpud.dgxc.lepton.ai/machine-id
-  # Interval in seconds between syncs.
-  updateIntervalSeconds: 60
-  # Extra environment variables for the exporter container.
+  # Extra environment variables for the node-label init container.
   extraEnv: []
   rbac:
     create: true

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -47,7 +47,7 @@ gpud:
     name: ""
     key: "TOKEN"
 
-  # Allow a node to re-register when its machine identity changes.
+  # Allow a node to check in when its machine identity changes.
   #
   # gpud persists its machine id + session token in /var/lib/gpud (a node-scoped
   # hostPath that survives reboots). In the DaemonSet pattern a node can be
@@ -55,10 +55,10 @@ gpud:
   # machine-id label) while the OLD identity is still persisted on disk. With this
   # enabled, gpud passes "gpud run --machine-id-overwrite": when the machine-id
   # label differs from the persisted one, it discards the stale login identity
-  # (machine id + session token) and re-registers as the new machine. Reboot/health
-  # state is preserved.
+  # (machine id + session token) and checks in with the requested machine. Reboot/
+  # health state is preserved.
   #
-  # Defaults to true because that re-enroll-on-rejoin behavior is what the
+  # Defaults to true because that re-check-in-on-rejoin behavior is what the
   # container/DaemonSet pattern wants, and it trusts the platform-managed
   # machine-id node label as the source of truth. Set to false to keep gpud's
   # strict guard (fail instead of retarget) -- appropriate when machine identity
@@ -69,12 +69,12 @@ gpud:
   #
   # gpud caches its session token in /var/lib/gpud and normally takes a "skip
   # login" fast path on restart when a machine id is already persisted, reusing
-  # that cached token. The control plane re-issues the (workspace-scoped) session
-  # token on every successful login, so with this enabled gpud passes
+  # that cached token. The control plane returns the current workspace-scoped
+  # session token on every successful login, so with this enabled gpud passes
   # "gpud run --refresh-session-token" to always re-login and re-fetch a current
   # token instead of trusting the cached one. This prevents a stale cached token
-  # (e.g. after a server-side session reset for BYOK machines, or a workspace
-  # token rotation) from breaking session keepalive, at the cost of one extra
+  # (e.g. after a workspace token rotation) from breaking session keepalive, at
+  # the cost of one extra
   # login round-trip per start.
   #
   # Defaults to true for the container/DaemonSet pattern (pods restart often and

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -47,6 +47,42 @@ gpud:
     name: ""
     key: "TOKEN"
 
+  # Allow a node to re-register when its machine identity changes.
+  #
+  # gpud persists its machine id + session token in /var/lib/gpud (a node-scoped
+  # hostPath that survives reboots). In the DaemonSet pattern a node can be
+  # deleted from its node group and rejoined, binding a NEW machine object (new
+  # machine-id label) while the OLD identity is still persisted on disk. With this
+  # enabled, gpud passes "gpud run --machine-id-overwrite": when the machine-id
+  # label differs from the persisted one, it discards the stale login identity
+  # (machine id + session token) and re-registers as the new machine. Reboot/health
+  # state is preserved.
+  #
+  # Defaults to true because that re-enroll-on-rejoin behavior is what the
+  # container/DaemonSet pattern wants, and it trusts the platform-managed
+  # machine-id node label as the source of truth. Set to false to keep gpud's
+  # strict guard (fail instead of retarget) -- appropriate when machine identity
+  # must never change without manually clearing /var/lib/gpud.
+  machineIdOverwrite: true
+
+  # Re-fetch the session token from the control plane on every start.
+  #
+  # gpud caches its session token in /var/lib/gpud and normally takes a "skip
+  # login" fast path on restart when a machine id is already persisted, reusing
+  # that cached token. The control plane re-issues the (workspace-scoped) session
+  # token on every successful login, so with this enabled gpud passes
+  # "gpud run --refresh-session-token" to always re-login and re-fetch a current
+  # token instead of trusting the cached one. This prevents a stale cached token
+  # (e.g. after a server-side session reset for BYOK machines, or a workspace
+  # token rotation) from breaking session keepalive, at the cost of one extra
+  # login round-trip per start.
+  #
+  # Defaults to true for the container/DaemonSet pattern (pods restart often and
+  # should always come up with a fresh token). Set to false to keep the
+  # skip-login optimization. TODO: make always-refresh the default gpud behavior
+  # and retire this toggle once validated in production.
+  refreshSessionToken: true
+
   # Enable auto update of gpud.
   enableAutoUpdate: false
 

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -32,27 +32,27 @@ type LoginConfig struct {
 	NodeGroup string // optional
 
 	// MachineIDOverwrite, when true, allows an explicitly-supplied MachineID that
-	// differs from the locally-persisted one to REPLACE it: the persisted login
+	// differs from the locally-persisted one to replace it: the persisted login
 	// identity (machine ID + session token, in the metadata table) is discarded
-	// and a fresh login registers the new machine. Health/system state (reboot
-	// history, events) in other tables is preserved.
+	// and the next login checks in using the supplied MachineID. Health/system
+	// state (reboot history, events) in other tables is preserved.
 	//
 	// When false (the default), a differing MachineID is rejected with an error
 	// instead of silently retargeting the node. This is the safe default for
 	// host/systemd installs; the container/DaemonSet pattern sets it true so a
-	// node re-enrolled with a new machine object re-registers automatically.
+	// node re-enrolled with a new machine object checks in automatically.
 	MachineIDOverwrite bool
 
 	// RefreshSessionToken, when true, forces a fresh login on every start even
 	// when a machine ID is already persisted -- instead of taking the "skip login"
 	// fast path and reusing the persisted session token.
 	//
-	// The control plane returns the (workspace-scoped) session token on every
-	// successful login, so re-login reliably re-fetches a current token. This keeps
-	// the persisted token from going stale (e.g. after a server-side session reset
-	// for BYOK machines, or a workspace token rotation) at the cost of one extra
-	// login round-trip per start. The container/DaemonSet pattern sets it true; the
-	// default (false) preserves the skip-login optimization for host/systemd installs.
+	// The control plane looks up the current workspace-scoped session token on
+	// every successful login, so re-login persists the token currently served by
+	// the control plane. This handles workspace token rotation at the cost of one
+	// extra login round-trip per start. The container/DaemonSet pattern sets it
+	// true; the default (false) preserves the skip-login optimization for
+	// host/systemd installs.
 	RefreshSessionToken bool
 
 	DataDir string
@@ -104,14 +104,15 @@ type LoginConfig struct {
 //   - ID Generation Error: "failed to generate id"
 //   - Machine Creation Error: "failed to add machine"
 //   - Login Finalization Error: "failed to login, please try again"
+//
 // reconcileMachineID reconciles an explicitly-supplied machine ID against the
 // one already persisted in the local state DB, returning the machine ID that
 // the rest of the login flow should treat as "previous".
 //
 // In the container/DaemonSet pattern, /var/lib/gpud is a node-scoped hostPath
 // that outlives the machine object: when a node is deleted from its node group
-// and rejoined, it binds a NEW machine object (new requestedMachineID, e.g. from
-// the node label) while the OLD machine ID is still persisted on disk. Without
+// and rejoined, it receives a new requestedMachineID (for the new machine object,
+// e.g. from the node label) while the OLD machine ID is still persisted on disk. Without
 // this check, gpud would "skip login" on the stale ID and run under a mismatched
 // identity (the persisted session token belongs to the old machine) -- so the
 // node never joins.
@@ -123,9 +124,9 @@ type LoginConfig struct {
 //   - Supplied ID differs and overwrite=false -> fail loudly rather than
 //     silently retarget the persisted identity.
 //   - Supplied ID differs and overwrite=true  -> discard the persisted login
-//     identity (metadata table only) and return "" so the caller performs a
-//     fresh registration as the new machine. Reboot/event history lives in
-//     separate tables and is intentionally NOT touched.
+//     identity (metadata table only) and return "" so the caller checks in with
+//     the requested machine ID. Reboot/event history lives in separate tables
+//     and is intentionally NOT touched.
 func reconcileMachineID(ctx context.Context, dbRW *sql.DB, prevMachineID, requestedMachineID string, overwrite bool) (string, error) {
 	if prevMachineID == "" || requestedMachineID == "" || requestedMachineID == prevMachineID {
 		return prevMachineID, nil
@@ -135,13 +136,13 @@ func reconcileMachineID(ctx context.Context, dbRW *sql.DB, prevMachineID, reques
 		return prevMachineID, fmt.Errorf(
 			"persisted machine ID %q differs from requested machine ID %q; "+
 				"pass --machine-id-overwrite to discard the persisted login identity and "+
-				"re-register as the new machine (use this only if you intend to change the machine identity)",
+				"check in with the requested machine (use this only if you intend to change the machine identity)",
 			prevMachineID, requestedMachineID,
 		)
 	}
 
 	// Loud, auditable: we are dropping a previously-registered identity.
-	log.Logger.Warnw("!!! MACHINE ID OVERWRITE !!! discarding persisted login identity and re-registering as a NEW machine",
+	log.Logger.Warnw("!!! MACHINE ID OVERWRITE !!! discarding persisted login identity and checking in with requested machine ID",
 		"persistedMachineID", prevMachineID,
 		"requestedMachineID", requestedMachineID,
 	)
@@ -235,9 +236,9 @@ func Login(ctx context.Context, cfg LoginConfig) error {
 		}
 		if shouldRefreshLogin || cfg.RefreshSessionToken {
 			reloginExistingMachine = true
-			// The control plane re-issues the session token on every successful login,
-			// so re-running login here re-fetches a current token (and/or refreshes node
-			// labels) instead of reusing a possibly-stale persisted one.
+			// The control plane returns its current session token on every successful
+			// login, so re-running login here re-fetches that token (and/or refreshes
+			// node labels) instead of reusing a possibly-stale persisted one.
 			log.Logger.Infow("re-running login for already-assigned machine",
 				"machineID", prevMachineID,
 				"nodeLabelsChanged", shouldRefreshLogin,

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -31,6 +31,30 @@ type LoginConfig struct {
 	MachineID string // optional: can be empty
 	NodeGroup string // optional
 
+	// MachineIDOverwrite, when true, allows an explicitly-supplied MachineID that
+	// differs from the locally-persisted one to REPLACE it: the persisted login
+	// identity (machine ID + session token, in the metadata table) is discarded
+	// and a fresh login registers the new machine. Health/system state (reboot
+	// history, events) in other tables is preserved.
+	//
+	// When false (the default), a differing MachineID is rejected with an error
+	// instead of silently retargeting the node. This is the safe default for
+	// host/systemd installs; the container/DaemonSet pattern sets it true so a
+	// node re-enrolled with a new machine object re-registers automatically.
+	MachineIDOverwrite bool
+
+	// RefreshSessionToken, when true, forces a fresh login on every start even
+	// when a machine ID is already persisted -- instead of taking the "skip login"
+	// fast path and reusing the persisted session token.
+	//
+	// The control plane returns the (workspace-scoped) session token on every
+	// successful login, so re-login reliably re-fetches a current token. This keeps
+	// the persisted token from going stale (e.g. after a server-side session reset
+	// for BYOK machines, or a workspace token rotation) at the cost of one extra
+	// login round-trip per start. The container/DaemonSet pattern sets it true; the
+	// default (false) preserves the skip-login optimization for host/systemd installs.
+	RefreshSessionToken bool
+
 	DataDir string
 
 	// GPUCount is the number of GPUs to be reported to the control plane.
@@ -80,6 +104,56 @@ type LoginConfig struct {
 //   - ID Generation Error: "failed to generate id"
 //   - Machine Creation Error: "failed to add machine"
 //   - Login Finalization Error: "failed to login, please try again"
+// reconcileMachineID reconciles an explicitly-supplied machine ID against the
+// one already persisted in the local state DB, returning the machine ID that
+// the rest of the login flow should treat as "previous".
+//
+// In the container/DaemonSet pattern, /var/lib/gpud is a node-scoped hostPath
+// that outlives the machine object: when a node is deleted from its node group
+// and rejoined, it binds a NEW machine object (new requestedMachineID, e.g. from
+// the node label) while the OLD machine ID is still persisted on disk. Without
+// this check, gpud would "skip login" on the stale ID and run under a mismatched
+// identity (the persisted session token belongs to the old machine) -- so the
+// node never joins.
+//
+// Behavior:
+//   - No persisted ID, no supplied ID, or they already match -> no-op (returns
+//     the persisted ID unchanged). This is the non-container path and is
+//     completely unaffected.
+//   - Supplied ID differs and overwrite=false -> fail loudly rather than
+//     silently retarget the persisted identity.
+//   - Supplied ID differs and overwrite=true  -> discard the persisted login
+//     identity (metadata table only) and return "" so the caller performs a
+//     fresh registration as the new machine. Reboot/event history lives in
+//     separate tables and is intentionally NOT touched.
+func reconcileMachineID(ctx context.Context, dbRW *sql.DB, prevMachineID, requestedMachineID string, overwrite bool) (string, error) {
+	if prevMachineID == "" || requestedMachineID == "" || requestedMachineID == prevMachineID {
+		return prevMachineID, nil
+	}
+
+	if !overwrite {
+		return prevMachineID, fmt.Errorf(
+			"persisted machine ID %q differs from requested machine ID %q; "+
+				"pass --machine-id-overwrite to discard the persisted login identity and "+
+				"re-register as the new machine (use this only if you intend to change the machine identity)",
+			prevMachineID, requestedMachineID,
+		)
+	}
+
+	// Loud, auditable: we are dropping a previously-registered identity.
+	log.Logger.Warnw("!!! MACHINE ID OVERWRITE !!! discarding persisted login identity and re-registering as a NEW machine",
+		"persistedMachineID", prevMachineID,
+		"requestedMachineID", requestedMachineID,
+	)
+	fmt.Printf("%s machine ID changed: overwriting %s -> %s (discarding persisted login identity)\n",
+		cmdcommon.WarningSign, prevMachineID, requestedMachineID)
+
+	if err := pkgmetadata.DeleteAllMetadata(ctx, dbRW); err != nil {
+		return prevMachineID, fmt.Errorf("failed to clear persisted login identity for machine-id overwrite: %w", err)
+	}
+	return "", nil
+}
+
 func Login(ctx context.Context, cfg LoginConfig) error {
 	if cfg.Token == "" {
 		return ErrEmptyToken
@@ -145,15 +219,30 @@ func Login(ctx context.Context, cfg LoginConfig) error {
 	}
 	log.Logger.Debugw("successfully read machine ID")
 
+	// Reconcile an explicitly-supplied machine ID against the persisted one
+	// before deciding whether to skip login. See reconcileMachineID for the
+	// container/DaemonSet rationale.
+	prevMachineID, err = reconcileMachineID(ctx, dbRW, prevMachineID, cfg.MachineID, cfg.MachineIDOverwrite)
+	if err != nil {
+		return err
+	}
+
 	reloginExistingMachine := false
 	if prevMachineID != "" {
 		shouldRefreshLogin, err := shouldRefreshLoginForNodeLabels(ctx, dbRO, desiredNodeLabelsJSON, cfg.NodeLabels != nil)
 		if err != nil {
 			return fmt.Errorf("failed to read previous node labels: %w", err)
 		}
-		if shouldRefreshLogin {
+		if shouldRefreshLogin || cfg.RefreshSessionToken {
 			reloginExistingMachine = true
-			log.Logger.Infow("re-running login to refresh node labels", "machineID", prevMachineID)
+			// The control plane re-issues the session token on every successful login,
+			// so re-running login here re-fetches a current token (and/or refreshes node
+			// labels) instead of reusing a possibly-stale persisted one.
+			log.Logger.Infow("re-running login for already-assigned machine",
+				"machineID", prevMachineID,
+				"nodeLabelsChanged", shouldRefreshLogin,
+				"refreshSessionToken", cfg.RefreshSessionToken,
+			)
 		} else {
 			fmt.Printf("machine ID %s already assigned (skipping login)\n", prevMachineID)
 			return nil
@@ -161,18 +250,15 @@ func Login(ctx context.Context, cfg LoginConfig) error {
 	}
 
 	if reloginExistingMachine {
-		// Once we have a locally persisted machine ID, a follow-up login is a refresh for that
-		// exact machine, not an opportunity to point this daemon at a different control-plane record.
-		// Before node-label refreshes existed, this code path always skipped the login entirely, so a
-		// hidden/manual machine-id override could never silently retarget an already-registered node.
-		// Keep that invariant explicit: if a caller wants to operate on a different machine ID, they
-		// must first clear the local state instead of piggybacking on the refresh flow.
-		if cfg.MachineID != "" && cfg.MachineID != prevMachineID {
-			return fmt.Errorf("stored machine ID %q does not match requested machine ID %q", prevMachineID, cfg.MachineID)
-		}
-
-		// Use the persisted machine ID for the refresh request even when the caller omitted it so the
-		// control plane sees an unambiguous relogin for the machine already assigned to this host.
+		// A relogin is a refresh for this exact machine, not an opportunity to point this
+		// daemon at a different control-plane record. reconcileMachineID above has already
+		// guaranteed the caller is not retargeting a different machine ID: a mismatch either
+		// returned an error, or (with --machine-id-overwrite) cleared the persisted identity
+		// and reset prevMachineID to "", which drops us out of this relogin path entirely.
+		//
+		// Use the persisted machine ID for the refresh request even when the caller omitted it
+		// so the control plane sees an unambiguous relogin for the machine already assigned to
+		// this host.
 		cfg.MachineID = prevMachineID
 	}
 

--- a/pkg/login/login_test.go
+++ b/pkg/login/login_test.go
@@ -2,6 +2,7 @@ package login
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -56,5 +57,93 @@ func TestShouldRefreshLoginForNodeLabels(t *testing.T) {
 		refresh, err := shouldRefreshLoginForNodeLabels(canceledCtx, dbRO, `{}`, true)
 		require.Error(t, err)
 		assert.False(t, refresh)
+	})
+}
+
+func TestReconcileMachineID(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	// seed installs a persisted login identity (machine ID + session token) into a
+	// fresh test DB so each subtest starts from a "previously logged-in" state.
+	seed := func(t *testing.T, machineID string) (*sql.DB, *sql.DB) {
+		t.Helper()
+		dbRW, dbRO, cleanup := sqlite.OpenTestDB(t)
+		t.Cleanup(cleanup)
+		require.NoError(t, pkgmetadata.CreateTableMetadata(ctx, dbRW))
+		if machineID != "" {
+			require.NoError(t, pkgmetadata.SetMetadata(ctx, dbRW, pkgmetadata.MetadataKeyMachineID, machineID))
+			require.NoError(t, pkgmetadata.SetMetadata(ctx, dbRW, pkgmetadata.MetadataKeyToken, "session-token-for-"+machineID))
+		}
+		return dbRW, dbRO
+	}
+
+	t.Run("no persisted ID is a no-op", func(t *testing.T) {
+		dbRW, _ := seed(t, "")
+		// overwrite=false must NOT error when there is nothing persisted to overwrite.
+		got, err := reconcileMachineID(ctx, dbRW, "", "new-machine", false)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("empty requested ID keeps persisted identity (non-container path)", func(t *testing.T) {
+		dbRW, dbRO := seed(t, "old-machine")
+		// No --machine-id supplied: must keep the persisted ID untouched, even with
+		// overwrite=false. This proves non-container/CLI usage is unaffected.
+		got, err := reconcileMachineID(ctx, dbRW, "old-machine", "", false)
+		require.NoError(t, err)
+		assert.Equal(t, "old-machine", got)
+
+		persisted, err := pkgmetadata.ReadMachineID(ctx, dbRO)
+		require.NoError(t, err)
+		assert.Equal(t, "old-machine", persisted)
+	})
+
+	t.Run("matching IDs is a no-op", func(t *testing.T) {
+		dbRW, dbRO := seed(t, "same-machine")
+		got, err := reconcileMachineID(ctx, dbRW, "same-machine", "same-machine", false)
+		require.NoError(t, err)
+		assert.Equal(t, "same-machine", got)
+
+		persisted, err := pkgmetadata.ReadMachineID(ctx, dbRO)
+		require.NoError(t, err)
+		assert.Equal(t, "same-machine", persisted)
+	})
+
+	t.Run("mismatch without overwrite fails and leaves identity intact", func(t *testing.T) {
+		dbRW, dbRO := seed(t, "old-machine")
+		got, err := reconcileMachineID(ctx, dbRW, "old-machine", "new-machine", false)
+		require.Error(t, err)
+		// the returned prevMachineID is unchanged so callers never act on a half-state
+		assert.Equal(t, "old-machine", got)
+		// actionable, mentions the escape hatch
+		assert.Contains(t, err.Error(), "differs from requested")
+		assert.Contains(t, err.Error(), "--machine-id-overwrite")
+
+		// persisted identity must be untouched on the failure path
+		persisted, err := pkgmetadata.ReadMachineID(ctx, dbRO)
+		require.NoError(t, err)
+		assert.Equal(t, "old-machine", persisted)
+		token, err := pkgmetadata.ReadMetadata(ctx, dbRO, pkgmetadata.MetadataKeyToken)
+		require.NoError(t, err)
+		assert.Equal(t, "session-token-for-old-machine", token)
+	})
+
+	t.Run("mismatch with overwrite clears identity for fresh registration", func(t *testing.T) {
+		dbRW, dbRO := seed(t, "old-machine")
+		got, err := reconcileMachineID(ctx, dbRW, "old-machine", "new-machine", true)
+		require.NoError(t, err)
+		// returns "" so the caller performs a fresh login as the new machine
+		assert.Empty(t, got)
+
+		// the whole persisted login identity (machine ID + session token) is gone
+		persisted, err := pkgmetadata.ReadMachineID(ctx, dbRO)
+		require.NoError(t, err)
+		assert.Empty(t, persisted)
+		token, err := pkgmetadata.ReadMetadata(ctx, dbRO, pkgmetadata.MetadataKeyToken)
+		require.NoError(t, err)
+		assert.Empty(t, token)
 	})
 }

--- a/pkg/login/mock_login_test.go
+++ b/pkg/login/mock_login_test.go
@@ -382,6 +382,98 @@ func TestLogin_MachineIDAlreadyAssignedWithChangedNodeLabelsRelogsIn(t *testing.
 	})
 }
 
+// TestLogin_RefreshSessionTokenRelogsIn verifies that RefreshSessionToken forces a
+// fresh login even when a machine id is already persisted and node labels are
+// unchanged -- bypassing the "skip login" fast path so the session token is always
+// re-fetched from the control plane. Contrast with TestLogin_MachineIDAlreadyAssigned,
+// which skips login (never reaches SendRequest) under the same conditions.
+func TestLogin_RefreshSessionTokenRelogsIn(t *testing.T) {
+	mockey.PatchConvey("refresh session token forces relogin for already-assigned machine", t, func() {
+		mockDB := &sql.DB{}
+		requestSent := false
+		tokenPersisted := ""
+
+		mockey.Mock(config.ResolveDataDir).To(func(_ string) (string, error) {
+			return "/tmp/test", nil
+		}).Build()
+
+		mockey.Mock(sqlite.Open).To(func(_ string, _ ...sqlite.OpOption) (*sql.DB, error) {
+			return mockDB, nil
+		}).Build()
+
+		mockey.Mock((*sql.DB).Close).To(func(*sql.DB) error {
+			return nil
+		}).Build()
+
+		mockey.Mock(pkgmetadata.CreateTableMetadata).To(func(context.Context, *sql.DB) error {
+			return nil
+		}).Build()
+
+		mockey.Mock(sessionstates.CreateTable).To(func(context.Context, *sql.DB) error {
+			return nil
+		}).Build()
+
+		// a machine id is already persisted...
+		mockey.Mock(pkgmetadata.ReadMachineID).To(func(context.Context, *sql.DB) (string, error) {
+			return "existing-machine-id", nil
+		}).Build()
+
+		mockey.Mock(pkgmetadata.ReadMetadata).To(func(context.Context, *sql.DB, string) (string, error) {
+			return "", nil
+		}).Build()
+
+		mockey.Mock(nvidianvml.New).To(func() (nvidianvml.Instance, error) {
+			return nvidianvml.NewNoOp(), nil
+		}).Build()
+
+		mockey.Mock((nvidianvml.Instance).Shutdown).To(func() error {
+			return nil
+		}).Build()
+
+		var receivedMachineID string
+		mockey.Mock(pkgmachineinfo.CreateLoginRequest).To(func(_, machineID, _, _ string, _ nvidianvml.Instance) (*apiv1.LoginRequest, error) {
+			receivedMachineID = machineID
+			return &apiv1.LoginRequest{Network: &apiv1.MachineNetwork{}}, nil
+		}).Build()
+
+		mockey.Mock(SendRequest).To(func(context.Context, string, apiv1.LoginRequest) (*apiv1.LoginResponse, error) {
+			requestSent = true
+			return &apiv1.LoginResponse{MachineID: "existing-machine-id", Token: "fresh-session-token"}, nil
+		}).Build()
+
+		mockey.Mock(pkgmetadata.SetMetadata).To(func(_ context.Context, _ *sql.DB, key, value string) error {
+			if key == pkgmetadata.MetadataKeyToken {
+				tokenPersisted = value
+			}
+			return nil
+		}).Build()
+
+		mockey.Mock(config.FifoFilePath).To(func(string) string {
+			return "/tmp/test/fifo"
+		}).Build()
+
+		mockey.Mock(serverRunning).To(func() bool {
+			return false
+		}).Build()
+
+		ctx := context.Background()
+		// no NodeLabels and no differing machine id: without RefreshSessionToken this
+		// would take the skip-login fast path and never re-login.
+		cfg := LoginConfig{
+			Token:               "test-token",
+			Endpoint:            "https://example.com",
+			DataDir:             "/tmp/test",
+			RefreshSessionToken: true,
+		}
+
+		err := Login(ctx, cfg)
+		require.NoError(t, err)
+		assert.True(t, requestSent, "refresh-session-token should force a fresh login request")
+		assert.Equal(t, "existing-machine-id", receivedMachineID, "relogin must reuse the persisted machine id")
+		assert.Equal(t, "fresh-session-token", tokenPersisted, "the re-fetched session token should be persisted")
+	})
+}
+
 func TestLogin_MachineIDAlreadyAssignedWithChangedNodeLabelsAndMismatchedOverrideFails(t *testing.T) {
 	mockey.PatchConvey("machine id already assigned with changed node labels and mismatched override", t, func() {
 		mockDB := &sql.DB{}
@@ -446,10 +538,108 @@ func TestLogin_MachineIDAlreadyAssignedWithChangedNodeLabelsAndMismatchedOverrid
 
 		err := Login(ctx, cfg)
 		require.Error(t, err)
-		assert.EqualError(t, err, `stored machine ID "existing-machine-id" does not match requested machine ID "different-machine-id"`)
+		// reconcileMachineID now catches the mismatch before the relogin/refresh fork,
+		// failing with an actionable message that points at the --machine-id-overwrite
+		// escape hatch (instead of silently skipping login on the stale persisted ID).
+		assert.Contains(t, err.Error(), `persisted machine ID "existing-machine-id" differs from requested machine ID "different-machine-id"`)
+		assert.Contains(t, err.Error(), "--machine-id-overwrite")
 		assert.False(t, nvmlCreated)
 		assert.False(t, loginRequestCreated)
 		assert.False(t, requestSent)
+	})
+}
+
+// TestLogin_MachineIDOverwriteReRegisters verifies the --machine-id-overwrite path:
+// when the supplied machine ID differs from the persisted one, gpud clears the stale
+// login identity and performs a fresh registration as the new machine. This is the
+// container/DaemonSet recovery path for a node that rejoined with a new machine object
+// while /var/lib/gpud still held the old identity.
+func TestLogin_MachineIDOverwriteReRegisters(t *testing.T) {
+	mockey.PatchConvey("machine id overwrite clears stale identity and re-registers", t, func() {
+		mockDB := &sql.DB{}
+		deleteAllCalled := false
+		requestSent := false
+		newMachineIDPersisted := false
+
+		mockey.Mock(config.ResolveDataDir).To(func(_ string) (string, error) {
+			return "/tmp/test", nil
+		}).Build()
+
+		mockey.Mock(sqlite.Open).To(func(_ string, _ ...sqlite.OpOption) (*sql.DB, error) {
+			return mockDB, nil
+		}).Build()
+
+		mockey.Mock((*sql.DB).Close).To(func(*sql.DB) error {
+			return nil
+		}).Build()
+
+		mockey.Mock(pkgmetadata.CreateTableMetadata).To(func(context.Context, *sql.DB) error {
+			return nil
+		}).Build()
+
+		mockey.Mock(sessionstates.CreateTable).To(func(context.Context, *sql.DB) error {
+			return nil
+		}).Build()
+
+		// stale identity is persisted on disk
+		mockey.Mock(pkgmetadata.ReadMachineID).To(func(context.Context, *sql.DB) (string, error) {
+			return "stale-machine-id", nil
+		}).Build()
+
+		// the overwrite path clears the whole persisted login identity
+		mockey.Mock(pkgmetadata.DeleteAllMetadata).To(func(context.Context, *sql.DB) error {
+			deleteAllCalled = true
+			return nil
+		}).Build()
+
+		mockey.Mock(nvidianvml.New).To(func() (nvidianvml.Instance, error) {
+			return nvidianvml.NewNoOp(), nil
+		}).Build()
+
+		mockey.Mock((nvidianvml.Instance).Shutdown).To(func() error {
+			return nil
+		}).Build()
+
+		mockey.Mock(pkgmachineinfo.CreateLoginRequest).To(func(_, machineID, _, _ string, _ nvidianvml.Instance) (*apiv1.LoginRequest, error) {
+			// fresh registration must NOT carry the stale machine ID
+			assert.NotEqual(t, "stale-machine-id", machineID)
+			return &apiv1.LoginRequest{Network: &apiv1.MachineNetwork{}}, nil
+		}).Build()
+
+		mockey.Mock(SendRequest).To(func(context.Context, string, apiv1.LoginRequest) (*apiv1.LoginResponse, error) {
+			requestSent = true
+			return &apiv1.LoginResponse{MachineID: "new-machine-id", Token: "new-session-token"}, nil
+		}).Build()
+
+		mockey.Mock(pkgmetadata.SetMetadata).To(func(_ context.Context, _ *sql.DB, key, value string) error {
+			if key == pkgmetadata.MetadataKeyMachineID && value == "new-machine-id" {
+				newMachineIDPersisted = true
+			}
+			return nil
+		}).Build()
+
+		mockey.Mock(config.FifoFilePath).To(func(_ string) string {
+			return "/tmp/test/fifo"
+		}).Build()
+
+		mockey.Mock(serverRunning).To(func() bool {
+			return false
+		}).Build()
+
+		ctx := context.Background()
+		cfg := LoginConfig{
+			Token:              "test-token",
+			Endpoint:           "https://example.com",
+			DataDir:            "/tmp/test",
+			MachineID:          "new-machine-id",
+			MachineIDOverwrite: true,
+		}
+
+		err := Login(ctx, cfg)
+		require.NoError(t, err)
+		assert.True(t, deleteAllCalled, "stale identity should be cleared")
+		assert.True(t, requestSent, "a fresh login request should be sent")
+		assert.True(t, newMachineIDPersisted, "the new machine ID should be persisted")
 	})
 }
 

--- a/pkg/login/mock_login_test.go
+++ b/pkg/login/mock_login_test.go
@@ -549,6 +549,19 @@ func TestLogin_MachineIDAlreadyAssignedWithChangedNodeLabelsAndMismatchedOverrid
 	})
 }
 
+func TestReconcileMachineID_OverwriteDeleteMetadataError(t *testing.T) {
+	mockey.PatchConvey("machine id overwrite reports metadata cleanup failure", t, func() {
+		mockey.Mock(pkgmetadata.DeleteAllMetadata).To(func(context.Context, *sql.DB) error {
+			return errors.New("metadata cleanup failed")
+		}).Build()
+
+		machineID, err := reconcileMachineID(context.Background(), &sql.DB{}, "stale-machine-id", "new-machine-id", true)
+		require.Error(t, err)
+		assert.Equal(t, "stale-machine-id", machineID)
+		assert.ErrorContains(t, err, "failed to clear persisted login identity for machine-id overwrite")
+	})
+}
+
 // TestLogin_MachineIDOverwriteChecksInWithRequestedMachineID verifies the --machine-id-overwrite path:
 // when the supplied machine ID differs from the persisted one, gpud clears the stale
 // login identity and checks in using the requested machine ID. This is the

--- a/pkg/login/mock_login_test.go
+++ b/pkg/login/mock_login_test.go
@@ -549,13 +549,13 @@ func TestLogin_MachineIDAlreadyAssignedWithChangedNodeLabelsAndMismatchedOverrid
 	})
 }
 
-// TestLogin_MachineIDOverwriteReRegisters verifies the --machine-id-overwrite path:
+// TestLogin_MachineIDOverwriteChecksInWithRequestedMachineID verifies the --machine-id-overwrite path:
 // when the supplied machine ID differs from the persisted one, gpud clears the stale
-// login identity and performs a fresh registration as the new machine. This is the
-// container/DaemonSet recovery path for a node that rejoined with a new machine object
-// while /var/lib/gpud still held the old identity.
-func TestLogin_MachineIDOverwriteReRegisters(t *testing.T) {
-	mockey.PatchConvey("machine id overwrite clears stale identity and re-registers", t, func() {
+// login identity and checks in using the requested machine ID. This is the
+// container/DaemonSet recovery path for a node that rejoined with a new machine
+// object while /var/lib/gpud still held the old identity.
+func TestLogin_MachineIDOverwriteChecksInWithRequestedMachineID(t *testing.T) {
+	mockey.PatchConvey("machine id overwrite clears stale identity and checks in with requested machine", t, func() {
 		mockDB := &sql.DB{}
 		deleteAllCalled := false
 		requestSent := false
@@ -600,9 +600,9 @@ func TestLogin_MachineIDOverwriteReRegisters(t *testing.T) {
 			return nil
 		}).Build()
 
+		var receivedMachineID string
 		mockey.Mock(pkgmachineinfo.CreateLoginRequest).To(func(_, machineID, _, _ string, _ nvidianvml.Instance) (*apiv1.LoginRequest, error) {
-			// fresh registration must NOT carry the stale machine ID
-			assert.NotEqual(t, "stale-machine-id", machineID)
+			receivedMachineID = machineID
 			return &apiv1.LoginRequest{Network: &apiv1.MachineNetwork{}}, nil
 		}).Build()
 
@@ -639,6 +639,7 @@ func TestLogin_MachineIDOverwriteReRegisters(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, deleteAllCalled, "stale identity should be cleared")
 		assert.True(t, requestSent, "a fresh login request should be sent")
+		assert.Equal(t, "new-machine-id", receivedMachineID, "the login request must use the requested machine ID, not the stale one")
 		assert.True(t, newMachineIDPersisted, "the new machine ID should be persisted")
 	})
 }


### PR DESCRIPTION
## Problem

gpud persists its login identity — **machine id**, **session token**, endpoint — in `/var/lib/gpud`, a node-scoped `hostPath` that survives reboots. In the container/DaemonSet pattern that cache can outlive what it describes, and gpud's "skip login if a machine id is already persisted" fast path then runs the node on **stale** state:

1. **Stale machine id** — a node deleted from its node group and rejoined binds a **NEW machine object** (new `machine-id` label) while the OLD id is still on disk → gpud either silently skips login on the stale id (runs under a mismatched identity, never joins) or fails with a terse mismatch error.
2. **Stale session token** — the persisted session token can be invalidated server-side (gpud-manager resets the BYOK session on every login; the workspace session SAK can rotate) → skip-login reuses a dead token → keepalive breaks.

This PR adds two opt-in flags (both **default `false`** in gpud for backward-compatibility, both **default `true`** in the chart, matching how the chart already enables container-pattern behaviors like `rebootCommands`/`findmntCommands`). They wire into the **same** skip/refresh fork in `login.Login`.

## 1. `--machine-id-overwrite`

When a supplied `--machine-id` differs from the persisted one:
- **false (default)** → reject with an actionable error (safe for host/systemd).
- **true** → discard the persisted login identity (machine id + session token, **metadata table only**) and re-register as the new machine. Reboot/event history is **preserved**.

Unified in `login.reconcileMachineID`, which runs *before* the skip/refresh fork so behavior is consistent whether or not node labels changed. The now-redundant deeper guard (`stored machine ID … does not match`) is removed (unreachable). The `--machine-id` flag docs now describe this.

## 2. `--refresh-session-token`

When set, gpud **always re-logins on start** even with a persisted machine id, instead of reusing the cached session token. The control plane re-issues the (workspace-scoped) session token on every successful login, so re-login reliably re-fetches a current one. Costs one extra login round-trip per start; keeps the cached token from going stale.

> Verified against gpud-manager: `server/handler_login.go` returns `sessionToken` on every success (`loginExistingMachine`/`loginNewMachine`), sourced from the workspace Secret via `tokenReader.GetToken(WorkspaceID, TokenPermissionSession)` — and `clearStaleSessionIfBYOK` resets the BYOK session on every login, so the server *expects* re-login.

A `TODO` is noted on both flags: once validated in production, make always-refresh the default and retire the toggle.

## Helm

`gpud.machineIdOverwrite` (default `true`) and `gpud.refreshSessionToken` (default `true`) → `GPUD_MACHINE_ID_OVERWRITE` / `GPUD_REFRESH_SESSION_TOKEN` env → the startup wrapper appends `--machine-id-overwrite` / `--refresh-session-token`. Set either to `false` to restore the strict/skip-login behavior.

## Backward compatibility

**Strict invariant preserved**: with both flags unset (`false`) and no `--machine-id` supplied — i.e. every existing host/systemd install — behavior is byte-for-byte identical. `reconcileMachineID` is a no-op when there's no persisted id, no supplied id, or they match; and without `--refresh-session-token` the skip-login fast path is unchanged.

## Testing

- `pkg/login/login_test.go` — `TestReconcileMachineID` (no-persisted / empty-requested / match / mismatch-fail / mismatch-overwrite).
- `pkg/login/mock_login_test.go` — full `Login` flow: `…MismatchedOverrideFails` (updated to the new error), `TestLogin_MachineIDOverwriteReRegisters`, and `TestLogin_RefreshSessionTokenRelogsIn` (forces relogin + re-persists the token when a machine id is already assigned and labels are unchanged; contrast with `TestLogin_MachineIDAlreadyAssigned`, which skips).
- `go build ./...`, `go vet`, `go test -gcflags="all=-N -l" ./pkg/login/` all green.
- `helm lint` + render verified for both flags: default → env + flag present; `--set …=false` → both omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)