### PR TITLE
fix(gpud): back off session reconnects

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -246,13 +246,21 @@ type Session struct {
 	// In production: time.Sleep, in tests: can be mocked to skip sleep
 	timeSleepFunc func(d time.Duration)
 
+	// nowFunc returns the current time.
+	// In production: time.Now, in tests: can be mocked for deterministic backoff.
+	nowFunc func() time.Time
+
+	// jitterFunc returns a delay in [0, max) for reconnect spreading.
+	// In production: random jitter, in tests: can be mocked for deterministic backoff.
+	jitterFunc func(max time.Duration) time.Duration
+
 	// startReaderFunc starts a reader connection
 	// In production: s.startReader, in tests: can be mocked
-	startReaderFunc func(ctx context.Context, readerExit chan any, jar *cookiejar.Jar)
+	startReaderFunc func(ctx context.Context, readerExit chan reconnectSignal, jar *cookiejar.Jar)
 
 	// startWriterFunc starts a writer connection
 	// In production: s.startWriter, in tests: can be mocked
-	startWriterFunc func(ctx context.Context, writerExit chan any, jar *cookiejar.Jar)
+	startWriterFunc func(ctx context.Context, writerExit chan reconnectSignal, jar *cookiejar.Jar)
 
 	// checkServerHealthFunc checks server health
 	// In production: s.checkServerHealth, in tests: can be mocked
@@ -344,6 +352,8 @@ func NewSession(ctx context.Context, epLocalGPUdServer string, epControlPlane st
 
 	s.timeAfterFunc = time.After
 	s.timeSleepFunc = time.Sleep
+	s.nowFunc = time.Now
+	s.jitterFunc = defaultJitter
 
 	s.startReaderFunc = s.startReader
 	s.startWriterFunc = s.startWriter
@@ -443,20 +453,22 @@ func controlPlaneOrigin(epControlPlane string) (string, error) {
 	return host, nil
 }
 
-func (s *Session) startWriter(ctx context.Context, writerExit chan any, jar *cookiejar.Jar) {
+func (s *Session) startWriter(ctx context.Context, writerExit chan reconnectSignal, jar *cookiejar.Jar) {
+	sig := reconnectSignal{side: reconnectSideWriter}
 	pipeFinishCh := make(chan any)
 	goroutineCloseCh := make(chan any)
 	defer func() {
 		close(goroutineCloseCh)
 		s.closer.Close()
 		<-pipeFinishCh
-		close(writerExit)
+		sendReconnectSignal(writerExit, sig)
 	}()
 	reader, writer := io.Pipe()
 	go s.handleWriterPipe(writer, goroutineCloseCh, pipeFinishCh)
 
 	req, err := createSessionRequest(ctx, s.epControlPlane, s.machineID, "write", s.token, reader)
 	if err != nil {
+		sig.err = err
 		log.Logger.Warnw("session writer: error creating request", "error", err)
 		return
 	}
@@ -464,9 +476,29 @@ func (s *Session) startWriter(ctx context.Context, writerExit chan any, jar *coo
 	client := createHTTPClient(jar)
 	resp, err := client.Do(req)
 	if err != nil {
+		if ctx.Err() != nil {
+			sig.err = ctx.Err()
+		} else {
+			sig.err = err
+		}
 		log.Logger.Warnw("session writer: error making request", "error", err)
 		return
 	}
+
+	if resp.StatusCode != http.StatusOK {
+		sig = classifySessionHTTPResponse(reconnectSideWriter, resp, s.now())
+		log.Logger.Warnw(
+			"session writer: request resp not ok -- retrying",
+			"status", resp.Status,
+			"statusCode", resp.StatusCode,
+			"retryAfter", sig.retryAfter.String(),
+			"reason", sig.reason,
+		)
+		return
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	serverID := resp.Header.Get("X-GPUD-Server-ID")
 	log.Logger.Infow("session writer: http closed", "status", resp.Status, "statusCode", resp.StatusCode, "serverID", serverID)
@@ -515,18 +547,20 @@ func (s *Session) writeBodyToPipe(writer *io.PipeWriter, body Body) error {
 	return nil
 }
 
-func (s *Session) startReader(ctx context.Context, readerExit chan any, jar *cookiejar.Jar) {
+func (s *Session) startReader(ctx context.Context, readerExit chan reconnectSignal, jar *cookiejar.Jar) {
+	sig := reconnectSignal{side: reconnectSideReader}
 	goroutineCloseCh := make(chan any)
 	pipeFinishCh := make(chan any)
 	defer func() {
 		close(goroutineCloseCh)
 		s.closer.Close()
 		<-pipeFinishCh
-		close(readerExit)
+		sendReconnectSignal(readerExit, sig)
 	}()
 
 	req, err := createSessionRequest(ctx, s.epControlPlane, s.machineID, "read", s.token, nil)
 	if err != nil {
+		sig.err = err
 		log.Logger.Debugw("session reader: error creating request", "error", err)
 		close(pipeFinishCh)
 		return
@@ -535,19 +569,29 @@ func (s *Session) startReader(ctx context.Context, readerExit chan any, jar *coo
 	client := createHTTPClient(jar)
 	resp, err := client.Do(req)
 	if err != nil {
+		if ctx.Err() != nil {
+			sig.err = ctx.Err()
+		} else {
+			sig.err = err
+		}
 		log.Logger.Warnw("session reader: error making request -- retrying", "error", err)
 		close(pipeFinishCh)
 		return
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		log.Logger.Warnw("session reader: request resp not ok -- retrying", "status", resp.Status, "statusCode", resp.StatusCode)
-
-		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusInternalServerError {
-			bodyBytes, _ := io.ReadAll(resp.Body)
-			if message, ok := loginFailureStatusMessage(resp.StatusCode, string(bodyBytes)); ok {
-				s.persistLoginStatus(ctx, false, message)
-			}
+		status := resp.Status
+		statusCode := resp.StatusCode
+		sig = classifySessionHTTPResponse(reconnectSideReader, resp, s.now())
+		log.Logger.Warnw(
+			"session reader: request resp not ok -- retrying",
+			"status", status,
+			"statusCode", statusCode,
+			"retryAfter", sig.retryAfter.String(),
+			"reason", sig.reason,
+		)
+		if sig.authFailure {
+			s.persistLoginStatus(ctx, false, sig.reason)
 		}
 
 		close(pipeFinishCh)
@@ -558,6 +602,9 @@ func (s *Session) startReader(ctx context.Context, readerExit chan any, jar *coo
 	log.Logger.Infow("session reader got X-GPUD-Server-ID", "serverID", serverID)
 
 	s.processReaderResponse(resp, goroutineCloseCh, pipeFinishCh)
+	if ctx.Err() != nil {
+		sig.err = ctx.Err()
+	}
 }
 
 // healthCheckHTTPError is returned by checkServerHealth when the control plane
@@ -566,6 +613,7 @@ func (s *Session) startReader(ctx context.Context, readerExit chan any, jar *coo
 type healthCheckHTTPError struct {
 	statusCode int
 	body       string
+	retryAfter time.Duration
 }
 
 func (e *healthCheckHTTPError) Error() string {
@@ -639,18 +687,21 @@ func (s *Session) checkServerHealth(ctx context.Context, jar *cookiejar.Jar, tok
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
 
 	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		body := string(bodyBytes)
+		body := readLimitedResponseBody(resp, sessionErrorBodyReadLimit)
 		if len(body) > 500 {
 			body = body[:500]
 		}
-		return &healthCheckHTTPError{statusCode: resp.StatusCode, body: body}
+		return &healthCheckHTTPError{
+			statusCode: resp.StatusCode,
+			body:       body,
+			retryAfter: parseRetryAfter(resp.Header.Get("Retry-After"), s.now()),
+		}
 	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	return nil
 }
 

--- a/pkg/session/session_keepalive.go
+++ b/pkg/session/session_keepalive.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"net/http/cookiejar"
-	"time"
 
 	"github.com/leptonai/gpud/pkg/log"
 )
 
 func (s *Session) keepAlive() {
-	// Start the initial connection immediately
-	firstConnection := true
+	backoff := reconnectBackoff{}
+	if !s.waitReconnectDelay(s.ctx, s.jitter(startupJitterMax)) {
+		return
+	}
 
 	for {
 		select {
@@ -19,29 +20,6 @@ func (s *Session) keepAlive() {
 			log.Logger.Debug("session keep alive: closing keep alive")
 			return
 		default:
-			// CRITICAL: Reconnection delay to prevent race conditions
-			//
-			// Without this delay, rapid connection failures would create multiple
-			// overlapping reader/writer goroutines that all write to the same channels,
-			// causing "reader channel full" errors and making GPUd unresponsive.
-			//
-			// The 3-second delay ensures:
-			// - Previous connections have time to fully clean up
-			// - We don't overwhelm the control plane with rapid reconnection attempts
-			// - Only one set of reader/writer goroutines exists at a time
-			if !firstConnection {
-				select {
-				case <-s.ctx.Done():
-					return
-				case <-s.timeAfterFunc(3 * time.Second):
-					log.Logger.Debug("session keep alive: attempting reconnection after delay")
-				}
-			}
-			firstConnection = false
-
-			readerExit := make(chan any)
-			writerExit := make(chan any)
-
 			// CLEANUP: Ensure previous connections are fully terminated
 			//
 			// This cleanup is essential to prevent the "reader channel full" bug:
@@ -55,7 +33,7 @@ func (s *Session) keepAlive() {
 				s.closer.Close()
 
 				// Give old goroutines time to detect closer signal and exit
-				s.timeSleepFunc(100 * time.Millisecond)
+				s.sleep(cleanupDrainDelay)
 
 				// Drain any stale messages left in the reader channel
 				s.drainReaderChannel()
@@ -78,14 +56,28 @@ func (s *Session) keepAlive() {
 				// "failed to validate token" when the token is invalid.
 				var httpErr *healthCheckHTTPError
 				if errors.As(err, &httpErr) {
-					if message, ok := loginFailureStatusMessage(httpErr.statusCode, httpErr.body); ok {
-						s.persistLoginStatus(ctx, false, message)
+					sig := classifyHealthCheckError(httpErr)
+					if sig.authFailure {
+						s.persistLoginStatus(ctx, false, sig.reason)
 					}
 				}
 
 				cancel()
+				if s.ctx.Err() != nil {
+					return
+				}
+				sig := classifyHealthCheckError(err)
+				delay := backoff.nextDelay(s, sig)
+				log.Logger.Debugw("session keep alive: attempting reconnection after delay", "delay", delay.String(), "reason", sig.reason, "retryAfter", sig.retryAfter.String())
+				if !s.waitReconnectDelay(s.ctx, delay) {
+					return
+				}
 				continue
 			}
+
+			readerExit := make(chan reconnectSignal, 1)
+			writerExit := make(chan reconnectSignal, 1)
+			connectionStartedAt := s.now()
 
 			go s.startReaderFunc(ctx, readerExit, jar)
 			go s.startWriterFunc(ctx, writerExit, jar)
@@ -107,17 +99,32 @@ func (s *Session) keepAlive() {
 			// - No deadlock: We handle both possible exit orders
 			// - Clean shutdown: Both goroutines exit before we create new ones
 			// - No goroutine leaks: Context cancellation ensures termination
+			var firstExit reconnectSignal
+			var secondExit reconnectSignal
 			select {
-			case <-readerExit:
+			case firstExit = <-readerExit:
 				log.Logger.Debug("session reader: reader exited first")
-				cancel()     // Signal writer to exit
-				<-writerExit // Wait for writer cleanup
+				cancel()                  // Signal writer to exit
+				secondExit = <-writerExit // Wait for writer cleanup
 				log.Logger.Debug("session writer: writer exited after cancellation")
-			case <-writerExit:
+			case firstExit = <-writerExit:
 				log.Logger.Debug("session writer: writer exited first")
-				cancel()     // Signal reader to exit
-				<-readerExit // Wait for reader cleanup
+				cancel()                  // Signal reader to exit
+				secondExit = <-readerExit // Wait for reader cleanup
 				log.Logger.Debug("session reader: reader exited after cancellation")
+			}
+			if s.ctx.Err() != nil {
+				return
+			}
+
+			if s.now().Sub(connectionStartedAt) >= reconnectStableWindow {
+				backoff.reset()
+			}
+			sig := chooseReconnectSignal(firstExit, secondExit)
+			delay := backoff.nextDelay(s, sig)
+			log.Logger.Debugw("session keep alive: attempting reconnection after delay", "delay", delay.String(), "reason", sig.reason, "retryAfter", sig.retryAfter.String())
+			if !s.waitReconnectDelay(s.ctx, delay) {
+				return
 			}
 		}
 	}

--- a/pkg/session/session_keepalive_health_check_test.go
+++ b/pkg/session/session_keepalive_health_check_test.go
@@ -69,10 +69,10 @@ func TestKeepAliveHealthCheck403PersistsFailure(t *testing.T) {
 	s.timeSleepFunc = func(d time.Duration) {}
 
 	// These should never be called since health check fails before reader/writer start
-	s.startReaderFunc = func(ctx context.Context, readerExit chan any, jar *cookiejar.Jar) {
+	s.startReaderFunc = func(ctx context.Context, readerExit chan reconnectSignal, jar *cookiejar.Jar) {
 		t.Fatal("startReader should not be called when health check fails")
 	}
-	s.startWriterFunc = func(ctx context.Context, writerExit chan any, jar *cookiejar.Jar) {
+	s.startWriterFunc = func(ctx context.Context, writerExit chan reconnectSignal, jar *cookiejar.Jar) {
 		t.Fatal("startWriter should not be called when health check fails")
 	}
 
@@ -146,10 +146,10 @@ func TestKeepAliveHealthCheck500TokenValidationPersistsFailure(t *testing.T) {
 		return ch
 	}
 	s.timeSleepFunc = func(d time.Duration) {}
-	s.startReaderFunc = func(ctx context.Context, readerExit chan any, jar *cookiejar.Jar) {
+	s.startReaderFunc = func(ctx context.Context, readerExit chan reconnectSignal, jar *cookiejar.Jar) {
 		t.Fatal("startReader should not be called when health check fails")
 	}
-	s.startWriterFunc = func(ctx context.Context, writerExit chan any, jar *cookiejar.Jar) {
+	s.startWriterFunc = func(ctx context.Context, writerExit chan reconnectSignal, jar *cookiejar.Jar) {
 		t.Fatal("startWriter should not be called when health check fails")
 	}
 
@@ -210,7 +210,7 @@ func TestStartReader500TokenValidationPersistsAuthenticationFailure(t *testing.T
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)
 
-	readerExit := make(chan any)
+	readerExit := make(chan reconnectSignal, 1)
 	s.startReader(ctx, readerExit, jar)
 
 	dbRO, err := sqlite.Open(stateFile, sqlite.WithReadOnly(true))
@@ -323,10 +323,10 @@ func TestKeepAliveHealthCheckNon403DoesNotPersist(t *testing.T) {
 		return ch
 	}
 	s.timeSleepFunc = func(d time.Duration) {}
-	s.startReaderFunc = func(ctx context.Context, readerExit chan any, jar *cookiejar.Jar) {
+	s.startReaderFunc = func(ctx context.Context, readerExit chan reconnectSignal, jar *cookiejar.Jar) {
 		t.Fatal("startReader should not be called when health check fails")
 	}
-	s.startWriterFunc = func(ctx context.Context, writerExit chan any, jar *cookiejar.Jar) {
+	s.startWriterFunc = func(ctx context.Context, writerExit chan reconnectSignal, jar *cookiejar.Jar) {
 		t.Fatal("startWriter should not be called when health check fails")
 	}
 
@@ -390,10 +390,10 @@ func TestKeepAliveHealthCheckNetworkErrorDoesNotPersist(t *testing.T) {
 		return ch
 	}
 	s.timeSleepFunc = func(d time.Duration) {}
-	s.startReaderFunc = func(ctx context.Context, readerExit chan any, jar *cookiejar.Jar) {
+	s.startReaderFunc = func(ctx context.Context, readerExit chan reconnectSignal, jar *cookiejar.Jar) {
 		t.Fatal("startReader should not be called when health check fails")
 	}
-	s.startWriterFunc = func(ctx context.Context, writerExit chan any, jar *cookiejar.Jar) {
+	s.startWriterFunc = func(ctx context.Context, writerExit chan reconnectSignal, jar *cookiejar.Jar) {
 		t.Fatal("startWriter should not be called when health check fails")
 	}
 

--- a/pkg/session/session_keepalive_test.go
+++ b/pkg/session/session_keepalive_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/http/cookiejar"
 	"sync"
 	"sync/atomic"
@@ -12,7 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestKeepAliveReconnectionDelay verifies that keepAlive waits 3 seconds before reconnecting
+// TestKeepAliveReconnectionDelay verifies that keepAlive uses startup jitter and
+// reconnect backoff between connection attempts.
 func TestKeepAliveReconnectionDelay(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -28,63 +30,143 @@ func TestKeepAliveReconnectionDelay(t *testing.T) {
 		return nil
 	}
 
-	// Track when timeAfter is called
-	var timeAfterCalled int32
+	s.jitterFunc = func(max time.Duration) time.Duration {
+		return max
+	}
+
+	var durationsMu sync.Mutex
+	var durations []time.Duration
 	s.timeAfterFunc = func(d time.Duration) <-chan time.Time {
-		atomic.AddInt32(&timeAfterCalled, 1)
-		assert.Equal(t, 3*time.Second, d, "Expected 3 second delay")
+		durationsMu.Lock()
+		durations = append(durations, d)
+		durationsMu.Unlock()
+
 		ch := make(chan time.Time, 1)
-		ch <- time.Now() // Return immediately for testing
+		ch <- time.Now()
 		return ch
 	}
 
-	// Mock sleep to avoid delays in test
 	var sleepCalled int32
 	s.timeSleepFunc = func(d time.Duration) {
 		atomic.AddInt32(&sleepCalled, 1)
-		assert.Equal(t, 100*time.Millisecond, d, "Expected 100ms cleanup sleep")
+		assert.Equal(t, cleanupDrainDelay, d, "Expected cleanup drain delay")
 	}
 
-	// Track reader/writer starts
 	var readerStarts int32
 	var writerStarts int32
 
-	s.startReaderFunc = func(ctx context.Context, readerExit chan any, jar *cookiejar.Jar) {
-		atomic.AddInt32(&readerStarts, 1)
-		// Simulate immediate exit to trigger reconnection
+	s.startReaderFunc = func(ctx context.Context, readerExit chan reconnectSignal, jar *cookiejar.Jar) {
+		if atomic.AddInt32(&readerStarts, 1) >= 3 {
+			cancel()
+		}
 		close(readerExit)
 	}
 
-	s.startWriterFunc = func(ctx context.Context, writerExit chan any, jar *cookiejar.Jar) {
+	s.startWriterFunc = func(ctx context.Context, writerExit chan reconnectSignal, jar *cookiejar.Jar) {
 		atomic.AddInt32(&writerStarts, 1)
-		// Simulate exit after reader
 		go func() {
 			<-ctx.Done()
-			close(writerExit)
+			sendReconnectSignal(writerExit, reconnectSignal{side: reconnectSideWriter, err: ctx.Err()})
 		}()
 	}
 
-	// Run keepAlive in background
-	go s.keepAlive()
+	done := make(chan struct{})
+	go func() {
+		s.keepAlive()
+		close(done)
+	}()
 
-	// Give it time to run through at least 2 connection attempts
-	time.Sleep(200 * time.Millisecond)
-	cancel()
-	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		cancel()
+		t.Fatal("keepAlive did not exit in time")
+	}
 
-	// Verify reconnection delay was used (called for second connection attempt)
-	assert.GreaterOrEqual(t, atomic.LoadInt32(&timeAfterCalled), int32(1),
-		"timeAfter should be called for reconnection delay")
-
-	// Verify cleanup sleep was called
 	assert.GreaterOrEqual(t, atomic.LoadInt32(&sleepCalled), int32(1),
 		"Sleep should be called for cleanup")
 
-	// Verify reader and writer were started
 	assert.GreaterOrEqual(t, atomic.LoadInt32(&readerStarts), int32(1),
 		"Reader should be started at least once")
 	assert.GreaterOrEqual(t, atomic.LoadInt32(&writerStarts), int32(1),
 		"Writer should be started at least once")
+
+	durationsMu.Lock()
+	gotDurations := append([]time.Duration(nil), durations...)
+	durationsMu.Unlock()
+	if assert.GreaterOrEqual(t, len(gotDurations), 2, "startup jitter and reconnect backoff should both wait") {
+		assert.Equal(t, startupJitterMax, gotDurations[0])
+		assert.Equal(t, reconnectInitialBackoff, gotDurations[1])
+	}
+}
+
+func TestKeepAliveReaderRetryAfterControlsReconnectDelay(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := &Session{
+		ctx:    ctx,
+		reader: make(chan Body, 20),
+		writer: make(chan Body, 20),
+	}
+
+	s.checkServerHealthFunc = func(ctx context.Context, jar *cookiejar.Jar, token string) error {
+		return nil
+	}
+	s.jitterFunc = func(max time.Duration) time.Duration {
+		switch max {
+		case startupJitterMax:
+			return 0
+		case retryAfterJitterMax:
+			return 2 * time.Second
+		default:
+			return time.Second
+		}
+	}
+	s.timeSleepFunc = func(d time.Duration) {}
+
+	delayCh := make(chan time.Duration, 1)
+	s.timeAfterFunc = func(d time.Duration) <-chan time.Time {
+		delayCh <- d
+		cancel()
+		ch := make(chan time.Time, 1)
+		ch <- time.Now()
+		return ch
+	}
+
+	s.startReaderFunc = func(ctx context.Context, readerExit chan reconnectSignal, jar *cookiejar.Jar) {
+		sendReconnectSignal(readerExit, reconnectSignal{
+			side:       reconnectSideReader,
+			statusCode: http.StatusServiceUnavailable,
+			retryAfter: 20 * time.Second,
+			reason:     "control plane busy",
+		})
+	}
+	s.startWriterFunc = func(ctx context.Context, writerExit chan reconnectSignal, jar *cookiejar.Jar) {
+		go func() {
+			<-ctx.Done()
+			sendReconnectSignal(writerExit, reconnectSignal{side: reconnectSideWriter, err: ctx.Err()})
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		s.keepAlive()
+		close(done)
+	}()
+
+	select {
+	case delay := <-delayCh:
+		assert.Equal(t, 22*time.Second, delay)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for reconnect delay")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("keepAlive did not exit in time")
+	}
 }
 
 // TestKeepAliveChannelDraining verifies that stale messages are drained
@@ -155,7 +237,7 @@ func TestKeepAliveDeadlockPrevention(t *testing.T) {
 			var mu sync.Mutex
 			var firstCall int32
 
-			s.startReaderFunc = func(ctx context.Context, readerExit chan any, jar *cookiejar.Jar) {
+			s.startReaderFunc = func(ctx context.Context, readerExit chan reconnectSignal, jar *cookiejar.Jar) {
 				// Only track the first call
 				if atomic.AddInt32(&firstCall, 1) > 2 {
 					close(readerExit)
@@ -194,7 +276,7 @@ func TestKeepAliveDeadlockPrevention(t *testing.T) {
 				}()
 			}
 
-			s.startWriterFunc = func(ctx context.Context, writerExit chan any, jar *cookiejar.Jar) {
+			s.startWriterFunc = func(ctx context.Context, writerExit chan reconnectSignal, jar *cookiejar.Jar) {
 				// Only track the first call
 				if atomic.LoadInt32(&firstCall) > 2 {
 					close(writerExit)
@@ -288,7 +370,7 @@ func TestKeepAliveNoRapidReconnection(t *testing.T) {
 	}
 	s.timeSleepFunc = func(d time.Duration) {}
 
-	s.startReaderFunc = func(ctx context.Context, readerExit chan any, jar *cookiejar.Jar) {
+	s.startReaderFunc = func(ctx context.Context, readerExit chan reconnectSignal, jar *cookiejar.Jar) {
 		current := atomic.AddInt32(&activeReaders, 1)
 		// Track max concurrent readers
 		for {
@@ -306,7 +388,7 @@ func TestKeepAliveNoRapidReconnection(t *testing.T) {
 		}()
 	}
 
-	s.startWriterFunc = func(ctx context.Context, writerExit chan any, jar *cookiejar.Jar) {
+	s.startWriterFunc = func(ctx context.Context, writerExit chan reconnectSignal, jar *cookiejar.Jar) {
 		current := atomic.AddInt32(&activeWriters, 1)
 		// Track max concurrent writers
 		for {

--- a/pkg/session/session_reconnect.go
+++ b/pkg/session/session_reconnect.go
@@ -1,0 +1,277 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	randv2 "math/rand/v2"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	reconnectSideReader      = "reader"
+	reconnectSideWriter      = "writer"
+	reconnectSideHealthCheck = "health_check"
+
+	sessionErrorBodyReadLimit = 4 << 10
+
+	reconnectInitialBackoff = 3 * time.Second
+	reconnectMaxBackoff     = 60 * time.Second
+	reconnectStableWindow   = 2 * time.Minute
+	startupJitterMax        = 10 * time.Second
+	retryAfterJitterMax     = 5 * time.Second
+	tokenReconnectJitterMin = 2 * time.Second
+	tokenReconnectJitterMax = 30 * time.Second
+	cleanupDrainDelay       = 100 * time.Millisecond
+)
+
+type reconnectSignal struct {
+	side        string
+	statusCode  int
+	retryAfter  time.Duration
+	reason      string
+	authFailure bool
+	err         error
+}
+
+func (s reconnectSignal) isZero() bool {
+	return s.side == "" && s.statusCode == 0 && s.retryAfter == 0 && s.reason == "" && !s.authFailure && s.err == nil
+}
+
+func (s reconnectSignal) isOverload() bool {
+	return isOverloadStatus(s.statusCode)
+}
+
+func (s reconnectSignal) isContextShutdown() bool {
+	return errors.Is(s.err, context.Canceled) || errors.Is(s.err, context.DeadlineExceeded)
+}
+
+type reconnectBackoff struct {
+	attempt int
+}
+
+func (b *reconnectBackoff) reset() {
+	b.attempt = 0
+}
+
+func (b *reconnectBackoff) nextDelay(s *Session, sig reconnectSignal) time.Duration {
+	maxDelay := reconnectInitialBackoff
+	for i := 0; i < b.attempt && maxDelay < reconnectMaxBackoff; i++ {
+		maxDelay *= 2
+		if maxDelay > reconnectMaxBackoff {
+			maxDelay = reconnectMaxBackoff
+		}
+	}
+
+	delay := s.jitter(maxDelay)
+	if sig.retryAfter > delay {
+		delay = sig.retryAfter
+	}
+	if sig.retryAfter > 0 {
+		delay += s.jitter(retryAfterJitterMax)
+	}
+	b.attempt++
+	return delay
+}
+
+func sendReconnectSignal(ch chan reconnectSignal, sig reconnectSignal) {
+	select {
+	case ch <- sig:
+	default:
+	}
+	close(ch)
+}
+
+func chooseReconnectSignal(first, second reconnectSignal) reconnectSignal {
+	if first.isContextShutdown() && !second.isZero() && !second.isContextShutdown() {
+		return second
+	}
+	if second.isContextShutdown() && !first.isZero() && !first.isContextShutdown() {
+		return first
+	}
+
+	if first.isOverload() && first.retryAfter > 0 && second.isOverload() && second.retryAfter > 0 {
+		if second.retryAfter > first.retryAfter {
+			return second
+		}
+		return first
+	}
+	if first.isOverload() && first.retryAfter > 0 {
+		return first
+	}
+	if second.isOverload() && second.retryAfter > 0 {
+		return second
+	}
+	if first.authFailure {
+		return first
+	}
+	if second.authFailure {
+		return second
+	}
+	if first.isOverload() {
+		return first
+	}
+	if second.isOverload() {
+		return second
+	}
+	if !first.isZero() {
+		return first
+	}
+	return second
+}
+
+func parseRetryAfter(value string, now time.Time) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+
+	t, err := http.ParseTime(value)
+	if err != nil {
+		return 0
+	}
+	if !t.After(now) {
+		return 0
+	}
+	return t.Sub(now)
+}
+
+func readLimitedResponseBody(resp *http.Response, limit int64) string {
+	if resp == nil || resp.Body == nil {
+		return ""
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if limit <= 0 {
+		limit = sessionErrorBodyReadLimit
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, limit))
+	if err != nil {
+		return ""
+	}
+	return string(body)
+}
+
+func extractResponseReason(body string) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(body), &payload); err == nil {
+		for _, key := range []string{"reason", "message", "error_summary", "error", "code"} {
+			if value, ok := payload[key]; ok {
+				reason := strings.TrimSpace(fmt.Sprint(value))
+				if reason != "" {
+					return reason
+				}
+			}
+		}
+	}
+	return body
+}
+
+func classifySessionHTTPResponse(side string, resp *http.Response, now time.Time) reconnectSignal {
+	sig := reconnectSignal{side: side}
+	if resp == nil {
+		return sig
+	}
+
+	body := readLimitedResponseBody(resp, sessionErrorBodyReadLimit)
+	sig.statusCode = resp.StatusCode
+	sig.retryAfter = parseRetryAfter(resp.Header.Get("Retry-After"), now)
+	sig.reason = extractResponseReason(body)
+	if sig.reason == "" {
+		sig.reason = resp.Status
+	}
+
+	if message, ok := loginFailureStatusMessage(resp.StatusCode, body); ok {
+		sig.authFailure = true
+		sig.reason = message
+	}
+	return sig
+}
+
+func classifyHealthCheckError(err error) reconnectSignal {
+	sig := reconnectSignal{side: reconnectSideHealthCheck, err: err}
+	if err == nil {
+		return sig
+	}
+
+	var httpErr *healthCheckHTTPError
+	if errors.As(err, &httpErr) {
+		sig.statusCode = httpErr.statusCode
+		sig.retryAfter = httpErr.retryAfter
+		sig.reason = extractResponseReason(httpErr.body)
+		if sig.reason == "" {
+			sig.reason = http.StatusText(httpErr.statusCode)
+		}
+		if message, ok := loginFailureStatusMessage(httpErr.statusCode, httpErr.body); ok {
+			sig.authFailure = true
+			sig.reason = message
+		}
+	}
+	return sig
+}
+
+func isOverloadStatus(statusCode int) bool {
+	return statusCode == http.StatusTooManyRequests || statusCode == http.StatusServiceUnavailable
+}
+
+func defaultJitter(max time.Duration) time.Duration {
+	if max <= 0 {
+		return 0
+	}
+	return time.Duration(randv2.Int64N(int64(max)))
+}
+
+func (s *Session) now() time.Time {
+	if s != nil && s.nowFunc != nil {
+		return s.nowFunc()
+	}
+	return time.Now()
+}
+
+func (s *Session) jitter(max time.Duration) time.Duration {
+	if s != nil && s.jitterFunc != nil {
+		return s.jitterFunc(max)
+	}
+	return defaultJitter(max)
+}
+
+func (s *Session) waitReconnectDelay(ctx context.Context, delay time.Duration) bool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if delay <= 0 {
+		return ctx.Err() == nil
+	}
+
+	timeAfter := time.After
+	if s != nil && s.timeAfterFunc != nil {
+		timeAfter = s.timeAfterFunc
+	}
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timeAfter(delay):
+		return true
+	}
+}

--- a/pkg/session/session_reconnect_test.go
+++ b/pkg/session/session_reconnect_test.go
@@ -1,0 +1,327 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Date(2026, 6, 29, 10, 0, 0, 0, time.UTC)
+	future := now.Add(2 * time.Minute).Format(http.TimeFormat)
+	past := now.Add(-time.Minute).Format(http.TimeFormat)
+
+	tests := []struct {
+		name string
+		in   string
+		want time.Duration
+	}{
+		{name: "empty", in: "", want: 0},
+		{name: "seconds", in: "15", want: 15 * time.Second},
+		{name: "zero seconds", in: "0", want: 0},
+		{name: "negative seconds", in: "-1", want: 0},
+		{name: "future http date", in: future, want: 2 * time.Minute},
+		{name: "past http date", in: past, want: 0},
+		{name: "invalid", in: "soon", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseRetryAfter(tt.in, now); got != tt.want {
+				t.Fatalf("parseRetryAfter(%q) = %s, want %s", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifySessionHTTPResponse(t *testing.T) {
+	now := time.Date(2026, 6, 29, 10, 0, 0, 0, time.UTC)
+
+	t.Run("overload retry after", func(t *testing.T) {
+		resp := &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Status:     "503 Service Unavailable",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"message":"control plane busy"}`)),
+		}
+		resp.Header.Set("Retry-After", "7")
+
+		sig := classifySessionHTTPResponse(reconnectSideReader, resp, now)
+		if sig.side != reconnectSideReader {
+			t.Fatalf("side = %q, want %q", sig.side, reconnectSideReader)
+		}
+		if sig.statusCode != http.StatusServiceUnavailable {
+			t.Fatalf("statusCode = %d, want %d", sig.statusCode, http.StatusServiceUnavailable)
+		}
+		if sig.retryAfter != 7*time.Second {
+			t.Fatalf("retryAfter = %s, want 7s", sig.retryAfter)
+		}
+		if sig.reason != "control plane busy" {
+			t.Fatalf("reason = %q, want control plane busy", sig.reason)
+		}
+		if !sig.isOverload() {
+			t.Fatal("expected overload signal")
+		}
+		if sig.authFailure {
+			t.Fatal("did not expect auth failure")
+		}
+	})
+
+	t.Run("token validation internal failure normalized as auth", func(t *testing.T) {
+		resp := &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Internal Server Error",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"code":"InternalFailure","message":"failed to validate token"}`)),
+		}
+
+		sig := classifySessionHTTPResponse(reconnectSideWriter, resp, now)
+		if !sig.authFailure {
+			t.Fatal("expected auth failure")
+		}
+		if !strings.Contains(sig.reason, "HTTP 401") {
+			t.Fatalf("reason %q should contain normalized HTTP 401", sig.reason)
+		}
+		if !strings.Contains(sig.reason, "InvalidToken") {
+			t.Fatalf("reason %q should contain InvalidToken", sig.reason)
+		}
+	})
+
+	t.Run("falls back to response status", func(t *testing.T) {
+		resp := &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Status:     "429 Too Many Requests",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+		}
+
+		sig := classifySessionHTTPResponse(reconnectSideReader, resp, now)
+		if sig.reason != "429 Too Many Requests" {
+			t.Fatalf("reason = %q, want response status", sig.reason)
+		}
+	})
+}
+
+func TestStartReaderRetryAfterSignal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-GPUD-Session-Type"); got != "read" {
+			http.Error(w, "unexpected session type: "+got, http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Retry-After", "13")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"message":"reader overloaded"}`))
+	}))
+	defer server.Close()
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("failed to create cookie jar: %v", err)
+	}
+	s := &Session{
+		epControlPlane: server.URL,
+		machineID:      "machine-id",
+		token:          "token",
+		closer:         &closeOnce{closer: make(chan any)},
+		nowFunc: func() time.Time {
+			return time.Date(2026, 6, 29, 10, 0, 0, 0, time.UTC)
+		},
+	}
+
+	readerExit := make(chan reconnectSignal, 1)
+	s.startReader(context.Background(), readerExit, jar)
+
+	sig := <-readerExit
+	if sig.side != reconnectSideReader {
+		t.Fatalf("side = %q, want reader", sig.side)
+	}
+	if sig.statusCode != http.StatusServiceUnavailable {
+		t.Fatalf("statusCode = %d, want %d", sig.statusCode, http.StatusServiceUnavailable)
+	}
+	if sig.retryAfter != 13*time.Second {
+		t.Fatalf("retryAfter = %s, want 13s", sig.retryAfter)
+	}
+	if sig.reason != "reader overloaded" {
+		t.Fatalf("reason = %q, want reader overloaded", sig.reason)
+	}
+}
+
+func TestStartWriterRetryAfterSignal(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-GPUD-Session-Type"); got != "write" {
+			http.Error(w, "unexpected session type: "+got, http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Retry-After", "17")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"writer throttled"}`))
+	}))
+	defer server.Close()
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("failed to create cookie jar: %v", err)
+	}
+	s := &Session{
+		epControlPlane: server.URL,
+		machineID:      "machine-id",
+		token:          "token",
+		closer:         &closeOnce{closer: make(chan any)},
+		writer:         make(chan Body, 1),
+		nowFunc: func() time.Time {
+			return time.Date(2026, 6, 29, 10, 0, 0, 0, time.UTC)
+		},
+	}
+
+	writerExit := make(chan reconnectSignal, 1)
+	s.startWriter(context.Background(), writerExit, jar)
+
+	sig := <-writerExit
+	if sig.side != reconnectSideWriter {
+		t.Fatalf("side = %q, want writer", sig.side)
+	}
+	if sig.statusCode != http.StatusTooManyRequests {
+		t.Fatalf("statusCode = %d, want %d", sig.statusCode, http.StatusTooManyRequests)
+	}
+	if sig.retryAfter != 17*time.Second {
+		t.Fatalf("retryAfter = %s, want 17s", sig.retryAfter)
+	}
+	if sig.reason != "writer throttled" {
+		t.Fatalf("reason = %q, want writer throttled", sig.reason)
+	}
+}
+
+func TestReconnectBackoffNextDelay(t *testing.T) {
+	t.Run("exponential jitter window", func(t *testing.T) {
+		s := &Session{
+			jitterFunc: func(max time.Duration) time.Duration {
+				return max / 2
+			},
+		}
+		backoff := reconnectBackoff{}
+
+		if got := backoff.nextDelay(s, reconnectSignal{}); got != reconnectInitialBackoff/2 {
+			t.Fatalf("first delay = %s, want %s", got, reconnectInitialBackoff/2)
+		}
+		if got := backoff.nextDelay(s, reconnectSignal{}); got != reconnectInitialBackoff {
+			t.Fatalf("second delay = %s, want %s", got, reconnectInitialBackoff)
+		}
+	})
+
+	t.Run("retry after overrides jitter and adds spreading jitter", func(t *testing.T) {
+		s := &Session{
+			jitterFunc: func(max time.Duration) time.Duration {
+				if max == retryAfterJitterMax {
+					return 2 * time.Second
+				}
+				return time.Second
+			},
+		}
+		backoff := reconnectBackoff{}
+
+		got := backoff.nextDelay(s, reconnectSignal{
+			statusCode: http.StatusServiceUnavailable,
+			retryAfter: 20 * time.Second,
+		})
+		if got != 22*time.Second {
+			t.Fatalf("delay = %s, want 22s", got)
+		}
+	})
+}
+
+func TestChooseReconnectSignal(t *testing.T) {
+	t.Run("uses longest overload retry after", func(t *testing.T) {
+		first := reconnectSignal{side: reconnectSideReader, statusCode: http.StatusTooManyRequests, retryAfter: 5 * time.Second}
+		second := reconnectSignal{side: reconnectSideWriter, statusCode: http.StatusServiceUnavailable, retryAfter: 11 * time.Second}
+
+		got := chooseReconnectSignal(first, second)
+		if got.side != reconnectSideWriter {
+			t.Fatalf("selected side = %q, want writer", got.side)
+		}
+		if got.retryAfter != 11*time.Second {
+			t.Fatalf("selected retryAfter = %s, want 11s", got.retryAfter)
+		}
+	})
+
+	t.Run("auth failure outranks generic exit", func(t *testing.T) {
+		first := reconnectSignal{side: reconnectSideReader}
+		second := reconnectSignal{side: reconnectSideWriter, authFailure: true, reason: "bad token"}
+
+		got := chooseReconnectSignal(first, second)
+		if got.side != reconnectSideWriter {
+			t.Fatalf("selected side = %q, want writer", got.side)
+		}
+		if !got.authFailure {
+			t.Fatal("expected auth failure to be selected")
+		}
+	})
+
+	t.Run("sibling context shutdown does not hide failure reason", func(t *testing.T) {
+		first := reconnectSignal{side: reconnectSideReader, statusCode: http.StatusServiceUnavailable, retryAfter: 30 * time.Second}
+		second := reconnectSignal{side: reconnectSideWriter, err: context.Canceled}
+
+		got := chooseReconnectSignal(first, second)
+		if got.side != reconnectSideReader {
+			t.Fatalf("selected side = %q, want reader", got.side)
+		}
+		if got.retryAfter != 30*time.Second {
+			t.Fatalf("selected retryAfter = %s, want 30s", got.retryAfter)
+		}
+	})
+
+	t.Run("context shutdown selected when no failure reason exists", func(t *testing.T) {
+		first := reconnectSignal{side: reconnectSideReader, err: context.Canceled}
+		second := reconnectSignal{}
+
+		got := chooseReconnectSignal(first, second)
+		if !errors.Is(got.err, context.Canceled) {
+			t.Fatalf("selected err = %v, want context.Canceled", got.err)
+		}
+	})
+}
+
+func TestCheckServerHealthCapturesRetryAfter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Retry-After", "9")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"message":"slow down"}`))
+	}))
+	defer server.Close()
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatalf("failed to create cookie jar: %v", err)
+	}
+	s := &Session{
+		epControlPlane: server.URL,
+		token:          "token",
+		nowFunc: func() time.Time {
+			return time.Date(2026, 6, 29, 10, 0, 0, 0, time.UTC)
+		},
+	}
+
+	err = s.checkServerHealth(context.Background(), jar, "")
+	var httpErr *healthCheckHTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected healthCheckHTTPError, got %v", err)
+	}
+	if httpErr.statusCode != http.StatusTooManyRequests {
+		t.Fatalf("statusCode = %d, want %d", httpErr.statusCode, http.StatusTooManyRequests)
+	}
+	if httpErr.retryAfter != 9*time.Second {
+		t.Fatalf("retryAfter = %s, want 9s", httpErr.retryAfter)
+	}
+	if httpErr.body != `{"message":"slow down"}` {
+		t.Fatalf("body = %q", httpErr.body)
+	}
+}

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -189,6 +189,12 @@ func TestStartWriterAndReader(t *testing.T) {
 
 	// Initialize testable functions with controlled implementations to make
 	// goroutine lifecycles deterministic during the test.
+	s.jitterFunc = func(max time.Duration) time.Duration {
+		if max == startupJitterMax {
+			return 0
+		}
+		return max
+	}
 	s.timeAfterFunc = func(d time.Duration) <-chan time.Time {
 		// Block reconnection attempts after the first session so we can
 		// explicitly control shutdown ordering in the test.
@@ -199,17 +205,17 @@ func TestStartWriterAndReader(t *testing.T) {
 	originalStartWriter := s.startWriter
 
 	var exitMu sync.Mutex
-	var readerExitChans []<-chan any
-	var writerExitChans []<-chan any
+	var readerExitChans []<-chan reconnectSignal
+	var writerExitChans []<-chan reconnectSignal
 
-	s.startReaderFunc = func(ctx context.Context, readerExit chan any, jar *cookiejar.Jar) {
+	s.startReaderFunc = func(ctx context.Context, readerExit chan reconnectSignal, jar *cookiejar.Jar) {
 		exitMu.Lock()
 		readerExitChans = append(readerExitChans, readerExit)
 		exitMu.Unlock()
 		originalStartReader(ctx, readerExit, jar)
 	}
 
-	s.startWriterFunc = func(ctx context.Context, writerExit chan any, jar *cookiejar.Jar) {
+	s.startWriterFunc = func(ctx context.Context, writerExit chan reconnectSignal, jar *cookiejar.Jar) {
 		exitMu.Lock()
 		writerExitChans = append(writerExitChans, writerExit)
 		exitMu.Unlock()
@@ -290,7 +296,7 @@ func TestStartWriterAndReader(t *testing.T) {
 	// Signal active session goroutines to exit and wait for them to finish
 	s.closer.Close()
 
-	waitForExit := func(chans []<-chan any, name string) {
+	waitForExit := func(chans []<-chan reconnectSignal, name string) {
 		t.Helper()
 		for idx, ch := range chans {
 			select {
@@ -302,8 +308,8 @@ func TestStartWriterAndReader(t *testing.T) {
 	}
 
 	exitMu.Lock()
-	readerChans := append([]<-chan any(nil), readerExitChans...)
-	writerChans := append([]<-chan any(nil), writerExitChans...)
+	readerChans := append([]<-chan reconnectSignal(nil), readerExitChans...)
+	writerChans := append([]<-chan reconnectSignal(nil), writerExitChans...)
 	exitMu.Unlock()
 
 	if len(readerChans) == 0 {
@@ -405,7 +411,7 @@ func TestReaderWriterServerError(t *testing.T) {
 	localCtx, localCancel := context.WithCancel(context.Background()) // create local context for each session
 	defer localCancel()
 	// start reader
-	readerExit := make(chan any)
+	readerExit := make(chan reconnectSignal, 1)
 	jar, _ := cookiejar.New(nil)
 	go s.startReader(localCtx, readerExit, jar)
 
@@ -415,7 +421,7 @@ func TestReaderWriterServerError(t *testing.T) {
 		t.Error("reader timeout")
 	}
 	// start writer
-	writerExit := make(chan any)
+	writerExit := make(chan reconnectSignal, 1)
 	go s.startWriter(localCtx, writerExit, jar)
 
 	select {
@@ -738,17 +744,17 @@ func TestSessionKeepAlive(t *testing.T) {
 	originalStartWriter := s.startWriter
 
 	var exitMu sync.Mutex
-	var readerExitChans []<-chan any
-	var writerExitChans []<-chan any
+	var readerExitChans []<-chan reconnectSignal
+	var writerExitChans []<-chan reconnectSignal
 
-	s.startReaderFunc = func(ctx context.Context, readerExit chan any, jar *cookiejar.Jar) {
+	s.startReaderFunc = func(ctx context.Context, readerExit chan reconnectSignal, jar *cookiejar.Jar) {
 		exitMu.Lock()
 		readerExitChans = append(readerExitChans, readerExit)
 		exitMu.Unlock()
 		originalStartReader(ctx, readerExit, jar)
 	}
 
-	s.startWriterFunc = func(ctx context.Context, writerExit chan any, jar *cookiejar.Jar) {
+	s.startWriterFunc = func(ctx context.Context, writerExit chan reconnectSignal, jar *cookiejar.Jar) {
 		exitMu.Lock()
 		writerExitChans = append(writerExitChans, writerExit)
 		exitMu.Unlock()
@@ -775,7 +781,7 @@ func TestSessionKeepAlive(t *testing.T) {
 	s.closer.Close()
 
 	// Wait for all goroutines to exit
-	waitForExit := func(chans []<-chan any, name string) {
+	waitForExit := func(chans []<-chan reconnectSignal, name string) {
 		t.Helper()
 		for idx, ch := range chans {
 			select {
@@ -787,8 +793,8 @@ func TestSessionKeepAlive(t *testing.T) {
 	}
 
 	exitMu.Lock()
-	readerChans := append([]<-chan any(nil), readerExitChans...)
-	writerChans := append([]<-chan any(nil), writerExitChans...)
+	readerChans := append([]<-chan reconnectSignal(nil), readerExitChans...)
+	writerChans := append([]<-chan reconnectSignal(nil), writerExitChans...)
 	exitMu.Unlock()
 
 	// Only wait if goroutines were started (they may not start if server health check fails)

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -735,6 +735,12 @@ func TestSessionKeepAlive(t *testing.T) {
 	}
 
 	// Initialize testable functions with controlled implementations to prevent race conditions
+	s.jitterFunc = func(max time.Duration) time.Duration {
+		if max == startupJitterMax {
+			return 0
+		}
+		return max
+	}
 	s.timeAfterFunc = func(d time.Duration) <-chan time.Time {
 		// Block reconnection attempts to control shutdown
 		return make(chan time.Time)
@@ -797,13 +803,10 @@ func TestSessionKeepAlive(t *testing.T) {
 	writerChans := append([]<-chan reconnectSignal(nil), writerExitChans...)
 	exitMu.Unlock()
 
-	// Only wait if goroutines were started (they may not start if server health check fails)
-	if len(readerChans) > 0 {
-		waitForExit(readerChans, "reader")
-	}
-	if len(writerChans) > 0 {
-		waitForExit(writerChans, "writer")
-	}
+	require.NotEmpty(t, readerChans, "reader goroutine should start")
+	require.NotEmpty(t, writerChans, "writer goroutine should start")
+	waitForExit(readerChans, "reader")
+	waitForExit(writerChans, "writer")
 
 	// Give a bit of time for any pending operations
 	time.Sleep(100 * time.Millisecond)

--- a/pkg/session/token.go
+++ b/pkg/session/token.go
@@ -11,7 +11,7 @@ import (
 )
 
 // processUpdateToken updates the session token in the database with the new token from the control plane.
-// It validates the new token before updating, and immediately reconnects the session with the new token.
+// It validates the new token before updating, then schedules the current session to reconnect with the new token.
 func (s *Session) processUpdateToken(payload Request, response *Response) {
 	if payload.Token == "" {
 		response.Error = "token cannot be empty"
@@ -56,9 +56,9 @@ func (s *Session) processUpdateToken(payload Request, response *Response) {
 
 	log.Logger.Infow("token updated successfully in database and memory")
 
-	// Immediately close the current session to force reconnection with the new token
+	// Schedule the current session to close after jitter so it reconnects with the new token.
 	delay := tokenReconnectJitterMin + s.jitter(tokenReconnectJitterMax-tokenReconnectJitterMin)
-	log.Logger.Infow("closing current session to reconnect with new token after delay", "delay", delay.String())
+	log.Logger.Infow("scheduling current session reconnect with new token", "delay", delay.String())
 	go func() {
 		if !s.waitReconnectDelay(s.ctx, delay) {
 			return

--- a/pkg/session/token.go
+++ b/pkg/session/token.go
@@ -57,11 +57,15 @@ func (s *Session) processUpdateToken(payload Request, response *Response) {
 	log.Logger.Infow("token updated successfully in database and memory")
 
 	// Immediately close the current session to force reconnection with the new token
-	log.Logger.Infow("closing current session to immediately reconnect with new token")
+	delay := tokenReconnectJitterMin + s.jitter(tokenReconnectJitterMax-tokenReconnectJitterMin)
+	log.Logger.Infow("closing current session to reconnect with new token after delay", "delay", delay.String())
 	go func() {
-		// Give some time for the response to be sent back to control plane
-		time.Sleep(2 * time.Second)
-		s.closer.Close()
+		if !s.waitReconnectDelay(s.ctx, delay) {
+			return
+		}
+		if s.closer != nil {
+			s.closer.Close()
+		}
 	}()
 }
 

--- a/pkg/session/token_test.go
+++ b/pkg/session/token_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	pkgmetadata "github.com/leptonai/gpud/pkg/metadata"
 	pkgsqlite "github.com/leptonai/gpud/pkg/sqlite"
@@ -172,6 +173,65 @@ func TestProcessUpdateToken(t *testing.T) {
 				t.Errorf("expected in-memory token %q, got %q", tt.expectedToken, actualToken)
 			}
 		})
+	}
+}
+
+func TestProcessUpdateTokenReconnectUsesJitteredDelay(t *testing.T) {
+	ctx := context.Background()
+
+	dbRW, dbRO, cleanup := pkgsqlite.OpenTestDB(t)
+	defer cleanup()
+
+	if err := pkgmetadata.CreateTableMetadata(ctx, dbRW); err != nil {
+		t.Fatalf("failed to create metadata table: %v", err)
+	}
+	if err := pkgmetadata.SetMetadata(ctx, dbRW, pkgmetadata.MetadataKeyToken, "old-token"); err != nil {
+		t.Fatalf("failed to set initial token: %v", err)
+	}
+
+	delayCh := make(chan time.Duration, 1)
+	s := &Session{
+		ctx:    ctx,
+		token:  "old-token",
+		dbRW:   dbRW,
+		dbRO:   dbRO,
+		closer: &closeOnce{closer: make(chan any)},
+		checkServerHealthFunc: func(ctx context.Context, jar *cookiejar.Jar, token string) error {
+			return nil
+		},
+		jitterFunc: func(max time.Duration) time.Duration {
+			if max != tokenReconnectJitterMax-tokenReconnectJitterMin {
+				t.Errorf("jitter max = %s, want %s", max, tokenReconnectJitterMax-tokenReconnectJitterMin)
+			}
+			return 7 * time.Second
+		},
+		timeAfterFunc: func(d time.Duration) <-chan time.Time {
+			delayCh <- d
+			ch := make(chan time.Time, 1)
+			ch <- time.Now()
+			return ch
+		},
+	}
+
+	response := &Response{}
+	s.processUpdateToken(Request{Token: "new-token"}, response)
+	if response.Error != "" {
+		t.Fatalf("unexpected error: %s", response.Error)
+	}
+
+	select {
+	case delay := <-delayCh:
+		if delay != 9*time.Second {
+			t.Fatalf("delay = %s, want 9s", delay)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for reconnect delay")
+	}
+
+	select {
+	case <-s.closer.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for session closer")
 	}
 }
 


### PR DESCRIPTION
  ## Summary

  - Add structured reconnect signals for gpud session reader, writer, and health-check failures.
  - Parse `Retry-After` from 429/503 responses and use it as the lower bound for reconnect delay.
  - Replace fixed reconnect timing with exponential backoff plus jitter, including startup jitter.
  - Add jittered reconnect after `updateToken` so token rotation does not reconnect all agents at once.
  - Preserve auth failure persistence for 401/403 and token-validation 500 responses.

  ## Testing

  - `go test -gcflags="all=-N -l" ./pkg/session`
  - E2E single-machine replacement on worker node `fargate-ip-10-50-115-131.ec2.internal`
  - Verified real gpud service health, states, components, metrics, and control/worker machine status
  - Verified fake manager scenarios for health 503, reader 503, writer 429, auth 500, and token update