### PR TITLE
fix(containerd): support native CDI runtime configuration

### DIFF
--- a/components/containerd/component.go
+++ b/components/containerd/component.go
@@ -49,6 +49,11 @@ const (
 // written by nvidia-container-toolkit-daemonset) can be inspected too.
 var containerdConfigImportsRe = regexp.MustCompile(`(?m)^\s*imports\s*=\s*\[([^\]]*)\]`)
 
+// containerdConfigCDIEnabledRe matches containerd's native CDI setting.
+// Native CDI allows runc to remain the default runtime while GPU workloads
+// select the configured NVIDIA runtime handler.
+var containerdConfigCDIEnabledRe = regexp.MustCompile(`(?m)^\s*enable_cdi\s*=\s*true\s*(?:#.*)?$`)
+
 var _ components.Component = &component{}
 
 type component struct {
@@ -385,14 +390,12 @@ func (c *component) Check() components.CheckResult {
 				if err == nil {
 					config = appendImportedContainerdConfigs(config)
 				}
-				hasNvidiaPlugin := bytes.Contains(config, []byte(containerdConfigNvidiaRuntimePlugin)) ||
-					bytes.Contains(config, []byte(containerdConfigNvidiaRuntimePluginV2))
 				switch {
 				case err != nil:
 					reason := "error getting containerd config"
 					cr.appendReason(reason)
 					log.Logger.Warnw(reason)
-				case !bytes.Contains(config, []byte(containerdConfigNvidiaDefaultRuntime)) || !hasNvidiaPlugin:
+				case !hasNvidiaRuntimeConfiguration(config):
 					reason := fmt.Sprintf("nvidia-container-toolkit pod is running but %s is missing NVIDIA runtime configuration", defaultContainerdConfigPath)
 					cr.appendReason(reason)
 					log.Logger.Warnw(reason)
@@ -520,6 +523,20 @@ func (cr *checkResult) HealthStates() apiv1.HealthStates {
 		state.ExtraInfo = map[string]string{"data": string(b)}
 	}
 	return apiv1.HealthStates{state}
+}
+
+// hasNvidiaRuntimeConfiguration accepts both supported toolkit layouts:
+// NVIDIA as containerd's default runtime, or containerd native CDI enabled
+// with an NVIDIA runtime handler. The handler is required in both cases.
+func hasNvidiaRuntimeConfiguration(config []byte) bool {
+	hasNvidiaRuntimePlugin := bytes.Contains(config, []byte(containerdConfigNvidiaRuntimePlugin)) ||
+		bytes.Contains(config, []byte(containerdConfigNvidiaRuntimePluginV2))
+	if !hasNvidiaRuntimePlugin {
+		return false
+	}
+
+	return bytes.Contains(config, []byte(containerdConfigNvidiaDefaultRuntime)) ||
+		containerdConfigCDIEnabledRe.Match(config)
 }
 
 // appendImportedContainerdConfigs returns config with the contents of any

--- a/components/containerd/component_config_test.go
+++ b/components/containerd/component_config_test.go
@@ -30,13 +30,86 @@ func TestContainerdConfigConstants(t *testing.T) {
 	assert.Contains(t, containerdConfigNvidiaRuntimePluginV2, "io.containerd.cri.v1.runtime")
 }
 
+func TestHasNvidiaRuntimeConfiguration(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+		want   bool
+	}{
+		{
+			name: "legacy plugin with nvidia as default runtime",
+			config: `default_runtime_name = "nvidia"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+  runtime_type = "io.containerd.runc.v2"`,
+			want: true,
+		},
+		{
+			name: "v2 plugin with nvidia as default runtime",
+			config: `default_runtime_name = "nvidia"
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia]
+  runtime_type = "io.containerd.runc.v2"`,
+			want: true,
+		},
+		{
+			name: "legacy plugin with native CDI",
+			config: `[plugins."io.containerd.grpc.v1.cri"]
+  enable_cdi = true
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+  runtime_type = "io.containerd.runc.v2"`,
+			want: true,
+		},
+		{
+			name: "v2 plugin with native CDI and runc as default",
+			config: `[plugins."io.containerd.cri.v1.runtime".containerd]
+  default_runtime_name = "runc"
+[plugins."io.containerd.cri.v1.runtime"]
+  enable_cdi=true # enabled by GPU Operator
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia]
+  runtime_type = "io.containerd.runc.v2"`,
+			want: true,
+		},
+		{
+			name: "native CDI without nvidia runtime handler",
+			config: `[plugins."io.containerd.cri.v1.runtime"]
+  enable_cdi = true`,
+			want: false,
+		},
+		{
+			name: "nvidia runtime handler without default or native CDI",
+			config: `[plugins."io.containerd.cri.v1.runtime".containerd]
+  default_runtime_name = "runc"
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia]
+  runtime_type = "io.containerd.runc.v2"`,
+			want: false,
+		},
+		{
+			name: "commented native CDI setting",
+			config: `# enable_cdi = true
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia]
+  runtime_type = "io.containerd.runc.v2"`,
+			want: false,
+		},
+		{
+			name:   "no nvidia configuration",
+			config: `[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.runc]`,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hasNvidiaRuntimeConfiguration([]byte(tt.config)))
+		})
+	}
+}
+
 // TestAppendImportedContainerdConfigs verifies that imports referenced in a
 // containerd config are read and appended so substring checks see drop-in files.
 func TestAppendImportedContainerdConfigs(t *testing.T) {
 	dir := t.TempDir()
 	dropIn := filepath.Join(dir, "99-nvidia.toml")
-	dropInBody := `[plugins."io.containerd.cri.v1.runtime".containerd]
-  default_runtime_name = "nvidia"
+	dropInBody := `[plugins."io.containerd.cri.v1.runtime"]
+  enable_cdi = true
 [plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia]
   runtime_type = "io.containerd.runc.v2"
 `
@@ -47,8 +120,9 @@ func TestAppendImportedContainerdConfigs(t *testing.T) {
 	main := []byte("version = 3\nimports = [\"" + filepath.Join(dir, "*.toml") + "\"]\n")
 	out := appendImportedContainerdConfigs(main)
 
-	assert.Contains(t, string(out), containerdConfigNvidiaDefaultRuntime)
+	assert.True(t, containerdConfigCDIEnabledRe.Match(out))
 	assert.Contains(t, string(out), containerdConfigNvidiaRuntimePluginV2)
+	assert.True(t, hasNvidiaRuntimeConfiguration(out))
 }
 
 // TestAppendImportedContainerdConfigs_NoImports returns the input unchanged

--- a/components/containerd/component_test.go
+++ b/components/containerd/component_test.go
@@ -2094,6 +2094,39 @@ func TestNVMLValidationWithContainerToolkit(t *testing.T) {
 			expectedReason:                    "ok",
 		},
 		{
+			name: "nvml with native CDI and runc as default runtime",
+			nvmlInstance: &mockNVMLInstance{
+				nvmlExists:  true,
+				productName: "Tesla V100",
+			},
+			getContainerdConfigFunc: func() ([]byte, error) {
+				config := `[plugins."io.containerd.cri.v1.runtime".containerd]
+  default_runtime_name = "runc"
+[plugins."io.containerd.cri.v1.runtime"]
+  enable_cdi = true
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.nvidia]
+  runtime_type = "io.containerd.runc.v2"`
+				return []byte(config), nil
+			},
+			pods: []PodSandbox{
+				{
+					Name:  "nvidia-container-toolkit-daemonset-cdi",
+					State: "SANDBOX_READY",
+					Containers: []PodSandboxContainerStatus{
+						{
+							Name:      "nvidia-container-toolkit-ctr",
+							State:     "CONTAINER_RUNNING",
+							CreatedAt: time.Now().Add(-15 * time.Minute).UnixNano(),
+						},
+					},
+				},
+			},
+			getTimeNowFunc:                    time.Now,
+			containerToolkitCreationThreshold: 10 * time.Minute,
+			expectedHealth:                    apiv1.HealthStateTypeHealthy,
+			expectedReason:                    "ok",
+		},
+		{
 			name: "nvml without nvidia config but container toolkit present and running long enough",
 			nvmlInstance: &mockNVMLInstance{
 				nvmlExists:  true,


### PR DESCRIPTION
# Summary

  GPUd currently requires the NVIDIA runtime to be configured as containerd's default runtime. This causes nodes using GPU Operator's native CDI mode to be reported as unhealthy, because CDI mode keeps `runc` as the default runtime.

  Update the containerd health check to accept both supported configurations:

  - NVIDIA runtime handler is present and set as the default runtime.
  - NVIDIA runtime handler is present and native CDI is enabled with `enable_cdi = true`.

  The NVIDIA runtime handler remains required in both cases.