### PR TITLE
[LEP-6029] feat(os): track persistent D-state processes with GPU-aware, configurable escalation

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -25,6 +25,7 @@ import (
 	componentssxid "github.com/leptonai/gpud/components/accelerator/nvidia/sxid"
 	componentsnvidiatemperature "github.com/leptonai/gpud/components/accelerator/nvidia/temperature"
 	componentsxid "github.com/leptonai/gpud/components/accelerator/nvidia/xid"
+	componentsos "github.com/leptonai/gpud/components/os"
 	pkgconfig "github.com/leptonai/gpud/pkg/config"
 	pkgcustomplugins "github.com/leptonai/gpud/pkg/custom-plugins"
 	pkgupdate "github.com/leptonai/gpud/pkg/update"
@@ -330,6 +331,15 @@ sudo rm /etc/systemd/system/gpud.service
 				&cli.StringFlag{
 					Name:  "sxid-thresholds",
 					Usage: `set per-SXID thresholds in JSON, e.g. '{"overrides":{"11004":{"rebootThreshold":7}}}'`,
+				},
+				&cli.StringFlag{
+					Name:  "os-blocked-process-name-regexes",
+					Usage: "comma-separated regexes matching process names; persistent D-state (blocked) processes matching any of them escalate the os component to unhealthy with a reboot suggestion (defaults to ^nvidia when an NVIDIA GPU is detected, otherwise the check is disabled; set to empty to disable explicitly)",
+				},
+				&cli.IntFlag{
+					Name:  "os-blocked-process-persistence-threshold",
+					Usage: fmt.Sprintf("consecutive checks a D-state (blocked) process must persist before being flagged (defaults to %d)", componentsos.DefaultBlockedProcessPersistenceThreshold),
+					Value: componentsos.DefaultBlockedProcessPersistenceThreshold,
 				},
 				&cli.DurationFlag{
 					Name:  "xid-lookback-period",
@@ -693,6 +703,15 @@ sudo rm /etc/systemd/system/gpud.service
 					Name:  "sxid-lookback-period",
 					Usage: "set the lookback period for SXID errors",
 					Value: componentssxid.DefaultLookbackPeriod,
+				},
+				&cli.StringFlag{
+					Name:  "os-blocked-process-name-regexes",
+					Usage: "comma-separated regexes matching process names; persistent D-state (blocked) processes matching any of them escalate the os component to unhealthy with a reboot suggestion (defaults to ^nvidia when an NVIDIA GPU is detected, otherwise the check is disabled; set to empty to disable explicitly)",
+				},
+				&cli.IntFlag{
+					Name:  "os-blocked-process-persistence-threshold",
+					Usage: fmt.Sprintf("consecutive checks a D-state (blocked) process must persist before being flagged (defaults to %d; auto-lowers to 1 when an NVIDIA GPU is detected, since a one-off scan cannot observe consecutive checks)", componentsos.DefaultBlockedProcessPersistenceThreshold),
+					Value: componentsos.DefaultBlockedProcessPersistenceThreshold,
 				},
 				&cli.IntFlag{
 					Name:  "threshold-celsius-slowdown-margin",

--- a/cmd/gpud/common/os_blocked_processes.go
+++ b/cmd/gpud/common/os_blocked_processes.go
@@ -1,0 +1,83 @@
+package common
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/urfave/cli"
+
+	componentsos "github.com/leptonai/gpud/components/os"
+	"github.com/leptonai/gpud/pkg/log"
+	nvidiapci "github.com/leptonai/gpud/pkg/nvidia/pci"
+)
+
+// DetectNvidiaGPU reports whether the machine has NVIDIA GPU devices, detected
+// via lspci "3D controller" lines. lspci reads PCI configuration space
+// directly, so detection works even when the NVIDIA driver/NVML is wedged --
+// the exact failure mode D-state process tracking targets (LEP-6029).
+func DetectNvidiaGPU(ctx context.Context) (bool, error) {
+	devs, err := nvidiapci.ListPCIGPUs(ctx)
+	if err != nil {
+		return false, err
+	}
+	return len(devs) > 0, nil
+}
+
+// ApplyOSBlockedProcessThresholds resolves and applies the os component's
+// D-state blocked-process thresholds (LEP-6029) from CLI flags, auto-enabling
+// detection on machines with NVIDIA GPUs:
+//
+//   - explicit flags win; an explicitly empty --os-blocked-process-name-regexes
+//     disables the check even on GPU machines
+//   - otherwise, when an NVIDIA GPU is detected, the name regexes default to
+//     matching NVIDIA processes (e.g., nvidia-smi) so a released gpud detects
+//     D-state issues out of the box
+//   - oneOffScan (gpud scan) lowers the auto persistence threshold to 1, since
+//     a one-off check cannot observe consecutive failures
+//   - without an NVIDIA GPU and without flags, the built-in default (empty
+//     regexes) keeps D-state checking disabled
+func ApplyOSBlockedProcessThresholds(cliContext *cli.Context, detectGPU func(ctx context.Context) (bool, error), oneOffScan bool) error {
+	regexesSet := cliContext.IsSet("os-blocked-process-name-regexes")
+	thresholdSet := cliContext.IsSet("os-blocked-process-persistence-threshold")
+
+	thresholds := componentsos.GetDefaultBlockedProcessThresholds()
+
+	if (!regexesSet || !thresholdSet) && detectGPU != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		hasGPU, err := detectGPU(ctx)
+		if err != nil {
+			log.Logger.Warnw("failed to detect NVIDIA GPUs; leaving os blocked-process thresholds at defaults", "error", err)
+		} else if hasGPU {
+			if !regexesSet {
+				thresholds.NameRegexes = componentsos.DefaultBlockedProcessNameRegexes()
+			}
+			if !thresholdSet && oneOffScan {
+				thresholds.PersistenceThreshold = 1
+			}
+		}
+	}
+
+	if regexesSet {
+		thresholds.NameRegexes = strings.Split(cliContext.String("os-blocked-process-name-regexes"), ",")
+	}
+	if thresholdSet {
+		thresholds.PersistenceThreshold = cliContext.Int("os-blocked-process-persistence-threshold")
+	}
+
+	if err := componentsos.SetDefaultBlockedProcessThresholds(thresholds); err != nil {
+		return err
+	}
+	// record the startup-resolved thresholds so the session updateConfig
+	// fallback can restore them when the control-plane config omits the os
+	// component (otherwise unrelated config pushes would silently disable
+	// D-state tracking on GPU machines)
+	componentsos.SetStartupBlockedProcessThresholds(componentsos.GetDefaultBlockedProcessThresholds())
+	log.Logger.Infow("applied os blocked process thresholds",
+		"persistenceThreshold", componentsos.GetDefaultBlockedProcessThresholds().PersistenceThreshold,
+		"nameRegexes", componentsos.GetDefaultBlockedProcessThresholds().NameRegexes,
+		"oneOffScan", oneOffScan,
+	)
+	return nil
+}

--- a/cmd/gpud/common/os_blocked_processes_test.go
+++ b/cmd/gpud/common/os_blocked_processes_test.go
@@ -1,0 +1,171 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli"
+
+	componentsos "github.com/leptonai/gpud/components/os"
+)
+
+func newOSBlockedProcessCLIContext(t *testing.T, regexes *string, threshold *int) *cli.Context {
+	t.Helper()
+
+	set := flag.NewFlagSet("gpud-test", flag.ContinueOnError)
+	set.String("os-blocked-process-name-regexes", "", "")
+	set.Int("os-blocked-process-persistence-threshold", 0, "")
+
+	if regexes != nil {
+		require.NoError(t, set.Set("os-blocked-process-name-regexes", *regexes))
+	}
+	if threshold != nil {
+		require.NoError(t, set.Set("os-blocked-process-persistence-threshold", strconv.Itoa(*threshold)))
+	}
+
+	app := cli.NewApp()
+	return cli.NewContext(app, set, nil)
+}
+
+func withDefaultBlockedProcessThresholds(t *testing.T) {
+	t.Helper()
+	original := componentsos.GetDefaultBlockedProcessThresholds()
+	originalStartup := componentsos.GetStartupBlockedProcessThresholds()
+	t.Cleanup(func() {
+		require.NoError(t, componentsos.SetDefaultBlockedProcessThresholds(original))
+		componentsos.SetStartupBlockedProcessThresholds(originalStartup)
+	})
+}
+
+func gpuDetector(hasGPU bool, err error) func(ctx context.Context) (bool, error) {
+	return func(ctx context.Context) (bool, error) {
+		return hasGPU, err
+	}
+}
+
+func TestApplyOSBlockedProcessThresholds(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	intPtr := func(i int) *int { return &i }
+
+	tests := []struct {
+		name          string
+		regexes       *string
+		threshold     *int
+		hasGPU        bool
+		detectErr     error
+		oneOffScan    bool
+		wantThreshold int
+		wantRegexes   []string
+		wantErr       bool
+	}{
+		{
+			name:          "daemon on GPU machine auto-enables nvidia regexes with default threshold",
+			hasGPU:        true,
+			wantThreshold: componentsos.DefaultBlockedProcessPersistenceThreshold,
+			wantRegexes:   []string{"^nvidia"},
+		},
+		{
+			name:          "one-off scan on GPU machine auto-lowers threshold to 1",
+			hasGPU:        true,
+			oneOffScan:    true,
+			wantThreshold: 1,
+			wantRegexes:   []string{"^nvidia"},
+		},
+		{
+			name:          "no GPU keeps the check disabled",
+			hasGPU:        false,
+			wantThreshold: componentsos.DefaultBlockedProcessPersistenceThreshold,
+			wantRegexes:   []string{},
+		},
+		{
+			name:          "detection error keeps the check disabled",
+			detectErr:     errors.New("lspci not found"),
+			wantThreshold: componentsos.DefaultBlockedProcessPersistenceThreshold,
+			wantRegexes:   []string{},
+		},
+		{
+			name:          "explicit regexes honored without GPU",
+			regexes:       strPtr("^dd$,uvm_"),
+			hasGPU:        false,
+			wantThreshold: componentsos.DefaultBlockedProcessPersistenceThreshold,
+			wantRegexes:   []string{"^dd$", "uvm_"},
+		},
+		{
+			name:          "explicitly empty regexes disable the check even on GPU machines",
+			regexes:       strPtr(""),
+			hasGPU:        true,
+			wantThreshold: componentsos.DefaultBlockedProcessPersistenceThreshold,
+			wantRegexes:   []string{},
+		},
+		{
+			name:          "explicit threshold honored, regexes auto-filled on GPU machine",
+			threshold:     intPtr(3),
+			hasGPU:        true,
+			oneOffScan:    true,
+			wantThreshold: 3,
+			wantRegexes:   []string{"^nvidia"},
+		},
+		{
+			name:          "explicit regexes and threshold skip GPU detection",
+			regexes:       strPtr("^dd$"),
+			threshold:     intPtr(7),
+			hasGPU:        true,
+			wantThreshold: 7,
+			wantRegexes:   []string{"^dd$"},
+		},
+		{
+			name:    "invalid regex fails",
+			regexes: strPtr("(("),
+			hasGPU:  false,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withDefaultBlockedProcessThresholds(t)
+
+			ctx := newOSBlockedProcessCLIContext(t, tt.regexes, tt.threshold)
+			err := ApplyOSBlockedProcessThresholds(ctx, gpuDetector(tt.hasGPU, tt.detectErr), tt.oneOffScan)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			got := componentsos.GetDefaultBlockedProcessThresholds()
+			assert.Equal(t, tt.wantThreshold, got.PersistenceThreshold)
+			if len(tt.wantRegexes) == 0 {
+				assert.Empty(t, got.NameRegexes)
+			} else {
+				assert.Equal(t, tt.wantRegexes, got.NameRegexes)
+			}
+
+			// the startup baseline (session updateConfig fallback target) must
+			// be recorded with the same resolved thresholds
+			startup := componentsos.GetStartupBlockedProcessThresholds()
+			assert.Equal(t, got.PersistenceThreshold, startup.PersistenceThreshold)
+			if len(tt.wantRegexes) == 0 {
+				assert.Empty(t, startup.NameRegexes)
+			} else {
+				assert.Equal(t, tt.wantRegexes, startup.NameRegexes)
+			}
+		})
+	}
+}
+
+func TestApplyOSBlockedProcessThresholds_NilDetector(t *testing.T) {
+	withDefaultBlockedProcessThresholds(t)
+
+	ctx := newOSBlockedProcessCLIContext(t, nil, nil)
+	require.NoError(t, ApplyOSBlockedProcessThresholds(ctx, nil, false))
+
+	got := componentsos.GetDefaultBlockedProcessThresholds()
+	assert.Equal(t, componentsos.DefaultBlockedProcessPersistenceThreshold, got.PersistenceThreshold)
+	assert.Empty(t, got.NameRegexes, "nil detector must leave the check disabled")
+}

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -235,6 +235,13 @@ func Command(cliContext *cli.Context) error {
 		log.Logger.Infow("set sxid thresholds", "sxidOverrides", thresholds.Overrides)
 	}
 
