### PR TITLE
fix(providers): use native Nebius instance ID

### DIFF
--- a/pkg/providers/nebius/nebius.go
+++ b/pkg/providers/nebius/nebius.go
@@ -2,7 +2,7 @@ package nebius
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/leptonai/gpud/pkg/providers"
 	"github.com/leptonai/gpud/pkg/providers/nebius/imds"
@@ -31,15 +31,8 @@ func GetInstanceID(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if data.ParentID == "" || data.ID == "" {
-		return "", fmt.Errorf("nebius instance metadata is missing parent_id or id")
+	if data.ID == "" {
+		return "", errors.New("nebius instance metadata is missing id")
 	}
-	return formatInstanceID(data.ParentID, data.GPUClusterID, data.ID), nil
-}
-
-func formatInstanceID(parentID, gpuClusterID, instanceID string) string {
-	if gpuClusterID != "" {
-		return fmt.Sprintf("%s/%s/%s", parentID, gpuClusterID, instanceID)
-	}
-	return fmt.Sprintf("%s/%s", parentID, instanceID)
+	return data.ID, nil
 }

--- a/pkg/providers/nebius/nebius_test.go
+++ b/pkg/providers/nebius/nebius_test.go
@@ -40,10 +40,7 @@ func TestNewAndDetectProvider_WithMockey(t *testing.T) {
 
 		instanceID, err := detector.InstanceID(context.Background())
 		require.NoError(t, err)
-		require.Equal(t, "project-test123/computegpucluster-gpu456/computeinstance-inst789", instanceID)
-
-		require.Equal(t, "project-test123/computeinstance-inst789",
-			formatInstanceID("project-test123", "", "computeinstance-inst789"))
+		require.Equal(t, "computeinstance-inst789", instanceID)
 	})
 }
 
@@ -80,13 +77,13 @@ func TestProviderMetadataErrors(t *testing.T) {
 		require.Empty(t, instanceID)
 	})
 
-	mockey.PatchConvey("GetInstanceID requires parent_id and id", t, func() {
+	mockey.PatchConvey("GetInstanceID requires id", t, func() {
 		mockey.Mock(imds.FetchInstanceData).To(func(context.Context) (*imds.InstanceData, error) {
 			return &imds.InstanceData{}, nil
 		}).Build()
 
 		instanceID, err := GetInstanceID(context.Background())
-		require.ErrorContains(t, err, "missing parent_id or id")
+		require.ErrorContains(t, err, "missing id")
 		require.Empty(t, instanceID)
 	})
 }


### PR DESCRIPTION
Nebius IMDS exposes the VM ID as id, but GPUd previously rebuilt it as parent_id[/gpu_cluster_id]/id to preserve the legacy cloud-metadata format. That made provider metadata return a resource path instead of the native computeinstance-* identifier.

Return the IMDS id field directly and require only that field.

> project-123/computegpucluster-123/computeinstance-aaa

becomes

> computeinstance-aaa

ref. https://docs.nebius.com/compute/virtual-machines/instance-metadata

```
|  Instance ID   | computeinstance-e01qzmjv7fdxx0hxyn |
+----------------+------------------------------------+
```