### PR TITLE
[LEP-6128] fix(containerd): skip activeness checks when CRI-O is the runtime

### DIFF
--- a/components/containerd/component.go
+++ b/components/containerd/component.go
@@ -64,6 +64,7 @@ type component struct {
 
 	checkDependencyInstalledFunc  func() bool
 	checkSocketExistsFunc         func() bool
+	checkCRIORunningFunc          func(context.Context) bool
 	checkContainerdRunningFunc    func(context.Context) bool
 	checkServiceActiveFunc        func(context.Context) (bool, error)
 	getContainerdUptimeFunc       func() (*time.Duration, error)
@@ -109,6 +110,7 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 
 		checkDependencyInstalledFunc: checkContainerdInstalled,
 		checkSocketExistsFunc:        checkSocketExistsFunc,
+		checkCRIORunningFunc:         CheckCRIORunning,
 		checkContainerdRunningFunc:   CheckContainerdRunning,
 		// checkServiceActiveFunc defaults to the in-namespace systemd.IsActive
 		// check. When ContainerdServiceActiveCommands is set (e.g. wrapping
@@ -263,6 +265,29 @@ func (c *component) Check() components.CheckResult {
 		cr.health = apiv1.HealthStateTypeHealthy
 		cr.reason = "containerd not installed"
 		return cr
+	}
+
+	// An installed containerd binary does not make containerd the node's
+	// container runtime: BYOK clusters that use CRI-O still ship the
+	// containerd binary (the gpud image installs containerd.io), but
+	// containerd is never started and its socket never appears. Without this
+	// skip, the activeness check below marks such nodes Unhealthy after five
+	// consecutive misses even though nothing is wrong (LEP-6128).
+	//
+	// CRI-O is probed with a real CRI connection (CheckCRIORunning) rather
+	// than a bare socket stat so a stale socket left by a crashed CRI-O does
+	// not spoof a containerd node into skipping a genuine containerd outage.
+	if c.checkSocketExistsFunc != nil && !c.checkSocketExistsFunc() &&
+		c.checkCRIORunningFunc != nil {
+		cctx, ccancel := context.WithTimeout(c.ctx, 15*time.Second)
+		crioRunning := c.checkCRIORunningFunc(cctx)
+		ccancel()
+		if crioRunning {
+			c.recordSocketMissing(false)
+			cr.health = apiv1.HealthStateTypeHealthy
+			cr.reason = "containerd installed but CRI-O is the active container runtime, skipping containerd checks"
+			return cr
+		}
 	}
 
 	// below are the checks in case "containerd" is installed, thus requires activeness checks

--- a/components/containerd/component_test.go
+++ b/components/containerd/component_test.go
@@ -1984,6 +1984,179 @@ func TestCheckOnceSocketNotExistsComprehensive(t *testing.T) {
 	assert.False(t, comp.lastCheckResult.ContainerdServiceActive)
 }
 
+// TestCheckSocketMissingButCRIOActive tests that a node whose active container
+// runtime is CRI-O (CRI-O socket present, containerd socket missing) is not
+// marked unhealthy, even though the containerd binary is installed.
+func TestCheckSocketMissingButCRIOActive(t *testing.T) {
+	ctx := context.Background()
+
+	runningFuncCalled := false
+	serviceActiveFuncCalled := false
+	listAllSandboxesFuncCalled := false
+
+	comp := &component{
+		ctx:    ctx,
+		cancel: func() {},
+		checkDependencyInstalledFunc: func() bool {
+			return true // containerd binary is installed
+		},
+		checkSocketExistsFunc: func() bool {
+			return false // containerd socket does not exist
+		},
+		checkCRIORunningFunc: func(ctx context.Context) bool {
+			return true // CRI-O answers its CRI endpoint -- CRI-O is the active runtime
+		},
+		checkContainerdRunningFunc: func(ctx context.Context) bool {
+			runningFuncCalled = true
+			return false
+		},
+		checkServiceActiveFunc: func(ctx context.Context) (bool, error) {
+			serviceActiveFuncCalled = true
+			return false, nil
+		},
+		listAllSandboxesFunc: func(ctx context.Context, endpoint string) ([]PodSandbox, error) {
+			listAllSandboxesFuncCalled = true
+			return nil, nil
+		},
+		getTimeNowFunc: func() time.Time {
+			return time.Now().UTC()
+		},
+		endpoint: "unix:///mock/endpoint",
+	}
+
+	// even beyond the consecutive-missing threshold, the node must stay healthy
+	for range socketMissingConsecutiveThreshold + 2 {
+		cr := comp.Check()
+		require.NotNil(t, cr)
+		assert.Equal(t, apiv1.HealthStateTypeHealthy, comp.lastCheckResult.health)
+		assert.Contains(t, comp.lastCheckResult.reason, "CRI-O is the active container runtime")
+		assert.Nil(t, comp.lastCheckResult.err)
+	}
+
+	// the missing-socket counter must not accumulate on CRI-O nodes
+	assert.Equal(t, 0, comp.socketMissingCount)
+
+	// containerd activeness checks must be skipped entirely on CRI-O nodes
+	assert.False(t, runningFuncCalled)
+	assert.False(t, serviceActiveFuncCalled)
+	assert.False(t, listAllSandboxesFuncCalled)
+}
+
+// TestCheckSocketMissingCRIONotPresent tests that the original socket-missing
+// behavior is preserved when CRI-O is not detected on the node.
+func TestCheckSocketMissingCRIONotPresent(t *testing.T) {
+	ctx := context.Background()
+	comp := &component{
+		ctx:    ctx,
+		cancel: func() {},
+		checkDependencyInstalledFunc: func() bool {
+			return true
+		},
+		checkSocketExistsFunc: func() bool {
+			return false // containerd socket does not exist
+		},
+		checkCRIORunningFunc: func(ctx context.Context) bool {
+			return false // no CRI-O either
+		},
+		getTimeNowFunc: func() time.Time {
+			return time.Now().UTC()
+		},
+		endpoint: "unix:///mock/endpoint",
+	}
+
+	for range socketMissingConsecutiveThreshold - 1 {
+		cr := comp.Check()
+		require.NotNil(t, cr)
+		assert.Equal(t, apiv1.HealthStateTypeHealthy, comp.lastCheckResult.health)
+		assert.Contains(t, comp.lastCheckResult.reason, "socket file does not exist")
+	}
+
+	cr := runContainerdChecks(comp, 1)
+	require.NotNil(t, cr)
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, cr.health)
+	assert.Contains(t, cr.reason, "socket file does not exist")
+	assert.Contains(t, cr.reason, "failed continuously")
+}
+
+// TestCheckSocketPresentWithCRIO tests that a node where containerd is running
+// (socket exists) is checked normally even when a CRI-O socket is also present.
+func TestCheckSocketPresentWithCRIO(t *testing.T) {
+	ctx := context.Background()
+
+	runningFuncCalled := false
+
+	comp := &component{
+		ctx:    ctx,
+		cancel: func() {},
+		checkDependencyInstalledFunc: func() bool {
+			return true
+		},
+		checkSocketExistsFunc: func() bool {
+			return true // containerd socket exists
+		},
+		checkCRIORunningFunc: func(ctx context.Context) bool {
+			return true // CRI-O also running
+		},
+		checkContainerdRunningFunc: func(ctx context.Context) bool {
+			runningFuncCalled = true
+			return true
+		},
+		checkServiceActiveFunc: func(ctx context.Context) (bool, error) {
+			return true, nil
+		},
+		getTimeNowFunc: func() time.Time {
+			return time.Now().UTC()
+		},
+		endpoint: "unix:///mock/endpoint",
+	}
+
+	cr := comp.Check()
+	require.NotNil(t, cr)
+	assert.True(t, runningFuncCalled)
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, comp.lastCheckResult.health)
+	assert.Equal(t, "ok", comp.lastCheckResult.reason)
+}
+
+// TestCheckCRIOToContainerdTransition tests that the missing-socket counter is
+// reset while CRI-O is active, so a later CRI-O disappearance restarts the
+// consecutive-missing detection from zero.
+func TestCheckCRIOToContainerdTransition(t *testing.T) {
+	ctx := context.Background()
+	crioRunning := true
+
+	comp := &component{
+		ctx:    ctx,
+		cancel: func() {},
+		checkDependencyInstalledFunc: func() bool {
+			return true
+		},
+		checkSocketExistsFunc: func() bool {
+			return false // containerd socket never exists
+		},
+		checkCRIORunningFunc: func(ctx context.Context) bool {
+			return crioRunning
+		},
+		getTimeNowFunc: func() time.Time {
+			return time.Now().UTC()
+		},
+		endpoint: "unix:///mock/endpoint",
+	}
+
+	cr := runContainerdChecks(comp, socketMissingConsecutiveThreshold+2)
+	require.NotNil(t, cr)
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, cr.health)
+	assert.Contains(t, cr.reason, "CRI-O is the active container runtime")
+
+	// CRI-O goes away: detection must restart from the first miss,
+	// not immediately trip the consecutive-failure threshold
+	crioRunning = false
+	cr = runContainerdChecks(comp, 1)
+	require.NotNil(t, cr)
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, cr.health)
+	assert.Contains(t, cr.reason, "socket file does not exist")
+	assert.Contains(t, cr.reason, "detected 1/")
+}
+
 func Test_checkContainerdRunningFunc(t *testing.T) {
 	ctx := context.Background()
 
@@ -3900,6 +4073,13 @@ func TestContainerdSocketMissingFailureInjectorIntegration(t *testing.T) {
 	// Override checkDependencyInstalledFunc to return true (containerd is installed)
 	c.checkDependencyInstalledFunc = func() bool {
 		return true
+	}
+
+	// Keep this test independent of the host: New wires the real
+	// CheckCRIORunning, which would take the CRI-O skip path on a machine
+	// where a CRI-O endpoint happens to be reachable.
+	c.checkCRIORunningFunc = func(ctx context.Context) bool {
+		return false
 	}
 
 	// Disable uptime check so it doesn't override the health state when containerd uptime < threshold

--- a/components/containerd/cri.go
+++ b/components/containerd/cri.go
@@ -28,6 +28,12 @@ const (
 	defaultSocketFile = "/run/containerd/containerd.sock"
 	// DefaultContainerRuntimeEndpoint is the default CRI socket for containerd.
 	DefaultContainerRuntimeEndpoint = "unix:///run/containerd/containerd.sock"
+
+	// DefaultCRIOEndpoint is the default CRI socket for CRI-O, which is also
+	// the endpoint kubelet uses for CRI-O runtimes. Uses /run (not /var/run) to
+	// match the containerd convention above and the DaemonSet's hostPath mount;
+	// on the host /var/run is a symlink to /run.
+	DefaultCRIOEndpoint = "unix:///run/crio/crio.sock"
 )
 
 // NOTE
@@ -225,6 +231,30 @@ func CheckSocketExists() bool {
 	}
 
 	log.Logger.Debugw("containerd default socket file exists, containerd installed", "file", defaultSocketFile)
+	return true
+}
+
+// CheckCRIORunning reports whether CRI-O answers a real CRI connection on its
+// default endpoint.
+//
+// The containerd component uses this to tell "containerd socket missing
+// because CRI-O runs the node" (expected, healthy) apart from "containerd
+// socket missing on a containerd node" (a real failure). It dials instead of
+// doing a bare os.Stat so that a stale socket left behind by a crashed CRI-O
+// cannot make a containerd node look like a CRI-O node and mask a genuine
+// containerd outage.
+func CheckCRIORunning(ctx context.Context) bool {
+	cctx, ccancel := context.WithTimeout(ctx, 5*time.Second)
+	defer ccancel()
+
+	conn, err := connect(cctx, DefaultCRIOEndpoint)
+	if err != nil {
+		log.Logger.Debugw("cri-o default cri endpoint not open", "endpoint", DefaultCRIOEndpoint, "error", err)
+		return false
+	}
+	_ = conn.Close()
+
+	log.Logger.Debugw("cri-o default cri endpoint open, cri-o running", "endpoint", DefaultCRIOEndpoint)
 	return true
 }
 

--- a/components/containerd/mock_cri_test.go
+++ b/components/containerd/mock_cri_test.go
@@ -169,6 +169,39 @@ func TestCheckContainerdRunning_ConnectErrorWithMockey(t *testing.T) {
 	})
 }
 
