### PR TITLE
[LEP-5797] fix(machine-info): use host disk commands

### DIFF
--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -30,6 +30,7 @@ import (
 	gpudmanager "github.com/leptonai/gpud/pkg/gpud-manager"
 	"github.com/leptonai/gpud/pkg/log"
 	"github.com/leptonai/gpud/pkg/login"
+	pkgmachineinfo "github.com/leptonai/gpud/pkg/machine-info"
 	pkgmetadata "github.com/leptonai/gpud/pkg/metadata"
 	pkgnfschecker "github.com/leptonai/gpud/pkg/nfs-checker"
 	gpudserver "github.com/leptonai/gpud/pkg/server"
@@ -53,6 +54,11 @@ func Command(cliContext *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	findmntCommands := cliContext.String("findmnt-commands")
+	lsblkCommands := cliContext.String("lsblk-commands")
+	blockdevUsageCommands := cliContext.String("blockdev-usage-commands")
+	pkgmachineinfo.SetDiskCommands(findmntCommands, lsblkCommands, blockdevUsageCommands)
 
 	// Parse db-in-memory early as it affects login behavior
 	dbInMemory := cliContext.Bool("db-in-memory")
@@ -136,9 +142,6 @@ func Command(cliContext *cli.Context) error {
 	enableAutoUpdate := cliContext.Bool("enable-auto-update")
 	autoUpdateExitCode := cliContext.Int("auto-update-exit-code")
 	rebootCommands := cliContext.String("reboot-commands")
-	findmntCommands := cliContext.String("findmnt-commands")
-	lsblkCommands := cliContext.String("lsblk-commands")
-	blockdevUsageCommands := cliContext.String("blockdev-usage-commands")
 	containerdServiceActiveCommands := cliContext.String("containerd-service-active-commands")
 	versionFile := cliContext.String("version-file")
 	versionFileSet := cliContext.IsSet("version-file")

--- a/pkg/machine-info/machine_info.go
+++ b/pkg/machine-info/machine_info.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
@@ -38,17 +39,28 @@ import (
 
 const diskPartitionsTimeout = 10 * time.Second
 
-var (
+type diskCommands struct {
 	findmntCommand       string
 	lsblkCommand         string
 	blockdevUsageCommand string
-)
+}
+
+var diskCommandConfig atomic.Pointer[diskCommands]
 
 // SetDiskCommands configures machine-info disk collection to run in the host namespace.
 func SetDiskCommands(findmnt, lsblk, blockdevUsage string) {
-	findmntCommand = findmnt
-	lsblkCommand = lsblk
-	blockdevUsageCommand = blockdevUsage
+	diskCommandConfig.Store(&diskCommands{
+		findmntCommand:       findmnt,
+		lsblkCommand:         lsblk,
+		blockdevUsageCommand: blockdevUsage,
+	})
+}
+
+func getDiskCommands() diskCommands {
+	if commands := diskCommandConfig.Load(); commands != nil {
+		return *commands
+	}
+	return diskCommands{}
 }
 
 func currentGOOS() string {
@@ -141,8 +153,9 @@ func GetSystemResourceRootVolumeTotal() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	commands := getDiskCommands()
 	var usage *disk.Usage
-	if blockdevUsageCommand == "" {
+	if commands.blockdevUsageCommand == "" {
 		var err error
 		usage, err = disk.GetUsage(ctx, "/")
 		if err != nil {
@@ -152,7 +165,7 @@ func GetSystemResourceRootVolumeTotal() (string, error) {
 		partitions, err := disk.GetPartitions(
 			ctx,
 			disk.WithMountPoint(func(mountPoint string) bool { return mountPoint == "/" }),
-			disk.WithBlockdevUsageCommand(blockdevUsageCommand),
+			disk.WithBlockdevUsageCommand(commands.blockdevUsageCommand),
 		)
 		if err != nil {
 			return "", fmt.Errorf("failed to get disk usage: %w", err)
@@ -462,12 +475,13 @@ func GetMachineGPUInfo(nvmlInstance nvidianvml.Instance) (*apiv1.MachineGPUInfo,
 }
 
 func GetMachineDiskInfo(ctx context.Context) (*apiv1.MachineDiskInfo, error) {
+	commands := getDiskCommands()
 	blks, err := disk.GetBlockDevicesWithLsblk(
 		ctx,
 		disk.WithFstype(disk.DefaultFsTypeFunc),
 		disk.WithDeviceType(disk.DefaultDeviceTypeFunc),
-		disk.WithFindmntCommand(findmntCommand),
-		disk.WithLsblkCommand(lsblkCommand),
+		disk.WithFindmntCommand(commands.findmntCommand),
+		disk.WithLsblkCommand(commands.lsblkCommand),
 	)
 	if err != nil {
 		return nil, err
@@ -506,7 +520,7 @@ func GetMachineDiskInfo(ctx context.Context) (*apiv1.MachineDiskInfo, error) {
 			timeoutCtx,
 			disk.WithFstype(disk.DefaultNFSFsTypeFunc),
 			disk.WithMountPoint(disk.DefaultMountPointFunc),
-			disk.WithBlockdevUsageCommand(blockdevUsageCommand),
+			disk.WithBlockdevUsageCommand(commands.blockdevUsageCommand),
 		)
 		cancel()
 		if err != nil {
@@ -532,7 +546,7 @@ func GetMachineDiskInfo(ctx context.Context) (*apiv1.MachineDiskInfo, error) {
 	}
 
 	if currentGOOS() == "linux" {
-		kubeletRootExists := findmntCommand != ""
+		kubeletRootExists := commands.findmntCommand != ""
 		if !kubeletRootExists {
 			_, serr := os.Stat("/var/lib/kubelet")
 			if serr != nil && !os.IsNotExist(serr) {
@@ -543,10 +557,10 @@ func GetMachineDiskInfo(ctx context.Context) (*apiv1.MachineDiskInfo, error) {
 		if kubeletRootExists {
 			var out *disk.FindMntOutput
 			var err error
-			if findmntCommand == "" {
+			if commands.findmntCommand == "" {
 				out, err = disk.FindMnt(ctx, "/var/lib/kubelet")
 			} else {
-				out, err = disk.FindMntWithCommand(ctx, "/var/lib/kubelet", findmntCommand)
+				out, err = disk.FindMntWithCommand(ctx, "/var/lib/kubelet", commands.findmntCommand)
 			}
 			if err != nil {
 				return nil, err

--- a/pkg/machine-info/machine_info.go
+++ b/pkg/machine-info/machine_info.go
@@ -38,6 +38,19 @@ import (
 
 const diskPartitionsTimeout = 10 * time.Second
 
+var (
+	findmntCommand       string
+	lsblkCommand         string
+	blockdevUsageCommand string
+)
+
+// SetDiskCommands configures machine-info disk collection to run in the host namespace.
+func SetDiskCommands(findmnt, lsblk, blockdevUsage string) {
+	findmntCommand = findmnt
+	lsblkCommand = lsblk
+	blockdevUsageCommand = blockdevUsage
+}
+
 func currentGOOS() string {
 	return runtime.GOOS
 }
@@ -128,9 +141,26 @@ func GetSystemResourceRootVolumeTotal() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	usage, err := disk.GetUsage(ctx, "/")
-	if err != nil {
-		return "", fmt.Errorf("failed to get disk usage: %w", err)
+	var usage *disk.Usage
+	if blockdevUsageCommand == "" {
+		var err error
+		usage, err = disk.GetUsage(ctx, "/")
+		if err != nil {
+			return "", fmt.Errorf("failed to get disk usage: %w", err)
+		}
+	} else {
+		partitions, err := disk.GetPartitions(
+			ctx,
+			disk.WithMountPoint(func(mountPoint string) bool { return mountPoint == "/" }),
+			disk.WithBlockdevUsageCommand(blockdevUsageCommand),
+		)
+		if err != nil {
+			return "", fmt.Errorf("failed to get disk usage: %w", err)
+		}
+		if len(partitions) == 0 || partitions[0].Usage == nil {
+			return "", fmt.Errorf("failed to get disk usage: root partition not found")
+		}
+		usage = partitions[0].Usage
 	}
 
 	qty := resource.NewQuantity(uint64ToInt64Capped(usage.TotalBytes), resource.DecimalSI)
@@ -436,6 +466,8 @@ func GetMachineDiskInfo(ctx context.Context) (*apiv1.MachineDiskInfo, error) {
 		ctx,
 		disk.WithFstype(disk.DefaultFsTypeFunc),
 		disk.WithDeviceType(disk.DefaultDeviceTypeFunc),
+		disk.WithFindmntCommand(findmntCommand),
+		disk.WithLsblkCommand(lsblkCommand),
 	)
 	if err != nil {
 		return nil, err
@@ -474,6 +506,7 @@ func GetMachineDiskInfo(ctx context.Context) (*apiv1.MachineDiskInfo, error) {
 			timeoutCtx,
 			disk.WithFstype(disk.DefaultNFSFsTypeFunc),
 			disk.WithMountPoint(disk.DefaultMountPointFunc),
+			disk.WithBlockdevUsageCommand(blockdevUsageCommand),
 		)
 		cancel()
 		if err != nil {
@@ -499,12 +532,22 @@ func GetMachineDiskInfo(ctx context.Context) (*apiv1.MachineDiskInfo, error) {
 	}
 
 	if currentGOOS() == "linux" {
-		_, serr := os.Stat("/var/lib/kubelet")
-		if serr != nil && !os.IsNotExist(serr) {
-			return nil, serr
+		kubeletRootExists := findmntCommand != ""
+		if !kubeletRootExists {
+			_, serr := os.Stat("/var/lib/kubelet")
+			if serr != nil && !os.IsNotExist(serr) {
+				return nil, serr
+			}
+			kubeletRootExists = serr == nil
 		}
-		if serr == nil {
-			out, err := disk.FindMnt(ctx, "/var/lib/kubelet")
+		if kubeletRootExists {
+			var out *disk.FindMntOutput
+			var err error
+			if findmntCommand == "" {
+				out, err = disk.FindMnt(ctx, "/var/lib/kubelet")
+			} else {
+				out, err = disk.FindMntWithCommand(ctx, "/var/lib/kubelet", findmntCommand)
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/machine-info/machine_info.go
+++ b/pkg/machine-info/machine_info.go
@@ -563,9 +563,11 @@ func GetMachineDiskInfo(ctx context.Context) (*apiv1.MachineDiskInfo, error) {
 				out, err = disk.FindMntWithCommand(ctx, "/var/lib/kubelet", commands.findmntCommand)
 			}
 			if err != nil {
-				return nil, err
-			}
-			if len(out.Filesystems) > 0 && len(out.Filesystems[0].Sources) > 0 {
+				if commands.findmntCommand == "" {
+					return nil, err
+				}
+				log.Logger.Warnw("failed to find container root disk", "error", err)
+			} else if len(out.Filesystems) > 0 && len(out.Filesystems[0].Sources) > 0 {
 				info.ContainerRootDisk = out.Filesystems[0].Sources[0]
 			}
 		}

--- a/pkg/machine-info/mock_machine_info_coverage_test.go
+++ b/pkg/machine-info/mock_machine_info_coverage_test.go
@@ -95,6 +95,34 @@ func (fakeFileInfo) ModTime() time.Time { return time.Time{} }
 func (fakeFileInfo) IsDir() bool        { return true }
 func (fakeFileInfo) Sys() interface{}   { return nil }
 
+func TestDiskCommandsAtomicSnapshot(t *testing.T) {
+	first := diskCommands{findmntCommand: "findmnt-a", lsblkCommand: "lsblk-a", blockdevUsageCommand: "df-a"}
+	second := diskCommands{findmntCommand: "findmnt-b", lsblkCommand: "lsblk-b", blockdevUsageCommand: "df-b"}
+	SetDiskCommands(first.findmntCommand, first.lsblkCommand, first.blockdevUsageCommand)
+	defer SetDiskCommands("", "", "")
+
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 10_000; i++ {
+			SetDiskCommands(second.findmntCommand, second.lsblkCommand, second.blockdevUsageCommand)
+			SetDiskCommands(first.findmntCommand, first.lsblkCommand, first.blockdevUsageCommand)
+		}
+		close(done)
+	}()
+
+	for {
+		commands := getDiskCommands()
+		if commands != first && commands != second {
+			t.Fatalf("observed partial disk command snapshot: %+v", commands)
+		}
+		select {
+		case <-done:
+			return
+		default:
+		}
+	}
+}
+
 func TestGetMachineGPUInfo_CoverageBranches_WithMockey(t *testing.T) {
 	mockey.PatchConvey("GetMachineGPUInfo handles not-supported serial/minor/board", t, func() {
 		dev := newMachineInfoCoverageDevice()

--- a/pkg/machine-info/mock_machine_info_coverage_test.go
+++ b/pkg/machine-info/mock_machine_info_coverage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -119,6 +120,7 @@ func TestDiskCommandsAtomicSnapshot(t *testing.T) {
 		case <-done:
 			return
 		default:
+			runtime.Gosched()
 		}
 	}
 }
@@ -320,6 +322,26 @@ func TestGetMachineDiskInfo_LinuxBranches_WithMockey(t *testing.T) {
 		_, err := GetMachineDiskInfo(context.Background())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "findmnt failed")
+	})
+
+	mockey.PatchConvey("GetMachineDiskInfo ignores configured host findmnt error", t, func() {
+		SetDiskCommands("host-findmnt", "", "")
+		defer SetDiskCommands("", "", "")
+		mockey.Mock(currentGOOS).To(func() string { return "linux" }).Build()
+		mockey.Mock(disk.GetBlockDevicesWithLsblk).To(func(ctx context.Context, opts ...disk.OpOption) (disk.BlockDevices, error) {
+			return disk.BlockDevices{{Name: "/dev/sda1", MountPoint: "/", FSType: "ext4"}}, nil
+		}).Build()
+		mockey.Mock(disk.GetPartitions).To(func(ctx context.Context, opts ...disk.OpOption) (disk.Partitions, error) {
+			return nil, nil
+		}).Build()
+		mockey.Mock(disk.FindMntWithCommand).To(func(ctx context.Context, target, command string) (*disk.FindMntOutput, error) {
+			return nil, errors.New("findmnt failed")
+		}).Build()
+
+		info, err := GetMachineDiskInfo(context.Background())
+		require.NoError(t, err)
+		assert.Empty(t, info.ContainerRootDisk)
+		require.Len(t, info.BlockDevices, 1)
 	})
 }
 

--- a/pkg/machine-info/mock_machine_info_coverage_test.go
+++ b/pkg/machine-info/mock_machine_info_coverage_test.go
@@ -295,6 +295,29 @@ func TestGetMachineDiskInfo_LinuxBranches_WithMockey(t *testing.T) {
 	})
 }
 
+func TestMachineInfoDiskCommands_WithMockey(t *testing.T) {
+	mockey.PatchConvey("machine info uses configured host disk commands", t, func() {
+		mockey.Mock(currentGOOS).To(func() string { return "linux" }).Build()
+
+		findmnt := `printf '%s\n' '{"filesystems":[{"target":"/","source":"/dev/sda1","fstype":"ext4","size":"1000B","used":"400B","avail":"600B","use%":"40%"}]}' #`
+		lsblk := `printf '%s\n' '{"blockdevices":[{"name":"/dev/sda","type":"disk","size":1000,"mountpoint":null,"fstype":null,"children":[{"name":"/dev/sda1","type":"part","size":1000,"mountpoint":"/","fstype":"ext4","fsused":"400"}]}]}' #`
+		df := `printf '%s\n' 'Filesystem Type 1B-blocks Used Available Use% Mounted on' '/dev/sda1 ext4 1000 400 600 40% /' 'server:/data nfs4 2000 1000 1000 50% /mnt/nfs' #`
+		SetDiskCommands(findmnt, lsblk, df)
+		defer SetDiskCommands("", "", "")
+
+		info, err := GetMachineDiskInfo(context.Background())
+		require.NoError(t, err)
+		require.Len(t, info.BlockDevices, 2)
+		assert.Equal(t, "/dev/sda1", info.ContainerRootDisk)
+		assert.Equal(t, "/dev/sda1", info.BlockDevices[0].Name)
+		assert.Equal(t, "server:/data", info.BlockDevices[1].Name)
+
+		total, err := GetSystemResourceRootVolumeTotal()
+		require.NoError(t, err)
+		assert.Equal(t, "1k", total)
+	})
+}
+
 func TestGetMachineInfo_LinuxBranches_WithMockey(t *testing.T) {
 	baseNVML := &mockNvmlInstanceForMockey{
 		driverVersion: "550.90.07",

--- a/pkg/machine-info/mock_machine_info_coverage_test.go
+++ b/pkg/machine-info/mock_machine_info_coverage_test.go
@@ -96,6 +96,15 @@ func (fakeFileInfo) ModTime() time.Time { return time.Time{} }
 func (fakeFileInfo) IsDir() bool        { return true }
 func (fakeFileInfo) Sys() interface{}   { return nil }
 
+func TestGetDiskCommandsZeroValue(t *testing.T) {
+	previous := diskCommandConfig.Swap(nil)
+	t.Cleanup(func() {
+		diskCommandConfig.Store(previous)
+	})
+
+	assert.Equal(t, diskCommands{}, getDiskCommands())
+}
+
 func TestDiskCommandsAtomicSnapshot(t *testing.T) {
 	first := diskCommands{findmntCommand: "findmnt-a", lsblkCommand: "lsblk-a", blockdevUsageCommand: "df-a"}
 	second := diskCommands{findmntCommand: "findmnt-b", lsblkCommand: "lsblk-b", blockdevUsageCommand: "df-b"}
@@ -111,6 +120,9 @@ func TestDiskCommandsAtomicSnapshot(t *testing.T) {
 		close(done)
 	}()
 
+	timeout := time.NewTimer(2 * time.Second)
+	defer timeout.Stop()
+
 	for {
 		commands := getDiskCommands()
 		if commands != first && commands != second {
@@ -119,6 +131,8 @@ func TestDiskCommandsAtomicSnapshot(t *testing.T) {
 		select {
 		case <-done:
 			return
+		case <-timeout.C:
+			t.Fatal("timed out waiting for disk command updates")
 		default:
 			runtime.Gosched()
 		}

--- a/pkg/machine-info/mock_machine_info_test.go
+++ b/pkg/machine-info/mock_machine_info_test.go
@@ -541,6 +541,45 @@ func TestGetSystemResourceRootVolumeTotal_WithMockedDisk(t *testing.T) {
 		assert.Empty(t, volume)
 		assert.Contains(t, err.Error(), "failed to get disk usage")
 	})
+
+	mockey.PatchConvey("GetSystemResourceRootVolumeTotal host df error", t, func() {
+		SetDiskCommands("", "", "host-df")
+		defer SetDiskCommands("", "", "")
+		mockey.Mock(disk.GetPartitions).To(func(ctx context.Context, opts ...disk.OpOption) (disk.Partitions, error) {
+			return nil, errors.New("host df failed")
+		}).Build()
+
+		volume, err := GetSystemResourceRootVolumeTotal()
+		require.Error(t, err)
+		assert.Empty(t, volume)
+		assert.Contains(t, err.Error(), "host df failed")
+	})
+
+	mockey.PatchConvey("GetSystemResourceRootVolumeTotal host root missing", t, func() {
+		SetDiskCommands("", "", "host-df")
+		defer SetDiskCommands("", "", "")
+		mockey.Mock(disk.GetPartitions).To(func(ctx context.Context, opts ...disk.OpOption) (disk.Partitions, error) {
+			return nil, nil
+		}).Build()
+
+		volume, err := GetSystemResourceRootVolumeTotal()
+		require.Error(t, err)
+		assert.Empty(t, volume)
+		assert.Contains(t, err.Error(), "root partition not found")
+	})
+
+	mockey.PatchConvey("GetSystemResourceRootVolumeTotal host root usage missing", t, func() {
+		SetDiskCommands("", "", "host-df")
+		defer SetDiskCommands("", "", "")
+		mockey.Mock(disk.GetPartitions).To(func(ctx context.Context, opts ...disk.OpOption) (disk.Partitions, error) {
+			return disk.Partitions{{MountPoint: "/"}}, nil
+		}).Build()
+
+		volume, err := GetSystemResourceRootVolumeTotal()
+		require.Error(t, err)
+		assert.Empty(t, volume)
+		assert.Contains(t, err.Error(), "root partition not found")
+	})
 }
 
 // TestGetMachineNICInfo_WithMockedNetutil tests GetMachineNICInfo with mocked network interfaces


### PR DESCRIPTION
<img width="337" height="84" alt="Screenshot 2026-07-28 at 12 05 57 PM" src="https://github.com/user-attachments/assets/fdd75c96-5a2b-4414-8fde-33247849dc80" />

Fix missing disk usage when running in a helm chart