### PR TITLE
[LEP-6171] feat(login): add --region flag and unknown-region fallback

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -106,6 +106,10 @@ nohup sudo gpud run &>> <your log file path> &
 					Usage: "(optional) can specify public ip for machine",
 				},
 				cli.StringFlag{
+					Name:  "region",
+					Usage: "(optional) override the region reported in the login request; skips provider-metadata and DERP-latency region detection",
+				},
+				cli.StringFlag{
 					Name:   "machine-id",
 					Hidden: true,
 					Usage:  "(optional) machine id to register/run as. If it matches the machine id already persisted in the state DB, login is skipped (reused across reboots). If it DIFFERS from the persisted one, login fails unless --machine-id-overwrite is set -- this prevents silently retargeting an already-registered node.",

--- a/cmd/gpud/up/command.go
+++ b/cmd/gpud/up/command.go
@@ -82,6 +82,7 @@ func Command(cliContext *cli.Context) (retErr error) {
 
 			PublicIP:  cliContext.String("public-ip"),
 			PrivateIP: cliContext.String("private-ip"),
+			Region:    cliContext.String("region"),
 		}
 
 		if lerr := login.Login(loginCtx, loginCfg); lerr != nil {

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	apiv1 "github.com/leptonai/gpud/api/v1"
 	cmdcommon "github.com/leptonai/gpud/cmd/common"
 	"github.com/leptonai/gpud/pkg/config"
 	"github.com/leptonai/gpud/pkg/log"
@@ -67,6 +68,13 @@ type LoginConfig struct {
 
 	PublicIP  string // optional: overrides detected public IP
 	PrivateIP string // optional: overrides detected private IP
+
+	// Region optionally overrides the region reported in the login request
+	// (Location.Region). When set, it takes precedence over both the
+	// provider-native region (e.g., IMDS regionID) and the DERP-latency
+	// fallback. Useful when the provider metadata exposes no human-readable
+	// region name (e.g., nscale reports an opaque region UUID).
+	Region string
 }
 
 // Login performs the login operation with the control plane.
@@ -304,6 +312,13 @@ func Login(ctx context.Context, cfg LoginConfig) error {
 
 	if cfg.PrivateIP != "" { // overwrite if not empty
 		req.Network.PrivateIP = cfg.PrivateIP
+	}
+
+	if cfg.Region != "" { // overwrite if not empty
+		if req.Location == nil {
+			req.Location = &apiv1.MachineLocation{}
+		}
+		req.Location.Region = cfg.Region
 	}
 
 	// machine ID has not been assigned yet

--- a/pkg/login/mock_login_test.go
+++ b/pkg/login/mock_login_test.go
@@ -1742,3 +1742,120 @@ func TestSendRequestWrapper_SendRequestError(t *testing.T) {
 		assert.Nil(t, resp)
 	})
 }
+
+// TestLogin_RegionOverride verifies that LoginConfig.Region overrides the login
+// request location regardless of what provider detection or the DERP-latency
+// fallback produced, and that an empty override leaves the detected location
+// untouched.
+func TestLogin_RegionOverride(t *testing.T) {
+	type step struct {
+		name           string
+		regionOverride string
+		detected       *apiv1.MachineLocation
+		wantRegion     string
+		wantNilLoc     bool
+	}
+	steps := []step{
+		{
+			name:           "overrides provider-native region",
+			regionOverride: "eu-north-1",
+			detected:       &apiv1.MachineLocation{Region: "d0ba550d-1be4-4c4e-8ef9-3adb23b3fe3b"},
+			wantRegion:     "eu-north-1",
+		},
+		{
+			name:           "sets location when detection returned none",
+			regionOverride: "eu-north-1",
+			detected:       nil,
+			wantRegion:     "eu-north-1",
+		},
+		{
+			name:           "empty override keeps detected region",
+			regionOverride: "",
+			detected:       &apiv1.MachineLocation{Region: "us-west-2"},
+			wantRegion:     "us-west-2",
+		},
+		{
+			name:           "empty override with no detected location stays nil",
+			regionOverride: "",
+			detected:       nil,
+			wantNilLoc:     true,
+		},
+	}
+
+	for _, tc := range steps {
+		t.Run(tc.name, func(t *testing.T) {
+			mockey.PatchConvey("login region override", t, func() {
+				mockDB := &sql.DB{}
+
+				mockey.Mock(config.ResolveDataDir).To(func(_ string) (string, error) {
+					return "/tmp/test", nil
+				}).Build()
+				mockey.Mock(sqlite.Open).To(func(_ string, _ ...sqlite.OpOption) (*sql.DB, error) {
+					return mockDB, nil
+				}).Build()
+				mockey.Mock((*sql.DB).Close).To(func(*sql.DB) error {
+					return nil
+				}).Build()
+				mockey.Mock(pkgmetadata.CreateTableMetadata).To(func(context.Context, *sql.DB) error {
+					return nil
+				}).Build()
+				mockey.Mock(sessionstates.CreateTable).To(func(context.Context, *sql.DB) error {
+					return nil
+				}).Build()
+				mockey.Mock(pkgmetadata.ReadMachineID).To(func(context.Context, *sql.DB) (string, error) {
+					return "", nil
+				}).Build()
+				mockey.Mock(pkgmetadata.ReadMetadata).To(func(context.Context, *sql.DB, string) (string, error) {
+					return "", nil
+				}).Build()
+				mockey.Mock(nvidianvml.New).To(func() (nvidianvml.Instance, error) {
+					return nvidianvml.NewNoOp(), nil
+				}).Build()
+				mockey.Mock((nvidianvml.Instance).Shutdown).To(func() error {
+					return nil
+				}).Build()
+
+				mockey.Mock(pkgmachineinfo.CreateLoginRequest).To(func(_, _, _, _ string, _ nvidianvml.Instance) (*apiv1.LoginRequest, error) {
+					return &apiv1.LoginRequest{
+						Network:  &apiv1.MachineNetwork{},
+						Location: tc.detected,
+					}, nil
+				}).Build()
+
+				var receivedRequest apiv1.LoginRequest
+				mockey.Mock(SendRequest).To(func(_ context.Context, _ string, req apiv1.LoginRequest) (*apiv1.LoginResponse, error) {
+					receivedRequest = req
+					return &apiv1.LoginResponse{
+						MachineID: "new-machine-id",
+						Token:     "session-token",
+					}, nil
+				}).Build()
+
+				mockey.Mock(pkgmetadata.SetMetadata).To(func(context.Context, *sql.DB, string, string) error {
+					return nil
+				}).Build()
+				mockey.Mock(config.FifoFilePath).To(func(string) string {
+					return "/tmp/test/fifo"
+				}).Build()
+				mockey.Mock(serverRunning).To(func() bool {
+					return false
+				}).Build()
+
+				err := Login(context.Background(), LoginConfig{
+					Token:    "test-token",
+					Endpoint: "https://example.com",
+					DataDir:  "/tmp/test",
+					Region:   tc.regionOverride,
+				})
+				require.NoError(t, err)
+
+				if tc.wantNilLoc {
+					assert.Nil(t, receivedRequest.Location)
+					return
+				}
+				require.NotNil(t, receivedRequest.Location)
+				assert.Equal(t, tc.wantRegion, receivedRequest.Location.Region)
+			})
+		})
+	}
+}

--- a/pkg/machine-info/login_request.go
+++ b/pkg/machine-info/login_request.go
@@ -14,6 +14,13 @@ import (
 	"github.com/leptonai/gpud/pkg/providers"
 )
 
+// RegionUnknown is reported as the login request region when neither the
+// provider metadata (e.g., IMDS unsupported or unreachable) nor the
+// DERP-latency fallback produced one. Matches the "unknown" provider
+// convention in GetProvider, and gives downstream consumers (e.g., node
+// region label propagation) a stable non-empty value.
+const RegionUnknown = "unknown"
+
 func CreateLoginRequest(token string, machineID string, nodeGroup string, gpuCount string, nvmlInstance nvidianvml.Instance) (*apiv1.LoginRequest, error) {
 	return createLoginRequest(
 		token,
@@ -150,6 +157,19 @@ func createLoginRequest(
 		req.Location = providerLocation
 	} else if machineLocationCh != nil {
 		req.Location = <-machineLocationCh
+	}
+
+	// Never report an empty region: when the provider metadata lookup
+	// failed or is unsupported AND the DERP-latency fallback also failed,
+	// mark the region "unknown" so downstream region consumers (e.g.,
+	// node region label propagation) see a stable value instead of "". An
+	// explicit region override (e.g., "gpud up --region") is applied by
+	// the caller after this and still takes precedence.
+	if req.Location == nil {
+		req.Location = &apiv1.MachineLocation{}
+	}
+	if strings.TrimSpace(req.Location.Region) == "" {
+		req.Location.Region = RegionUnknown
 	}
 
 	return req, nil

--- a/pkg/machine-info/login_request_test.go
+++ b/pkg/machine-info/login_request_test.go
@@ -1199,6 +1199,72 @@ func TestCreateLoginRequest_ProviderRegionOverridesLatencyLocation(t *testing.T)
 	assert.False(t, machineLocationCalled)
 }
 
+// TestCreateLoginRequest_UnknownRegionFallback verifies that the login request
+// reports region "unknown" (never empty) when the provider metadata lookup
+// failed or is unsupported AND the DERP-latency fallback also failed.
+func TestCreateLoginRequest_UnknownRegionFallback(t *testing.T) {
+	getMachineInfoFunc := func(nvidianvml.Instance) (*apiv1.MachineInfo, error) {
+		return &apiv1.MachineInfo{
+			CPUInfo:    &apiv1.MachineCPUInfo{LogicalCores: 4},
+			MemoryInfo: &apiv1.MachineMemoryInfo{TotalBytes: 16 * 1024 * 1024 * 1024},
+			NICInfo:    &apiv1.MachineNICInfo{},
+		}, nil
+	}
+
+	steps := []struct {
+		name              string
+		getProviderFunc   func(string) *providers.Info
+		getMachineLocFunc func() *apiv1.MachineLocation
+	}{
+		{
+			name: "provider without region and DERP returns nil",
+			getProviderFunc: func(ip string) *providers.Info {
+				return &providers.Info{Provider: "nscale", PublicIP: ip, PrivateIP: "7.247.195.146", InstanceID: "i-00001923"}
+			},
+			getMachineLocFunc: func() *apiv1.MachineLocation { return nil },
+		},
+		{
+			// mirrors real GetProvider behavior: returns Info{Provider: "unknown"}
+			// with no region when no provider is detected (never returns nil)
+			name: "provider unsupported and DERP returns nil",
+			getProviderFunc: func(string) *providers.Info {
+				return &providers.Info{Provider: "unknown"}
+			},
+			getMachineLocFunc: func() *apiv1.MachineLocation { return nil },
+		},
+		{
+			name: "provider region empty and DERP returns empty region",
+			getProviderFunc: func(ip string) *providers.Info {
+				return &providers.Info{Provider: "nscale", PublicIP: ip, Region: "  "}
+			},
+			getMachineLocFunc: func() *apiv1.MachineLocation { return &apiv1.MachineLocation{} },
+		},
+	}
+
+	for _, tc := range steps {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := createLoginRequest(
+				"token",
+				"machine-id",
+				"",
+				"1",
+				&mockNvmlInstance{},
+				func() (string, error) { return "46.148.127.98", nil },
+				tc.getMachineLocFunc,
+				getMachineInfoFunc,
+				tc.getProviderFunc,
+				func() (string, error) { return "100Gi", nil },
+				func(nvidianvml.Instance) (string, error) { return "1", nil },
+			)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, req)
+			assert.NotNil(t, req.Location)
+			assert.Equal(t, RegionUnknown, req.Location.Region)
+		})
+	}
+}
+
 func TestGetProviderLocation(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Some providers expose no human-readable region in instance metadata. nscale OpenStack IMDS returns only an opaque regionID UUID (and an unconfigured availability_zone of nova), so the provider-native region detector reports a UUID while the previous behavior derived a human-looking region from DERP-latency proximity.

Two changes to the login request region handling:

1. Add gpud up --region to let provisioning tooling (which knows the real region name) override Location.Region, following the existing --public-ip/--private-ip override pattern. When set, it takes precedence over both the provider-native region and the DERP-latency fallback.

2. Report region as unknown instead of empty when the provider metadata lookup failed or is unsupported AND the DERP-latency fallback also failed. Previously this case sent no location at all, and downstream node region labels (e.g., lepton.ai/provider-region) were never written, leaving dependent init containers stuck indefinitely. Matches the existing unknown provider convention.