+func TestCheckCRIORunning_WithMockey(t *testing.T) {
+	srv := &fakeRuntimeServer{
+		version: "1.30.3",
+	}
+	endpoint, cleanup := startFakeRuntimeServer(t, srv)
+	t.Cleanup(cleanup)
+
+	addr, err := parseUnixEndpoint(endpoint)
+	require.NoError(t, err)
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithContextDialer(dialUnix))
+	require.NoError(t, err)
+
+	mockey.PatchConvey("CheckCRIORunning returns true when the CRI-O endpoint answers", t, func() {
+		mockey.Mock(connect).To(func(_ context.Context, _ string) (*grpc.ClientConn, error) {
+			return conn, nil
+		}).Build()
+
+		assert.True(t, CheckCRIORunning(context.Background()))
+	})
+}
+
+func TestCheckCRIORunning_ConnectErrorWithMockey(t *testing.T) {
+	mockey.PatchConvey("CheckCRIORunning returns false on connect error", t, func() {
+		// the missing-socket path is the common one: on a node without CRI-O,
+		// connect fails its os.Stat pre-check and CheckCRIORunning must say
+		// "not running" so the containerd failure logic stays in charge
+		mockey.Mock(connect).To(func(_ context.Context, _ string) (*grpc.ClientConn, error) {
+			return nil, errors.New("socket file does not exist: /run/crio/crio.sock")
+		}).Build()
+		assert.False(t, CheckCRIORunning(context.Background()))
+	})
+}
+
 func TestCheckSocketExists_WithMockey(t *testing.T) {
 	mockey.PatchConvey("CheckSocketExists respects Stat results", t, func() {
 		tempFile, err := os.CreateTemp("", "containerd-sock")

--- a/deployments/helm/gpud/README.md
+++ b/deployments/helm/gpud/README.md
@@ -170,13 +170,26 @@ gpud:
   # Both use hostPath DirectoryOrCreate, so the pod still starts without containerd.
   mountContainerd: true
 
+  # Bind-mount the host's CRI-O dir (default true):
+  #   /run/crio (read-write)        -> crio.sock CRI endpoint, dialed to detect
+  #                                    that CRI-O is the node's runtime so a
+  #                                    missing containerd socket is not
+  #                                    misreported as unhealthy
+  mountCrio: true
+
   # Check whether the host's containerd service is active (exit code 0 = active),
   # mapped to "gpud run --containerd-service-active-commands".
   containerdServiceActiveCommands: "nsenter --target 1 --mount -- systemctl is-active containerd"
 ```
 
-Set `gpud.mountContainerd: false` and `gpud.containerdServiceActiveCommands: ""`
-on nodes that do not run containerd (e.g. docker or cri-o only).
+On nodes that run CRI-O instead of containerd, keep `gpud.mountCrio: true`
+(the default): the component dials the CRI endpoint at `/run/crio/crio.sock`
+to recognize a live CRI-O node and treats the absent containerd socket as
+expected, not unhealthy. Leaving the default on nodes without CRI-O is also
+safe: the mount creates an empty `/run/crio`, gpud finds no `crio.sock`, and
+the containerd check behaves as before. On nodes that run neither containerd
+nor CRI-O, set `gpud.mountContainerd: false` and
+`gpud.containerdServiceActiveCommands: ""`.
 
 ### Session Token from a Secret
 

--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -178,6 +178,22 @@ spec:
             path: /etc/containerd
             type: DirectoryOrCreate
         {{- end }}
+
+        {{- if .Values.gpud.mountCrio }}
+        # Host CRI-O runtime directory (holds crio.sock).
+        # Required by: components/containerd (dial the CRI endpoint at
+        # unix:///run/crio/crio.sock to detect that CRI-O is the node's
+        # container runtime, and skip the containerd check instead of
+        # reporting a missing containerd socket as unhealthy).
+        # DirectoryOrCreate so the pod still starts on nodes without CRI-O:
+        # kubelet creates an empty /run/crio on such hosts, gpud finds no
+        # crio.sock there, and the containerd check runs exactly as it would
+        # without this mount.
+        - name: host-run-crio
+          hostPath:
+            path: /run/crio
+            type: DirectoryOrCreate
+        {{- end }}
       {{- if .Values.extraVolumes }}
       {{- toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
@@ -579,6 +595,15 @@ spec:
             - name: host-etc-containerd
               mountPath: /etc/containerd
               readOnly: true
+            {{- end }}
+
+            {{- if .Values.gpud.mountCrio }}
+            # Host CRI-O socket directory for the containerd component's CRI-O
+            # detection. Mounted at the same path gpud expects
+            # (/run/crio/crio.sock). Not read-only: connecting to the CRI unix
+            # socket requires write access (same reason /run/containerd is rw).
+            - name: host-run-crio
+              mountPath: /run/crio
             {{- end }}
           {{- if .Values.extraVolumeMounts }}
           {{- toYaml .Values.extraVolumeMounts | nindent 12 }}

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -170,6 +170,24 @@ gpud:
   # Set to false on nodes that do not run containerd (e.g. docker/cri-o only).
   mountContainerd: true
 
+  # Mount the host CRI-O runtime directory (/run/crio, read-write so the CRI
+  # unix socket can be dialed) so the containerd component can detect that
+  # CRI-O is the node's container runtime. On a CRI-O node the containerd
+  # socket is expected to be absent; without this mount the component cannot
+  # reach the CRI-O socket from inside the pod and would report the node
+  # unhealthy for a missing containerd socket that is not actually a failure.
+  #
+  # Leaving this at the default true on a node without CRI-O is safe.
+  # DirectoryOrCreate makes kubelet create an empty /run/crio on the host, so
+  # the pod starts normally; gpud then finds no crio.sock, the CRI-O probe
+  # reports "not running", and the containerd check behaves exactly as if this
+  # mount did not exist. The only side effect is the empty /run/crio directory
+  # left on the host. On nodes where the containerd socket does exist, the
+  # CRI-O probe is never called at all.
+  #
+  # Set to false only if the node group uses a non-standard CRI-O socket path.
+  mountCrio: true
+
   # Mount /dev/mem for deep hardware inspection and memory diagnostics (e.g., PCIe config space).
   # Defaults to false for maximum compatibility across platforms (addresses issue #1144).
   # Set to true if you need deep memory inspection and your environment supports /dev/mem.

--- a/pkg/machine-info/machine_info.go
+++ b/pkg/machine-info/machine_info.go
@@ -116,6 +116,22 @@ func GetMachineInfo(nvmlInstance nvidianvml.Instance) (*apiv1.MachineInfo, error
 			}
 		}
 
+		// On a CRI-O node the containerd binary is installed but not running,
+		// so the block above leaves the runtime version empty even though the
+		// node has a live runtime. Fall back to CRI-O so the reported runtime
+		// reflects what actually runs the node's containers (LEP-6128).
+		if info.ContainerRuntimeVersion == "" && componentcontainerd.CheckCRIORunning(ctx) {
+			crioVersion, err := componentcontainerd.GetVersion(ctx, componentcontainerd.DefaultCRIOEndpoint)
+			if err != nil {
+				log.Logger.Warnw("failed to check cri-o version", "error", err)
+			} else {
+				if !strings.HasPrefix(crioVersion, "cri-o://") {
+					crioVersion = "cri-o://" + crioVersion
+				}
+				info.ContainerRuntimeVersion = crioVersion
+			}
+		}
+
 		// Collect tailscale version if installed
 		if componenttailscale.CheckTailscaleInstalled() {
 			tailscaleVersion, err := componenttailscale.GetTailscaleVersion()

--- a/pkg/machine-info/mock_machine_info_coverage_test.go
+++ b/pkg/machine-info/mock_machine_info_coverage_test.go
@@ -445,6 +445,10 @@ func TestGetMachineInfo_LinuxBranches_WithMockey(t *testing.T) {
 		mockey.Mock(componentcontainerd.GetVersion).To(func(ctx context.Context, endpoint string) (string, error) {
 			return "", errors.New("containerd version failed")
 		}).Build()
+		// Pin CRI-O detection so this test stays host-independent: with
+		// ContainerRuntimeVersion empty, GetMachineInfo would otherwise probe
+		// the host's real CRI-O endpoint and could set the version on a CRI-O box.
+		mockey.Mock(componentcontainerd.CheckCRIORunning).To(func(ctx context.Context) bool { return false }).Build()
 		mockey.Mock(componenttailscale.CheckTailscaleInstalled).To(func() bool { return true }).Build()
 		mockey.Mock(componenttailscale.GetTailscaleVersion).To(func() (string, error) {
 			return "", errors.New("tailscale version failed")
@@ -455,5 +459,78 @@ func TestGetMachineInfo_LinuxBranches_WithMockey(t *testing.T) {
 		require.NotNil(t, info)
 		assert.Equal(t, "", info.ContainerRuntimeVersion)
 		assert.Equal(t, "", info.TailscaleVersion)
+	})
+
+	mockey.PatchConvey("GetMachineInfo falls back to CRI-O version when containerd is absent", t, func() {
+		mockey.Mock(currentGOOS).To(func() string { return "linux" }).Build()
+		mockey.Mock(GetMachineGPUInfo).To(func(nvidianvml.Instance) (*apiv1.MachineGPUInfo, error) {
+			return &apiv1.MachineGPUInfo{}, nil
+		}).Build()
+		mockey.Mock(GetMachineDiskInfo).To(func(ctx context.Context) (*apiv1.MachineDiskInfo, error) {
+			return &apiv1.MachineDiskInfo{}, nil
+		}).Build()
+		// containerd binary present but not running (CRI-O node): containerd
+		// version stays empty, so the CRI-O fallback must supply the runtime.
+		mockey.Mock(componentcontainerd.CheckContainerdInstalled).To(func() bool { return true }).Build()
+		mockey.Mock(componentcontainerd.CheckContainerdRunning).To(func(ctx context.Context) bool { return false }).Build()
+		mockey.Mock(componentcontainerd.CheckCRIORunning).To(func(ctx context.Context) bool { return true }).Build()
+		mockey.Mock(componentcontainerd.GetVersion).To(func(ctx context.Context, endpoint string) (string, error) {
+			if endpoint == componentcontainerd.DefaultCRIOEndpoint {
+				return "1.30.3", nil
+			}
+			return "", errors.New("containerd endpoint unreachable")
+		}).Build()
+		mockey.Mock(componenttailscale.CheckTailscaleInstalled).To(func() bool { return false }).Build()
+
+		info, err := GetMachineInfo(baseNVML)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "cri-o://1.30.3", info.ContainerRuntimeVersion)
+	})
+
+	mockey.PatchConvey("GetMachineInfo keeps runtime empty when the CRI-O version lookup fails", t, func() {
+		mockey.Mock(currentGOOS).To(func() string { return "linux" }).Build()
+		mockey.Mock(GetMachineGPUInfo).To(func(nvidianvml.Instance) (*apiv1.MachineGPUInfo, error) {
+			return &apiv1.MachineGPUInfo{}, nil
+		}).Build()
+		mockey.Mock(GetMachineDiskInfo).To(func(ctx context.Context) (*apiv1.MachineDiskInfo, error) {
+			return &apiv1.MachineDiskInfo{}, nil
+		}).Build()
+		// CRI-O is live but its Version RPC fails: the runtime must stay empty
+		// rather than report a version we never actually read.
+		mockey.Mock(componentcontainerd.CheckContainerdInstalled).To(func() bool { return false }).Build()
+		mockey.Mock(componentcontainerd.CheckContainerdRunning).To(func(ctx context.Context) bool { return false }).Build()
+		mockey.Mock(componentcontainerd.CheckCRIORunning).To(func(ctx context.Context) bool { return true }).Build()
+		mockey.Mock(componentcontainerd.GetVersion).To(func(ctx context.Context, endpoint string) (string, error) {
+			return "", errors.New("cri-o version failed")
+		}).Build()
+		mockey.Mock(componenttailscale.CheckTailscaleInstalled).To(func() bool { return false }).Build()
+
+		info, err := GetMachineInfo(baseNVML)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "", info.ContainerRuntimeVersion)
+	})
+
+	mockey.PatchConvey("GetMachineInfo does not double-prefix an already-prefixed CRI-O version", t, func() {
+		mockey.Mock(currentGOOS).To(func() string { return "linux" }).Build()
+		mockey.Mock(GetMachineGPUInfo).To(func(nvidianvml.Instance) (*apiv1.MachineGPUInfo, error) {
+			return &apiv1.MachineGPUInfo{}, nil
+		}).Build()
+		mockey.Mock(GetMachineDiskInfo).To(func(ctx context.Context) (*apiv1.MachineDiskInfo, error) {
+			return &apiv1.MachineDiskInfo{}, nil
+		}).Build()
+		mockey.Mock(componentcontainerd.CheckContainerdInstalled).To(func() bool { return false }).Build()
+		mockey.Mock(componentcontainerd.CheckContainerdRunning).To(func(ctx context.Context) bool { return false }).Build()
+		mockey.Mock(componentcontainerd.CheckCRIORunning).To(func(ctx context.Context) bool { return true }).Build()
+		mockey.Mock(componentcontainerd.GetVersion).To(func(ctx context.Context, endpoint string) (string, error) {
+			return "cri-o://1.31.0", nil
+		}).Build()
+		mockey.Mock(componenttailscale.CheckTailscaleInstalled).To(func() bool { return false }).Build()
+
+		info, err := GetMachineInfo(baseNVML)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "cri-o://1.31.0", info.ContainerRuntimeVersion)
 	})
 }


### PR DESCRIPTION
BYOK Kubernetes clusters that use CRI-O still ship the containerd binary (the gpud image installs containerd.io), but containerd is never started and its socket never appears. The component treated "binary installed" as "must be healthy", so after five consecutive socket misses it marked the node Unhealthy even though nothing was wrong.

Check now treats a live CRI-O endpoint as the node's runtime signal: when the containerd socket is missing but CRI-O answers a real CRI connection at unix:///run/crio/crio.sock, containerd is not applicable, the missing-socket counter resets, and the node stays Healthy. CRI-O is dialed rather than socket-stat'd so a stale socket left by a crashed CRI-O cannot spoof a containerd node into skipping a genuine containerd outage. When neither runtime answers, the original consecutive-failure behavior is unchanged, and a running containerd is checked as before.

Because BYOK runs gpud as a containerized DaemonSet, the host's CRI-O socket is not visible inside the pod. The chart now mounts the host /run/crio directory read-write (gpud.mountCrio, default true) so the detection can dial it; DirectoryOrCreate keeps the pod starting on non-CRI-O nodes.

GetMachineInfo also falls back to the CRI-O endpoint for the reported container-runtime version, so a CRI-O node no longer reports an empty runtime.

Adds tests for the CRI-O skip, the preserved failure path, the both-runtimes case, the CRI-O-to-containerd transition, and the machine-info CRI-O version fallback, and pins CRI-O detection in the host-dependent integration tests so they stay hermetic.