+	// D-state process tracking (LEP-6029): auto-enables with nvidia-matching
+	// regexes when an NVIDIA GPU is detected, unless configured via flags;
+	// the daemon keeps the default persistence threshold (one-off scan uses 1)
+	if err := common.ApplyOSBlockedProcessThresholds(cliContext, common.DetectNvidiaGPU, false); err != nil {
+		return err
+	}
+
 	if eventsRetentionPeriod > 0 && !cliContext.IsSet("xid-lookback-period") {
 		componentsxid.SetLookbackPeriod(eventsRetentionPeriod)
 		log.Logger.Infow("set xid lookback period from events retention period", "xidLookbackPeriod", eventsRetentionPeriod)

--- a/cmd/gpud/scan/command.go
+++ b/cmd/gpud/scan/command.go
@@ -47,6 +47,13 @@ func CreateCommand() func(*cli.Context) error {
 			componentssxid.SetLookbackPeriod(cliContext.Duration("sxid-lookback-period"))
 		}
 
+		// D-state process tracking (LEP-6029): a one-off scan cannot observe
+		// consecutive checks, so on NVIDIA GPU machines the persistence threshold
+		// auto-lowers to 1 and any current D-state nvidia process flags unhealthy
+		if err := common.ApplyOSBlockedProcessThresholds(cliContext, common.DetectNvidiaGPU, true); err != nil {
+			return err
+		}
+
 		return cmdScan(
 			cliContext.String("log-level"),
 			cliContext.Int("gpu-count"),

--- a/components/os/blocked_processes.go
+++ b/components/os/blocked_processes.go
@@ -1,0 +1,212 @@
+//nolint:revive // package name follows the directory import path used across the codebase.
+package os
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/leptonai/gpud/pkg/log"
+	"github.com/leptonai/gpud/pkg/process"
+)
+
+// This file implements tracking of processes stuck in uninterruptible sleep
+// (Linux "D" state, surfaced by gopsutil as "blocked") for LEP-6029.
+//
+// Design constraints validated against production clusters (2026-08-12):
+//   - Detection reuses the existing per-minute CountProcessesByStatus scan; no
+//     additional process enumeration, no external commands (nvidia-smi, NVML).
+//   - Healthy GPU nodes showed zero D-state processes; a real D-state process
+//     persists for minutes, so a persistence threshold of consecutive checks
+//     (not a single observation) is required to avoid false flags.
+//   - A tracked PID that is absent from a single check (PID churn between
+//     enumeration and metadata reads, transient /proc read errors) must not
+//     reset its persistence counter.
+//   - Diagnostic payloads must be bounded and must not contain environment
+//     variables or unbounded command lines.
+//
+// The configurable thresholds (persistence, process-name regexes) live in
+// threshold.go, following the gpu-counts threshold pattern.
+
+const (
+	// blockedProcessAbsenceGrace is the number of consecutive checks a tracked
+	// process may be missing (PID reuse/churn, transient /proc read errors)
+	// before it is dropped from tracking. One missed check neither extends nor
+	// resets the persistence counter.
+	blockedProcessAbsenceGrace = 1
+
+	// maxBlockedProcessesOutput bounds the number of persistent blocked
+	// processes persisted in the check result payload.
+	maxBlockedProcessesOutput = 20
+
+	// checkInterval is the cadence the persistence threshold is calibrated
+	// against: Start runs Check once per minute. The duration gate in update
+	// makes the ticket's "five consecutive ONE-MINUTE checks" robust to
+	// out-of-band Check() invocations (/v1/components/trigger-check, session
+	// triggerComponent call comp.Check() directly, ungated): without it, a
+	// burst of manual triggers would inflate consecutiveChecks within seconds
+	// and flag a seconds-old D-state process as persistent.
+	checkInterval = time.Minute
+
+	// DefaultBlockedProcessRebootThreshold is the number of reboot events (with
+	// no recovery in between) after which a persistent blocked-process
+	// condition escalates from reboot suggestion to hardware inspection.
+	// Kept at parity with the XID component's DefaultRebootThreshold
+	// (components/accelerator/nvidia/xid).
+	DefaultBlockedProcessRebootThreshold = 2
+)
+
+// BlockedProcess describes one process observed in uninterruptible sleep.
+type BlockedProcess struct {
+	// PID is the process ID.
+	PID int32 `json:"pid"`
+	// Name is the process name (Linux comm, truncated to 15 chars by the kernel).
+	Name string `json:"name"`
+	// FirstSeenUnixSeconds is when the process was first observed blocked.
+	FirstSeenUnixSeconds int64 `json:"first_seen_unix_seconds"`
+	// LastSeenUnixSeconds is when the process was most recently observed blocked.
+	LastSeenUnixSeconds int64 `json:"last_seen_unix_seconds"`
+	// BlockedSeconds is the observed blocked duration (last seen - first seen).
+	BlockedSeconds int64 `json:"blocked_seconds"`
+	// ConsecutiveChecks is the number of consecutive checks the process was blocked.
+	ConsecutiveChecks int `json:"consecutive_checks"`
+}
+
+// BlockedProcesses summarizes the blocked-process state of one check.
+type BlockedProcesses struct {
+	// CurrentCount is the number of processes blocked at this check.
+	CurrentCount int `json:"current_count"`
+	// PersistentCount is the number of processes that met the persistence
+	// threshold (may exceed len(Persistent) when the output is capped).
+	PersistentCount int `json:"persistent_count"`
+	// Persistent is the bounded list of persistent blocked processes.
+	Persistent []BlockedProcess `json:"persistent,omitempty"`
+}
+
+type blockedProcessEntry struct {
+	name              string
+	firstSeen         time.Time
+	lastSeen          time.Time
+	consecutiveChecks int
+	absentChecks      int
+}
+
+// blockedProcessTracker tracks blocked PIDs across checks.
+type blockedProcessTracker struct {
+	mu      sync.Mutex
+	entries map[int32]*blockedProcessEntry
+}
+
+func newBlockedProcessTracker() *blockedProcessTracker {
+	return &blockedProcessTracker{
+		entries: make(map[int32]*blockedProcessEntry),
+	}
+}
+
+// reset drops all tracked processes, e.g. when an operator marks the
+// component healthy: a process still blocked must re-earn the persistence
+// threshold before being flagged again.
+func (t *blockedProcessTracker) reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.entries = make(map[int32]*blockedProcessEntry)
+}
+
+// update ingests the currently blocked processes observed at "now" and returns
+// the number of persistent blocked processes along with a bounded list of their
+// details (sorted by first-seen time, then PID). A process is persistent once
+// it has been blocked for persistenceThreshold consecutive checks; a
+// non-positive persistenceThreshold falls back to the default.
+//
+// Tolerates processes disappearing between enumeration and metadata reads:
+// a process absent for at most blockedProcessAbsenceGrace consecutive checks is
+// kept (its persistence counter is preserved, not extended); longer absence
+// drops the entry (recovered).
+func (t *blockedProcessTracker) update(now time.Time, blocked []process.ProcessStatus, persistenceThreshold int) (int, []BlockedProcess) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if persistenceThreshold <= 0 {
+		persistenceThreshold = DefaultBlockedProcessPersistenceThreshold
+	}
+
+	seen := make(map[int32]struct{}, len(blocked))
+	for _, p := range blocked {
+		if p == nil {
+			continue
+		}
+		pid := p.PID()
+		seen[pid] = struct{}{}
+
+		name, err := p.Name()
+		if err != nil {
+			log.Logger.Warnw("failed to read blocked process name", "pid", pid, "error", err)
+			name = ""
+		}
+
+		e, ok := t.entries[pid]
+		if !ok {
+			t.entries[pid] = &blockedProcessEntry{
+				name:              name,
+				firstSeen:         now,
+				lastSeen:          now,
+				consecutiveChecks: 1,
+			}
+			continue
+		}
+		if name != "" {
+			e.name = name
+		}
+		e.lastSeen = now
+		e.consecutiveChecks++
+		e.absentChecks = 0
+	}
+
+	for pid, e := range t.entries {
+		if _, ok := seen[pid]; ok {
+			continue
+		}
+		e.absentChecks++
+		if e.absentChecks > blockedProcessAbsenceGrace {
+			delete(t.entries, pid)
+		}
+	}
+
+	persistentCount := 0
+	persistent := make([]BlockedProcess, 0)
+	// A process must persist for at least (threshold-1) check intervals in
+	// wall time, in addition to the consecutive-check count. At the normal
+	// one-minute cadence the two gates coincide (5 checks span 4 minutes);
+	// the duration gate only binds when Check is invoked faster than that.
+	minDuration := time.Duration(persistenceThreshold-1) * checkInterval
+	for pid, e := range t.entries {
+		if e.consecutiveChecks < persistenceThreshold {
+			continue
+		}
+		if now.Sub(e.firstSeen) < minDuration {
+			continue
+		}
+		persistentCount++
+		persistent = append(persistent, BlockedProcess{
+			PID:                  pid,
+			Name:                 e.name,
+			FirstSeenUnixSeconds: e.firstSeen.Unix(),
+			LastSeenUnixSeconds:  e.lastSeen.Unix(),
+			BlockedSeconds:       int64(e.lastSeen.Sub(e.firstSeen).Seconds()),
+			ConsecutiveChecks:    e.consecutiveChecks,
+		})
+	}
+
+	sort.Slice(persistent, func(i, j int) bool {
+		if persistent[i].FirstSeenUnixSeconds == persistent[j].FirstSeenUnixSeconds {
+			return persistent[i].PID < persistent[j].PID
+		}
+		return persistent[i].FirstSeenUnixSeconds < persistent[j].FirstSeenUnixSeconds
+	})
+
+	if len(persistent) > maxBlockedProcessesOutput {
+		persistent = persistent[:maxBlockedProcessesOutput]
+	}
+
+	return persistentCount, persistent
+}

