### PR TITLE
feat(helm): optionally create GPUd token secret

### DIFF
--- a/deployments/helm/gpud/Chart.yaml
+++ b/deployments/helm/gpud/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: gpud
 description: GPUd Helm chart for Kubernetes
 type: application
-version: 0.12.5
+version: 0.12.6
 appVersion: "0.12.5"
 icon: https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png

--- a/deployments/helm/gpud/Chart.yaml
+++ b/deployments/helm/gpud/Chart.yaml
@@ -3,5 +3,5 @@ name: gpud
 description: GPUd Helm chart for Kubernetes
 type: application
 version: 0.12.6
-appVersion: "0.12.5"
+appVersion: "0.12.6"
 icon: https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png

--- a/deployments/helm/gpud/README.md
+++ b/deployments/helm/gpud/README.md
@@ -26,7 +26,7 @@ the repository above:
 
 ```bash
 helm upgrade --install my-gpud gpud/gpud \
-  --version 0.12.5 \
+  --version 0.12.6 \
   --create-namespace \
   --namespace gpud
 ```
@@ -164,10 +164,25 @@ gpud:
     key: TOKEN
 ```
 
+To have the Helm release create and own that Secret, also set `create` and
+`value`:
+
+```yaml
+gpud:
+  tokenSecret:
+    create: true
+    name: gpud-token
+    key: TOKEN
+    value: "<YOUR_GPUD_SESSION_TOKEN>"
+```
+
+The token is stored in Helm values and release state when `value` is used.
+Restrict access to both.
+
 ### BYOK Worker Cluster Example
 
 For a BYOK worker cluster using a private NVCR image, create the image pull
-secret and the gpud session-token secret in the release namespace:
+secret in the release namespace:
 
 ```bash
 source ~/nvapi.sh
@@ -180,10 +195,6 @@ kubectl create secret docker-registry nvcr-staging-pull \
   --docker-password="$NVAPI_KEY" \
   --namespace "$NAMESPACE"
 
-# gpud session token (read by gpud.tokenSecret below).
-kubectl create secret generic gpud-token \
-  --from-literal=TOKEN="<YOUR_GPUD_SESSION_TOKEN>" \
-  --namespace "$NAMESPACE"
 ```
 
 Then install or upgrade with a values file like this (a full BYOK overlay):
@@ -198,10 +209,12 @@ imagePullSecrets:
 
 gpud:
   endpoint: gpud-manager-dev02.dev02.dgxc-lepton-dev.nvidia.com
-  # Session token from the gpud-token Secret created above.
+  # Create and use the gpud-token Secret as part of this Helm release.
   tokenSecret:
+    create: true
     name: gpud-token
     key: TOKEN
+    value: "<YOUR_GPUD_SESSION_TOKEN>"
   # The node also exposes /dev/mem on this platform.
   mountHostDevMem: true
   # reboot / disk (findmnt,lsblk,df) / containerd command overrides and the

--- a/deployments/helm/gpud/README.md
+++ b/deployments/helm/gpud/README.md
@@ -202,7 +202,7 @@ Then install or upgrade with a values file like this (a full BYOK overlay):
 ```yaml
 image:
   repository: nvcr.io/nvstaging/dgx-cloud-lepton/gpud
-  tag: 0.12.5   # no "v" prefix from 0.12.2 onward
+  tag: 0.12.6   # no "v" prefix from 0.12.2 onward
 
 imagePullSecrets:
   - name: nvcr-staging-pull

--- a/deployments/helm/gpud/templates/secret.yaml
+++ b/deployments/helm/gpud/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.gpud.tokenSecret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ required "gpud.tokenSecret.name is required when gpud.tokenSecret.create=true" .Values.gpud.tokenSecret.name | quote }}
+  labels:
+    {{- include "gpud.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ required "gpud.tokenSecret.key is required when gpud.tokenSecret.create=true" .Values.gpud.tokenSecret.key | quote }}: {{ required "gpud.tokenSecret.value is required when gpud.tokenSecret.create=true" .Values.gpud.tokenSecret.value | quote }}
+{{- end }}

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -29,10 +29,11 @@ gpud:
   # The endpoint for the control plane.
   endpoint: "gpud-manager-prod01.dgxc-lepton.nvidia.com"
 
-  # Optional: read the gpud session token from an existing Secret instead of a
-  # node label. When name is set, the token is injected as the TOKEN env via
-  # secretKeyRef and takes priority over any token node label. Leave name empty
-  # to rely on the node label (nodeLabelExporter) or no token.
+  # Optional: read the gpud session token from a Secret instead of a node label.
+  # Set create=true and value to have this chart create the Secret, or leave
+  # create=false to reference an existing Secret. When name is set, the token is
+  # injected as the TOKEN env via secretKeyRef and takes priority over any token
+  # node label. Leave name empty to rely on the node label or no token.
   #
   # TOKEN MODEL: this is a SHARED, cluster/node-group-level enrollment credential.
   # Every gpud pod in the DaemonSet reads the SAME Secret, so all machines
@@ -44,8 +45,10 @@ gpud:
   # For per-machine tokens instead (e.g. to revoke a single node), leave this
   # empty and put a distinct token in each node's label via nodeLabelExporter.
   tokenSecret:
+    create: false
     name: ""
     key: "TOKEN"
+    value: ""
 
   # Allow a node to check in when its machine identity changes.
   #


### PR DESCRIPTION
## Summary

- add native `gpud.tokenSecret.create` and `gpud.tokenSecret.value` support
- render an Opaque Secret owned by the GPUd Helm release when enabled
- preserve the existing externally managed Secret mode by default
- bump chart version to `0.12.6`

## Verification

- `helm lint deployments/helm/gpud`
- rendered the chart with Secret creation enabled and verified `TOKEN` plus the DaemonSet `secretKeyRef`
- rendered default values and verified no Secret is created
- rendered existing-Secret mode and verified `GPUD_TOKEN` remains wired through `secretKeyRef`