### PR TITLE
[LEP-5936] fix(helm): NFS checks with host mount

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -254,6 +254,11 @@ sudo rm /etc/systemd/system/gpud.service
 					Value: "",
 				},
 				cli.StringFlag{
+					Name:  "nfs-host-root",
+					Usage: "host filesystem root used by the NFS checker (e.g. '/proc/1/root' in a privileged hostPID container); the empty default preserves direct host paths for systemd installations",
+					Value: "",
+				},
+				cli.StringFlag{
 					Name:  "containerd-service-active-commands",
 					Usage: "command used to check whether the containerd service is active (e.g. 'nsenter --target 1 --mount -- systemctl is-active containerd' to query the host service manager from inside a container; exit code 0 means active); leave empty to use the built-in systemd check",
 					Value: "",

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -58,6 +58,7 @@ func Command(cliContext *cli.Context) error {
 	findmntCommands := cliContext.String("findmnt-commands")
 	lsblkCommands := cliContext.String("lsblk-commands")
 	blockdevUsageCommands := cliContext.String("blockdev-usage-commands")
+	nfsHostRoot := cliContext.String("nfs-host-root")
 	pkgmachineinfo.SetDiskCommands(findmntCommands, lsblkCommands, blockdevUsageCommands)
 
 	// Parse db-in-memory early as it affects login behavior
@@ -356,6 +357,7 @@ func Command(cliContext *cli.Context) error {
 	cfg.FindmntCommands = findmntCommands
 	cfg.LsblkCommands = lsblkCommands
 	cfg.BlockdevUsageCommands = blockdevUsageCommands
+	cfg.NFSHostRoot = nfsHostRoot
 	cfg.ContainerdServiceActiveCommands = containerdServiceActiveCommands
 	if !versionFileSet {
 		versionFile = config.VersionFilePath(cfg.DataDir)

--- a/components/nfs/component.go
+++ b/components/nfs/component.go
@@ -44,7 +44,8 @@ type component struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	machineID string
+	machineID   string
+	nfsHostRoot string
 
 	getGroupConfigsFunc func() pkgnfschecker.Configs
 	findMntTargetDevice func(dir string) (string, string, error)
@@ -95,14 +96,32 @@ func newComponent(
 	}
 
 	cctx, ccancel := context.WithCancel(gpudInstance.RootCtx)
+	findMntTargetDevice := disk.FindMntTargetDevice
+	if gpudInstance.FindmntCommands != "" {
+		findMntTargetDevice = func(dir string) (string, string, error) {
+			timeoutCtx, cancel := context.WithTimeout(cctx, 5*time.Second)
+			defer cancel()
+			out, err := disk.FindMntWithCommand(timeoutCtx, dir, gpudInstance.FindmntCommands)
+			if err != nil || out == nil || len(out.Filesystems) == 0 {
+				return "", "", err
+			}
+			found := out.Filesystems[0]
+			if len(found.Sources) == 0 {
+				return "", found.Fstype, nil
+			}
+			return found.Sources[0], found.Fstype, nil
+		}
+	}
+
 	c := &component{
 		ctx:    cctx,
 		cancel: ccancel,
 
-		machineID: gpudInstance.MachineID,
+		machineID:   gpudInstance.MachineID,
+		nfsHostRoot: gpudInstance.NFSHostRoot,
 
 		getGroupConfigsFunc: GetDefaultConfigs,
-		findMntTargetDevice: disk.FindMntTargetDevice,
+		findMntTargetDevice: findMntTargetDevice,
 		isNFSFSType:         disk.DefaultNFSFsTypeFunc,
 		getTimeNowFunc:      func() time.Time { return time.Now().UTC() },
 
@@ -302,6 +321,9 @@ func (c *component) Check() components.CheckResult {
 	}
 
 	memberConfigs := groupConfigs.GetMemberConfigs(c.machineID)
+	for i := range memberConfigs {
+		memberConfigs[i].HostRoot = c.nfsHostRoot
+	}
 	timeoutCtx, cancel := context.WithTimeout(c.ctx, 5*time.Second)
 	err := c.validateMemberConfigs(timeoutCtx, memberConfigs)
 	cancel()

--- a/components/nfs/component_test.go
+++ b/components/nfs/component_test.go
@@ -240,7 +240,7 @@ func TestCheckWithInvalidConfigs(t *testing.T) {
 	assert.Contains(t, result.Summary(), "invalid nfs group configs")
 }
 
-func TestCheckWithValidConfigs(t *testing.T) {
+func TestCheckWithoutNFSHostRootPreservesDirectPath(t *testing.T) {
 	// Create a temporary directory for testing
 	tmpDir := t.TempDir()
 
@@ -267,6 +267,37 @@ func TestCheckWithValidConfigs(t *testing.T) {
 	assert.Equal(t, apiv1.HealthStateTypeHealthy, result.HealthStateType())
 	assert.Len(t, cr.NFSCheckResults, 1)
 	assert.Equal(t, tmpDir, cr.NFSCheckResults[0].Dir)
+}
+
+func TestCheckWithNFSHostRoot(t *testing.T) {
+	hostRoot := t.TempDir()
+	volumePath := "/mnt/nfs-share"
+	rootedVolumePath := filepath.Join(hostRoot, "mnt", "nfs-share")
+	require.NoError(t, os.MkdirAll(rootedVolumePath, 0755))
+
+	c := createTestComponent()
+	c.nfsHostRoot = hostRoot
+	c.getGroupConfigsFunc = func() pkgnfschecker.Configs {
+		return pkgnfschecker.Configs{{
+			VolumePath:   volumePath,
+			DirName:      ".gpud-nfs-checker",
+			FileContents: "test content",
+		}}
+	}
+	c.findMntTargetDevice = func(path string) (string, string, error) {
+		assert.Equal(t, volumePath, path)
+		return "server:/export/path", "nfs", nil
+	}
+	c.isNFSFSType = func(_ string) bool { return true }
+
+	result := c.Check()
+	cr := mustCheckResult(t, result)
+
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, result.HealthStateType())
+	require.Len(t, cr.NFSCheckResults, 1)
+	assert.Equal(t, filepath.Join(volumePath, ".gpud-nfs-checker"), cr.NFSCheckResults[0].Dir)
+	_, err := os.Stat(filepath.Join(rootedVolumePath, ".gpud-nfs-checker"))
+	assert.NoError(t, err)
 }
 
 // Test checkResult methods

--- a/components/registry.go
+++ b/components/registry.go
@@ -63,6 +63,11 @@ type GPUdInstance struct {
 	// from that command's output in the host mount namespace.
 	BlockdevUsageCommands string
 
+	// NFSHostRoot prefixes NFS checker file operations. Empty preserves direct
+	// host paths for systemd installations. Containerized gpud can use
+	// /proc/1/root to operate on the node's configured NFS paths.
+	NFSHostRoot string
+
 	// ContainerdServiceActiveCommands overrides how the containerd component
 	// checks whether the containerd service is active. Empty (the default)
 	// preserves the legacy in-namespace systemd.IsActive behavior. When set (e.g.

--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -408,6 +408,17 @@ spec:
                 start_log_args="$start_log_args --blockdev-usage-commands=<set>"
                 set -- "$@" --blockdev-usage-commands="$GPUD_BLOCKDEV_USAGE_COMMANDS"
               fi
+
+              # BYOK: this is a node filesystem prefix, not a required NFS mount.
+              # It lets gpud resolve only the NFS paths configured for this
+              # machine through /proc/1/root. Nodes without an NFS config do not
+              # probe a path, and a missing configured mount degrades the check
+              # without preventing this DaemonSet pod from starting. Systemd
+              # installations do not use this Helm-only default.
+              if [ -n "${GPUD_NFS_HOST_ROOT:-}" ]; then
+                start_log_args="$start_log_args --nfs-host-root=$GPUD_NFS_HOST_ROOT"
+                set -- "$@" --nfs-host-root="$GPUD_NFS_HOST_ROOT"
+              fi
               if [ -n "${GPUD_CONTAINERD_SERVICE_ACTIVE_COMMANDS:-}" ]; then
                 start_log_args="$start_log_args --containerd-service-active-commands=<set>"
                 set -- "$@" --containerd-service-active-commands="$GPUD_CONTAINERD_SERVICE_ACTIVE_COMMANDS"
@@ -457,6 +468,12 @@ spec:
             {{- if .Values.gpud.blockdevUsageCommands }}
             - name: GPUD_BLOCKDEV_USAGE_COMMANDS
               value: {{ .Values.gpud.blockdevUsageCommands | quote }}
+            {{- end }}
+            {{- if .Values.gpud.nfsHostRoot }}
+            # BYOK: this value is only a host filesystem prefix. It does not
+            # assert that any particular NFS path exists on every DaemonSet node.
+            - name: GPUD_NFS_HOST_ROOT
+              value: {{ .Values.gpud.nfsHostRoot | quote }}
             {{- end }}
             {{- if .Values.gpud.containerdServiceActiveCommands }}
             - name: GPUD_CONTAINERD_SERVICE_ACTIVE_COMMANDS

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -133,6 +133,22 @@ gpud:
   lsblkCommands: "nsenter --target 1 --mount -- lsblk"
   blockdevUsageCommands: "nsenter --target 1 --mount -- df"
 
+  # BYOK: root of the node filesystem used only when an NFS check is configured
+  # for this machine. This is NOT an NFS mount path and does NOT require paths
+  # such as /mnt/nfs-share to exist on every node. The control plane still sends
+  # each machine only its node-group-specific NFS paths. A machine with no NFS
+  # config performs no NFS path check; a configured machine whose mount is
+  # missing keeps gpud running and reports that NFS check as degraded.
+  #
+  # /proc/1/root exposes the node filesystem because this chart uses hostPID=true
+  # and runs gpud as privileged root. Using it avoids a hostPath volume for every
+  # possible node-group mount and therefore avoids blocking pod startup on nodes
+  # where another node group's path does not exist. Set this to "" only when the
+  # configured NFS paths are already visible in the container mount namespace.
+  # This Helm-only default does not affect systemd installations; the gpud CLI
+  # default is empty and preserves direct host-path behavior there.
+  nfsHostRoot: "/proc/1/root"
+
   # Command used by the containerd component to check whether the containerd
   # service is active. gpud runs inside a container here, so the container's own
   # systemd does not manage containerd; the chart wraps "systemctl is-active
@@ -181,7 +197,8 @@ gpud:
   # Override the default command for the gpud container.
   # If set, the chart's default startup wrapper is bypassed; include any gpud
   # flags you still need there, including --reboot-commands and the disk
-  # --findmnt-commands/--lsblk-commands/--blockdev-usage-commands when applicable.
+  # --findmnt-commands/--lsblk-commands/--blockdev-usage-commands, plus
+  # --nfs-host-root when NFS checks must access the node filesystem.
   commandOverride: []
 
 # The default image repository is public and needs no image pull secret.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -71,6 +72,12 @@ type Config struct {
 	// "nsenter --target 1 --mount -- df"), partitions and usage are read from
 	// that command's output in the host mount namespace.
 	BlockdevUsageCommands string `json:"blockdev_usage_commands,omitempty"`
+
+	// NFSHostRoot prefixes NFS volume paths for file operations. Empty preserves
+	// the existing direct-path behavior used by systemd installations. A
+	// containerized deployment can use /proc/1/root to access the node filesystem
+	// without mounting every node-group-specific NFS path into the container.
+	NFSHostRoot string `json:"nfs_host_root,omitempty"`
 
 	// ContainerdServiceActiveCommands overrides how the containerd component checks
 	// whether the containerd service is active. Empty preserves the legacy
@@ -141,6 +148,9 @@ func (config *Config) Validate() error {
 	}
 	if config.EventsRetentionPeriod.Duration > 0 && config.EventsRetentionPeriod.Duration < time.Minute {
 		return fmt.Errorf("events_retention_period must be at least 1 minute, got %d", config.EventsRetentionPeriod.Duration)
+	}
+	if config.NFSHostRoot != "" && !filepath.IsAbs(config.NFSHostRoot) {
+		return fmt.Errorf("nfs_host_root must be an absolute path, got %q", config.NFSHostRoot)
 	}
 	switch config.SessionProtocol {
 	case "", "v1", "v2", "auto":

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -18,6 +20,20 @@ func TestConfigValidateSessionProtocol(t *testing.T) {
 	if err := cfg.Validate(); err == nil {
 		t.Fatal("Validate() accepted an unsupported session protocol")
 	}
+}
+
+func TestConfigValidateNFSHostRoot(t *testing.T) {
+	base := Config{Address: ":15132", MetricsRetentionPeriod: metav1.Duration{Duration: time.Minute}}
+
+	for _, hostRoot := range []string{"", "/proc/1/root"} {
+		cfg := base
+		cfg.NFSHostRoot = hostRoot
+		require.NoError(t, cfg.Validate(), "NFS host root %q", hostRoot)
+	}
+
+	cfg := base
+	cfg.NFSHostRoot = "proc/1/root"
+	assert.Error(t, cfg.Validate())
 }
 
 func TestConfigValidate_AutoUpdateExitCode(t *testing.T) {

--- a/pkg/nfs-checker/checker.go
+++ b/pkg/nfs-checker/checker.go
@@ -64,7 +64,7 @@ func (c *checker) Write(ctx context.Context) error {
 	// make sure the directory is writable
 	// permission bit "0755" is used to allow the group to read the files
 	// and the owner to read and write the files.
-	if err := pkgfile.MkdirAllWithTimeout(ctx, c.cfg.VolumePath, 0755); err != nil {
+	if err := pkgfile.MkdirAllWithTimeout(ctx, c.cfg.resolvedVolumePath(), 0755); err != nil {
 		return err
 	}
 

--- a/pkg/nfs-checker/group_config.go
+++ b/pkg/nfs-checker/group_config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	pkgfile "github.com/leptonai/gpud/pkg/file"
 )
@@ -18,6 +19,11 @@ type Config struct {
 	// And writes are saved in the [Config.VolumePath] under [Config.DirName].
 	// This path must be an absolute path.
 	VolumePath string `json:"volume_path"`
+
+	// HostRoot prefixes VolumePath only for local filesystem operations. It is a
+	// deployment detail, not part of the node-group NFS configuration sent by the
+	// control plane, so it is intentionally excluded from JSON.
+	HostRoot string `json:"-"`
 
 	// DirName is the directory name under [Config.VolumePath]
 	// to write and read the files.
@@ -76,13 +82,14 @@ func (c *Config) ValidateAndMkdir(ctx context.Context) error {
 		return ErrVolumePathNotAbs
 	}
 
-	if _, err := pkgfile.StatWithTimeout(ctx, c.VolumePath); os.IsNotExist(err) {
+	volumePath := c.resolvedVolumePath()
+	if _, err := pkgfile.StatWithTimeout(ctx, volumePath); os.IsNotExist(err) {
 		return fmt.Errorf("%q %w", c.VolumePath, ErrVolumePathNotExists)
 	} else if err != nil {
 		return err
 	}
 
-	dir := filepath.Join(c.VolumePath, c.DirName)
+	dir := filepath.Join(volumePath, c.DirName)
 	if _, err := pkgfile.StatWithTimeout(ctx, dir); os.IsNotExist(err) {
 		if err := pkgfile.MkdirAllWithTimeout(ctx, dir, 0755); err != nil {
 			return err
@@ -96,4 +103,11 @@ func (c *Config) ValidateAndMkdir(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (c *Config) resolvedVolumePath() string {
+	if c.HostRoot == "" {
+		return c.VolumePath
+	}
+	return filepath.Join(c.HostRoot, strings.TrimPrefix(filepath.Clean(c.VolumePath), string(filepath.Separator)))
 }

--- a/pkg/nfs-checker/member_config.go
+++ b/pkg/nfs-checker/member_config.go
@@ -24,7 +24,7 @@ type MemberConfig struct {
 
 // fileSelf returns the file path of the file that is written by the checker.
 func (cfg *MemberConfig) fileSelf() string {
-	dir := filepath.Join(cfg.VolumePath, cfg.DirName)
+	dir := filepath.Join(cfg.resolvedVolumePath(), cfg.DirName)
 	return filepath.Join(dir, cfg.ID)
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -315,6 +315,7 @@ func New(ctx context.Context, auditLogger log.AuditLogger, config *lepconfig.Con
 		FindmntCommands:       config.FindmntCommands,
 		LsblkCommands:         config.LsblkCommands,
 		BlockdevUsageCommands: config.BlockdevUsageCommands,
+		NFSHostRoot:           config.NFSHostRoot,
 
 		ContainerdServiceActiveCommands: config.ContainerdServiceActiveCommands,
 

--- a/pkg/session/update_config.go
+++ b/pkg/session/update_config.go
@@ -1,9 +1,7 @@
 package session
 
 import (
-	"context"
 	"encoding/json"
-	"time"
 
 	componentsnvidiagpucounts "github.com/leptonai/gpud/components/accelerator/nvidia/gpu-counts"
 	componentsnvidiainfiniband "github.com/leptonai/gpud/components/accelerator/nvidia/infiniband"
@@ -95,20 +93,12 @@ func (s *Session) processUpdateConfig(configMap map[string]string, resp *Respons
 				return
 			}
 
-			// if NFS validation takes too long, it can block other session requests
-			// so we set a timeout and do it async
-			go func() {
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				err := updateCfgs.Validate(ctx)
-				cancel()
-				if err != nil {
-					log.Logger.Warnw("invalid nfs config but proceeding with update to allow the user to fix the config", "error", err)
-				}
-
-				if s.setDefaultNFSGroupConfigsFunc != nil {
-					s.setDefaultNFSGroupConfigsFunc(updateCfgs)
-				}
-			}()
+			// Path validation belongs to the NFS component, which has the deployment's
+			// host-root view. Validating here would inspect the container namespace and
+			// incorrectly reject valid BYOK node paths before /proc/1/root is applied.
+			if s.setDefaultNFSGroupConfigsFunc != nil {
+				s.setDefaultNFSGroupConfigsFunc(updateCfgs)
+			}
 
 		default:
 			log.Logger.Warnw("unsupported component for updateConfig", "component", componentName)

--- a/pkg/session/update_config_test.go
+++ b/pkg/session/update_config_test.go
@@ -2,9 +2,7 @@ package session
 
 import (
 	"encoding/json"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -384,7 +382,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 			expectedTemperatureThresholdsCallCount: 0,
 		},
 		{
-			name: "invalid nfs config - validation error",
+			name: "nfs config with empty path is stored for component validation",
 			configMap: map[string]string{
 				"nfs": `[{"volume_path": "", "file_contents": "test-content", "ttl_to_delete": "5m", "num_expected_files": 3}]`,
 			},
@@ -394,7 +392,7 @@ func TestProcessUpdateConfig(t *testing.T) {
 				assert.Equal(t, 0, states.AtLeastRate)
 			},
 			setDefaultNFSGroupConfigsFunc: func(cfgs pkgnfschecker.Configs) {
-				// This function should be called even for invalid configs to allow user to fix them
+				// The component owns path validation because it has the deployment host-root view.
 				assert.Len(t, cfgs, 1)
 				assert.Equal(t, "", cfgs[0].VolumePath) // invalid empty path
 			},
@@ -410,14 +408,14 @@ func TestProcessUpdateConfig(t *testing.T) {
 				// This gets called with default config due to fallback behavior
 				assert.Equal(t, componentstemperature.ThresholdCelsiusSlowdownMargin, thresholds.CelsiusSlowdownMargin)
 			},
-			expectedError:                          "", // validation errors are logged but not returned as errors
+			expectedError:                          "",
 			expectedIbExpectedPortStatesCalled:     true,
 			expectedNFSGroupConfigsCalled:          true,
 			expectedGPUCountsCalled:                true,
 			expectedXIDThresholdsCalled:            true,
 			expectedTemperatureThresholdsCalled:    true,
 			expectedIbExpectedPortStatesCallCount:  1,
-			expectedNFSGroupConfigsCallCount:       1, // function should be called even for invalid configs
+			expectedNFSGroupConfigsCallCount:       1,
 			expectedGPUCountsCallCount:             1,
 			expectedXIDThresholdsCallCount:         1,
 			expectedTemperatureThresholdsCallCount: 1,
@@ -608,17 +606,6 @@ func TestProcessUpdateConfig(t *testing.T) {
 			xidCallCount := 0
 			tempCallCount := 0
 
-			// Add wait group for async NFS processing
-			var wg sync.WaitGroup
-			hasNFSConfig := false
-			for componentName := range tt.configMap {
-				if componentName == "nfs" {
-					hasNFSConfig = true
-					wg.Add(1)
-					break
-				}
-			}
-
 			// Create session with mock functions
 			s := &Session{
 				setDefaultIbExpectedPortStatesFunc: func(states componentsnvidiainfinibanditypes.ExpectedPortStates) {
@@ -637,9 +624,6 @@ func TestProcessUpdateConfig(t *testing.T) {
 					nfsCallCount++
 					if tt.setDefaultNFSGroupConfigsFunc != nil {
 						tt.setDefaultNFSGroupConfigsFunc(cfgs)
-					}
-					if hasNFSConfig {
-						wg.Done()
 					}
 				},
 				setDefaultGPUCountsFunc: func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {
@@ -687,21 +671,6 @@ func TestProcessUpdateConfig(t *testing.T) {
 			// Call the method under test
 			s.processUpdateConfig(tt.configMap, resp)
 
-			// Wait for async NFS processing to complete
-			if hasNFSConfig && s.setDefaultNFSGroupConfigsFunc != nil && tt.expectedError == "" {
-				done := make(chan struct{})
-				go func() {
-					wg.Wait()
-					close(done)
-				}()
-				select {
-				case <-done:
-					// NFS processing completed
-				case <-time.After(10 * time.Second):
-					t.Fatal("Timeout waiting for NFS config processing")
-				}
-			}
-
 			// Verify error
 			if tt.expectedError != "" {
 				assert.Contains(t, resp.Error, tt.expectedError)
@@ -729,9 +698,6 @@ func TestProcessUpdateConfig(t *testing.T) {
 		gpuCallCount := 0
 		xidCallCount := 0
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-
 		s := &Session{
 			setDefaultIbExpectedPortStatesFunc: func(states componentsnvidiainfinibanditypes.ExpectedPortStates) {
 				ibCallCount++
@@ -749,7 +715,6 @@ func TestProcessUpdateConfig(t *testing.T) {
 				assert.Len(t, cfgs, 1)
 				assert.Equal(t, tempDir, cfgs[0].VolumePath)
 				assert.Equal(t, "test-content", cfgs[0].FileContents)
-				wg.Done()
 			},
 			setDefaultGPUCountsFunc: func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {
 				gpuCallCount++
@@ -770,19 +735,6 @@ func TestProcessUpdateConfig(t *testing.T) {
 		resp := &Response{}
 		s.processUpdateConfig(configMap, resp)
 
-		// Wait for async NFS processing
-		done := make(chan struct{})
-		go func() {
-			wg.Wait()
-			close(done)
-		}()
-		select {
-		case <-done:
-			// NFS processing completed
-		case <-time.After(10 * time.Second):
-			t.Fatal("Timeout waiting for NFS config processing")
-		}
-
 		assert.Empty(t, resp.Error)
 		assert.Equal(t, 1, ibCallCount, "Unexpected infiniband function call count")
 		assert.Equal(t, 1, nvlinkCallCount, "Unexpected NVLink function call count")
@@ -800,9 +752,6 @@ func TestProcessUpdateConfig(t *testing.T) {
 		gpuCallCount := 0
 		xidCallCount := 0
 
-		var wg sync.WaitGroup
-		wg.Add(1)
-
 		s := &Session{
 			setDefaultIbExpectedPortStatesFunc: func(states componentsnvidiainfinibanditypes.ExpectedPortStates) {
 				ibCallCount++
@@ -819,7 +768,6 @@ func TestProcessUpdateConfig(t *testing.T) {
 				assert.Len(t, cfgs, 1)
 				assert.Equal(t, tempDir, cfgs[0].VolumePath)
 				assert.Equal(t, "multi-content", cfgs[0].FileContents)
-				wg.Done()
 			},
 			setDefaultGPUCountsFunc: func(counts componentsnvidiagpucounts.ExpectedGPUCounts) {
 				gpuCallCount++
@@ -840,19 +788,6 @@ func TestProcessUpdateConfig(t *testing.T) {
 
 		resp := &Response{}
 		s.processUpdateConfig(configMap, resp)
-
-		// Wait for async NFS processing
-		done := make(chan struct{})
-		go func() {
-			wg.Wait()
-			close(done)
-		}()
-		select {
-		case <-done:
-			// NFS processing completed
-		case <-time.After(10 * time.Second):
-			t.Fatal("Timeout waiting for NFS config processing")
-		}
 
 		assert.Empty(t, resp.Error)
 		assert.Equal(t, 1, ibCallCount, "Unexpected infiniband function call count")
@@ -1054,13 +989,10 @@ func TestProcessUpdateConfig_RealConfigStructures(t *testing.T) {
 		assert.NoError(t, err)
 
 		var actualConfigs pkgnfschecker.Configs
-		var wg sync.WaitGroup
-		wg.Add(1)
 
 		s := &Session{
 			setDefaultNFSGroupConfigsFunc: func(cfgs pkgnfschecker.Configs) {
 				actualConfigs = cfgs
-				wg.Done()
 			},
 		}
 
@@ -1070,19 +1002,6 @@ func TestProcessUpdateConfig_RealConfigStructures(t *testing.T) {
 
 		resp := &Response{}
 		s.processUpdateConfig(configMap, resp)
-
-		// Wait for async processing
-		done := make(chan struct{})
-		go func() {
-			wg.Wait()
-			close(done)
-		}()
-		select {
-		case <-done:
-			// Processing completed
-		case <-time.After(10 * time.Second):
-			t.Fatal("Timeout waiting for NFS config processing")
-		}
 
 		assert.Empty(t, resp.Error)
 		assert.Len(t, actualConfigs, 1)
@@ -1111,13 +1030,10 @@ func TestProcessUpdateConfig_RealConfigStructures(t *testing.T) {
 		assert.NoError(t, err)
 
 		var actualConfigs pkgnfschecker.Configs
-		var wg sync.WaitGroup
-		wg.Add(1)
 
 		s := &Session{
 			setDefaultNFSGroupConfigsFunc: func(cfgs pkgnfschecker.Configs) {
 				actualConfigs = cfgs
-				wg.Done()
 			},
 		}
 
@@ -1127,19 +1043,6 @@ func TestProcessUpdateConfig_RealConfigStructures(t *testing.T) {
 
 		resp := &Response{}
 		s.processUpdateConfig(configMap, resp)
-
-		// Wait for async processing
-		done := make(chan struct{})
-		go func() {
-			wg.Wait()
-			close(done)
-		}()
-		select {
-		case <-done:
-			// Processing completed
-		case <-time.After(10 * time.Second):
-			t.Fatal("Timeout waiting for NFS config processing")
-		}
 
 		assert.Empty(t, resp.Error)
 		assert.Len(t, actualConfigs, 2)


### PR DESCRIPTION
The GPUd Helm release spans worker clusters with multiple node groups, while NFS paths are configured per node group. Mounting a specific path such as /mnt/nfs-share in the shared DaemonSet would prevent pods from starting on nodes where that path does not exist.

Add an optional --nfs-host-root setting and default it to /proc/1/root only in the Helm chart. NFS file operations now resolve configured paths through the node filesystem, while mount validation continues to use the logical host path through the existing nsenter-based findmnt command. Session updates store the configuration without touching filesystem paths; the NFS component performs deployment-aware validation.

The chart comments explicitly document that this value is not an NFS mount requirement: nodes without NFS configuration perform no NFS check, and a configured but missing mount degrades only the check without stopping GPUd. Systemd installations remain unchanged because the binary default is empty and retains direct host-path behavior.