### PR TITLE
fix(metrics): skip unsupported Prometheus metric types

### DIFF
--- a/pkg/metrics/scraper/prometheus.go
+++ b/pkg/metrics/scraper/prometheus.go
@@ -65,12 +65,15 @@ func (s *promScraper) Scrape(_ context.Context) (pkgmetrics.Metrics, error) {
 				continue
 			}
 
-			// for now, only support counter and gauge
+			// The flattened metric model only supports counter and gauge values.
+			// Skip unsupported types instead of recording their zero value.
 			switch {
 			case mtRaw.GetCounter() != nil:
 				m.Value = mtRaw.GetCounter().GetValue()
 			case mtRaw.GetGauge() != nil:
 				m.Value = mtRaw.GetGauge().GetValue()
+			default:
+				continue
 			}
 
 			ms = append(ms, m)

--- a/pkg/metrics/scraper/prometheus_test.go
+++ b/pkg/metrics/scraper/prometheus_test.go
@@ -246,14 +246,10 @@ func TestPrometheusScraper_MultipleMetricTypes(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Scrape and verify metrics
+	// Scrape and verify only supported metrics are returned.
 	ms, err := scraper.Scrape(ctx)
 	require.NoError(t, err)
-	require.NotEmpty(t, ms)
-
-	// Should have more than 4 metrics because histograms and summaries
-	// generate multiple underlying metrics
-	require.True(t, len(ms) >= 4, "Expected at least 4 metrics, got %d", len(ms))
+	require.Len(t, ms, 2)
 
 	// Verify the counter and gauge are included
 	var foundCounter, foundGauge bool
@@ -269,6 +265,8 @@ func TestPrometheusScraper_MultipleMetricTypes(t *testing.T) {
 			}
 			require.Equal(t, 75.5, m.Value)
 		}
+		require.NotEqual(t, "test_latency_seconds", m.Name)
+		require.NotEqual(t, "test_response_time_seconds", m.Name)
 	}
 	require.True(t, foundCounter, "Counter metric not found")
 	require.True(t, foundGauge, "Gauge metric not found")


### PR DESCRIPTION
  ## Summary

  GPUd's internal metrics scraper only supports Counter and Gauge metrics, but it previously appended unsupported metric types with a default value of zero.

  This caused Histogram metrics such as `gpud_disk_get_usage_seconds` to be persisted and forwarded as meaningless zero-valued records.

  This change:

  - skips Histogram, Summary, and other unsupported metric types
  - prevents invalid zero-valued metrics from entering SQLite, the session API, and downstream analytical storage
  - preserves the original Histogram on GPUd's Prometheus `/metrics` endpoint
  - updates the scraper test to verify that only Counter and Gauge metrics are returned

  ## Testing

  - `go test -mod=mod ./pkg/metrics/...`
  - `go test -mod=mod -race ./pkg/metrics/scraper`
  - `go vet -mod=mod ./pkg/metrics/scraper`