### PR TITLE
feat(helm): sane resource defaults and pod-scoped node-label file

### DIFF
--- a/deployments/helm/gpud/Chart.yaml
+++ b/deployments/helm/gpud/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: gpud
 description: GPUd Helm chart for Kubernetes
 type: application
-version: 0.12.6
-appVersion: "0.12.6"
+version: 0.12.7
+appVersion: "0.12.7"
 icon: https://assets.nvidiagrid.net/ngc/logos/Infrastructure.png

--- a/deployments/helm/gpud/README.md
+++ b/deployments/helm/gpud/README.md
@@ -229,6 +229,13 @@ nodeLabelExporter:
   enabled: true
   labelKeys:
     machineId: lepton.ai/machine-id
+  resources: null
+
+# GPU workloads on these nodes request whole nodes, so the DaemonSet should
+# consume none of the node's allocatable resources. null (not {}) deletes the
+# chart's default requests/limits; the pod runs as BestEffort and its
+# system-node-critical priority still keeps it scheduled first, evicted last.
+resources: null
 
 # Schedule only on the intended GPU worker nodes.
 affinity:

--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -117,11 +117,20 @@ spec:
         {{- end }}
 
         # GPUd's persistent data directory for state, cache, and configuration
-        # Used for storing GPUd runtime data and labels fetched by node-label-init.
         - name: lib-gpud
           hostPath:
             path: /var/lib/gpud
             type: DirectoryOrCreate
+
+        {{- if .Values.nodeLabelExporter.enabled }}
+        # Pod-scoped scratch space for the node-label snapshot that
+        # node-label-init hands to gpud. An emptyDir rather than the
+        # /var/lib/gpud hostPath: gpud reads the file once at startup, so it
+        # has no reason to persist on the host, and a fresh volume per pod
+        # means no stale label file from a previous release can leak in.
+        - name: node-labels
+          emptyDir: {}
+        {{- end }}
 
         # Machine ID for unique node identification
         # Required by: pkg/host/machine_id.go (reads machine-id for node identification)
@@ -198,11 +207,9 @@ spec:
           # Needs a shell-capable image; distroless kubectl images lack /bin/sh so the script would fail.
           image: "{{ .Values.nodeLabelExporter.image.repository }}:{{ .Values.nodeLabelExporter.image.tag }}"
           imagePullPolicy: {{ .Values.nodeLabelExporter.image.pullPolicy }}
-          # Run as root: the label file is written to the root-owned /var/lib/gpud
-          # hostPath (gpud runs as root and owns it). The kubectl image otherwise
-          # defaults to a non-root UID and cannot write there.
-          securityContext:
-            runAsUser: 0
+          # No securityContext: the label file goes to a kubelet-created
+          # (world-writable) emptyDir, so the kubectl image's default non-root
+          # UID can write it. Nothing here touches the host.
           command:
             - /bin/sh
             - -ec
@@ -246,10 +253,12 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: lib-gpud
-              mountPath: /var/lib/gpud
+            - name: node-labels
+              mountPath: {{ dir .Values.nodeLabelExporter.outputFile }}
+          {{- with .Values.nodeLabelExporter.resources }}
           resources:
-            {{- toYaml .Values.nodeLabelExporter.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- with .Values.initContainers }}
         {{- toYaml . | nindent 8 }}
@@ -299,9 +308,10 @@ spec:
               TOKEN=""
               MID=""
 
-              # /var/lib/gpud is a hostPath and can retain node-labels.env from a
-              # previous chart release. Honor that file only when this feature is
-              # enabled, so disabling nodeLabelExporter means no stale label can
+              # The label file lives on a pod-scoped emptyDir, so it cannot be
+              # stale by construction. Keep the enabled guard anyway: if
+              # outputFile is overridden to a host-persisted path, disabling
+              # nodeLabelExporter must still mean no leftover label file can
               # silently override the configured endpoint, token, or machine ID.
               if [ "$NODE_LABEL_EXPORTER_ENABLED" = "true" ] && [ -f "$LABEL_FILE" ]; then
                 # Parse label file using awk with index() for EXACT string matching:
@@ -467,8 +477,12 @@ spec:
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           # No readinessProbe is defined
+          {{- with .Values.resources }}
+          # Omitted entirely when values sets "resources: null", so the
+          # DaemonSet consumes none of the node's allocatable resources.
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
 
           volumeMounts:
             # System logs - GPUd writes logs here and monitors system logs