--- a/components/os/blocked_processes.go
+++ b/components/os/blocked_processes.go
@@ -13,6 +13,50 @@ import (
 // This file implements tracking of processes stuck in uninterruptible sleep
 // (Linux "D" state, surfaced by gopsutil as "blocked") for LEP-6029.
 //
+// # What D-state is
+//
+// A D-state task is waiting inside a kernel syscall -- usually I/O (disk,
+// NFS, device-mapper) or a device driver (e.g., an NVIDIA UVM ioctl) -- and
+// the kernel does not deliver signals to it until that wait completes. Even
+// SIGKILL is only queued, so a D-state process cannot be killed, stopped, or
+// restarted from user space; it exits only when the kernel wait finishes or
+// the machine reboots.
+//
+// # Why it happens, and when it is fine to ignore
+//
+// Not every D-state process is bad. Every synchronous read, write, or page-in
+// passes through D briefly, so catching a healthy process in D for a few
+// milliseconds or seconds is normal, especially under I/O load. Such
+// transient waits must not change node health: this is why flagging requires
+// a persistence threshold of consecutive one-minute checks rather than a
+// single observation. Validation on healthy production GPU nodes
+// (2026-08-12, two iad nodes, 2,305 processes enumerated, plus a 30x10s
+// sampling window) found zero D-state processes, so the default threshold
+// has wide margin against false flags on this fleet.
+//
+// # When it is NOT fine to ignore
+//
+// A process that stays in D for minutes means its kernel wait is not
+// completing: a wedged driver, a suspended device, a dead NFS server, or
+// failing hardware. Because SIGKILL cannot clear it, the stuck task wedges
+// whatever sits behind it. The LEP-6029 incident had nvidia-smi in D blocking
+// a kubelet package-upgrade script. The 2026-08-12 dev01 validation
+// reproduced the same wedge class deterministically (dd on a suspended
+// device-mapper device, wchan folio_wait_bit_common): the task stayed in D
+// for >=6 minutes, containerd could not SIGKILL it during teardown, and the
+// pod kept reporting "Running" while dead -- the stale-status trap from
+// LEP-5812.
+//
+// # What D-state does not tell you
+//
+// D-state says "a kernel wait is stuck"; it does not say the GPU is at
+// fault. A dd waiting on a suspended dm device and an nvidia-smi waiting on a
+// wedged driver look identical in /proc. That is why escalation is name-gated
+// (see threshold.go): every persistent D-state process degrades the
+// component, but only names matching the escalation regexes (default ^nvidia
+// on GPU machines) mark it unhealthy with a reboot suggestion, and repeated
+// reboots without recovery escalate to hardware inspection.
+//
 // Design constraints validated against production clusters (2026-08-12):
 //   - Detection reuses the existing per-minute CountProcessesByStatus scan; no
 //     additional process enumeration, no external commands (nvidia-smi, NVML).

--- a/components/os/blocked_processes.go
+++ b/components/os/blocked_processes.go
@@ -24,9 +24,9 @@ import (
 //
 // # Why it happens, and when it is fine to ignore
 //
-// Not every D-state process is bad. Every synchronous read, write, or page-in
-// passes through D briefly, so catching a healthy process in D for a few
-// milliseconds or seconds is normal, especially under I/O load. Such
+// Not every D-state process is bad. Most blocking disk I/O (reads, writes,
+// page faults hitting storage) passes through D briefly, so catching a
+// healthy process in D for a few milliseconds or seconds is normal, especially under I/O load. Such
 // transient waits must not change node health: this is why flagging requires
 // a persistence threshold of consecutive one-minute checks rather than a
 // single observation. Validation on healthy production GPU nodes
@@ -51,7 +51,8 @@ import (
 //
 // D-state says "a kernel wait is stuck"; it does not say the GPU is at
 // fault. A dd waiting on a suspended dm device and an nvidia-smi waiting on a
-// wedged driver look identical in /proc. That is why escalation is name-gated
+// wedged driver show the same D state letter in /proc/<pid>/stat (both
+// become process.Blocked in gopsutil). That is why escalation is name-gated
 // (see threshold.go): every persistent D-state process degrades the
 // component, but only names matching the escalation regexes (default ^nvidia
 // on GPU machines) mark it unhealthy with a reboot suggestion, and repeated

--- a/components/os/blocked_processes_test.go
+++ b/components/os/blocked_processes_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/prometheus/client_golang/prometheus"
+	prometheusdto "github.com/prometheus/client_model/go"
+
 	apiv1 "github.com/leptonai/gpud/api/v1"
 	"github.com/leptonai/gpud/components"
 	"github.com/leptonai/gpud/pkg/eventstore"
@@ -708,4 +711,63 @@ func TestCheck_BlockedProcesses_ProcessScanErrorStillUnhealthy(t *testing.T) {
 	cr := comp.Check()
 	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.HealthStateType())
 	assert.Contains(t, cr.Summary(), "error getting process count")
+}
+
+func TestCheck_BlockedProcesses_DisableClearsStateAndGauges(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	bucket := &recordingBucket{}
+	comp, now := newTestComponent(t, ctx, &mockRebootEventStore{}, bucket)
+	defer func() { _ = comp.Close() }()
+
+	// runtime-switchable thresholds, simulating a session updateConfig push
+	thresholds := mustBlockedProcessThresholds(t, 5, "^nvidia")
+	comp.getBlockedProcessThresholdsFunc = func() BlockedProcessThresholds { return thresholds }
+
+	// 1. enabled: 5 consecutive checks with a blocked nvidia-smi => unhealthy episode
+	cr := runChecks(comp, now, 5, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	require.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.HealthStateType())
+	require.Equal(t, []string{EventNameBlockedProcessesPersistent}, bucket.insertedNames())
+	assertGaugeValue(t, metricBlockedProcessesPersistent, 1)
+
+	// 2. disabled mid-episode (empty regexes): one check clears health,
+	// resets the tracker, closes the episode with a "disabled" recovery event,
+	// and zeroes the gauges
+	thresholds = mustBlockedProcessThresholds(t, 5)
+	cr = runChecks(comp, now, 1, nil)
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, cr.HealthStateType())
+
+	comp.blockedTracker.mu.Lock()
+	tracked := len(comp.blockedTracker.entries)
+	comp.blockedTracker.mu.Unlock()
+	assert.Zero(t, tracked, "disable must reset the tracker so re-enable re-earns the threshold")
+
+	names := bucket.insertedNames()
+	require.Equal(t, []string{EventNameBlockedProcessesPersistent, EventNameBlockedProcessesRecovered}, names)
+	events := bucket.insertedEvents()
+	assert.Contains(t, events[1].Message, "disabled", "recovery event must say the check was disabled, not that the processes actually cleared")
+
+	assertGaugeValue(t, metricBlockedProcesses, 0)
+	assertGaugeValue(t, metricBlockedProcessesPersistent, 0)
+
+	// 3. re-enabled while the same process is still blocked: must re-earn the
+	// full persistence threshold (not resume the stale counter), then fire a
+	// new episode
+	thresholds = mustBlockedProcessThresholds(t, 5, "^nvidia")
+	cr = runChecks(comp, now, 4, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, cr.HealthStateType(), "re-enabled check must re-earn the persistence threshold")
+	cr = runChecks(comp, now, 1, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.HealthStateType())
+	assert.Equal(t, []string{EventNameBlockedProcessesPersistent, EventNameBlockedProcessesRecovered, EventNameBlockedProcessesPersistent}, bucket.insertedNames())
+}
+
+// assertGaugeValue asserts the current value of a component gauge.
+func assertGaugeValue(t *testing.T, gaugeVec *prometheus.GaugeVec, want float64) {
+	t.Helper()
+	gauge, err := gaugeVec.GetMetricWith(prometheus.Labels{})
+	require.NoError(t, err)
+	dto := &prometheusdto.Metric{}
+	require.NoError(t, gauge.Write(dto))
+	assert.InDelta(t, want, dto.GetGauge().GetValue(), 0.0001)
 }

--- a/components/os/blocked_processes_test.go
+++ b/components/os/blocked_processes_test.go
@@ -1,0 +1,711 @@
+//nolint:forcetypeassert,revive // tests intentionally inspect concrete types; package name follows the directory import path.
+package os
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	procs "github.com/shirou/gopsutil/v4/process"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apiv1 "github.com/leptonai/gpud/api/v1"
+	"github.com/leptonai/gpud/components"
+	"github.com/leptonai/gpud/pkg/eventstore"
+	pkghost "github.com/leptonai/gpud/pkg/host"
+	"github.com/leptonai/gpud/pkg/process"
+)
+
+// mockProcessStatus implements process.ProcessStatus for tests.
+type mockProcessStatus struct {
+	pid     int32
+	name    string
+	nameErr error
+}
+
+func (m *mockProcessStatus) Name() (string, error)     { return m.name, m.nameErr }
+func (m *mockProcessStatus) PID() int32                { return m.pid }
+func (m *mockProcessStatus) Status() ([]string, error) { return []string{procs.Blocked}, nil }
+
+func blockedList(procs ...process.ProcessStatus) []process.ProcessStatus {
+	return procs
+}
+
+// mustBlockedProcessThresholds builds thresholds with compiled regexes for tests.
+func mustBlockedProcessThresholds(t *testing.T, threshold int, regexes ...string) BlockedProcessThresholds {
+	t.Helper()
+	th, err := newBlockedProcessThresholds(threshold, regexes)
+	require.NoError(t, err)
+	return th
+}
+
+// withBlockedProcessThresholds makes the component read the given thresholds
+// on every check, simulating a config applied via flags or session
+// updateConfig.
+func withBlockedProcessThresholds(comp *component, th BlockedProcessThresholds) {
+	comp.getBlockedProcessThresholdsFunc = func() BlockedProcessThresholds { return th }
+}
+
+// recordingBucket records inserted events and serves seeded events.
+type recordingBucket struct {
+	mu        sync.Mutex
+	inserted  []eventstore.Event
+	getEvents eventstore.Events
+	getError  error
+}
+
+func (m *recordingBucket) Name() string { return "mock-bucket" }
+func (m *recordingBucket) Insert(_ context.Context, event eventstore.Event) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.inserted = append(m.inserted, event)
+	return nil
+}
+func (m *recordingBucket) Find(_ context.Context, _ eventstore.Event) (*eventstore.Event, error) {
+	return nil, nil
+}
+func (m *recordingBucket) Get(_ context.Context, _ time.Time) (eventstore.Events, error) {
+	if m.getError != nil {
+		return nil, m.getError
+	}
+	// serve inserted events as a real bucket would, plus any seeded events
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ret := make(eventstore.Events, 0, len(m.getEvents)+len(m.inserted))
+	ret = append(ret, m.getEvents...)
+	ret = append(ret, m.inserted...)
+	return ret, nil
+}
+func (m *recordingBucket) Latest(_ context.Context) (*eventstore.Event, error) { return nil, nil }
+func (m *recordingBucket) Purge(_ context.Context, _ int64) (int, error)       { return 0, nil }
+func (m *recordingBucket) Close()                                              {}
+
+func (m *recordingBucket) insertedNames() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	names := make([]string, 0, len(m.inserted))
+	for _, ev := range m.inserted {
+		names = append(names, ev.Name)
+	}
+	return names
+}
+
+func (m *recordingBucket) insertedEvents() []eventstore.Event {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ret := make([]eventstore.Event, len(m.inserted))
+	copy(ret, m.inserted)
+	return ret
+}
+
+func TestBlockedProcessTracker_NoBlocked(t *testing.T) {
+	tr := newBlockedProcessTracker()
+	now := time.Unix(1000, 0)
+	for i := 0; i < 10; i++ {
+		count, persistent := tr.update(now.Add(time.Duration(i)*time.Minute), nil, 5)
+		assert.Zero(t, count)
+		assert.Empty(t, persistent)
+	}
+}
+
+func TestBlockedProcessTracker_TransientNotFlagged(t *testing.T) {
+	tr := newBlockedProcessTracker()
+	now := time.Unix(1000, 0)
+
+	// process blocked for 4 consecutive checks (< threshold of 5)
+	for i := 0; i < 4; i++ {
+		count, persistent := tr.update(now.Add(time.Duration(i)*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 5)
+		assert.Zero(t, count, "check %d must not be persistent yet", i)
+		assert.Empty(t, persistent)
+	}
+
+	// then disappears for good (2 consecutive absences drop the entry);
+	// when a process with the same PID appears later, the counter restarts
+	tr.update(now.Add(4*time.Minute), nil, 5)
+	tr.update(now.Add(5*time.Minute), nil, 5)
+	for i := 6; i < 10; i++ {
+		count, persistent := tr.update(now.Add(time.Duration(i)*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 5)
+		assert.Zero(t, count, "check %d must restart counting after recovery", i)
+		assert.Empty(t, persistent)
+	}
+}
+
+func TestBlockedProcessTracker_Persistent(t *testing.T) {
+	tr := newBlockedProcessTracker()
+	now := time.Unix(1000, 0)
+
+	var count int
+	var persistent []BlockedProcess
+	for i := 0; i < 5; i++ {
+		count, persistent = tr.update(now.Add(time.Duration(i)*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 5)
+	}
+	require.Equal(t, 1, count)
+	require.Len(t, persistent, 1)
+
+	bp := persistent[0]
+	assert.Equal(t, int32(100), bp.PID)
+	assert.Equal(t, "nvidia-smi", bp.Name)
+	assert.Equal(t, now.Unix(), bp.FirstSeenUnixSeconds)
+	assert.Equal(t, now.Add(4*time.Minute).Unix(), bp.LastSeenUnixSeconds)
+	assert.Equal(t, int64(240), bp.BlockedSeconds)
+	assert.Equal(t, 5, bp.ConsecutiveChecks)
+
+	// keeps being reported on the 6th check
+	count, persistent = tr.update(now.Add(5*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 5)
+	require.Equal(t, 1, count)
+	assert.Equal(t, 6, persistent[0].ConsecutiveChecks)
+}
+
+func TestBlockedProcessTracker_ThresholdOneFlagsImmediately(t *testing.T) {
+	tr := newBlockedProcessTracker()
+	now := time.Unix(1000, 0)
+
+	// threshold 1 (one-off gpud scan): a single observation is persistent
+	count, persistent := tr.update(now, blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 1)
+	require.Equal(t, 1, count)
+	require.Len(t, persistent, 1)
+	assert.Equal(t, 1, persistent[0].ConsecutiveChecks)
+	assert.Equal(t, int64(0), persistent[0].BlockedSeconds)
+}
+
+func TestBlockedProcessTracker_NonPositiveThresholdFallsBackToDefault(t *testing.T) {
+	tr := newBlockedProcessTracker()
+	now := time.Unix(1000, 0)
+
+	// threshold 0 must behave as DefaultBlockedProcessPersistenceThreshold
+	for i := 0; i < DefaultBlockedProcessPersistenceThreshold-1; i++ {
+		count, _ := tr.update(now.Add(time.Duration(i)*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 0)
+		assert.Zero(t, count)
+	}
+	count, persistent := tr.update(now.Add((DefaultBlockedProcessPersistenceThreshold-1)*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 0)
+	require.Equal(t, 1, count)
+	require.Len(t, persistent, 1)
+}
+
+func TestBlockedProcessTracker_Reset(t *testing.T) {
+	tr := newBlockedProcessTracker()
+	now := time.Unix(1000, 0)
+
+	for i := 0; i < 5; i++ {
+		tr.update(now.Add(time.Duration(i)*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 5)
+	}
+	count, _ := tr.update(now.Add(5*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 5)
+	require.Equal(t, 1, count)
+
+	tr.reset()
+
+	// after reset the same process must re-earn the persistence threshold
+	for i := 6; i < 10; i++ {
+		count, _ := tr.update(now.Add(time.Duration(i)*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 5)
+		assert.Zero(t, count, "check %d after reset must not be persistent yet", i)
+	}
+	count, persistent := tr.update(now.Add(10*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 5)
+	require.Equal(t, 1, count)
+	require.Len(t, persistent, 1)
+	assert.Equal(t, 5, persistent[0].ConsecutiveChecks)
+	assert.Equal(t, now.Add(6*time.Minute).Unix(), persistent[0].FirstSeenUnixSeconds,
+		"first-seen must restart from the post-reset observation")
+}
+
+func TestBlockedProcessTracker_SingleCheckAbsenceDoesNotReset(t *testing.T) {
+	tr := newBlockedProcessTracker()
+	now := time.Unix(1000, 0)
+
+	// present for 4 checks
+	for i := 0; i < 4; i++ {
+		tr.update(now.Add(time.Duration(i)*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 5)
+	}
+	// absent for 1 check (PID churn / transient /proc read error)
+	count, persistent := tr.update(now.Add(4*time.Minute), nil, 5)
+	assert.Zero(t, count)
+	assert.Empty(t, persistent)
+
+	// present again: consecutive counter must NOT have reset; this is the 5th
+	// consecutive observation and must become persistent
+	count, persistent = tr.update(now.Add(5*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 5)
+	require.Equal(t, 1, count, "single-check absence must not reset persistence")
+	require.Len(t, persistent, 1)
+	assert.Equal(t, 5, persistent[0].ConsecutiveChecks)
+}
+
+func TestBlockedProcessTracker_RecoveryAfterTwoAbsences(t *testing.T) {
+	tr := newBlockedProcessTracker()
+	now := time.Unix(1000, 0)
+
+	for i := 0; i < 5; i++ {
+		tr.update(now.Add(time.Duration(i)*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 5)
+	}
+	count, _ := tr.update(now.Add(5*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 5)
+	require.Equal(t, 1, count)
+
+	// one absent check: still tracked and still reported persistent
+	count, _ = tr.update(now.Add(6*time.Minute), nil, 5)
+	assert.Equal(t, 1, count, "single absence is within grace and must not clear the condition")
+
+	// two consecutive absent checks: dropped (recovered)
+	count, persistent := tr.update(now.Add(7*time.Minute), nil, 5)
+	assert.Zero(t, count)
+	assert.Empty(t, persistent)
+
+	// stays cleared
+	count, _ = tr.update(now.Add(8*time.Minute), nil, 5)
+	assert.Zero(t, count)
+}
+
+func TestBlockedProcessTracker_BurstChecksDoNotInflatePersistence(t *testing.T) {
+	tr := newBlockedProcessTracker()
+	now := time.Unix(1000, 0)
+
+	// 10 checks only 1s apart (out-of-band trigger burst via
+	// /v1/components/trigger-check or session triggerComponent): the
+	// consecutive count reaches 10, but the wall-clock duration gate
+	// (>= 4min for threshold 5) must not flag the process as persistent
+	for i := 0; i < 10; i++ {
+		count, persistent := tr.update(now.Add(time.Duration(i)*time.Second), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 5)
+		assert.Zero(t, count, "burst check %d must not be persistent", i)
+		assert.Empty(t, persistent)
+	}
+
+	// once the wall-clock duration is reached, it fires
+	count, persistent := tr.update(now.Add(4*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "nvidia-smi"}), 5)
+	require.Equal(t, 1, count)
+	require.Len(t, persistent, 1)
+	assert.Equal(t, 11, persistent[0].ConsecutiveChecks)
+}
+
+func TestBlockedProcessTracker_NameErrorTolerated(t *testing.T) {
+	tr := newBlockedProcessTracker()
+	now := time.Unix(1000, 0)
+
+	// name read fails (e.g., process disappeared between enumeration and metadata read)
+	for i := 0; i < 5; i++ {
+		tr.update(now.Add(time.Duration(i)*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "", nameErr: errors.New("no such file")}), 5)
+	}
+	count, persistent := tr.update(now.Add(5*time.Minute), blockedList(&mockProcessStatus{pid: 100, name: "", nameErr: errors.New("no such file")}), 5)
+	require.Equal(t, 1, count)
+	require.Len(t, persistent, 1)
+	assert.Equal(t, "", persistent[0].Name, "name error must be tolerated and recorded as empty")
+}
+
+func TestBlockedProcessTracker_NilEntriesSkipped(t *testing.T) {
+	tr := newBlockedProcessTracker()
+	now := time.Unix(1000, 0)
+	for i := 0; i < 6; i++ {
+		count, _ := tr.update(now.Add(time.Duration(i)*time.Minute), blockedList(nil, &mockProcessStatus{pid: 100, name: "nvidia-smi"}, nil), 5)
+		if i >= 4 {
+			assert.Equal(t, 1, count)
+		}
+	}
+}
+
+func TestBlockedProcessTracker_BoundedOutput(t *testing.T) {
+	tr := newBlockedProcessTracker()
+	now := time.Unix(1000, 0)
+
+	many := make([]process.ProcessStatus, 0, maxBlockedProcessesOutput+5)
+	for i := 0; i < maxBlockedProcessesOutput+5; i++ {
+		many = append(many, &mockProcessStatus{pid: int32(1000 + i), name: fmt.Sprintf("proc-%d", i)})
+	}
+
+	var count int
+	var persistent []BlockedProcess
+	for i := 0; i < 5; i++ {
+		count, persistent = tr.update(now.Add(time.Duration(i)*time.Minute), many, 5)
+	}
+	assert.Equal(t, maxBlockedProcessesOutput+5, count, "true persistent count must exceed the bounded list")
+	assert.Len(t, persistent, maxBlockedProcessesOutput, "output list must be bounded")
+
+	// sorted by first-seen (same ts here) then PID
+	for i := 1; i < len(persistent); i++ {
+		assert.Less(t, persistent[i-1].PID, persistent[i].PID)
+	}
+}
+
+// newTestComponent builds an os component with all external functions mocked
+// and a controllable clock.
+func newTestComponent(t *testing.T, ctx context.Context, rebootStore pkghost.RebootEventStore, bucket eventstore.Bucket) (*component, *time.Time) {
+	t.Helper()
+
+	c, err := New(&components.GPUdInstance{
+		RootCtx:          ctx,
+		RebootEventStore: rebootStore,
+	})
+	require.NoError(t, err)
+	comp, ok := c.(*component)
+	require.True(t, ok)
+
+	if bucket != nil {
+		comp.eventBucket = bucket
+	}
+
+	now := time.Unix(100000, 0).UTC()
+	comp.getTimeNowFunc = func() time.Time { return now }
+
+	comp.getHostUptimeFunc = func(ctx context.Context) (uint64, error) { return 1000, nil }
+	comp.getFileHandlesFunc = func() (uint64, uint64, error) { return 1000, 0, nil }
+	comp.countRunningPIDsFunc = func() (uint64, error) { return 100, nil }
+	comp.getUsageFunc = func() (uint64, error) { return 1000, nil }
+	comp.getLimitFunc = func() (uint64, error) { return 1000000, nil }
+	comp.checkFileHandlesSupportedFunc = func() bool { return true }
+	comp.checkFDLimitSupportedFunc = func() bool { return true }
+
+	return comp, &now
+}
+
+// runChecks runs comp.Check() n times, advancing the mock clock by one minute
+// between checks (mirroring the 1-minute check interval).
+func runChecks(comp *component, now *time.Time, n int, blocked []process.ProcessStatus) components.CheckResult {
+	comp.countProcessesByStatusFunc = func(ctx context.Context) (map[string][]process.ProcessStatus, error) {
+		m := map[string][]process.ProcessStatus{
+			procs.Running: make([]process.ProcessStatus, 10),
+		}
+		if len(blocked) > 0 {
+			m[procs.Blocked] = blocked
+		}
+		return m, nil
+	}
+
+	var cr components.CheckResult
+	for i := 0; i < n; i++ {
+		cr = comp.Check()
+		*now = now.Add(time.Minute)
+	}
+	return cr
+}
+
+func TestNewComponent_ReadsDefaultThresholds(t *testing.T) {
+	original := GetDefaultBlockedProcessThresholds()
+	t.Cleanup(func() {
+		require.NoError(t, SetDefaultBlockedProcessThresholds(original))
+	})
+
+	require.NoError(t, SetDefaultBlockedProcessThresholds(BlockedProcessThresholds{
+		PersistenceThreshold: 3,
+		NameRegexes:          []string{"^dd$"},
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	comp, _ := newTestComponent(t, ctx, &mockRebootEventStore{}, nil)
+	defer func() { _ = comp.Close() }()
+
+	got := comp.getBlockedProcessThresholdsFunc()
+	assert.Equal(t, 3, got.PersistenceThreshold)
+	assert.Equal(t, []string{"^dd$"}, got.NameRegexes)
+	assert.True(t, got.MatchesName("dd"))
+	assert.False(t, got.MatchesName("nvidia-smi"))
+}
+
+// TestCheck_BlockedProcesses_RuntimeConfigUpdate verifies that thresholds
+// updated at runtime (e.g., via session updateConfig for node-group config)
+// take effect on the running component without recreating it.
+func TestCheck_BlockedProcesses_RuntimeConfigUpdate(t *testing.T) {
+	original := GetDefaultBlockedProcessThresholds()
+	t.Cleanup(func() {
+		require.NoError(t, SetDefaultBlockedProcessThresholds(original))
+	})
+	// start from the built-in default: D-state checking disabled
+	require.NoError(t, SetDefaultBlockedProcessThresholds(BlockedProcessThresholds{}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	comp, now := newTestComponent(t, ctx, &mockRebootEventStore{}, &recordingBucket{})
+	defer func() { _ = comp.Close() }()
+
+	cr := runChecks(comp, now, 3, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	require.Equal(t, apiv1.HealthStateTypeHealthy, cr.HealthStateType(),
+		"disabled D-state check must not react to blocked processes")
+
+	// simulate a session updateConfig push enabling NVIDIA D-state detection
+	require.NoError(t, SetDefaultBlockedProcessThresholds(BlockedProcessThresholds{
+		PersistenceThreshold: 1,
+		NameRegexes:          []string{"^nvidia"},
+	}))
+
+	cr = runChecks(comp, now, 1, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.HealthStateType(),
+		"runtime-updated thresholds must apply on the next check")
+}
+
+func TestCheck_BlockedProcesses_DisabledWithoutNameRegexes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	bucket := &recordingBucket{}
+	comp, now := newTestComponent(t, ctx, &mockRebootEventStore{}, bucket)
+	defer func() { _ = comp.Close() }()
+
+	// built-in default: empty regexes disable the D-state check entirely
+	require.True(t, comp.getBlockedProcessThresholdsFunc().IsZero())
+
+	cr := runChecks(comp, now, 6, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, cr.HealthStateType(),
+		"disabled D-state check must never affect health")
+	assert.Zero(t, comp.lastCheckResult.BlockedProcesses.CurrentCount)
+	assert.Zero(t, comp.lastCheckResult.BlockedProcesses.PersistentCount)
+	assert.Empty(t, bucket.insertedNames(), "disabled D-state check must not emit events")
+}
+
+func TestCheck_BlockedProcesses_TransientStaysHealthy(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	comp, now := newTestComponent(t, ctx, &mockRebootEventStore{}, nil)
+	defer func() { _ = comp.Close() }()
+	withBlockedProcessThresholds(comp, mustBlockedProcessThresholds(t, 5, "^nvidia"))
+
+	// 4 consecutive checks with a blocked nvidia-smi (< threshold 5)
+	cr := runChecks(comp, now, 4, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, cr.HealthStateType(), "transient D-state must not change health")
+	assert.Zero(t, comp.lastCheckResult.BlockedProcesses.PersistentCount)
+	assert.Equal(t, 1, comp.lastCheckResult.BlockedProcesses.CurrentCount)
+}
+
+func TestCheck_BlockedProcesses_PersistentUnmatchedDegraded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	bucket := &recordingBucket{}
+	comp, now := newTestComponent(t, ctx, &mockRebootEventStore{}, bucket)
+	defer func() { _ = comp.Close() }()
+	withBlockedProcessThresholds(comp, mustBlockedProcessThresholds(t, 5, "^nvidia"))
+
+	// 5 consecutive checks with a blocked process NOT matching escalation regexes
+	cr := runChecks(comp, now, 5, blockedList(&mockProcessStatus{pid: 42, name: "dd"}))
+	assert.Equal(t, apiv1.HealthStateTypeDegraded, cr.HealthStateType())
+	assert.Contains(t, cr.Summary(), "persistent D-state")
+	assert.Contains(t, cr.Summary(), "name=dd")
+	assert.Equal(t, 1, comp.lastCheckResult.BlockedProcesses.PersistentCount)
+
+	// no repair suggestion for unmatched processes (LEP-6029 initial rollout)
+	states := cr.HealthStates()
+	require.Len(t, states, 1)
+	assert.Nil(t, states[0].SuggestedActions)
+
+	// episode start event recorded exactly once (rising edge), with a
+	// non-empty message (regression: message was set before reason existed)
+	names := bucket.insertedNames()
+	assert.Equal(t, []string{EventNameBlockedProcessesPersistent}, names)
+	events := bucket.insertedEvents()
+	require.Len(t, events, 1)
+	assert.NotEmpty(t, events[0].Message)
+	assert.Contains(t, events[0].Message, "name=dd")
+}
+
+func TestCheck_BlockedProcesses_PersistentMatchedUnhealthyReboot(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	bucket := &recordingBucket{}
+	comp, now := newTestComponent(t, ctx, &mockRebootEventStore{}, bucket)
+	defer func() { _ = comp.Close() }()
+	withBlockedProcessThresholds(comp, mustBlockedProcessThresholds(t, 5, "^nvidia"))
+
+	cr := runChecks(comp, now, 5, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.HealthStateType())
+	assert.Contains(t, cr.Summary(), "nvidia-smi")
+
+	states := cr.HealthStates()
+	require.Len(t, states, 1)
+	require.NotNil(t, states[0].SuggestedActions)
+	assert.Equal(t, []apiv1.RepairActionType{apiv1.RepairActionTypeRebootSystem}, states[0].SuggestedActions.RepairActions)
+}
+
+func TestCheck_BlockedProcesses_ThresholdOneFlagsImmediately(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	comp, now := newTestComponent(t, ctx, &mockRebootEventStore{}, &recordingBucket{})
+	defer func() { _ = comp.Close() }()
+	// one-off gpud scan semantics: a single observation flags unhealthy
+	withBlockedProcessThresholds(comp, mustBlockedProcessThresholds(t, 1, "^nvidia"))
+
+	cr := runChecks(comp, now, 1, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.HealthStateType(),
+		"threshold 1 must flag a currently blocked nvidia process on the first check")
+	assert.Contains(t, cr.Summary(), "nvidia-smi")
+
+	states := cr.HealthStates()
+	require.Len(t, states, 1)
+	require.NotNil(t, states[0].SuggestedActions)
+	assert.Equal(t, []apiv1.RepairActionType{apiv1.RepairActionTypeRebootSystem}, states[0].SuggestedActions.RepairActions)
+}
+
+func TestCheck_BlockedProcesses_EscalatesToHardwareInspectionAfterReboots(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// two reboots since the condition was first observed, no recovery in between
+	rebootStore := &mockRebootEventStore{
+		events: eventstore.Events{
+			{Time: time.Unix(99000, 0), Name: "reboot", Type: string(apiv1.EventTypeWarning)},
+			{Time: time.Unix(99500, 0), Name: "reboot", Type: string(apiv1.EventTypeWarning)},
+		},
+	}
+
+	comp, now := newTestComponent(t, ctx, rebootStore, &recordingBucket{})
+	defer func() { _ = comp.Close() }()
+	withBlockedProcessThresholds(comp, mustBlockedProcessThresholds(t, 5, "^nvidia"))
+
+	cr := runChecks(comp, now, 5, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.HealthStateType())
+
+	states := cr.HealthStates()
+	require.Len(t, states, 1)
+	require.NotNil(t, states[0].SuggestedActions)
+	assert.Equal(t, []apiv1.RepairActionType{apiv1.RepairActionTypeHardwareInspection}, states[0].SuggestedActions.RepairActions,
+		"repeated reboots without recovery must escalate to hardware inspection (xid parity)")
+}
+
+func TestCheck_BlockedProcesses_RebootsBeforeRecoveryDoNotEscalate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// reboots happened, but a recovery event afterwards resets the escalation window
+	rebootStore := &mockRebootEventStore{
+		events: eventstore.Events{
+			{Time: time.Unix(99000, 0), Name: "reboot", Type: string(apiv1.EventTypeWarning)},
+			{Time: time.Unix(99500, 0), Name: "reboot", Type: string(apiv1.EventTypeWarning)},
+		},
+	}
+	bucket := &recordingBucket{
+		getEvents: eventstore.Events{
+			{Time: time.Unix(99800, 0), Name: EventNameBlockedProcessesRecovered, Type: string(apiv1.EventTypeInfo)},
+		},
+	}
+
+	comp, now := newTestComponent(t, ctx, rebootStore, bucket)
+	defer func() { _ = comp.Close() }()
+	withBlockedProcessThresholds(comp, mustBlockedProcessThresholds(t, 5, "^nvidia"))
+
+	cr := runChecks(comp, now, 5, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	states := cr.HealthStates()
+	require.Len(t, states, 1)
+	require.NotNil(t, states[0].SuggestedActions)
+	assert.Equal(t, []apiv1.RepairActionType{apiv1.RepairActionTypeRebootSystem}, states[0].SuggestedActions.RepairActions,
+		"reboots followed by a recovery must not escalate to hardware inspection")
+}
+
+func TestCheck_BlockedProcesses_RecoveryClears(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	bucket := &recordingBucket{}
+	comp, now := newTestComponent(t, ctx, &mockRebootEventStore{}, bucket)
+	defer func() { _ = comp.Close() }()
+	withBlockedProcessThresholds(comp, mustBlockedProcessThresholds(t, 5, "^nvidia"))
+
+	// become persistent
+	cr := runChecks(comp, now, 5, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	require.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.HealthStateType())
+
+	// process disappears: 1st absent check keeps the condition (grace)...
+	cr = runChecks(comp, now, 1, nil)
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.HealthStateType(), "single absence must not clear (grace)")
+
+	// ...2nd consecutive absent check drops the tracker entry and clears
+	cr = runChecks(comp, now, 1, nil)
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, cr.HealthStateType(), "condition must clear after the process is gone")
+	assert.Zero(t, comp.lastCheckResult.BlockedProcesses.PersistentCount)
+
+	// episode events: persistent + recovered, in order
+	assert.Equal(t, []string{EventNameBlockedProcessesPersistent, EventNameBlockedProcessesRecovered}, bucket.insertedNames())
+
+	// and it can fire again later (no sticky state)
+	cr = runChecks(comp, now, 5, blockedList(&mockProcessStatus{pid: 43, name: "nvidia-smi"}))
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.HealthStateType())
+	assert.Equal(t, []string{EventNameBlockedProcessesPersistent, EventNameBlockedProcessesRecovered, EventNameBlockedProcessesPersistent}, bucket.insertedNames())
+}
+
+func TestCheck_BlockedProcesses_BurstTriggersDoNotFlag(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	comp, now := newTestComponent(t, ctx, &mockRebootEventStore{}, &recordingBucket{})
+	defer func() { _ = comp.Close() }()
+	withBlockedProcessThresholds(comp, mustBlockedProcessThresholds(t, 5, "^nvidia"))
+
+	comp.countProcessesByStatusFunc = func(ctx context.Context) (map[string][]process.ProcessStatus, error) {
+		return map[string][]process.ProcessStatus{
+			procs.Running: make([]process.ProcessStatus, 10),
+			procs.Blocked: {&mockProcessStatus{pid: 42, name: "nvidia-smi"}},
+		}, nil
+	}
+
+	// simulate a control-plane/HTTP trigger burst: 10 Check() calls 2s apart
+	for i := 0; i < 10; i++ {
+		cr := comp.Check()
+		assert.Equal(t, apiv1.HealthStateTypeHealthy, cr.HealthStateType(),
+			"trigger burst check %d must not flag a seconds-old D-state process", i)
+		*now = now.Add(2 * time.Second)
+	}
+
+	// the same process still blocked once 4+ minutes have elapsed fires
+	*now = now.Add(4 * time.Minute)
+	cr := comp.Check()
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.HealthStateType())
+}
+
+func TestCheck_BlockedProcesses_RebootStoreErrorFailsOpenToReboot(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	comp, now := newTestComponent(t, ctx, &errRebootEventStore{}, &recordingBucket{})
+	defer func() { _ = comp.Close() }()
+	withBlockedProcessThresholds(comp, mustBlockedProcessThresholds(t, 5, "^nvidia"))
+
+	cr := runChecks(comp, now, 5, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.HealthStateType())
+
+	states := cr.HealthStates()
+	require.Len(t, states, 1)
+	require.NotNil(t, states[0].SuggestedActions)
+	assert.Equal(t, []apiv1.RepairActionType{apiv1.RepairActionTypeRebootSystem}, states[0].SuggestedActions.RepairActions,
+		"reboot-store errors must fail open to a reboot suggestion, never silently escalate")
+}
+
+func TestCheck_BlockedProcesses_BucketGetErrorCountsWindowReboots(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// bucket.Get fails => lastRecovery stays zero => all window reboots count
+	rebootStore := &mockRebootEventStore{
+		events: eventstore.Events{
+			{Time: time.Unix(99000, 0), Name: "reboot", Type: string(apiv1.EventTypeWarning)},
+			{Time: time.Unix(99500, 0), Name: "reboot", Type: string(apiv1.EventTypeWarning)},
+		},
+	}
+	bucket := &recordingBucket{getError: errors.New("mock bucket get error")}
+
+	comp, now := newTestComponent(t, ctx, rebootStore, bucket)
+	defer func() { _ = comp.Close() }()
+	withBlockedProcessThresholds(comp, mustBlockedProcessThresholds(t, 5, "^nvidia"))
+
+	cr := runChecks(comp, now, 5, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	states := cr.HealthStates()
+	require.Len(t, states, 1)
+	require.NotNil(t, states[0].SuggestedActions)
+	assert.Equal(t, []apiv1.RepairActionType{apiv1.RepairActionTypeHardwareInspection}, states[0].SuggestedActions.RepairActions,
+		"when recovery history is unreadable, window reboots are counted (2 here) and escalate")
+}
+
+func TestCheck_BlockedProcesses_ProcessScanErrorStillUnhealthy(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	comp, _ := newTestComponent(t, ctx, &mockRebootEventStore{}, nil)
+	defer func() { _ = comp.Close() }()
+
+	comp.countProcessesByStatusFunc = func(ctx context.Context) (map[string][]process.ProcessStatus, error) {
+		return nil, errors.New("process count error")
+	}
+	cr := comp.Check()
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.HealthStateType())
+	assert.Contains(t, cr.Summary(), "error getting process count")
+}

--- a/components/os/component.go
+++ b/components/os/component.go
@@ -755,6 +755,19 @@ const (
 //     reboots without recovery, suggest hardware inspection instead
 //     (same escalation model as the XID component)
 //   - other persistent blocked processes: degraded, no repair suggestion
+//
+// Why degraded vs unhealthy: a persistent D-state process is never ignored --
+// the kernel wait underneath it is not completing, and SIGKILL cannot clear
+// the task (verified on dev01 2026-08-12: containerd teardown wedged on a
+// D-state dd while the pod kept reporting "Running"). But the stuck name is
+// the only signal about which subsystem wedged. A non-matching name (storage,
+// NFS, any driver) means "something is stuck on this node, investigate" --
+// degraded, no repair suggestion. A matching name (default ^nvidia) means
+// the GPU driver path is implicated, as in the LEP-6029 incident -- unhealthy,
+// with reboot suggested because a node-local, unkillable kernel wait leaves
+// no softer remedy. If reboots do not clear the condition, the wedge likely
+// sits in hardware or firmware rather than transient driver state, hence the
+// escalation to hardware inspection.
 func (c *component) evaluateBlockedProcesses(cr *checkResult, thresholds BlockedProcessThresholds) bool {
 	if cr.BlockedProcesses.PersistentCount == 0 {
 		c.clearBlockedProcessEpisode(cr.ts)

--- a/components/os/component.go
+++ b/components/os/component.go
@@ -397,6 +397,17 @@ func (c *component) Check() components.CheckResult {
 		cr.BlockedProcesses.Persistent = persistent
 		metricBlockedProcesses.With(prometheus.Labels{}).Set(float64(cr.BlockedProcesses.CurrentCount))
 		metricBlockedProcessesPersistent.With(prometheus.Labels{}).Set(float64(cr.BlockedProcesses.PersistentCount))
+	} else {
+		// Disabled (empty name regexes, e.g., a config push removed them):
+		// drop state carried over from a previously enabled window so that a
+		// re-enabled check re-earns the persistence threshold from scratch,
+		// close any active episode (marks the disabled window with a recovery
+		// event, resetting the reboot-escalation window), and zero the gauges
+		// so they do not report stale counts while disabled.
+		c.blockedTracker.reset()
+		c.clearBlockedProcessEpisode(cr.ts, "D-state process checking disabled (empty name regexes)")
+		metricBlockedProcesses.With(prometheus.Labels{}).Set(0)
+		metricBlockedProcessesPersistent.With(prometheus.Labels{}).Set(0)
 	}
 
 	if cr.ZombieProcesses > c.zombieProcessCountThresholdUnhealthy {
@@ -770,7 +781,7 @@ const (
 // escalation to hardware inspection.
 func (c *component) evaluateBlockedProcesses(cr *checkResult, thresholds BlockedProcessThresholds) bool {
 	if cr.BlockedProcesses.PersistentCount == 0 {
-		c.clearBlockedProcessEpisode(cr.ts)
+		c.clearBlockedProcessEpisode(cr.ts, "persistent blocked processes cleared")
 		return false
 	}
 
@@ -867,9 +878,12 @@ func (c *component) markBlockedProcessEpisode(cr *checkResult) {
 	}
 }
 
-// clearBlockedProcessEpisode records the falling edge (recovery) of a
-// persistent blocked-process episode in the event store.
-func (c *component) clearBlockedProcessEpisode(now time.Time) {
+// clearBlockedProcessEpisode records the falling edge of a persistent
+// blocked-process episode in the event store: recovery, operator set-healthy,
+// or the check being disabled. All three insert EventNameBlockedProcessesRecovered
+// because countBlockedEpisodeReboots anchors the reboot-escalation window on
+// that event name; the message distinguishes the cause for forensics.
+func (c *component) clearBlockedProcessEpisode(now time.Time, message string) {
 	c.blockedEpisodeMu.Lock()
 	active := c.blockedEpisodeActive
 	c.blockedEpisodeActive = false
@@ -884,7 +898,7 @@ func (c *component) clearBlockedProcessEpisode(now time.Time) {
 		Time:      now,
 		Name:      EventNameBlockedProcessesRecovered,
 		Type:      string(apiv1.EventTypeInfo),
-		Message:   "persistent blocked processes cleared",
+		Message:   message,
 	}); err != nil {
 		log.Logger.Warnw("failed to insert blocked processes recovery event", "error", err)
 	}

--- a/components/os/component.go
+++ b/components/os/component.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -68,6 +69,23 @@ type component struct {
 	zombieProcessCountThresholdDegraded  int
 	zombieProcessCountThresholdUnhealthy int
 
+	// blockedTracker tracks processes in uninterruptible sleep (Linux D-state,
+	// gopsutil "blocked") across checks to identify persistent ones (LEP-6029).
+	blockedTracker *blockedProcessTracker
+
+	// getBlockedProcessThresholdsFunc returns the D-state tracking
+	// configuration, read on every check (not snapshotted at creation) so
+	// session updateConfig changes take effect on the running daemon — the
+	// same pattern as gpu-counts' getThresholdsFunc. An empty NameRegexes
+	// set disables D-state process checking entirely (LEP-6029).
+	getBlockedProcessThresholdsFunc func() BlockedProcessThresholds
+
+	// blockedEpisodeMu guards blockedEpisodeActive.
+	blockedEpisodeMu sync.Mutex
+	// blockedEpisodeActive dedupes blocked-process episode start/recovery
+	// events (inserted only on transitions).
+	blockedEpisodeActive bool
+
 	getTimeNowFunc                func() time.Time
 	getHostUptimeFunc             func(ctx context.Context) (uint64, error)
 	getFileHandlesFunc            func() (uint64, uint64, error)
@@ -111,6 +129,9 @@ func newComponent(gpudInstance *components.GPUdInstance, pstoreDir string) (comp
 		countProcessesByStatusFunc:           process.CountProcessesByStatus,
 		zombieProcessCountThresholdDegraded:  defaultZombieProcessCountThresholdDegraded,
 		zombieProcessCountThresholdUnhealthy: defaultZombieProcessCountThresholdUnhealthy,
+
+		blockedTracker:                  newBlockedProcessTracker(),
+		getBlockedProcessThresholdsFunc: GetDefaultBlockedProcessThresholds,
 
 		getTimeNowFunc: func() time.Time {
 			return time.Now().UTC()
@@ -363,6 +384,21 @@ func (c *component) Check() components.CheckResult {
 
 	metricZombieProcesses.With(prometheus.Labels{}).Set(float64(cr.ZombieProcesses))
 
+	// track processes in uninterruptible sleep (Linux D-state) on every check,
+	// even if the zombie thresholds below return early (LEP-6029); skipped
+	// entirely when no process-name regexes are configured (e.g., machines
+	// without NVIDIA GPUs), so the check only runs where it is actionable
+	blockedThresholds := c.getBlockedProcessThresholdsFunc()
+	if !blockedThresholds.IsZero() {
+		blockedNow := allProcs[procs.Blocked]
+		cr.BlockedProcesses.CurrentCount = len(blockedNow)
+		persistentCount, persistent := c.blockedTracker.update(cr.ts, blockedNow, blockedThresholds.PersistenceThreshold)
+		cr.BlockedProcesses.PersistentCount = persistentCount
+		cr.BlockedProcesses.Persistent = persistent
+		metricBlockedProcesses.With(prometheus.Labels{}).Set(float64(cr.BlockedProcesses.CurrentCount))
+		metricBlockedProcessesPersistent.With(prometheus.Labels{}).Set(float64(cr.BlockedProcesses.PersistentCount))
+	}
+
 	if cr.ZombieProcesses > c.zombieProcessCountThresholdUnhealthy {
 		// exceeded high threshold, mark unhealthy
 		cr.health = apiv1.HealthStateTypeUnhealthy
@@ -377,6 +413,12 @@ func (c *component) Check() components.CheckResult {
 		cr.reason = fmt.Sprintf("too many zombie processes (degraded state threshold: %d)", c.zombieProcessCountThresholdDegraded)
 		cr.suggestedActions = defaultSuggestedActionsForFd
 		log.Logger.Warnw(cr.reason, "count", cr.ZombieProcesses)
+		return cr
+	}
+
+	// evaluate persistent D-state (blocked) processes after zombie checks;
+	// returns true if it determined the final health state for this check
+	if !blockedThresholds.IsZero() && c.evaluateBlockedProcesses(cr, blockedThresholds) {
 		return cr
 	}
 
@@ -516,6 +558,7 @@ type checkResult struct {
 	Platform                  Platform                          `json:"platform"`
 	Uptimes                   Uptimes                           `json:"uptimes"`
 	ZombieProcesses           int                               `json:"zombie_processes"`
+	BlockedProcesses          BlockedProcesses                  `json:"blocked_processes"`
 	FileDescriptors           FileDescriptors                   `json:"file_descriptors"`
 
 	// timestamp of the last check
@@ -593,6 +636,8 @@ func (cr *checkResult) String() string {
 	table.Append([]string{"Platform Version", cr.Platform.Version})
 	table.Append([]string{"Uptime", uptimeHumanized})
 	table.Append([]string{"Zombie Process Count", fmt.Sprintf("%d", cr.ZombieProcesses)})
+	table.Append([]string{"Blocked Process Count (D-state)", fmt.Sprintf("%d", cr.BlockedProcesses.CurrentCount)})
+	table.Append([]string{"Persistent Blocked Process Count", fmt.Sprintf("%d", cr.BlockedProcesses.PersistentCount)})
 
 	table.Append([]string{"File Descriptor Running PIDs", fmt.Sprintf("%d", cr.FileDescriptors.RunningPIDs)})
 	table.Append([]string{"File Descriptor Usage", fmt.Sprintf("%d", cr.FileDescriptors.Usage)})
@@ -688,4 +733,200 @@ func calcUsagePct(usage, limit uint64) float64 {
 		return float64(usage) / float64(limit) * 100
 	}
 	return 0
+}
+
+const (
+	// EventNameBlockedProcessesPersistent is emitted on the rising edge of a
+	// persistent blocked-process (Linux D-state) episode (LEP-6029).
+	EventNameBlockedProcessesPersistent = "blocked_processes_persistent"
+	// EventNameBlockedProcessesRecovered is emitted when a persistent
+	// blocked-process episode clears.
+	EventNameBlockedProcessesRecovered = "blocked_processes_recovered"
+)
+
+// evaluateBlockedProcesses sets the health state based on persistent
+// D-state processes. Returns true if it determined the final health state.
+//
+// Policy (LEP-6029):
+//   - no persistent blocked processes: clear any active episode, no opinion
+//     (returns false so other checks proceed)
+//   - persistent blocked processes whose names match the escalation regexes:
+//     unhealthy + reboot suggestion; after DefaultBlockedProcessRebootThreshold
+//     reboots without recovery, suggest hardware inspection instead
+//     (same escalation model as the XID component)
+//   - other persistent blocked processes: degraded, no repair suggestion
+func (c *component) evaluateBlockedProcesses(cr *checkResult, thresholds BlockedProcessThresholds) bool {
+	if cr.BlockedProcesses.PersistentCount == 0 {
+		c.clearBlockedProcessEpisode(cr.ts)
+		return false
+	}
+
+	matched := matchAnyBlockedProcess(cr.BlockedProcesses.Persistent, thresholds)
+
+	summary := summarizeBlockedProcesses(cr.BlockedProcesses.Persistent)
+
+	if len(matched) == 0 {
+		cr.health = apiv1.HealthStateTypeDegraded
+		cr.reason = fmt.Sprintf("persistent D-state (uninterruptible sleep) processes detected (persistent: %d): %s",
+			cr.BlockedProcesses.PersistentCount, summary)
+		log.Logger.Warnw(cr.reason, "persistentCount", cr.BlockedProcesses.PersistentCount)
+		c.markBlockedProcessEpisode(cr)
+		return true
+	}
+
+	reboots := c.countBlockedEpisodeReboots(cr.ts)
+	action := apiv1.RepairActionTypeRebootSystem
+	description := "reboot the system to clear persistent D-state processes stuck in uninterruptible kernel waits"
+	if reboots >= DefaultBlockedProcessRebootThreshold {
+		action = apiv1.RepairActionTypeHardwareInspection
+		description = fmt.Sprintf("persistent D-state processes reappeared after %d reboots; recommend hardware/driver inspection instead of another reboot", reboots)
+	}
+
+	cr.health = apiv1.HealthStateTypeUnhealthy
+	cr.reason = fmt.Sprintf("persistent D-state processes matching escalation rules %q: %s",
+		strings.Join(thresholds.NameRegexes, ","), summary)
+	cr.suggestedActions = &apiv1.SuggestedActions{
+		Description:   description,
+		RepairActions: []apiv1.RepairActionType{action},
+	}
+	log.Logger.Warnw(cr.reason, "persistentCount", cr.BlockedProcesses.PersistentCount, "reboots", reboots, "action", action)
+	c.markBlockedProcessEpisode(cr)
+	return true
+}
+
+// matchAnyBlockedProcess returns the persistent blocked processes whose names
+// match the configured escalation regexes.
+func matchAnyBlockedProcess(persistent []BlockedProcess, thresholds BlockedProcessThresholds) []BlockedProcess {
+	matched := make([]BlockedProcess, 0, len(persistent))
+	for _, bp := range persistent {
+		if thresholds.MatchesName(bp.Name) {
+			matched = append(matched, bp)
+		}
+	}
+	return matched
+}
+
+// summarizeBlockedProcesses renders a bounded human-readable summary of
+// persistent blocked processes, e.g. "pid=1234 name=nvidia-smi blocked=6m5s".
+func summarizeBlockedProcesses(persistent []BlockedProcess) string {
+	const maxSummary = 3
+	parts := make([]string, 0, min(len(persistent), maxSummary))
+	for i, bp := range persistent {
+		if i >= maxSummary {
+			parts = append(parts, fmt.Sprintf("+%d more", len(persistent)-maxSummary))
+			break
+		}
+		parts = append(parts, fmt.Sprintf("pid=%d name=%s blocked=%s consecutive_checks=%d",
+			bp.PID, bp.Name, time.Duration(bp.BlockedSeconds*int64(time.Second)).Round(time.Second), bp.ConsecutiveChecks))
+	}
+	return strings.Join(parts, "; ")
+}
+
+// markBlockedProcessEpisode records the rising edge of a persistent
+// blocked-process episode in the event store (bounded payload).
+func (c *component) markBlockedProcessEpisode(cr *checkResult) {
+	c.blockedEpisodeMu.Lock()
+	active := c.blockedEpisodeActive
+	c.blockedEpisodeActive = true
+	c.blockedEpisodeMu.Unlock()
+
+	if active || c.eventBucket == nil {
+		return
+	}
+
+	detail, err := json.Marshal(cr.BlockedProcesses)
+	if err != nil {
+		log.Logger.Warnw("failed to marshal blocked processes for event", "error", err)
+		detail = nil
+	}
+	ev := eventstore.Event{
+		Component: Name,
+		Time:      cr.ts,
+		Name:      EventNameBlockedProcessesPersistent,
+		Type:      string(apiv1.EventTypeWarning),
+		Message:   cr.reason,
+	}
+	if detail != nil {
+		ev.ExtraInfo = map[string]string{"blocked_processes": string(detail)}
+	}
+	if err := c.eventBucket.Insert(c.ctx, ev); err != nil {
+		log.Logger.Warnw("failed to insert blocked processes event", "error", err)
+	}
+}
+
+// clearBlockedProcessEpisode records the falling edge (recovery) of a
+// persistent blocked-process episode in the event store.
+func (c *component) clearBlockedProcessEpisode(now time.Time) {
+	c.blockedEpisodeMu.Lock()
+	active := c.blockedEpisodeActive
+	c.blockedEpisodeActive = false
+	c.blockedEpisodeMu.Unlock()
+
+	if !active || c.eventBucket == nil {
+		return
+	}
+
+	if err := c.eventBucket.Insert(c.ctx, eventstore.Event{
+		Component: Name,
+		Time:      now,
+		Name:      EventNameBlockedProcessesRecovered,
+		Type:      string(apiv1.EventTypeInfo),
+		Message:   "persistent blocked processes cleared",
+	}); err != nil {
+		log.Logger.Warnw("failed to insert blocked processes recovery event", "error", err)
+	}
+}
+
+// countBlockedEpisodeReboots counts reboot events since the most recent
+// blocked-process recovery (or within the lookback window if the condition
+// never recovered), mirroring the XID component's escalation model:
+// reboots that fail to clear the condition escalate the suggested action from
+// reboot to hardware inspection.
+//
+// NOTE: the escalation lookback is the fixed eventstore.DefaultRetention
+// (3 days), NOT the configured event retention (--events-retention-period,
+// default 14 days): reboots older than 3 days remain stored but no longer
+// count toward hardware-inspection escalation. This is deliberate for the
+// initial rollout (bounded escalation memory) but intentionally inconsistent
+// with the xid component, which wires its lookback to
+// --events-retention-period unless --xid-lookback-period is set (see
+// cmd/gpud/run/command.go). For strict xid parity, wire this lookback to the
+// retention flag the same way.
+func (c *component) countBlockedEpisodeReboots(now time.Time) int {
+	if c.rebootEventStore == nil {
+		return 0
+	}
+
+	since := now.Add(-eventstore.DefaultRetention)
+
+	cctx, ccancel := context.WithTimeout(c.ctx, 15*time.Second)
+	defer ccancel()
+
+	reboots, err := c.rebootEventStore.GetRebootEvents(cctx, since)
+	if err != nil {
+		log.Logger.Warnw("failed to get reboot events for blocked process escalation", "error", err)
+		return 0
+	}
+
+	var lastRecovery time.Time
+	if c.eventBucket != nil {
+		evs, err := c.eventBucket.Get(cctx, since)
+		if err != nil {
+			log.Logger.Warnw("failed to get os events for blocked process escalation", "error", err)
+		} else {
+			for _, ev := range evs {
+				if ev.Name == EventNameBlockedProcessesRecovered && ev.Time.After(lastRecovery) {
+					lastRecovery = ev.Time
+				}
+			}
+		}
+	}
+
+	count := 0
+	for _, ev := range reboots {
+		if ev.Time.After(lastRecovery) {
+			count++
+		}
+	}
+	return count
 }

--- a/components/os/metrics.go
+++ b/components/os/metrics.go
@@ -121,6 +121,26 @@ var (
 		},
 		[]string{pkgmetrics.MetricComponentLabelKey},
 	).MustCurryWith(componentLabel)
+
+	metricBlockedProcesses = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: metricSubSystem,
+			Name:      "blocked_processes",
+			Help:      "tracks the current number of processes in uninterruptible sleep (Linux D-state)",
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey},
+	).MustCurryWith(componentLabel)
+
+	metricBlockedProcessesPersistent = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "",
+			Subsystem: metricSubSystem,
+			Name:      "blocked_processes_persistent",
+			Help:      "tracks the number of D-state processes that met the persistence threshold (consecutive checks)",
+		},
+		[]string{pkgmetrics.MetricComponentLabelKey},
+	).MustCurryWith(componentLabel)
 )
 
 func init() {
@@ -136,5 +156,7 @@ func init() {
 		metricThresholdAllocatedFileHandles,
 		metricThresholdAllocatedFileHandlesPercent,
 		metricZombieProcesses,
+		metricBlockedProcesses,
+		metricBlockedProcessesPersistent,
 	)
 }

--- a/components/os/set_healthy.go
+++ b/components/os/set_healthy.go
@@ -1,0 +1,48 @@
+//nolint:revive // package name follows the directory import path used across the codebase.
+package os
+
+import (
+	"time"
+
+	"github.com/leptonai/gpud/components"
+	"github.com/leptonai/gpud/pkg/log"
+)
+
+var _ components.HealthSettable = &component{}
+
+// SetHealthy resets the D-state (blocked) process tracking state (LEP-6029).
+//
+// Unlike the xid/sxid components, this must NOT purge the event bucket: the
+// "os" bucket is shared with reboot events (pkghost.EventBucketName) that
+// reboot tracking and the xid component's escalation counting depend on. The
+// os health state is recomputed live on every Check from the current process
+// table, so purging history is unnecessary; instead, any active
+// blocked-process episode is closed (recording the recovery event that the
+// reboot-escalation window anchors on) and persistence tracking restarts from
+// scratch, giving the operator's fix the full persistence-threshold window to
+// take effect before the component can flag again.
+func (c *component) SetHealthy() error {
+	log.Logger.Infow("set healthy event received for os")
+
+	now := time.Now().UTC()
+	if c.getTimeNowFunc != nil {
+		now = c.getTimeNowFunc()
+	}
+
+	// inserts EventNameBlockedProcessesRecovered when an episode is active,
+	// which also resets the reboot-escalation window (reboots are counted only
+	// since the most recent recovery)
+	c.clearBlockedProcessEpisode(now)
+
+	// forget all tracked D-state processes: a process still blocked must
+	// re-earn the persistence threshold before being flagged again
+	if c.blockedTracker != nil {
+		c.blockedTracker.reset()
+	}
+
+	// no synchronous re-check: Check enumerates all processes and may take
+	// seconds, which would stall the session reader loop
+	// (pkg/session.processSetHealthy); the next periodic check (one-minute
+	// cadence) reflects the reset state
+	return nil
+}

--- a/components/os/set_healthy.go
+++ b/components/os/set_healthy.go
@@ -32,7 +32,7 @@ func (c *component) SetHealthy() error {
 	// inserts EventNameBlockedProcessesRecovered when an episode is active,
 	// which also resets the reboot-escalation window (reboots are counted only
 	// since the most recent recovery)
-	c.clearBlockedProcessEpisode(now)
+	c.clearBlockedProcessEpisode(now, "persistent blocked processes cleared (set-healthy)")
 
 	// forget all tracked D-state processes: a process still blocked must
 	// re-earn the persistence threshold before being flagged again

--- a/components/os/set_healthy_test.go
+++ b/components/os/set_healthy_test.go
@@ -1,0 +1,120 @@
+//nolint:forcetypeassert,revive // tests intentionally inspect concrete types; package name follows the directory import path.
+package os
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apiv1 "github.com/leptonai/gpud/api/v1"
+	"github.com/leptonai/gpud/components"
+	"github.com/leptonai/gpud/pkg/eventstore"
+)
+
+func TestSetHealthy_ClosesEpisodeAndResetsTracker(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	bucket := &recordingBucket{}
+	comp, now := newTestComponent(t, ctx, &mockRebootEventStore{}, bucket)
+	defer func() { _ = comp.Close() }()
+	withBlockedProcessThresholds(comp, mustBlockedProcessThresholds(t, 5, "^nvidia"))
+
+	// become persistent and unhealthy
+	cr := runChecks(comp, now, 5, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	require.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.HealthStateType())
+	require.Equal(t, []string{EventNameBlockedProcessesPersistent}, bucket.insertedNames())
+
+	require.NoError(t, comp.SetHealthy())
+
+	// the active episode is closed with a recovery event
+	assert.Equal(t, []string{EventNameBlockedProcessesPersistent, EventNameBlockedProcessesRecovered}, bucket.insertedNames())
+
+	// the tracker restarts: the same still-blocked process must re-earn the
+	// persistence threshold before being flagged again
+	cr = runChecks(comp, now, 4, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, cr.HealthStateType(),
+		"set healthy must restart persistence tracking even while the process stays blocked")
+
+	// and once it persists again, it flags a new episode
+	cr = runChecks(comp, now, 1, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.HealthStateType())
+	assert.Equal(t, []string{
+		EventNameBlockedProcessesPersistent,
+		EventNameBlockedProcessesRecovered,
+		EventNameBlockedProcessesPersistent,
+	}, bucket.insertedNames())
+}
+
+func TestSetHealthy_ResetsEscalationWindow(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// two reboots with no recovery in between escalate to hardware inspection
+	rebootStore := &mockRebootEventStore{
+		events: eventstore.Events{
+			{Time: time.Unix(99000, 0), Name: "reboot", Type: string(apiv1.EventTypeWarning)},
+			{Time: time.Unix(99500, 0), Name: "reboot", Type: string(apiv1.EventTypeWarning)},
+		},
+	}
+	bucket := &recordingBucket{}
+	comp, now := newTestComponent(t, ctx, rebootStore, bucket)
+	defer func() { _ = comp.Close() }()
+	withBlockedProcessThresholds(comp, mustBlockedProcessThresholds(t, 5, "^nvidia"))
+
+	cr := runChecks(comp, now, 5, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	states := cr.HealthStates()
+	require.Len(t, states, 1)
+	require.NotNil(t, states[0].SuggestedActions)
+	require.Equal(t, []apiv1.RepairActionType{apiv1.RepairActionTypeHardwareInspection}, states[0].SuggestedActions.RepairActions)
+
+	// operator acknowledges: the recovery event anchors the escalation window,
+	// so reboots before SetHealthy no longer count
+	require.NoError(t, comp.SetHealthy())
+
+	cr = runChecks(comp, now, 5, blockedList(&mockProcessStatus{pid: 42, name: "nvidia-smi"}))
+	states = cr.HealthStates()
+	require.Len(t, states, 1)
+	require.NotNil(t, states[0].SuggestedActions)
+	assert.Equal(t, []apiv1.RepairActionType{apiv1.RepairActionTypeRebootSystem}, states[0].SuggestedActions.RepairActions,
+		"reboots before set healthy must not count toward hardware-inspection escalation")
+}
+
+func TestSetHealthy_NoActiveEpisodeEmitsNoEvent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	bucket := &recordingBucket{}
+	comp, _ := newTestComponent(t, ctx, &mockRebootEventStore{}, bucket)
+	defer func() { _ = comp.Close() }()
+
+	require.NoError(t, comp.SetHealthy())
+	assert.Empty(t, bucket.insertedNames(), "no active episode must not emit a recovery event")
+}
+
+func TestSetHealthy_NilBucketAndTracker(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	// partially constructed component (no event bucket, no tracker, no clock)
+	comp := &component{ctx: ctx, cancel: cancel}
+	assert.NoError(t, comp.SetHealthy())
+}
+
+func TestSetHealthy_ImplementsHealthSettable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	c, err := New(&components.GPUdInstance{
+		RootCtx:          ctx,
+		RebootEventStore: &mockRebootEventStore{},
+	})
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+
+	_, ok := c.(components.HealthSettable)
+	assert.True(t, ok, "os component must implement components.HealthSettable")
+}

--- a/components/os/threshold.go
+++ b/components/os/threshold.go
@@ -15,6 +15,15 @@ const (
 	// checks a process must remain blocked (Linux D-state) before it is
 	// considered persistent. The OS component checks once per minute, so five
 	// consecutive checks correspond to roughly five minutes.
+	//
+	// Why five: transient D-state is normal -- any process doing synchronous
+	// I/O passes through D for milliseconds to seconds -- so a single
+	// observation must never flag a node. The 2026-08-12 validation found
+	// zero D-state processes on healthy production GPU nodes (instant scans
+	// plus a 30x10s sampling window), while an induced real D-state process
+	// (dd on a suspended device-mapper device) persisted >=6 minutes. Five
+	// one-minute checks sit between the two: long enough to ignore ordinary
+	// I/O waits, short enough to surface a wedged kernel path within minutes.
 	DefaultBlockedProcessPersistenceThreshold = 5
 
 	// defaultBlockedProcessNameRegex matches NVIDIA management processes
@@ -40,6 +49,15 @@ type BlockedProcessThresholds struct {
 	// NameRegexes gates which persistent D-state processes escalate to
 	// unhealthy with a repair suggestion. An empty set disables D-state
 	// process checking entirely.
+	//
+	// The gate exists because D-state alone does not identify the cause: a
+	// dd stuck on a suspended device and an nvidia-smi stuck in a wedged
+	// driver are the same state in /proc. A persistent D-state process from
+	// any name degrades the component (something in the kernel is stuck and
+	// SIGKILL cannot clear it), but a reboot suggestion is only attached when
+	// the name matches -- i.e., when the stuck process implicates the GPU
+	// driver path, as in the LEP-6029 incident (nvidia-smi in D during a
+	// kubelet package upgrade).
 	NameRegexes []string `json:"name_regexes"`
 
 	// compiledNameRegexes is the compiled form of NameRegexes, populated by

--- a/components/os/threshold.go
+++ b/components/os/threshold.go
@@ -13,17 +13,19 @@ import (
 const (
 	// DefaultBlockedProcessPersistenceThreshold is the number of consecutive
 	// checks a process must remain blocked (Linux D-state) before it is
-	// considered persistent. The OS component checks once per minute, so five
-	// consecutive checks correspond to roughly five minutes.
+	// considered persistent. The OS component checks once per minute: five
+	// consecutive checks means the process has been blocked for at least four
+	// minutes of wall time (persistenceThreshold check intervals).
 	//
-	// Why five: transient D-state is normal -- any process doing synchronous
-	// I/O passes through D for milliseconds to seconds -- so a single
-	// observation must never flag a node. The 2026-08-12 validation found
-	// zero D-state processes on healthy production GPU nodes (instant scans
-	// plus a 30x10s sampling window), while an induced real D-state process
-	// (dd on a suspended device-mapper device) persisted >=6 minutes. Five
-	// one-minute checks sit between the two: long enough to ignore ordinary
-	// I/O waits, short enough to surface a wedged kernel path within minutes.
+	// Why five: transient D-state is normal -- most blocking disk I/O
+	// (reads, writes, page faults hitting storage) passes through D for
+	// milliseconds to seconds -- so a single observation must never flag a
+	// node. The 2026-08-12 validation found zero D-state processes on healthy
+	// production GPU nodes (instant scans plus a 30x10s sampling window),
+	// while an induced real D-state process (dd on a suspended device-mapper
+	// device) persisted >=6 minutes. Five one-minute checks sit between the
+	// two: long enough to ignore ordinary I/O waits, short enough to surface
+	// a wedged kernel path within minutes after it stalls.
 	DefaultBlockedProcessPersistenceThreshold = 5
 
 	// defaultBlockedProcessNameRegex matches NVIDIA management processes
@@ -52,7 +54,8 @@ type BlockedProcessThresholds struct {
 	//
 	// The gate exists because D-state alone does not identify the cause: a
 	// dd stuck on a suspended device and an nvidia-smi stuck in a wedged
-	// driver are the same state in /proc. A persistent D-state process from
+	// driver show the same D state letter in /proc/<pid>/stat (both become
+	// process.Blocked at the level gpud reads). A persistent D-state process from
 	// any name degrades the component (something in the kernel is stuck and
 	// SIGKILL cannot clear it), but a reboot suggestion is only attached when
 	// the name matches -- i.e., when the stuck process implicates the GPU

--- a/components/os/threshold.go
+++ b/components/os/threshold.go
@@ -1,0 +1,170 @@
+//nolint:revive // package name follows the directory import path used across the codebase.
+package os
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/leptonai/gpud/pkg/log"
+)
+
+const (
+	// DefaultBlockedProcessPersistenceThreshold is the number of consecutive
+	// checks a process must remain blocked (Linux D-state) before it is
+	// considered persistent. The OS component checks once per minute, so five
+	// consecutive checks correspond to roughly five minutes.
+	DefaultBlockedProcessPersistenceThreshold = 5
+
+	// defaultBlockedProcessNameRegex matches NVIDIA management processes
+	// (e.g., nvidia-smi, nvidia-persistenced) per LEP-6029.
+	defaultBlockedProcessNameRegex = "^nvidia"
+)
+
+// DefaultBlockedProcessNameRegexes returns the default process-name regexes
+// used to escalate persistent D-state processes on machines with NVIDIA GPUs.
+func DefaultBlockedProcessNameRegexes() []string {
+	return []string{defaultBlockedProcessNameRegex}
+}
+
+// BlockedProcessThresholds configures the D-state (blocked) process tracking
+// of the os component (LEP-6029), following the same default-override pattern
+// as components/accelerator/nvidia/gpu-counts/threshold.go.
+type BlockedProcessThresholds struct {
+	// PersistenceThreshold is the number of consecutive checks a process must
+	// remain blocked before it is considered persistent. Values <= 0 reset to
+	// DefaultBlockedProcessPersistenceThreshold.
+	PersistenceThreshold int `json:"persistence_threshold"`
+
+	// NameRegexes gates which persistent D-state processes escalate to
+	// unhealthy with a repair suggestion. An empty set disables D-state
+	// process checking entirely.
+	NameRegexes []string `json:"name_regexes"`
+
+	// compiledNameRegexes is the compiled form of NameRegexes, populated by
+	// newBlockedProcessThresholds (and thus SetDefaultBlockedProcessThresholds).
+	compiledNameRegexes []*regexp.Regexp
+}
+
+// IsZero returns true when no process-name regexes are configured, meaning
+// D-state process checking is disabled.
+func (t BlockedProcessThresholds) IsZero() bool {
+	return len(t.NameRegexes) == 0
+}
+
+// MatchesName returns true if the process name matches any configured regex.
+func (t BlockedProcessThresholds) MatchesName(name string) bool {
+	for _, m := range t.compiledNameRegexes {
+		if m.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	defaultBlockedProcessThresholdsMu sync.RWMutex
+	// defaultBlockedProcessThresholds is the built-in default: D-state checking
+	// stays disabled (empty NameRegexes) unless auto-enabled on machines with
+	// NVIDIA GPUs or configured via flags (see ApplyOSBlockedProcessThresholds
+	// in cmd/gpud/common), so upgrading gpud never changes D-state alerting on
+	// non-GPU machines.
+	defaultBlockedProcessThresholds = BlockedProcessThresholds{
+		PersistenceThreshold: DefaultBlockedProcessPersistenceThreshold,
+	}
+
+	startupBlockedProcessThresholdsMu sync.RWMutex
+	// startupBlockedProcessThresholds records the thresholds resolved at
+	// process startup (CLI flags + NVIDIA GPU auto-detection, recorded by
+	// ApplyOSBlockedProcessThresholds in cmd/gpud/common). The session
+	// updateConfig fallback restores this baseline when the control-plane
+	// config does not specify os thresholds, so unrelated config pushes do
+	// not silently disable D-state tracking on GPU machines. Nil until
+	// recorded.
+	startupBlockedProcessThresholds *BlockedProcessThresholds
+)
+
+// GetDefaultBlockedProcessThresholds returns the configured default thresholds.
+func GetDefaultBlockedProcessThresholds() BlockedProcessThresholds {
+	defaultBlockedProcessThresholdsMu.RLock()
+	defer defaultBlockedProcessThresholdsMu.RUnlock()
+	ret := defaultBlockedProcessThresholds
+	ret.NameRegexes = append([]string(nil), ret.NameRegexes...)
+	return ret
+}
+
+// SetDefaultBlockedProcessThresholds validates, compiles, and updates the
+// default thresholds.
+func SetDefaultBlockedProcessThresholds(th BlockedProcessThresholds) error {
+	normalized, err := newBlockedProcessThresholds(th.PersistenceThreshold, th.NameRegexes)
+	if err != nil {
+		return err
+	}
+
+	defaultBlockedProcessThresholdsMu.Lock()
+	defer defaultBlockedProcessThresholdsMu.Unlock()
+	defaultBlockedProcessThresholds = normalized
+
+	log.Logger.Infow("set blocked process thresholds",
+		"persistenceThreshold", normalized.PersistenceThreshold,
+		"nameRegexes", normalized.NameRegexes,
+	)
+	return nil
+}
+
+// SetStartupBlockedProcessThresholds records the startup-resolved thresholds
+// as the baseline that session updateConfig falls back to when the
+// control-plane config omits the os component. Called once from the gpud
+// run/scan command wiring after flag resolution.
+func SetStartupBlockedProcessThresholds(th BlockedProcessThresholds) {
+	startupBlockedProcessThresholdsMu.Lock()
+	defer startupBlockedProcessThresholdsMu.Unlock()
+	copied := th
+	copied.NameRegexes = append([]string(nil), th.NameRegexes...)
+	startupBlockedProcessThresholds = &copied
+}
+
+// GetStartupBlockedProcessThresholds returns the thresholds resolved at
+// process startup. If none were recorded (e.g., tests), it returns the
+// current defaults so the updateConfig fallback leaves them unchanged.
+func GetStartupBlockedProcessThresholds() BlockedProcessThresholds {
+	startupBlockedProcessThresholdsMu.RLock()
+	recorded := startupBlockedProcessThresholds
+	startupBlockedProcessThresholdsMu.RUnlock()
+	if recorded == nil {
+		return GetDefaultBlockedProcessThresholds()
+	}
+	ret := *recorded
+	ret.NameRegexes = append([]string(nil), ret.NameRegexes...)
+	return ret
+}
+
+// newBlockedProcessThresholds validates and compiles the regexes, trimming
+// blanks and normalizing a non-positive persistence threshold to the default.
+func newBlockedProcessThresholds(persistenceThreshold int, nameRegexes []string) (BlockedProcessThresholds, error) {
+	compiled := make([]*regexp.Regexp, 0, len(nameRegexes))
+	cleaned := make([]string, 0, len(nameRegexes))
+	for _, r := range nameRegexes {
+		r = strings.TrimSpace(r)
+		if r == "" {
+			continue
+		}
+		c, err := regexp.Compile(r)
+		if err != nil {
+			return BlockedProcessThresholds{}, fmt.Errorf("invalid blocked process name regex %q: %w", r, err)
+		}
+		compiled = append(compiled, c)
+		cleaned = append(cleaned, r)
+	}
+
+	if persistenceThreshold <= 0 {
+		persistenceThreshold = DefaultBlockedProcessPersistenceThreshold
+	}
+
+	return BlockedProcessThresholds{
+		PersistenceThreshold: persistenceThreshold,
+		NameRegexes:          cleaned,
+		compiledNameRegexes:  compiled,
+	}, nil
+}

--- a/components/os/threshold_test.go
+++ b/components/os/threshold_test.go
@@ -1,0 +1,121 @@
+//nolint:revive // package name follows the directory import path used across the codebase.
+package os
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultBlockedProcessThresholds_BuiltIn(t *testing.T) {
+	th := GetDefaultBlockedProcessThresholds()
+	assert.Equal(t, DefaultBlockedProcessPersistenceThreshold, th.PersistenceThreshold)
+	assert.Empty(t, th.NameRegexes, "built-in default must keep D-state checking disabled until auto-enabled or configured")
+	assert.True(t, th.IsZero())
+	assert.False(t, th.MatchesName("nvidia-smi"))
+}
+
+func TestDefaultBlockedProcessNameRegexes(t *testing.T) {
+	regexes := DefaultBlockedProcessNameRegexes()
+	require.Equal(t, []string{"^nvidia"}, regexes)
+
+	// mutating the returned slice must not affect subsequent calls
+	regexes[0] = "mutated"
+	assert.Equal(t, []string{"^nvidia"}, DefaultBlockedProcessNameRegexes())
+}
+
+func TestSetDefaultBlockedProcessThresholds(t *testing.T) {
+	original := GetDefaultBlockedProcessThresholds()
+	t.Cleanup(func() {
+		require.NoError(t, SetDefaultBlockedProcessThresholds(original))
+	})
+
+	// round trip
+	require.NoError(t, SetDefaultBlockedProcessThresholds(BlockedProcessThresholds{
+		PersistenceThreshold: 3,
+		NameRegexes:          []string{"^nvidia", " uvm_ ", ""},
+	}))
+	th := GetDefaultBlockedProcessThresholds()
+	assert.Equal(t, 3, th.PersistenceThreshold)
+	assert.Equal(t, []string{"^nvidia", "uvm_"}, th.NameRegexes, "blank entries must be trimmed/dropped")
+	assert.False(t, th.IsZero())
+	assert.True(t, th.MatchesName("nvidia-smi"))
+	assert.True(t, th.MatchesName("uvm_va_space"))
+	assert.False(t, th.MatchesName("dd"))
+
+	// non-positive persistence threshold resets to the default
+	require.NoError(t, SetDefaultBlockedProcessThresholds(BlockedProcessThresholds{
+		PersistenceThreshold: -1,
+		NameRegexes:          []string{"^nvidia"},
+	}))
+	assert.Equal(t, DefaultBlockedProcessPersistenceThreshold, GetDefaultBlockedProcessThresholds().PersistenceThreshold)
+
+	// invalid regex rejected, previous config preserved
+	require.Error(t, SetDefaultBlockedProcessThresholds(BlockedProcessThresholds{
+		PersistenceThreshold: 1,
+		NameRegexes:          []string{"(("},
+	}))
+	th = GetDefaultBlockedProcessThresholds()
+	assert.Equal(t, DefaultBlockedProcessPersistenceThreshold, th.PersistenceThreshold)
+	assert.Equal(t, []string{"^nvidia"}, th.NameRegexes)
+
+	// empty regex set disables the check
+	require.NoError(t, SetDefaultBlockedProcessThresholds(BlockedProcessThresholds{
+		PersistenceThreshold: 5,
+		NameRegexes:          []string{},
+	}))
+	th = GetDefaultBlockedProcessThresholds()
+	assert.True(t, th.IsZero())
+	assert.False(t, th.MatchesName("nvidia-smi"))
+}
+
+func TestNewBlockedProcessThresholds(t *testing.T) {
+	th, err := newBlockedProcessThresholds(0, nil)
+	require.NoError(t, err)
+	assert.Equal(t, DefaultBlockedProcessPersistenceThreshold, th.PersistenceThreshold)
+	assert.True(t, th.IsZero())
+
+	th, err = newBlockedProcessThresholds(1, []string{"^nvidia"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, th.PersistenceThreshold)
+	assert.True(t, th.MatchesName("nvidia-smi"))
+
+	_, err = newBlockedProcessThresholds(1, []string{"(("})
+	require.Error(t, err)
+}
+
+func TestStartupBlockedProcessThresholds(t *testing.T) {
+	originalDefault := GetDefaultBlockedProcessThresholds()
+	t.Cleanup(func() {
+		require.NoError(t, SetDefaultBlockedProcessThresholds(originalDefault))
+		startupBlockedProcessThresholdsMu.Lock()
+		startupBlockedProcessThresholds = nil
+		startupBlockedProcessThresholdsMu.Unlock()
+	})
+
+	// never recorded in this test binary order-independently: falls back to
+	// the current defaults so the updateConfig fallback leaves them unchanged
+	require.NoError(t, SetDefaultBlockedProcessThresholds(BlockedProcessThresholds{
+		PersistenceThreshold: 2,
+		NameRegexes:          []string{"^dd$"},
+	}))
+	startup := GetStartupBlockedProcessThresholds()
+	assert.Equal(t, 2, startup.PersistenceThreshold)
+	assert.Equal(t, []string{"^dd$"}, startup.NameRegexes)
+
+	// record a startup baseline, then change the runtime defaults (e.g., via
+	// updateConfig): the baseline must stay at the startup-resolved value
+	SetStartupBlockedProcessThresholds(GetDefaultBlockedProcessThresholds())
+	require.NoError(t, SetDefaultBlockedProcessThresholds(BlockedProcessThresholds{
+		PersistenceThreshold: 9,
+		NameRegexes:          []string{"^other$"},
+	}))
+	startup = GetStartupBlockedProcessThresholds()
+	assert.Equal(t, 2, startup.PersistenceThreshold)
+	assert.Equal(t, []string{"^dd$"}, startup.NameRegexes)
+
+	// mutating the returned slice must not affect the recorded baseline
+	startup.NameRegexes[0] = "mutated"
+	assert.Equal(t, []string{"^dd$"}, GetStartupBlockedProcessThresholds().NameRegexes)
+}

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -31,6 +31,6 @@
 - [**`memory`**](https://pkg.go.dev/github.com/leptonai/gpud/components/memory): Tracks the memory usage of the host.
 - [**`network-latency`**](https://pkg.go.dev/github.com/leptonai/gpud/components/network/latency): Tracks global network connectivity statistics.
 - [**`nfs`**](https://pkg.go.dev/github.com/leptonai/gpud/components/nfs): Tracks the NFS volume healthiness.
-- [**`os`**](https://pkg.go.dev/github.com/leptonai/gpud/components/os): Queries the host OS information (e.g., kernel version, file descriptor usage).
+- [**`os`**](https://pkg.go.dev/github.com/leptonai/gpud/components/os): Queries the host OS information (e.g., kernel version, file descriptor usage) and tracks persistent D-state (uninterruptible sleep) processes.
 - [**`pci`**](https://pkg.go.dev/github.com/leptonai/gpud/components/pci): Tracks the PCI devices and their Access Control Services (ACS) status.
 - [**`tailscale`**](https://pkg.go.dev/github.com/leptonai/gpud/components/tailscale): Tracks the tailscale state (e.g., version) if available.

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -24,6 +24,7 @@ import (
 	componentstemperature "github.com/leptonai/gpud/components/accelerator/nvidia/temperature"
 	componentsxid "github.com/leptonai/gpud/components/accelerator/nvidia/xid"
 	componentsnfs "github.com/leptonai/gpud/components/nfs"
+	componentsos "github.com/leptonai/gpud/components/os"
 	"github.com/leptonai/gpud/pkg/config"
 	pkgcustomplugins "github.com/leptonai/gpud/pkg/custom-plugins"
 	pkgfaultinjector "github.com/leptonai/gpud/pkg/fault-injector"
@@ -225,6 +226,10 @@ type Session struct {
 	setDefaultNFSGroupConfigsFunc          func(cfgs pkgnfschecker.Configs)
 	setDefaultXIDThresholdsFunc            func(thresholds componentsxid.Thresholds)
 	setDefaultTemperatureThresholdsFunc    func(threshold componentstemperature.Thresholds)
+	// setDefaultOSBlockedProcessThresholdsFunc applies os D-state thresholds
+	// pushed via updateConfig (e.g., node-group config); returns an error on
+	// invalid regexes so the control plane gets feedback.
+	setDefaultOSBlockedProcessThresholdsFunc func(thresholds componentsos.BlockedProcessThresholds) error
 
 	nvmlInstance       nvidianvml.Instance
 	metricsStore       pkgmetrics.Store
@@ -384,12 +389,13 @@ func NewSession(ctx context.Context, epLocalGPUdServer string, epControlPlane st
 
 		createGossipRequestFunc: pkgmachineinfo.CreateGossipRequest,
 
-		setDefaultIbExpectedPortStatesFunc:     componentsnvidiainfiniband.SetDefaultExpectedPortStates,
-		setDefaultNVLinkExpectedLinkStatesFunc: componentsnvidianvlink.SetDefaultExpectedLinkStates,
-		setDefaultGPUCountsFunc:                componentsnvidiagpucounts.SetDefaultExpectedGPUCounts,
-		setDefaultNFSGroupConfigsFunc:          componentsnfs.SetDefaultConfigs,
-		setDefaultXIDThresholdsFunc:            componentsxid.SetDefaultThresholds,
-		setDefaultTemperatureThresholdsFunc:    componentstemperature.SetDefaultMarginThreshold,
+		setDefaultIbExpectedPortStatesFunc:       componentsnvidiainfiniband.SetDefaultExpectedPortStates,
+		setDefaultNVLinkExpectedLinkStatesFunc:   componentsnvidianvlink.SetDefaultExpectedLinkStates,
+		setDefaultGPUCountsFunc:                  componentsnvidiagpucounts.SetDefaultExpectedGPUCounts,
+		setDefaultNFSGroupConfigsFunc:            componentsnfs.SetDefaultConfigs,
+		setDefaultXIDThresholdsFunc:              componentsxid.SetDefaultThresholds,
+		setDefaultTemperatureThresholdsFunc:      componentstemperature.SetDefaultMarginThreshold,
+		setDefaultOSBlockedProcessThresholdsFunc: componentsos.SetDefaultBlockedProcessThresholds,
 
 		nvmlInstance:            op.nvmlInstance,
 		metricsStore:            op.metricsStore,

--- a/pkg/session/update_config.go
+++ b/pkg/session/update_config.go
@@ -10,6 +10,7 @@ import (
 	componentstemperature "github.com/leptonai/gpud/components/accelerator/nvidia/temperature"
 	componentsxid "github.com/leptonai/gpud/components/accelerator/nvidia/xid"
 	componentsnfs "github.com/leptonai/gpud/components/nfs"
+	componentsos "github.com/leptonai/gpud/components/os"
 	"github.com/leptonai/gpud/pkg/log"
 	pkgnfschecker "github.com/leptonai/gpud/pkg/nfs-checker"
 )
@@ -100,6 +101,22 @@ func (s *Session) processUpdateConfig(configMap map[string]string, resp *Respons
 				s.setDefaultNFSGroupConfigsFunc(updateCfgs)
 			}
 
+		case componentsos.Name:
+			setComponents[componentName] = struct{}{}
+			var updateCfg componentsos.BlockedProcessThresholds
+			if err := json.Unmarshal([]byte(value), &updateCfg); err != nil {
+				log.Logger.Warnw("failed to unmarshal os blocked process thresholds config", "error", err)
+				resp.Error = err.Error()
+				return
+			}
+			if s.setDefaultOSBlockedProcessThresholdsFunc != nil {
+				if err := s.setDefaultOSBlockedProcessThresholdsFunc(updateCfg); err != nil {
+					log.Logger.Warnw("failed to set os blocked process thresholds", "error", err)
+					resp.Error = err.Error()
+					return
+				}
+			}
+
 		default:
 			log.Logger.Warnw("unsupported component for updateConfig", "component", componentName)
 		}
@@ -129,5 +146,16 @@ func (s *Session) processUpdateConfig(configMap map[string]string, resp *Respons
 	if _, ok := setComponents[componentstemperature.Name]; !ok && s.setDefaultTemperatureThresholdsFunc != nil {
 		log.Logger.Infow("falling back to default temperature config")
 		s.setDefaultTemperatureThresholdsFunc(componentstemperature.Thresholds{CelsiusSlowdownMargin: componentstemperature.ThresholdCelsiusSlowdownMargin})
+	}
+	// os falls back to the startup-resolved thresholds (CLI flags + NVIDIA GPU
+	// auto-detection), not the built-in empty default: resetting to empty here
+	// would silently disable D-state tracking on GPU machines whenever the
+	// control plane pushes a config that does not mention the os component.
+	if _, ok := setComponents[componentsos.Name]; !ok && s.setDefaultOSBlockedProcessThresholdsFunc != nil {
+		log.Logger.Infow("falling back to startup os blocked process thresholds")
+		if err := s.setDefaultOSBlockedProcessThresholdsFunc(componentsos.GetStartupBlockedProcessThresholds()); err != nil {
+			// the startup baseline was validated when recorded; log defensively
+			log.Logger.Warnw("failed to restore startup os blocked process thresholds", "error", err)
+		}
 	}
 }

--- a/pkg/session/update_config_os_test.go
+++ b/pkg/session/update_config_os_test.go
@@ -1,0 +1,164 @@
+package session
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	componentsos "github.com/leptonai/gpud/components/os"
+)
+
+func TestProcessUpdateConfig_OSBlockedProcessThresholds(t *testing.T) {
+	t.Run("valid os config is applied", func(t *testing.T) {
+		var captured componentsos.BlockedProcessThresholds
+		called := false
+
+		s := &Session{
+			setDefaultOSBlockedProcessThresholdsFunc: func(thresholds componentsos.BlockedProcessThresholds) error {
+				called = true
+				captured = thresholds
+				return nil
+			},
+		}
+
+		configJSON, err := json.Marshal(componentsos.BlockedProcessThresholds{
+			PersistenceThreshold: 3,
+			NameRegexes:          []string{"^nvidia", "^myapp"},
+		})
+		require.NoError(t, err)
+
+		resp := &Response{}
+		s.processUpdateConfig(map[string]string{componentsos.Name: string(configJSON)}, resp)
+
+		assert.Empty(t, resp.Error)
+		require.True(t, called, "setDefaultOSBlockedProcessThresholdsFunc must be called for os config")
+		assert.Equal(t, 3, captured.PersistenceThreshold)
+		assert.Equal(t, []string{"^nvidia", "^myapp"}, captured.NameRegexes)
+	})
+
+	t.Run("invalid json returns error and does not call setter", func(t *testing.T) {
+		s := &Session{
+			setDefaultOSBlockedProcessThresholdsFunc: func(thresholds componentsos.BlockedProcessThresholds) error {
+				t.Error("setter must not be called for invalid JSON")
+				return nil
+			},
+		}
+
+		resp := &Response{}
+		s.processUpdateConfig(map[string]string{componentsos.Name: "{invalid json"}, resp)
+
+		assert.NotEmpty(t, resp.Error)
+	})
+
+	t.Run("setter error is surfaced", func(t *testing.T) {
+		s := &Session{
+			setDefaultOSBlockedProcessThresholdsFunc: func(thresholds componentsos.BlockedProcessThresholds) error {
+				return errors.New("invalid blocked process name regex")
+			},
+		}
+
+		configJSON, err := json.Marshal(componentsos.BlockedProcessThresholds{
+			PersistenceThreshold: 1,
+			NameRegexes:          []string{"(("},
+		})
+		require.NoError(t, err)
+
+		resp := &Response{}
+		s.processUpdateConfig(map[string]string{componentsos.Name: string(configJSON)}, resp)
+
+		assert.Contains(t, resp.Error, "invalid blocked process name regex")
+	})
+
+	t.Run("nil setter does not panic", func(t *testing.T) {
+		s := &Session{}
+
+		configJSON, err := json.Marshal(componentsos.BlockedProcessThresholds{
+			PersistenceThreshold: 3,
+			NameRegexes:          []string{"^nvidia"},
+		})
+		require.NoError(t, err)
+
+		resp := &Response{}
+		s.processUpdateConfig(map[string]string{componentsos.Name: string(configJSON)}, resp)
+
+		assert.Empty(t, resp.Error)
+	})
+
+	t.Run("empty os config object disables the check", func(t *testing.T) {
+		var captured componentsos.BlockedProcessThresholds
+		s := &Session{
+			setDefaultOSBlockedProcessThresholdsFunc: func(thresholds componentsos.BlockedProcessThresholds) error {
+				captured = thresholds
+				return nil
+			},
+		}
+
+		resp := &Response{}
+		s.processUpdateConfig(map[string]string{componentsos.Name: "{}"}, resp)
+
+		assert.Empty(t, resp.Error)
+		assert.True(t, captured.IsZero(), "explicit empty os config must disable D-state checking")
+	})
+}
+
+func TestProcessUpdateConfig_OSFallbackRestoresStartupThresholds(t *testing.T) {
+	startup := componentsos.BlockedProcessThresholds{
+		PersistenceThreshold: 5,
+		NameRegexes:          []string{"^nvidia"},
+	}
+	original := componentsos.GetStartupBlockedProcessThresholds()
+	componentsos.SetStartupBlockedProcessThresholds(startup)
+	t.Cleanup(func() {
+		componentsos.SetStartupBlockedProcessThresholds(original)
+	})
+
+	t.Run("config without os restores startup-resolved thresholds", func(t *testing.T) {
+		var captured componentsos.BlockedProcessThresholds
+		called := false
+		s := &Session{
+			setDefaultOSBlockedProcessThresholdsFunc: func(thresholds componentsos.BlockedProcessThresholds) error {
+				called = true
+				captured = thresholds
+				return nil
+			},
+		}
+
+		// a config push for an unrelated component must not silently disable
+		// D-state tracking on GPU machines: the fallback restores the
+		// startup-resolved (GPU-aware) thresholds
+		resp := &Response{}
+		s.processUpdateConfig(map[string]string{"unsupported-component": "{}"}, resp)
+
+		assert.Empty(t, resp.Error)
+		require.True(t, called, "fallback must restore startup thresholds when os is not configured")
+		assert.Equal(t, startup.PersistenceThreshold, captured.PersistenceThreshold)
+		assert.Equal(t, startup.NameRegexes, captured.NameRegexes)
+	})
+
+	t.Run("config with os does not trigger fallback", func(t *testing.T) {
+		var captured []componentsos.BlockedProcessThresholds
+		s := &Session{
+			setDefaultOSBlockedProcessThresholdsFunc: func(thresholds componentsos.BlockedProcessThresholds) error {
+				captured = append(captured, thresholds)
+				return nil
+			},
+		}
+
+		configJSON, err := json.Marshal(componentsos.BlockedProcessThresholds{
+			PersistenceThreshold: 7,
+			NameRegexes:          []string{"^custom"},
+		})
+		require.NoError(t, err)
+
+		resp := &Response{}
+		s.processUpdateConfig(map[string]string{componentsos.Name: string(configJSON)}, resp)
+
+		assert.Empty(t, resp.Error)
+		require.Len(t, captured, 1, "setter must be called exactly once (no fallback override)")
+		assert.Equal(t, 7, captured[0].PersistenceThreshold)
+		assert.Equal(t, []string{"^custom"}, captured[0].NameRegexes)
+	})
+}


### PR DESCRIPTION
Track processes in uninterruptible sleep (Linux D-state) across checks and escalate persistent ones: unhealthy with reboot/hardware-inspection suggestions when names match escalation regexes, degraded otherwise.

- thresholds (persistence count + name regexes) configurable via components/os/threshold.go, following the gpu-counts pattern; an empty regex set disables the check entirely
- gpud run/scan auto-enable NVIDIA process matching (^nvidia) when a GPU is detected via lspci (works even with broken drivers); gpud scan lowers the persistence threshold to 1 for one-off checks; CLI flags override
- session updateConfig support for node-group config, falling back to the startup-resolved thresholds so unrelated config pushes do not disable D-state tracking on GPU machines
- SetHealthy resets D-state tracking state without purging the shared os event bucket (kmsg events)