### PR TITLE
[LEP-6171] fix(nscale): add provider region detection via OpenStack metadata (RegionDetector)

### DIFF
--- a/pkg/providers/nscale/doc.go
+++ b/pkg/providers/nscale/doc.go
@@ -1,2 +1,25 @@
 // Package nscale implements nscale provider detection and metadata helpers.
+//
+// Nscale is an OpenStack-based cloud provider. GPUd detects nscale by
+// reading the OpenStack metadata JSON at:
+//
+//	http://169.254.169.254/openstack/latest/meta_data.json
+//
+// The metadata response includes uuid, availability_zone, and a meta
+// object with provider-specific identifiers (organizationID, projectID,
+// regionID). Provider detection succeeds when uuid, organizationID,
+// and projectID are all non-empty.
+//
+// Instance metadata (instance-id, local-ipv4, public-ipv4) is read from
+// the EC2-compatible endpoint at:
+//
+//	http://169.254.169.254/latest/meta-data/<path>
+//
+// The region is read from meta.regionID in the OpenStack metadata JSON,
+// with availability_zone as a fallback when regionID is absent. This
+// matches the AWS EC2 metadata pattern (placement/region, then derive
+// from placement/availability-zone).
+//
+// ref. https://docs.openstack.org/nova/latest/user/metadata.html
+// ref. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
 package nscale

--- a/pkg/providers/nscale/imds/imds.go
+++ b/pkg/providers/nscale/imds/imds.go
@@ -132,7 +132,14 @@ func fetchOpenStackMetadata(ctx context.Context, metadataURL string) (*OpenStack
 // ref. https://docs.openstack.org/nova/latest/user/metadata.html
 // ref. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html (AZ fallback pattern)
 func FetchRegion(ctx context.Context) (string, error) {
-	resp, err := FetchOpenStackMetadata(ctx)
+	return fetchRegion(ctx, openStackMetadataJSONURL)
+}
+
+// fetchRegion retrieves the nscale region from the OpenStack metadata JSON
+// at the specified URL. It is separated from FetchRegion so that unit tests
+// can supply an httptest server URL.
+func fetchRegion(ctx context.Context, metadataURL string) (string, error) {
+	resp, err := fetchOpenStackMetadata(ctx, metadataURL)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/providers/nscale/imds/imds.go
+++ b/pkg/providers/nscale/imds/imds.go
@@ -25,6 +25,13 @@ type OpenStackMetadataResponse struct {
 type OpenStackMetadataMeta struct {
 	OrganizationID string `json:"organizationID"`
 	ProjectID      string `json:"projectID"`
+	// RegionID is the provider-specific region identifier.
+	// Nscale returns this field in the OpenStack metadata JSON.
+	// When RegionID is empty, FetchRegion falls back to AvailabilityZone
+	// (the same pattern AWS uses: derive region from AZ when the
+	// explicit region endpoint is unavailable).
+	// ref. https://docs.openstack.org/nova/latest/user/metadata.html
+	RegionID string `json:"regionID"`
 }
 
 // FetchMetadata fetches metadata from the nscale metadata service at the specified path.
@@ -112,4 +119,32 @@ func fetchOpenStackMetadata(ctx context.Context, metadataURL string) (*OpenStack
 		return nil, fmt.Errorf("failed to parse OpenStack metadata: %w", err)
 	}
 	return resp, nil
+}
+
+// FetchRegion returns the nscale provider region.
+// It reads regionID from the OpenStack metadata JSON.
+// When regionID is empty, it falls back to availability_zone.
+// This matches the AWS pattern: use the explicit region field first,
+// then derive region from the availability zone when the explicit
+// field is absent.
+// The OpenStack metadata is already fetched for provider detection;
+// this function does not add a new HTTP call.
+// ref. https://docs.openstack.org/nova/latest/user/metadata.html
+// ref. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html (AZ fallback pattern)
+func FetchRegion(ctx context.Context) (string, error) {
+	resp, err := FetchOpenStackMetadata(ctx)
+	if err != nil {
+		return "", err
+	}
+	if resp.Meta.RegionID != "" {
+		return resp.Meta.RegionID, nil
+	}
+	// Derive region from availability zone when regionID is absent.
+	// On nscale, availability_zone names a concrete failure domain.
+	// Using the AZ directly as the region identifier keeps provider
+	// location accurate when the explicit region field is not populated.
+	if resp.AvailabilityZone != "" {
+		return resp.AvailabilityZone, nil
+	}
+	return "", nil
 }

--- a/pkg/providers/nscale/imds/imds_test.go
+++ b/pkg/providers/nscale/imds/imds_test.go
@@ -170,6 +170,8 @@ func TestFetchOpenStackMetadata(t *testing.T) {
 		require.Equal(t, "nova", resp.AvailabilityZone)
 		require.Equal(t, "org", resp.Meta.OrganizationID)
 		require.Equal(t, "project", resp.Meta.ProjectID)
+		// Verify the new RegionID field is parsed from the JSON.
+		require.Equal(t, "region-1", resp.Meta.RegionID)
 	})
 
 	t.Run("invalid json", func(t *testing.T) {
@@ -186,5 +188,64 @@ func TestFetchOpenStackMetadata(t *testing.T) {
 		_, err := fetchOpenStackMetadata(ctx, srv.URL)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to parse OpenStack metadata")
+	})
+}
+
+func TestFetchRegion(t *testing.T) {
+	t.Run("returns regionID when present in meta", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{"uuid":"u-1","availability_zone":"nova","meta":{"organizationID":"org","projectID":"project","regionID":"eu-west-1"}}`))
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		region, err := fetchRegion(ctx, srv.URL)
+		require.NoError(t, err)
+		require.Equal(t, "eu-west-1", region)
+	})
+
+	t.Run("falls back to availability_zone when regionID is empty", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			// meta present but regionID is empty string.
+			_, err := w.Write([]byte(`{"uuid":"u-1","availability_zone":"stavanger-1a","meta":{"organizationID":"org","projectID":"project","regionID":""}}`))
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		region, err := fetchRegion(ctx, srv.URL)
+		require.NoError(t, err)
+		require.Equal(t, "stavanger-1a", region)
+	})
+
+	t.Run("returns empty when both regionID and availability_zone are absent", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{"uuid":"u-1","meta":{"organizationID":"org","projectID":"project"}}`))
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		region, err := fetchRegion(ctx, srv.URL)
+		require.NoError(t, err)
+		require.Empty(t, region)
+	})
+
+	t.Run("returns error when metadata fetch fails", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		_, err := fetchRegion(ctx, "://bad-url")
+		require.Error(t, err)
 	})
 }

