### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build gpud binary
+name: Build and Store gpud binary
 
 on:
   push:
@@ -26,3 +26,9 @@ jobs:
       - name: Build project
         run: |
           make
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gpud
+          path: bin/gpud

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Store gpud binary
+name: Build gpud binary
 
 on:
   push:
@@ -26,9 +26,3 @@ jobs:
       - name: Build project
         run: |
           make
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: gpud
-          path: bin/gpud


### PR DESCRIPTION
Potential fix for [https://github.com/leptonai/gpud/security/code-scanning/1](https://github.com/leptonai/gpud/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (top-level, alongside `name` and `on`) so all jobs inherit least-privilege defaults unless overridden.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves current functionality (checkout/build/upload artifact) while constraining token access and satisfying CodeQL.

Change location:

- File: `.github/workflows/build.yml`
- Insert `permissions:` after the trigger block (`on:` section) and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
