### PR TITLE
feat(helm): publish charts through GitHub Pages

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -1,0 +1,29 @@
+name: Helm chart release
+
+"on":
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Release chart
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: deployments/helm
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/deployments/helm/gpud/README.md
+++ b/deployments/helm/gpud/README.md
@@ -11,10 +11,33 @@ GPUd is a lightweight, high-performance daemon that monitors GPU resources. This
 
 ## Installing the Chart
 
+Add the GPUd chart repository:
+
+```bash
+helm repo add gpud https://leptonai.github.io/gpud
+helm repo update
+```
+
+### Migrating from the OCI chart registry
+
+GitHub Container Registry no longer hosts GPUd charts. Replace an OCI install
+such as `oci://ghcr.io/leptonai/gpud` with the `gpud/gpud` chart after adding
+the repository above:
+
+```bash
+helm upgrade --install my-gpud gpud/gpud \
+  --version 0.12.5 \
+  --create-namespace \
+  --namespace gpud
+```
+
+The container image remains independently configurable through
+`image.repository` and `image.tag`.
+
 To install the chart with the release name `my-gpud`:
 
 ```bash
-helm install my-gpud <YOUR_REPO_NAME>/gpud \
+helm install my-gpud gpud/gpud \
   --create-namespace \
   --namespace gpud
 ```
@@ -24,7 +47,7 @@ helm install my-gpud <YOUR_REPO_NAME>/gpud \
 To install with a specific image tag and disable telemetry:
 
 ```bash
-helm install my-gpud <YOUR_REPO_NAME>/gpud \
+helm install my-gpud gpud/gpud \
   --create-namespace \
   --namespace gpud \
   --set image.tag="<MY_IMAGE_TAG>" \
@@ -34,7 +57,7 @@ helm install my-gpud <YOUR_REPO_NAME>/gpud \
 You can also provide a custom `values.yaml` file:
 
 ```bash
-helm install my-gpud <YOUR_REPO_NAME>/gpud \
+helm install my-gpud gpud/gpud \
   --namespace gpud -f my-values.yaml
 ```
 


### PR DESCRIPTION
## Summary

- Publish GPUd Helm charts through GitHub Pages instead of GitHub Container Registry.
- Use Helm Chart Releaser on `main` to create chart release assets and update `gh-pages/index.yaml`.
- Document the OCI-to-HTTP migration for chart consumers.

## How to use the new repository

```bash
helm repo add gpud https://leptonai.github.io/gpud
helm repo update
helm upgrade --install my-gpud gpud/gpud --version 0.12.5 --create-namespace --namespace gpud
```

## Branch responsibilities

- `main`: chart source, release workflow, Dockerfile, and Docker build scripts.
- `gh-pages`: generated Helm repository index only; no Dockerfile or chart source.

## Validation

- `ct lint --debug --all --config ./.github/configs/ct-lint.yaml --lint-conf ./.github/configs/lintconf.yaml --target-branch main`
- `yamllint --config-file .github/configs/lintconf.yaml .github/workflows/helm.yaml`
- Public endpoint check: `helm repo add gpud-pages-test https://leptonai.github.io/gpud`