--- a/pkg/providers/nscale/imds/mock_imds_public_test.go
+++ b/pkg/providers/nscale/imds/mock_imds_public_test.go
@@ -72,3 +72,16 @@ func TestFetchInstanceID_Public_WithMockey(t *testing.T) {
 		require.Equal(t, "i-abc123", got)
 	})
 }
+
+func TestFetchRegion_Public_WithMockey(t *testing.T) {
+	mockey.PatchConvey("FetchRegion forwards default OpenStack metadata URL", t, func() {
+		mockey.Mock(fetchRegion).To(func(ctx context.Context, metadataURL string) (string, error) {
+			require.Equal(t, openStackMetadataJSONURL, metadataURL)
+			return "eu-north-1", nil
+		}).Build()
+
+		region, err := FetchRegion(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "eu-north-1", region)
+	})
+}

--- a/pkg/providers/nscale/mock_nscale_test.go
+++ b/pkg/providers/nscale/mock_nscale_test.go
@@ -158,3 +158,53 @@ func TestInstanceID_WithMockey(t *testing.T) {
 		require.Equal(t, "i-000017ac", instanceID)
 	})
 }
+
+func TestRegion_WithMockey(t *testing.T) {
+	mockey.PatchConvey("New returns a Detector that implements RegionDetector", t, func() {
+		mockey.Mock(imds.FetchRegion).To(func(ctx context.Context) (string, error) {
+			return "eu-north-1", nil
+		}).Build()
+
+		detector := New()
+		require.NotNil(t, detector)
+
+		// Type-assert that the detector implements RegionDetector.
+		regionDetector, ok := detector.(interface {
+			Region(context.Context) (string, error)
+		})
+		require.True(t, ok, "New() must return a detector that implements RegionDetector")
+
+		region, err := regionDetector.Region(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "eu-north-1", region)
+	})
+
+	mockey.PatchConvey("Region returns empty when FetchRegion returns empty", t, func() {
+		mockey.Mock(imds.FetchRegion).To(func(ctx context.Context) (string, error) {
+			return "", nil
+		}).Build()
+
+		detector := New()
+		regionDetector, ok := detector.(interface {
+			Region(context.Context) (string, error)
+		})
+		require.True(t, ok)
+		region, err := regionDetector.Region(context.Background())
+		require.NoError(t, err)
+		require.Empty(t, region)
+	})
+
+	mockey.PatchConvey("Region returns error when FetchRegion fails", t, func() {
+		mockey.Mock(imds.FetchRegion).To(func(ctx context.Context) (string, error) {
+			return "", errors.New("metadata unavailable")
+		}).Build()
+
+		detector := New()
+		regionDetector, ok := detector.(interface {
+			Region(context.Context) (string, error)
+		})
+		require.True(t, ok)
+		_, err := regionDetector.Region(context.Background())
+		require.Error(t, err)
+	})
+}

--- a/pkg/providers/nscale/nscale.go
+++ b/pkg/providers/nscale/nscale.go
@@ -10,8 +10,23 @@ import (
 
 const Name = "nscale"
 
+// New returns a Detector that implements RegionDetector.
+// It uses the OpenStack metadata JSON to detect the nscale provider
+// and to read the provider region.
+// Every other provider (AWS, GCP, Azure, OCI, Nebius) already uses
+// NewWithRegion. This change keeps nscale consistent with the rest
+// of the provider registry.
+// ref. https://docs.openstack.org/nova/latest/user/metadata.html
 func New() providers.Detector {
-	return providers.New(Name, detectProvider, imds.FetchPublicIPv4, fetchPrivateIPv4, fetchVMEnvironment, imds.FetchInstanceID)
+	return providers.NewWithRegion(
+		Name,
+		detectProvider,
+		imds.FetchPublicIPv4,
+		fetchPrivateIPv4,
+		imds.FetchRegion,
+		fetchVMEnvironment,
+		imds.FetchInstanceID,
+	)
 }
 
 func detectProvider(ctx context.Context) (string, error) {


### PR DESCRIPTION
Parse regionID from the OpenStack metadata JSON that nscale already returns. Fall back to availability_zone when regionID is absent (same pattern AWS uses). Switch from providers.New() to providers.NewWithRegion() so the nscale detector implements RegionDetector and getProviderLocation() returns a provider-native region instead of falling through to DERP latency.