### PR TITLE
revert(login): keep session-token refresh opt-in

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -114,10 +114,12 @@ nohup sudo gpud run &>> <your log file path> &
 					Hidden: true,
 					Usage:  "(optional) when --machine-id differs from the persisted machine id, discard the persisted login identity (machine id + session token) and check in with the requested machine instead of failing. Health/system state (reboot history, events) is preserved. Use for the container/DaemonSet pattern where a node can be deleted from its node group and rejoined with a new machine object.",
 				},
-				cli.BoolTFlag{
+				// Re-login requires the registration token, which GPUd intentionally does not persist.
+				// Keep this opt-in for BYOK deployments that inject the token on every start.
+				cli.BoolFlag{
 					Name:   "refresh-session-token",
 					Hidden: true,
-					Usage:  "on every start, re-run login to re-fetch the current session token from the control plane instead of reusing the persisted one (enabled by default; set to false to keep the 'machine id already assigned' fast path)",
+					Usage:  "(optional) re-run login on start to fetch the current session token. Use only for BYOK deployments that supply a valid registration token on every start.",
 				},
 				cli.StringFlag{
 					Name:  "node-group",
@@ -193,10 +195,12 @@ sudo rm /etc/systemd/system/gpud.service
 					Hidden: true,
 					Usage:  "(optional) when --machine-id differs from the persisted machine id, discard the persisted login identity (machine id + session token) and check in with the requested machine instead of failing. Health/system state (reboot history, events) is preserved. Use for the container/DaemonSet pattern where a node can be deleted from its node group and rejoined with a new machine object.",
 				},
-				&cli.BoolTFlag{
+				// Re-login requires the registration token, which GPUd intentionally does not persist.
+				// Keep this opt-in for BYOK deployments that inject the token on every start.
+				&cli.BoolFlag{
 					Name:   "refresh-session-token",
 					Hidden: true,
-					Usage:  "on every start, re-run login to re-fetch the current session token from the control plane instead of reusing the persisted one (enabled by default; set to false to keep the 'machine id already assigned' fast path)",
+					Usage:  "(optional) re-run login on start to fetch the current session token. Use only for BYOK deployments that supply a valid registration token on every start.",
 				},
 				&cli.StringFlag{
 					Name:   "token",

--- a/cmd/gpud/command/command_test.go
+++ b/cmd/gpud/command/command_test.go
@@ -44,7 +44,7 @@ func TestAppRunAndUpHaveSessionProtocolFlag(t *testing.T) {
 	}
 }
 
-func TestAppRunAndUpRefreshSessionTokenDefaultsToTrue(t *testing.T) {
+func TestAppRunAndUpRefreshSessionTokenDefaultsToFalse(t *testing.T) {
 	t.Parallel()
 
 	app := App()
@@ -67,11 +67,11 @@ func TestAppRunAndUpRefreshSessionTokenDefaultsToTrue(t *testing.T) {
 		set := flag.NewFlagSet(cmd.Name, flag.ContinueOnError)
 		refreshFlag.Apply(set)
 		ctx := cli.NewContext(app, set, nil)
-		require.True(t, ctx.Bool("refresh-session-token"))
-
-		require.NoError(t, set.Parse([]string{"--refresh-session-token=false"}))
-		ctx = cli.NewContext(app, set, nil)
 		require.False(t, ctx.Bool("refresh-session-token"))
+
+		require.NoError(t, set.Parse([]string{"--refresh-session-token"}))
+		ctx = cli.NewContext(app, set, nil)
+		require.True(t, ctx.Bool("refresh-session-token"))
 	}
 
 	for cmdName, found := range wantCommands {

--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -371,11 +371,10 @@ spec:
                 set -- "$@" --machine-id-overwrite
               fi
 
-              # Pods restart often; the cached /var/lib/gpud session token can be stale
-              # (for example, after workspace token rotation). Preserve the chart's
-              # explicit opt-out now that refresh is enabled by default in gpud.
-              if [ "${GPUD_REFRESH_SESSION_TOKEN:-}" = "false" ]; then
-                set -- "$@" --refresh-session-token=false
+              # Re-login needs the registration token injected above. Keep this opt-in
+              # for BYOK deployments that provide that token on every start.
+              if [ "${GPUD_REFRESH_SESSION_TOKEN:-}" = "true" ]; then
+                set -- "$@" --refresh-session-token
               fi
 
               set -- "$@" --enable-auto-update={{ .Values.gpud.enableAutoUpdate }}
@@ -437,10 +436,12 @@ spec:
             - name: GPUD_MACHINE_ID_OVERWRITE
               value: "true"
             {{- end }}
-            # Re-fetch the session token on start unless explicitly disabled.
+            {{- if .Values.gpud.refreshSessionToken }}
+            # BYOK only: re-login on startup using the injected registration token.
             # Consumed as $GPUD_REFRESH_SESSION_TOKEN.
             - name: GPUD_REFRESH_SESSION_TOKEN
-              value: {{ .Values.gpud.refreshSessionToken | quote }}
+              value: "true"
+            {{- end }}
             {{- if .Values.gpud.rebootCommands }}
             - name: GPUD_REBOOT_COMMANDS
               value: {{ .Values.gpud.rebootCommands | quote }}

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -68,15 +68,10 @@ gpud:
   # must never change without manually clearing /var/lib/gpud.
   machineIdOverwrite: true
 
-  # Re-fetch the session token from the control plane on every start.
-  #
-  # The control plane returns the current workspace-scoped session token on
-  # every successful login. GPUd refreshes it by default instead of trusting
-  # the cached token in /var/lib/gpud, preventing token rotation from breaking
-  # session keepalive at the cost of one extra login round-trip per start.
-  #
-  # Set to false to keep the skip-login optimization.
-  refreshSessionToken: true
+  # Re-login requires the registration token, which gpud does not persist.
+  # Keep this disabled unless a BYOK deployment injects a valid registration
+  # token on every start and needs to recover a stale session token.
+  refreshSessionToken: false
 
   # Enable auto update of gpud.
   enableAutoUpdate: false

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -49,9 +49,9 @@ type LoginConfig struct {
 	//
 	// The control plane looks up the current workspace-scoped session token on
 	// every successful login, so re-login persists the token currently served by
-	// the control plane. This handles workspace token rotation at the cost of one
-	// extra login round-trip per start. The gpud CLI enables it by default;
-	// package callers can set it false to preserve the skip-login optimization.
+	// the control plane. Re-login requires the caller-provided registration token,
+	// which GPUd does not persist. Keep this false outside BYOK deployments that
+	// inject a valid registration token on every start.
 	RefreshSessionToken bool
 
 	DataDir string


### PR DESCRIPTION
Re-login requires a registration token, which GPUd does not persist. Leave the generic CLI and chart defaults disabled. The BYOK overlay opts in because it injects the registration token on each start.