### PR TITLE
[LEP-5832] fix(peermem): anchor dedup windows to the first event

### DIFF
--- a/components/accelerator/nvidia/peermem/component.go
+++ b/components/accelerator/nvidia/peermem/component.go
@@ -20,8 +20,11 @@ import (
 	nvidianvml "github.com/leptonai/gpud/pkg/nvidia/nvml"
 )
 
-// Name is the ID of the NVIDIA peermem component.
-const Name = "accelerator-nvidia-peermem"
+const (
+	// Name is the ID of the NVIDIA peermem component.
+	Name                    = "accelerator-nvidia-peermem"
+	peermemEventDedupWindow = 5 * time.Minute
+)
 
 var _ components.Component = &component{}
 
@@ -66,7 +69,9 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 				Match,
 				c.eventBucket,
 				// Peermem errors can spam during transient GPU/NIC issues; coalesce within 5 minutes to reduce event noise.
-				kmsg.WithCacheKeyTruncateSeconds(300),
+				kmsg.WithEventDedupWindowFunc(func(event eventstore.Event) (time.Duration, bool) {
+					return peermemEventDedupWindow, event.Name == eventPeermemInvalidContext
+				}),
 			)
 			if err != nil {
 				ccancel()

--- a/pkg/kmsg/deduper.go
+++ b/pkg/kmsg/deduper.go
@@ -48,8 +48,7 @@ func withDisableDedup() OpOption {
 
 // WithEventDedupWindowFunc applies an event-specific dedup window in the syncer.
 // When the callback returns a positive window, pkg/kmsg deduplicates matching
-// events against recent persisted events inside that time window instead of
-// using the generic parsed-message cache and infinite exact-match lookup.
+// events from their first occurrence instead of using epoch-aligned buckets.
 func WithEventDedupWindowFunc(fn EventDedupWindowFunc) OpOption {
 	return func(op *Op) {
 		op.eventDedupWindowFunc = fn
@@ -77,6 +76,11 @@ func (m Message) cacheKeyWithTruncateSeconds(truncateSeconds int) string {
 type deduper struct {
 	cache                   *cache.Cache
 	cacheKeyTruncateSeconds int
+}
+
+type windowEntry struct {
+	firstSeen   time.Time
+	occurrences int
 }
 
 func newDeduper(cacheExpiration time.Duration, cachePurgeInterval time.Duration, opts ...OpOption) *deduper {
@@ -122,4 +126,20 @@ func (d *deduper) addCacheWithWindow(m Message, truncateSeconds int, expiration 
 
 	d.cache.Set(k, freq, expiration)
 	return freq
+}
+
+func (d *deduper) addCacheWithinWindow(m Message, window time.Duration) int {
+	k := "window-" + m.Message
+	cur, found := d.cache.Get(k)
+	if found {
+		entry, ok := cur.(windowEntry)
+		if ok && m.Timestamp.Time.Before(entry.firstSeen.Add(window)) {
+			entry.occurrences++
+			d.cache.Set(k, entry, window)
+			return entry.occurrences
+		}
+	}
+
+	d.cache.Set(k, windowEntry{firstSeen: m.Timestamp.Time, occurrences: 1}, window)
+	return 1
 }

--- a/pkg/kmsg/syncer.go
+++ b/pkg/kmsg/syncer.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	cache "github.com/patrickmn/go-cache"
-
 	apiv1 "github.com/leptonai/gpud/api/v1"
 	"github.com/leptonai/gpud/pkg/eventstore"
 	"github.com/leptonai/gpud/pkg/log"
@@ -97,15 +95,20 @@ func (w *Syncer) sync(ch <-chan Message) {
 			// Deduplicate by parsed event name and message using the in-memory
 			// cache. Raw kernel messages may contain varying strings (e.g., PIDs)
 			// that the matcher normalizes, so we dedup on the parsed form.
-			// Events with a custom dedup window get a longer truncation bucket
-			// and cache TTL so they are coalesced over the configured period.
+			// Event-specific windows start at the first occurrence instead of
+			// using the generic epoch-aligned cache buckets.
 			if w.parsedDeduper != nil {
 				parsedMsg := Message{
 					Timestamp: kmsg.Timestamp,
 					Message:   name + "_" + message,
 				}
-				truncSec, expiration := w.dedupParams(event)
-				if occurrences := w.parsedDeduper.addCacheWithWindow(parsedMsg, truncSec, expiration); occurrences > 1 {
+				var occurrences int
+				if window, ok := w.eventDedupWindow(event); ok {
+					occurrences = w.parsedDeduper.addCacheWithinWindow(parsedMsg, window)
+				} else {
+					occurrences = w.parsedDeduper.addCache(parsedMsg)
+				}
+				if occurrences > 1 {
 					log.Logger.Debugw("skipping duplicate parsed kmsg message", "occurrences", occurrences, "eventName", name, "message", message)
 					continue
 				}
@@ -136,16 +139,12 @@ func (w *Syncer) sync(ch <-chan Message) {
 	}
 }
 
-// dedupParams returns the cache truncation seconds and per-item TTL to use for
-// the given event. Events with a custom dedup window get a wider truncation
-// bucket and a TTL matching the window. All other events use the deduper defaults.
-func (w *Syncer) dedupParams(event eventstore.Event) (truncateSeconds int, expiration time.Duration) {
-	if w.eventDedupWindowFunc != nil {
-		if window, ok := w.eventDedupWindowFunc(event); ok && window > 0 {
-			return int(window.Seconds()), window
-		}
+func (w *Syncer) eventDedupWindow(event eventstore.Event) (time.Duration, bool) {
+	if w.eventDedupWindowFunc == nil {
+		return 0, false
 	}
-	return w.parsedDeduper.cacheKeyTruncateSeconds, cache.DefaultExpiration
+	window, ok := w.eventDedupWindowFunc(event)
+	return window, ok && window > 0
 }
 
 func (w *Syncer) Close() {

--- a/pkg/kmsg/syncer_test.go
+++ b/pkg/kmsg/syncer_test.go
@@ -198,12 +198,12 @@ func TestSyncer_EventDedupWindowFunc(t *testing.T) {
 	require.NoError(t, err, "failed to create syncer")
 	defer w.Close()
 
-	// Use a fixed timestamp well within a 300-second (5-minute) truncation window
-	// so the test is deterministic regardless of wall-clock time.
-	baseTime := time.Date(2026, 1, 1, 12, 30, 10, 0, time.UTC)
+	// Cross an epoch-aligned 5-minute boundary two seconds after the first event.
+	// The aggregation window must still start at the first event.
+	baseTime := time.Date(2026, 1, 1, 12, 34, 58, 0, time.UTC)
 	ch <- Message{Timestamp: metav1.NewTime(baseTime), Message: "raw message with pid 123"}
-	ch <- Message{Timestamp: metav1.NewTime(baseTime.Add(4 * time.Minute)), Message: "raw message with pid 456"}
-	ch <- Message{Timestamp: metav1.NewTime(baseTime.Add(6 * time.Minute)), Message: "raw message with pid 789"}
+	ch <- Message{Timestamp: metav1.NewTime(baseTime.Add(2 * time.Second)), Message: "raw message with pid 456"}
+	ch <- Message{Timestamp: metav1.NewTime(baseTime.Add(5 * time.Minute)), Message: "raw message with pid 789"}
 	close(ch)
 
 	require.Eventually(t, func() bool {
@@ -211,6 +211,12 @@ func TestSyncer_EventDedupWindowFunc(t *testing.T) {
 		require.NoError(t, err)
 		return len(events) == 2
 	}, time.Second, 10*time.Millisecond)
+
+	events, err := bucket.Get(ctx, time.Unix(0, 0))
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	assert.True(t, events[0].Time.Equal(baseTime.Add(5*time.Minute)))
+	assert.True(t, events[1].Time.Equal(baseTime))
 }
 
 func TestSyncer_EventDedupWindowFunc_BypassesGenericDedup(t *testing.T) {


### PR DESCRIPTION
Peermem keyed duplicates by an epoch-aligned five-minute timestamp. Messages at 12:34:58 and 12:35:00 therefore landed in different keys even though they were only two seconds apart.

Start peermem's five-minute window at the first matching event. The existing fixed buckets remain unchanged for kmsg events without an event-specific window.