@@ -509,6 +523,14 @@ spec:
             # GPUd data directory for runtime state and configuration
             - name: lib-gpud
               mountPath: /var/lib/gpud
+
+            {{- if .Values.nodeLabelExporter.enabled }}
+            # Node-label snapshot written by node-label-init; the startup
+            # script reads endpoint/token/machine-id from it once.
+            - name: node-labels
+              mountPath: {{ dir .Values.nodeLabelExporter.outputFile }}
+              readOnly: true
+            {{- end }}
 
             # Machine ID for unique node identification (read-only)
             - name: host-machine-id

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -258,14 +258,29 @@ securityContext:
 podSecurityContext: {}
   # fsGroup: 2000
 
-# Resource requests and limits for the container.
+# Resource requests and limits for the gpud container. The defaults below are
+# sane out of the box — end users do not need to set anything here.
+#
+# Sizing basis: gpud measured at a stable ~20m CPU / ~130Mi memory on a GPU
+# worker node. Requests are ~2x that steady state, so the kubelet never ranks
+# the pod as exceeding its requests, while still reserving little of the node.
+# The limits cap a misbehaving daemon (8x memory headroom before OOM) without
+# risking kills in normal operation.
+#
+# Any request is subtracted from the node's allocatable resources, which
+# matters where GPU workloads request whole nodes. To make this DaemonSet
+# consume NO allocatable resources, set this to null — NOT {}: an empty map
+# merges with and keeps these defaults, while null deletes them:
+#   resources: null
+# The pod then runs as BestEffort QoS; priorityClassName system-node-critical
+# still keeps it scheduled first and evicted last under node pressure.
 resources:
+  requests:
+    cpu: 50m
+    memory: 256Mi
   limits:
     cpu: 1
     memory: 1Gi
-  requests:
-    cpu: 10m
-    memory: 10Mi
 
 # How long to wait in seconds for the pod to shut down gracefully.
 terminationGracePeriodSeconds: 10
@@ -324,8 +339,13 @@ nodeLabelExporter:
     repository: docker.io/bitnami/kubectl
     tag: latest
     pullPolicy: IfNotPresent
-  # File written on the host (via the shared /var/lib/gpud volume).
-  outputFile: /var/lib/gpud/node-labels.env
+  # Path of the label file handed from the init container to gpud. Its parent
+  # directory is a pod-scoped emptyDir mounted in both containers: gpud reads
+  # the file only once at startup, so nothing needs to persist on the host,
+  # and a fresh volume per pod means no stale file from a previous release.
+  # Keep it OUTSIDE paths the gpud container already mounts (e.g.
+  # /var/lib/gpud), or the two mounts would collide.
+  outputFile: /run/gpud-node-labels/node-labels.env
   # Label keys to look for in the node labels.
   # For BYOK worker clusters, set machineId to the label that stores the
   # platform machine ID (for example, lepton.ai/machine-id) so gpud rejoins
@@ -346,13 +366,16 @@ nodeLabelExporter:
   extraEnv: []
   rbac:
     create: true
+  # Sized for a one-shot "kubectl get node". These requests sit below the
+  # gpud container's, so they do not raise the pod's effective request.
+  # As with the top-level resources, set to null (not {}) to remove them.
   resources:
-    limits:
-      cpu: 50m
-      memory: 64Mi
     requests:
       cpu: 5m
       memory: 16Mi
+    limits:
+      cpu: 50m
+      memory: 64Mi
 
 # [Init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to add to the pod definition.
 initContainers: []


### PR DESCRIPTION
Address deployment review feedback on the gpud chart:

- Move the node-label snapshot off the /var/lib/gpud hostPath onto a pod-scoped emptyDir (default /run/gpud-node-labels/node-labels.env). gpud reads the file once at startup, so it never needs to persist on the host; a fresh volume per pod also removes any stale-label risk. The init container no longer needs runAsUser: 0 (it wrote to the root-owned hostPath before).

- Right-size default resources to the measured steady state (~20m CPU / ~130Mi memory): requests 50m/256Mi, limits 1/1Gi. End users need to set nothing. To reserve none of the node's allocatable resources, set resources: null (an overlay-level choice; documented in the README). Both the gpud and node-label-init resources blocks now render only when non-null.

- Bump chart version and appVersion to 0.12.7.