### PR TITLE
feat(session): add nodeCredentials for control-plane credential delivery

### DIFF
--- a/pkg/session/kap_mtls.go
+++ b/pkg/session/kap_mtls.go
@@ -104,6 +104,14 @@ func redactSessionCredentials(value any) {
 				}
 				continue
 			}
+			if strings.EqualFold(key, "node_credentials") {
+				// Every file under here is credential material, and the
+				// per-subsystem grouping means new kinds appear without this
+				// function being touched. Redact the whole subtree rather than
+				// naming fields that will drift.
+				typed[key] = "<redacted>"
+				continue
+			}
 			redactSessionCredentials(child)
 		}
 	case []any:

--- a/pkg/session/node_credentials.go
+++ b/pkg/session/node_credentials.go
@@ -44,22 +44,39 @@ type NodeCredentialFile struct {
 	Mode uint32 `json:"mode,omitempty"`
 }
 
+// KubeletCredentials is what a kubelet needs to register. The fields are named
+// rather than a list, so each file's role is part of the contract instead of
+// something this side has to infer from a path.
+type KubeletCredentials struct {
+	// Config is the kubelet configuration, which carries the providerID.
+	Config *NodeCredentialFile `json:"config,omitempty"`
+	// ClientCertificate is the client certificate and its private key, in the
+	// single file kubelet reads them from.
+	ClientCertificate *NodeCredentialFile `json:"client_certificate,omitempty"`
+}
+
 // NodeCredentialsRequest carries credential material for one node, grouped by
 // the subsystem that owns it. Grouping rather than flattening means a new kind
 // of credential is a new field, not a change to an existing one.
 type NodeCredentialsRequest struct {
-	// Kubelet is the material a kubelet needs to register: its client
-	// certificate and key, its config, and whatever else the control plane
-	// decides belongs with them.
-	Kubelet []NodeCredentialFile `json:"kubelet,omitempty"`
+	// Kubelet is the material a kubelet needs to register.
+	Kubelet *KubeletCredentials `json:"kubelet,omitempty"`
 }
 
-// Files returns every file in the request, in the order they should be written.
+// Files flattens the request into the order the files should be written. Every
+// named field a caller may set has to appear here, or the file it carries is
+// accepted by the wire format and then silently never written.
 func (r *NodeCredentialsRequest) Files() []NodeCredentialFile {
-	if r == nil {
+	if r == nil || r.Kubelet == nil {
 		return nil
 	}
-	return r.Kubelet
+	var files []NodeCredentialFile
+	for _, f := range []*NodeCredentialFile{r.Kubelet.Config, r.Kubelet.ClientCertificate} {
+		if f != nil {
+			files = append(files, *f)
+		}
+	}
+	return files
 }
 
 // processNodeCredentials writes credential material the control plane sends.

--- a/pkg/session/node_credentials.go
+++ b/pkg/session/node_credentials.go
@@ -1,0 +1,176 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// nodeCredentialsAllowedPrefixes bounds where the control plane may place
+// credential material.
+//
+// The destination travels in the request so that adding a credential kind, or
+// moving one, does not need a GPUd release. That generality is why the prefixes
+// exist: without them the method is an arbitrary root-owned file write, and a
+// control plane that is wrong or compromised could replace a unit file or an
+// authorized_keys. These two trees hold everything a node's identity is made
+// of and nothing that grants code execution on its own.
+var nodeCredentialsAllowedPrefixes = []string{
+	"/var/lib/gpud/",
+	"/etc/kubernetes/",
+}
+
+// allowedNodeCredentialPrefixes is a func so a test can point the allow-list at
+// a temporary directory and exercise the real validation rather than a copy of
+// it. Production always sees the list above.
+var allowedNodeCredentialPrefixes = func() []string { return nodeCredentialsAllowedPrefixes }
+
+// defaultNodeCredentialFileMode is what a credential gets when the request does
+// not say. Private keys are the common case, so the default is owner-only.
+const defaultNodeCredentialFileMode = 0o600
+
+// NodeCredentialFile is one file to place on the node.
+type NodeCredentialFile struct {
+	// Path is absolute and must fall under an allowed prefix.
+	Path string `json:"path"`
+	// Contents is the file body. Empty contents are rejected: a credential
+	// truncated to nothing looks like a successful write to the caller and
+	// fails much later, wherever the file is actually read.
+	Contents []byte `json:"contents"`
+	// Mode defaults to 0600 when zero.
+	Mode uint32 `json:"mode,omitempty"`
+}
+
+// NodeCredentialsRequest carries credential material for one node, grouped by
+// the subsystem that owns it. Grouping rather than flattening means a new kind
+// of credential is a new field, not a change to an existing one.
+type NodeCredentialsRequest struct {
+	// Kubelet is the material a kubelet needs to register: its client
+	// certificate and key, its config, and whatever else the control plane
+	// decides belongs with them.
+	Kubelet []NodeCredentialFile `json:"kubelet,omitempty"`
+}
+
+// Files returns every file in the request, in the order they should be written.
+func (r *NodeCredentialsRequest) Files() []NodeCredentialFile {
+	if r == nil {
+		return nil
+	}
+	return r.Kubelet
+}
+
+// processNodeCredentials writes credential material the control plane sends.
+//
+// It writes files and nothing else: it starts no process, installs no package
+// and restarts no service. Whatever consumes the material decides when to act
+// on it, which keeps this method safe to retry and safe to call on a node whose
+// state the control plane cannot see.
+//
+// Every file is validated before any file is written, so a request with one bad
+// path leaves the node exactly as it was rather than half-updated.
+func (s *Session) processNodeCredentials(_ context.Context, request Request, response *Response) {
+	if request.NodeCredentials == nil {
+		response.Error = "node credentials are required"
+		return
+	}
+
+	files := request.NodeCredentials.Files()
+	if len(files) == 0 {
+		response.Error = "node credentials contain no files"
+		return
+	}
+
+	for _, file := range files {
+		if err := validateNodeCredentialFile(file); err != nil {
+			response.Error = err.Error()
+			return
+		}
+	}
+
+	for _, file := range files {
+		if err := writeNodeCredentialFile(file); err != nil {
+			response.Error = err.Error()
+			return
+		}
+	}
+}
+
+func validateNodeCredentialFile(file NodeCredentialFile) error {
+	if file.Path == "" {
+		return errors.New("node credential path is required")
+	}
+	if !filepath.IsAbs(file.Path) {
+		return fmt.Errorf("node credential path %q must be absolute", file.Path)
+	}
+	// Compared after cleaning so that a path spelled with ".." cannot leave an
+	// allowed tree while still matching its prefix as written.
+	cleaned := filepath.Clean(file.Path)
+	allowed := false
+	prefixes := allowedNodeCredentialPrefixes()
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(cleaned, prefix) {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return fmt.Errorf("node credential path %q is outside %s",
+			file.Path, strings.Join(prefixes, ", "))
+	}
+	if len(file.Contents) == 0 {
+		return fmt.Errorf("node credential %q has no contents", file.Path)
+	}
+	return nil
+}
+
+// writeNodeCredentialFile publishes one file by renaming it into place, so a
+// reader either sees the previous contents or the new ones and never a partial
+// write. The staging file is created in the destination directory to keep the
+// rename on one filesystem, and with its final mode so the contents are never
+// briefly readable under a permissive umask.
+func writeNodeCredentialFile(file NodeCredentialFile) error {
+	path := filepath.Clean(file.Path)
+	mode := os.FileMode(defaultNodeCredentialFileMode)
+	if file.Mode != 0 {
+		mode = os.FileMode(file.Mode)
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create %s: %w", dir, err)
+	}
+
+	staged, err := os.CreateTemp(dir, ".node-credential-*")
+	if err != nil {
+		return fmt.Errorf("failed to stage %s: %w", path, err)
+	}
+	stagedPath := staged.Name()
+	defer func() {
+		_ = os.Remove(stagedPath)
+	}()
+
+	if err := staged.Chmod(mode); err != nil {
+		_ = staged.Close()
+		return fmt.Errorf("failed to set mode on %s: %w", path, err)
+	}
+	if _, err := staged.Write(file.Contents); err != nil {
+		_ = staged.Close()
+		return fmt.Errorf("failed to write %s: %w", path, err)
+	}
+	// Flushed before the rename: a rename that outlives the data would publish
+	// an empty file after a crash.
+	if err := staged.Sync(); err != nil {
+		_ = staged.Close()
+		return fmt.Errorf("failed to flush %s: %w", path, err)
+	}
+	if err := staged.Close(); err != nil {
+		return fmt.Errorf("failed to close staged %s: %w", path, err)
+	}
+	if err := os.Rename(stagedPath, path); err != nil {
+		return fmt.Errorf("failed to publish %s: %w", path, err)
+	}
+	return nil
+}

--- a/pkg/session/node_credentials_test.go
+++ b/pkg/session/node_credentials_test.go
@@ -1,0 +1,165 @@
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The destination travels in the request, so the prefix list is the only thing
+// standing between a wrong control plane and an arbitrary root-owned write.
+func TestValidateNodeCredentialFileRejectsPathsOutsideAllowedTrees(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"a unit file", "/etc/systemd/system/evil.service"},
+		{"an authorized_keys", "/root/.ssh/authorized_keys"},
+		{"a shell profile", "/etc/profile.d/evil.sh"},
+		{"a relative path", "var/lib/gpud/x"},
+		{"traversal out of an allowed tree", "/var/lib/gpud/../../etc/systemd/system/evil.service"},
+		{"a prefix that only looks allowed", "/var/lib/gpud-evil/x"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateNodeCredentialFile(NodeCredentialFile{Path: tc.path, Contents: []byte("x")})
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestValidateNodeCredentialFileAcceptsAllowedTrees(t *testing.T) {
+	for _, path := range []string{
+		"/var/lib/gpud/packages/kubelet/kubelet.yaml",
+		"/var/lib/gpud/packages/kubelet/kubelet-client-current.pem",
+		"/etc/kubernetes/pki/kubelet-client-current.pem",
+	} {
+		require.NoError(t, validateNodeCredentialFile(NodeCredentialFile{Path: path, Contents: []byte("x")}), path)
+	}
+}
+
+// A credential truncated to nothing looks like a successful write to the caller
+// and fails wherever the file is read, which is much further from the cause.
+func TestValidateNodeCredentialFileRejectsEmptyContents(t *testing.T) {
+	err := validateNodeCredentialFile(NodeCredentialFile{Path: "/var/lib/gpud/x", Contents: nil})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no contents")
+}
+
+// One bad path must leave the node exactly as it was, not half-updated. The
+// good file is listed first so that a per-file validate-then-write loop would
+// have created it before reaching the bad one.
+func TestProcessNodeCredentialsWritesNothingWhenAnyFileIsRejected(t *testing.T) {
+	dir := t.TempDir()
+	previous := allowedNodeCredentialPrefixes
+	allowedNodeCredentialPrefixes = func() []string { return []string{dir + "/"} }
+	t.Cleanup(func() { allowedNodeCredentialPrefixes = previous })
+
+	good := filepath.Join(dir, "good.pem")
+
+	session := &Session{}
+	response := &Response{}
+	session.processNodeCredentials(context.Background(), Request{
+		NodeCredentials: &NodeCredentialsRequest{Kubelet: []NodeCredentialFile{
+			{Path: good, Contents: []byte("first")},
+			{Path: "/etc/systemd/system/evil.service", Contents: []byte("second")},
+		}},
+	}, response)
+
+	require.NotEmpty(t, response.Error)
+	_, err := os.Stat(good)
+	assert.True(t, os.IsNotExist(err), "a rejected request must not write any file")
+}
+
+func TestProcessNodeCredentialsRequiresContent(t *testing.T) {
+	session := &Session{}
+
+	response := &Response{}
+	session.processNodeCredentials(context.Background(), Request{}, response)
+	assert.Contains(t, response.Error, "required")
+
+	response = &Response{}
+	session.processNodeCredentials(context.Background(), Request{
+		NodeCredentials: &NodeCredentialsRequest{},
+	}, response)
+	assert.Contains(t, response.Error, "no files")
+}
+
+// The mode is applied to the staged file before any contents are written, so a
+// permissive umask cannot expose a private key even briefly.
+func TestWriteNodeCredentialFileNeverExposesContentsUnderPermissiveUmask(t *testing.T) {
+	previous := syscall.Umask(0o000)
+	defer syscall.Umask(previous)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "key.pem")
+	require.NoError(t, writeNodeCredentialFile(NodeCredentialFile{Path: path, Contents: []byte("secret")}))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "default mode must be owner-only")
+
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "secret", string(contents))
+}
+
+func TestWriteNodeCredentialFileHonorsRequestedMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, writeNodeCredentialFile(NodeCredentialFile{
+		Path: path, Contents: []byte("providerID: x"), Mode: 0o644,
+	}))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+}
+
+// Rewriting a credential must replace it in one step, and must not leave the
+// staging file behind for something else to pick up.
+func TestWriteNodeCredentialFileReplacesAtomicallyAndLeavesNoResidue(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "key.pem")
+
+	require.NoError(t, writeNodeCredentialFile(NodeCredentialFile{Path: path, Contents: []byte("first")}))
+	require.NoError(t, writeNodeCredentialFile(NodeCredentialFile{Path: path, Contents: []byte("second")}))
+
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "second", string(contents))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		assert.False(t, strings.HasPrefix(entry.Name(), ".node-credential-"),
+			"staging file left behind: %s", entry.Name())
+	}
+	assert.Len(t, entries, 1)
+}
+
+// The audit copy is written to logs, so nothing under node_credentials may
+// survive it. Redacting the whole subtree keeps that true as fields are added.
+func TestAuditSessionRequestDataRedactsNodeCredentials(t *testing.T) {
+	raw, err := json.Marshal(Request{
+		Method: "nodeCredentials",
+		NodeCredentials: &NodeCredentialsRequest{Kubelet: []NodeCredentialFile{
+			{Path: "/var/lib/gpud/packages/kubelet/kubelet-client-current.pem",
+				Contents: []byte("BEGIN EC PRIVATE KEY very-secret")},
+		}},
+	})
+	require.NoError(t, err)
+
+	audited, err := json.Marshal(auditSessionRequestData(raw))
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(audited), "very-secret")
+	assert.NotContains(t, string(audited), "PRIVATE KEY")
+	assert.Contains(t, string(audited), "<redacted>")
+}

--- a/pkg/session/node_credentials_test.go
+++ b/pkg/session/node_credentials_test.go
@@ -156,10 +156,16 @@ func TestAuditSessionRequestDataRedactsNodeCredentials(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	audited, err := json.Marshal(auditSessionRequestData(raw))
-	require.NoError(t, err)
+	audited := auditSessionRequestData(raw)
 
-	assert.NotContains(t, string(audited), "very-secret")
-	assert.NotContains(t, string(audited), "PRIVATE KEY")
-	assert.Contains(t, string(audited), "<redacted>")
+	serialized, err := json.Marshal(audited)
+	require.NoError(t, err)
+	assert.NotContains(t, string(serialized), "very-secret")
+	assert.NotContains(t, string(serialized), "PRIVATE KEY")
+
+	// Asserted on the value rather than the serialized form, which escapes the
+	// angle brackets.
+	fields, ok := audited.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "<redacted>", fields["node_credentials"])
 }

--- a/pkg/session/node_credentials_test.go
+++ b/pkg/session/node_credentials_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"syscall"
 	"testing"
@@ -66,9 +67,9 @@ func TestProcessNodeCredentialsWritesNothingWhenAnyFileIsRejected(t *testing.T) 
 	session := &Session{}
 	response := &Response{}
 	session.processNodeCredentials(context.Background(), Request{
-		NodeCredentials: &NodeCredentialsRequest{Kubelet: []NodeCredentialFile{
-			{Path: good, Contents: []byte("first")},
-			{Path: "/etc/systemd/system/evil.service", Contents: []byte("second")},
+		NodeCredentials: &NodeCredentialsRequest{Kubelet: &KubeletCredentials{
+			Config:            &NodeCredentialFile{Path: good, Contents: []byte("first")},
+			ClientCertificate: &NodeCredentialFile{Path: "/etc/systemd/system/evil.service", Contents: []byte("second")},
 		}},
 	}, response)
 
@@ -87,6 +88,12 @@ func TestProcessNodeCredentialsRequiresContent(t *testing.T) {
 	response = &Response{}
 	session.processNodeCredentials(context.Background(), Request{
 		NodeCredentials: &NodeCredentialsRequest{},
+	}, response)
+	assert.Contains(t, response.Error, "no files")
+
+	response = &Response{}
+	session.processNodeCredentials(context.Background(), Request{
+		NodeCredentials: &NodeCredentialsRequest{Kubelet: &KubeletCredentials{}},
 	}, response)
 	assert.Contains(t, response.Error, "no files")
 }
@@ -149,9 +156,11 @@ func TestWriteNodeCredentialFileReplacesAtomicallyAndLeavesNoResidue(t *testing.
 func TestAuditSessionRequestDataRedactsNodeCredentials(t *testing.T) {
 	raw, err := json.Marshal(Request{
 		Method: "nodeCredentials",
-		NodeCredentials: &NodeCredentialsRequest{Kubelet: []NodeCredentialFile{
-			{Path: "/var/lib/gpud/packages/kubelet/kubelet-client-current.pem",
-				Contents: []byte("BEGIN EC PRIVATE KEY very-secret")},
+		NodeCredentials: &NodeCredentialsRequest{Kubelet: &KubeletCredentials{
+			ClientCertificate: &NodeCredentialFile{
+				Path:     "/var/lib/gpud/packages/kubelet/kubelet-client-current.pem",
+				Contents: []byte("BEGIN EC PRIVATE KEY very-secret"),
+			},
 		}},
 	})
 	require.NoError(t, err)
@@ -168,4 +177,55 @@ func TestAuditSessionRequestDataRedactsNodeCredentials(t *testing.T) {
 	fields, ok := audited.(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "<redacted>", fields["node_credentials"])
+}
+
+// Files is where named fields become an ordered write list. A field added to
+// KubeletCredentials but not flattened here is accepted by the wire format and
+// then silently never written, which is the failure mode named fields trade
+// for the one a list had.
+//
+// If this fails after a field was added, add it to Files rather than to this
+// list.
+func TestNodeCredentialsFilesCoversEveryKubeletField(t *testing.T) {
+	kubelet := &KubeletCredentials{}
+	v := reflect.ValueOf(kubelet).Elem()
+	typ := v.Type()
+
+	for i := 0; i < typ.NumField(); i++ {
+		require.Equal(t, reflect.TypeOf(&NodeCredentialFile{}), typ.Field(i).Type,
+			"field %s is not a credential file; teach this test about it", typ.Field(i).Name)
+		v.Field(i).Set(reflect.ValueOf(&NodeCredentialFile{
+			Path:     "/var/lib/gpud/" + typ.Field(i).Name,
+			Contents: []byte("x"),
+		}))
+	}
+
+	files := (&NodeCredentialsRequest{Kubelet: kubelet}).Files()
+	assert.Len(t, files, typ.NumField(),
+		"Files() drops a KubeletCredentials field; every named file must be written")
+}
+
+// Order matters to a reader of the node: the certificate is what the kubelet
+// package waits for, so the config has to be in place by the time it lands.
+func TestNodeCredentialsFilesOrder(t *testing.T) {
+	files := (&NodeCredentialsRequest{Kubelet: &KubeletCredentials{
+		Config:            &NodeCredentialFile{Path: "/var/lib/gpud/kubelet.yaml", Contents: []byte("c")},
+		ClientCertificate: &NodeCredentialFile{Path: "/var/lib/gpud/cert.pem", Contents: []byte("k")},
+	}}).Files()
+	require.Len(t, files, 2)
+	assert.Equal(t, "/var/lib/gpud/kubelet.yaml", files[0].Path)
+	assert.Equal(t, "/var/lib/gpud/cert.pem", files[1].Path)
+}
+
+// An absent field must stay absent rather than become an empty file.
+func TestNodeCredentialsFilesSkipsAbsentFields(t *testing.T) {
+	files := (&NodeCredentialsRequest{Kubelet: &KubeletCredentials{
+		Config: &NodeCredentialFile{Path: "/var/lib/gpud/kubelet.yaml", Contents: []byte("c")},
+	}}).Files()
+	require.Len(t, files, 1)
+	assert.Equal(t, "/var/lib/gpud/kubelet.yaml", files[0].Path)
+
+	assert.Empty(t, (&NodeCredentialsRequest{Kubelet: &KubeletCredentials{}}).Files())
+	assert.Empty(t, (&NodeCredentialsRequest{}).Files())
+	assert.Empty(t, (*NodeCredentialsRequest)(nil).Files())
 }

--- a/pkg/session/session_process_request.go
+++ b/pkg/session/session_process_request.go
@@ -151,6 +151,9 @@ func (s *Session) processRequest(ctx context.Context, reqID string, payload Requ
 
 	case "activateKAPMTLS":
 		s.processActivateKAPMTLS(ctx, response)
+
+	case "nodeCredentials":
+		s.processNodeCredentials(ctx, payload, response)
 	}
 
 	return false // Request is handled synchronously

--- a/pkg/session/session_serve.go
+++ b/pkg/session/session_serve.go
@@ -52,6 +52,11 @@ type Request struct {
 	// KAPMTLSCredentials carries short-lived client credentials for the
 	// node-local KAP mTLS agent. The private key must never be logged.
 	KAPMTLSCredentials *KAPMTLSCredentialsRequest `json:"kap_mtls_credentials,omitempty"`
+
+	// NodeCredentials carries credential material the control plane places on
+	// the node, with the destination of each file in the request. Private keys
+	// travel here, so it must never be logged.
+	NodeCredentials *NodeCredentialsRequest `json:"node_credentials,omitempty"`
 }
 
 // Response is the response from GPUd to the control plane.

--- a/pkg/session/session_v2_adapter.go
+++ b/pkg/session/session_v2_adapter.go
@@ -185,7 +185,7 @@ func requestFromV2(packet *sessionv2.ManagerPacket) (Request, error) {
 		}
 		legacy.Method = "nodeCredentials"
 		legacy.NodeCredentials = &NodeCredentialsRequest{
-			Kubelet: nodeCredentialFilesFromV2(payload.NodeCredentials.Kubelet),
+			Kubelet: kubeletCredentialsFromV2(payload.NodeCredentials.Kubelet),
 		}
 	case nil:
 		return Request{}, fmt.Errorf("v2 request payload is missing")
@@ -196,22 +196,24 @@ func requestFromV2(packet *sessionv2.ManagerPacket) (Request, error) {
 	return legacy, nil
 }
 
-// nodeCredentialFilesFromV2 drops nil entries rather than turning them into
-// empty files: an empty path fails validation anyway, and a nil element is a
-// malformed packet rather than a request to write nothing.
-func nodeCredentialFilesFromV2(files []*sessionv2.NodeCredentialFile) []NodeCredentialFile {
-	converted := make([]NodeCredentialFile, 0, len(files))
-	for _, file := range files {
-		if file == nil {
-			continue
-		}
-		converted = append(converted, NodeCredentialFile{
-			Path:     file.Path,
-			Contents: file.Contents,
-			Mode:     file.Mode,
-		})
+// kubeletCredentialsFromV2 converts the named kubelet files. An absent field
+// stays absent rather than becoming an empty file: a credential truncated to
+// nothing looks like a successful write and fails wherever the file is read.
+func kubeletCredentialsFromV2(k *sessionv2.KubeletCredentials) *KubeletCredentials {
+	if k == nil {
+		return nil
 	}
-	return converted
+	return &KubeletCredentials{
+		Config:            nodeCredentialFileFromV2(k.Config),
+		ClientCertificate: nodeCredentialFileFromV2(k.ClientCertificate),
+	}
+}
+
+func nodeCredentialFileFromV2(f *sessionv2.NodeCredentialFile) *NodeCredentialFile {
+	if f == nil {
+		return nil
+	}
+	return &NodeCredentialFile{Path: f.Path, Contents: f.Contents, Mode: f.Mode}
 }
 
 func pluginSpecsFromV2(specs []*sessionv2.PluginSpec) pkgcustomplugins.Specs {

--- a/pkg/session/session_v2_adapter.go
+++ b/pkg/session/session_v2_adapter.go
@@ -179,6 +179,14 @@ func requestFromV2(packet *sessionv2.ManagerPacket) (Request, error) {
 			return Request{}, fmt.Errorf("activate-KAP-mTLS payload is missing")
 		}
 		legacy.Method = "activateKAPMTLS"
+	case *sessionv2.ManagerPacket_NodeCredentials:
+		if payload.NodeCredentials == nil {
+			return Request{}, fmt.Errorf("node-credentials payload is missing")
+		}
+		legacy.Method = "nodeCredentials"
+		legacy.NodeCredentials = &NodeCredentialsRequest{
+			Kubelet: nodeCredentialFilesFromV2(payload.NodeCredentials.Kubelet),
+		}
 	case nil:
 		return Request{}, fmt.Errorf("v2 request payload is missing")
 	default:
@@ -186,6 +194,24 @@ func requestFromV2(packet *sessionv2.ManagerPacket) (Request, error) {
 	}
 
 	return legacy, nil
+}
+
+// nodeCredentialFilesFromV2 drops nil entries rather than turning them into
+// empty files: an empty path fails validation anyway, and a nil element is a
+// malformed packet rather than a request to write nothing.
+func nodeCredentialFilesFromV2(files []*sessionv2.NodeCredentialFile) []NodeCredentialFile {
+	converted := make([]NodeCredentialFile, 0, len(files))
+	for _, file := range files {
+		if file == nil {
+			continue
+		}
+		converted = append(converted, NodeCredentialFile{
+			Path:     file.Path,
+			Contents: file.Contents,
+			Mode:     file.Mode,
+		})
+	}
+	return converted
 }
 
 func pluginSpecsFromV2(specs []*sessionv2.PluginSpec) pkgcustomplugins.Specs {

--- a/pkg/session/session_v2_adapter_test.go
+++ b/pkg/session/session_v2_adapter_test.go
@@ -261,27 +261,32 @@ func TestRequestFromV2ConvertsConcreteRequests(t *testing.T) {
 			// read it, so both have to survive the conversion.
 			name: "node credentials",
 			request: newV2ManagerPacket(&sessionv2.ManagerPacket_NodeCredentials{NodeCredentials: &sessionv2.NodeCredentialsRequest{
-				Kubelet: []*sessionv2.NodeCredentialFile{
-					{Path: "/var/lib/gpud/packages/kubelet/kubelet-client-current.pem", Contents: []byte("cert"), Mode: 0o600},
-					{Path: "/var/lib/gpud/packages/kubelet/kubelet.yaml", Contents: []byte("providerID: x"), Mode: 0o644},
+				Kubelet: &sessionv2.KubeletCredentials{
+					Config:            &sessionv2.NodeCredentialFile{Path: "/var/lib/gpud/packages/kubelet/kubelet.yaml", Contents: []byte("providerID: x"), Mode: 0o644},
+					ClientCertificate: &sessionv2.NodeCredentialFile{Path: "/var/lib/gpud/packages/kubelet/kubelet-client-current.pem", Contents: []byte("cert"), Mode: 0o600},
 				},
 			}}),
 			want: Request{Method: "nodeCredentials", NodeCredentials: &NodeCredentialsRequest{
-				Kubelet: []NodeCredentialFile{
-					{Path: "/var/lib/gpud/packages/kubelet/kubelet-client-current.pem", Contents: []byte("cert"), Mode: 0o600},
-					{Path: "/var/lib/gpud/packages/kubelet/kubelet.yaml", Contents: []byte("providerID: x"), Mode: 0o644},
+				Kubelet: &KubeletCredentials{
+					Config:            &NodeCredentialFile{Path: "/var/lib/gpud/packages/kubelet/kubelet.yaml", Contents: []byte("providerID: x"), Mode: 0o644},
+					ClientCertificate: &NodeCredentialFile{Path: "/var/lib/gpud/packages/kubelet/kubelet-client-current.pem", Contents: []byte("cert"), Mode: 0o600},
 				},
 			}},
 		},
 		{
-			// A nil element is a malformed packet, not a request to write an
-			// empty file, so it is dropped rather than converted.
-			name: "node credentials with a nil file",
+			// An absent field stays absent rather than becoming an empty file:
+			// a credential truncated to nothing looks like a successful write
+			// and fails wherever the file is read.
+			name: "node credentials with only one file set",
 			request: newV2ManagerPacket(&sessionv2.ManagerPacket_NodeCredentials{NodeCredentials: &sessionv2.NodeCredentialsRequest{
-				Kubelet: []*sessionv2.NodeCredentialFile{nil, {Path: "/var/lib/gpud/x", Contents: []byte("y")}},
+				Kubelet: &sessionv2.KubeletCredentials{
+					Config: &sessionv2.NodeCredentialFile{Path: "/var/lib/gpud/x", Contents: []byte("y")},
+				},
 			}}),
 			want: Request{Method: "nodeCredentials", NodeCredentials: &NodeCredentialsRequest{
-				Kubelet: []NodeCredentialFile{{Path: "/var/lib/gpud/x", Contents: []byte("y")}},
+				Kubelet: &KubeletCredentials{
+					Config: &NodeCredentialFile{Path: "/var/lib/gpud/x", Contents: []byte("y")},
+				},
 			}},
 		},
 	}

--- a/pkg/session/session_v2_adapter_test.go
+++ b/pkg/session/session_v2_adapter_test.go
@@ -256,6 +256,34 @@ func TestRequestFromV2ConvertsConcreteRequests(t *testing.T) {
 			request: newV2ManagerPacket(&sessionv2.ManagerPacket_ActivateKapMtls{ActivateKapMtls: &sessionv2.ActivateKAPMTLSRequest{}}),
 			want:    Request{Method: "activateKAPMTLS"},
 		},
+		{
+			// The path and the mode decide where the material lands and who can
+			// read it, so both have to survive the conversion.
+			name: "node credentials",
+			request: newV2ManagerPacket(&sessionv2.ManagerPacket_NodeCredentials{NodeCredentials: &sessionv2.NodeCredentialsRequest{
+				Kubelet: []*sessionv2.NodeCredentialFile{
+					{Path: "/var/lib/gpud/packages/kubelet/kubelet-client-current.pem", Contents: []byte("cert"), Mode: 0o600},
+					{Path: "/var/lib/gpud/packages/kubelet/kubelet.yaml", Contents: []byte("providerID: x"), Mode: 0o644},
+				},
+			}}),
+			want: Request{Method: "nodeCredentials", NodeCredentials: &NodeCredentialsRequest{
+				Kubelet: []NodeCredentialFile{
+					{Path: "/var/lib/gpud/packages/kubelet/kubelet-client-current.pem", Contents: []byte("cert"), Mode: 0o600},
+					{Path: "/var/lib/gpud/packages/kubelet/kubelet.yaml", Contents: []byte("providerID: x"), Mode: 0o644},
+				},
+			}},
+		},
+		{
+			// A nil element is a malformed packet, not a request to write an
+			// empty file, so it is dropped rather than converted.
+			name: "node credentials with a nil file",
+			request: newV2ManagerPacket(&sessionv2.ManagerPacket_NodeCredentials{NodeCredentials: &sessionv2.NodeCredentialsRequest{
+				Kubelet: []*sessionv2.NodeCredentialFile{nil, {Path: "/var/lib/gpud/x", Contents: []byte("y")}},
+			}}),
+			want: Request{Method: "nodeCredentials", NodeCredentials: &NodeCredentialsRequest{
+				Kubelet: []NodeCredentialFile{{Path: "/var/lib/gpud/x", Contents: []byte("y")}},
+			}},
+		},
 	}
 
 	for _, test := range tests {
@@ -300,6 +328,7 @@ func TestRequestFromV2RejectsInvalidRequests(t *testing.T) {
 		{name: "KAP status", payload: &sessionv2.ManagerPacket_GetKapMtlsStatus{}, message: "get-KAP-mTLS-status payload is missing"},
 		{name: "KAP credentials", payload: &sessionv2.ManagerPacket_UpdateKapMtlsCredentials{}, message: "update-KAP-mTLS-credentials payload is missing"},
 		{name: "activate KAP", payload: &sessionv2.ManagerPacket_ActivateKapMtls{}, message: "activate-KAP-mTLS payload is missing"},
+		{name: "node credentials", payload: &sessionv2.ManagerPacket_NodeCredentials{}, message: "node-credentials payload is missing"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := requestFromV2(newV2ManagerPacket(test.payload))

--- a/pkg/session/v2/session.pb.go
+++ b/pkg/session/v2/session.pb.go
@@ -133,6 +133,7 @@ type ManagerPacket struct {
 	//	*ManagerPacket_GetKapMtlsStatus
 	//	*ManagerPacket_UpdateKapMtlsCredentials
 	//	*ManagerPacket_ActivateKapMtls
+	//	*ManagerPacket_NodeCredentials
 	Payload       isManagerPacket_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -371,6 +372,15 @@ func (x *ManagerPacket) GetActivateKapMtls() *ActivateKAPMTLSRequest {
 	return nil
 }
 
+func (x *ManagerPacket) GetNodeCredentials() *NodeCredentialsRequest {
+	if x != nil {
+		if x, ok := x.Payload.(*ManagerPacket_NodeCredentials); ok {
+			return x.NodeCredentials
+		}
+	}
+	return nil
+}
+
 type isManagerPacket_Payload interface {
 	isManagerPacket_Payload()
 }
@@ -459,6 +469,10 @@ type ManagerPacket_ActivateKapMtls struct {
 	ActivateKapMtls *ActivateKAPMTLSRequest `protobuf:"bytes,28,opt,name=activate_kap_mtls,json=activateKapMtls,proto3,oneof"`
 }
 
+type ManagerPacket_NodeCredentials struct {
+	NodeCredentials *NodeCredentialsRequest `protobuf:"bytes,29,opt,name=node_credentials,json=nodeCredentials,proto3,oneof"`
+}
+
 func (*ManagerPacket_HelloAck) isManagerPacket_Payload() {}
 
 func (*ManagerPacket_DrainNotice) isManagerPacket_Payload() {}
@@ -500,6 +514,8 @@ func (*ManagerPacket_GetKapMtlsStatus) isManagerPacket_Payload() {}
 func (*ManagerPacket_UpdateKapMtlsCredentials) isManagerPacket_Payload() {}
 
 func (*ManagerPacket_ActivateKapMtls) isManagerPacket_Payload() {}
+
+func (*ManagerPacket_NodeCredentials) isManagerPacket_Payload() {}
 
 type Hello struct {
 	state                  protoimpl.MessageState `protogen:"open.v1"`
@@ -2123,6 +2139,117 @@ func (*ActivateKAPMTLSRequest) Descriptor() ([]byte, []int) {
 	return file_session_proto_rawDescGZIP(), []int{31}
 }
 
+// NodeCredentialFile is one file the control plane places on a node. The
+// destination travels with the file so that adding or moving a credential does
+// not need a GPUd release; the agent confines the path to the trees it allows.
+type NodeCredentialFile struct {
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Path     string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	Contents []byte                 `protobuf:"bytes,2,opt,name=contents,proto3" json:"contents,omitempty"`
+	// Mode is the file mode. The agent applies 0600 when this is zero.
+	Mode          uint32 `protobuf:"varint,3,opt,name=mode,proto3" json:"mode,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NodeCredentialFile) Reset() {
+	*x = NodeCredentialFile{}
+	mi := &file_session_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NodeCredentialFile) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NodeCredentialFile) ProtoMessage() {}
+
+func (x *NodeCredentialFile) ProtoReflect() protoreflect.Message {
+	mi := &file_session_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NodeCredentialFile.ProtoReflect.Descriptor instead.
+func (*NodeCredentialFile) Descriptor() ([]byte, []int) {
+	return file_session_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *NodeCredentialFile) GetPath() string {
+	if x != nil {
+		return x.Path
+	}
+	return ""
+}
+
+func (x *NodeCredentialFile) GetContents() []byte {
+	if x != nil {
+		return x.Contents
+	}
+	return nil
+}
+
+func (x *NodeCredentialFile) GetMode() uint32 {
+	if x != nil {
+		return x.Mode
+	}
+	return 0
+}
+
+// NodeCredentialsRequest carries credential material for one node, grouped by
+// the subsystem that owns it, so a new kind of credential is a new field rather
+// than a change to an existing one.
+type NodeCredentialsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Kubelet       []*NodeCredentialFile  `protobuf:"bytes,1,rep,name=kubelet,proto3" json:"kubelet,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *NodeCredentialsRequest) Reset() {
+	*x = NodeCredentialsRequest{}
+	mi := &file_session_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *NodeCredentialsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*NodeCredentialsRequest) ProtoMessage() {}
+
+func (x *NodeCredentialsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_session_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use NodeCredentialsRequest.ProtoReflect.Descriptor instead.
+func (*NodeCredentialsRequest) Descriptor() ([]byte, []int) {
+	return file_session_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *NodeCredentialsRequest) GetKubelet() []*NodeCredentialFile {
+	if x != nil {
+		return x.Kubelet
+	}
+	return nil
+}
+
 type DrainNotice struct {
 	state                protoimpl.MessageState `protogen:"open.v1"`
 	ReconnectAfterMillis int64                  `protobuf:"varint,1,opt,name=reconnect_after_millis,json=reconnectAfterMillis,proto3" json:"reconnect_after_millis,omitempty"`
@@ -2132,7 +2259,7 @@ type DrainNotice struct {
 
 func (x *DrainNotice) Reset() {
 	*x = DrainNotice{}
-	mi := &file_session_proto_msgTypes[32]
+	mi := &file_session_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2144,7 +2271,7 @@ func (x *DrainNotice) String() string {
 func (*DrainNotice) ProtoMessage() {}
 
 func (x *DrainNotice) ProtoReflect() protoreflect.Message {
-	mi := &file_session_proto_msgTypes[32]
+	mi := &file_session_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2157,7 +2284,7 @@ func (x *DrainNotice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DrainNotice.ProtoReflect.Descriptor instead.
 func (*DrainNotice) Descriptor() ([]byte, []int) {
-	return file_session_proto_rawDescGZIP(), []int{32}
+	return file_session_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *DrainNotice) GetReconnectAfterMillis() int64 {
@@ -2175,7 +2302,7 @@ const file_session_proto_rawDesc = "" +
 	"\vAgentPacket\x12.\n" +
 	"\x05hello\x18\x01 \x01(\v2\x16.gpud.session.v2.HelloH\x00R\x05hello\x121\n" +
 	"\x06result\x18\x02 \x01(\v2\x17.gpud.session.v2.ResultH\x00R\x06resultB\t\n" +
-	"\apayload\"\xe3\f\n" +
+	"\apayload\"\xb9\r\n" +
 	"\rManagerPacket\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x04 \x01(\tR\trequestId\x128\n" +
@@ -2205,7 +2332,8 @@ const file_session_proto_rawDesc = "" +
 	"\fupdate_token\x18\x19 \x01(\v2#.gpud.session.v2.UpdateTokenRequestH\x00R\vupdateToken\x12Y\n" +
 	"\x13get_kap_mtls_status\x18\x1a \x01(\v2(.gpud.session.v2.GetKAPMTLSStatusRequestH\x00R\x10getKapMtlsStatus\x12q\n" +
 	"\x1bupdate_kap_mtls_credentials\x18\x1b \x01(\v20.gpud.session.v2.UpdateKAPMTLSCredentialsRequestH\x00R\x18updateKapMtlsCredentials\x12U\n" +
-	"\x11activate_kap_mtls\x18\x1c \x01(\v2'.gpud.session.v2.ActivateKAPMTLSRequestH\x00R\x0factivateKapMtlsB\t\n" +
+	"\x11activate_kap_mtls\x18\x1c \x01(\v2'.gpud.session.v2.ActivateKAPMTLSRequestH\x00R\x0factivateKapMtls\x12T\n" +
+	"\x10node_credentials\x18\x1d \x01(\v2'.gpud.session.v2.NodeCredentialsRequestH\x00R\x0fnodeCredentialsB\t\n" +
 	"\apayloadJ\x04\b\x02\x10\x03\"\xf3\x01\n" +
 	"\x05Hello\x122\n" +
 	"\x15min_protocol_revision\x18\x01 \x01(\rR\x13minProtocolRevision\x122\n" +
@@ -2322,7 +2450,13 @@ const file_session_proto_rawDesc = "" +
 	"serverName\x122\n" +
 	"\x15client_ca_fingerprint\x18\x06 \x01(\tR\x13clientCaFingerprint\x124\n" +
 	"\x16gateway_ca_fingerprint\x18\a \x01(\tR\x14gatewayCaFingerprint\"\x18\n" +
-	"\x16ActivateKAPMTLSRequest\"C\n" +
+	"\x16ActivateKAPMTLSRequest\"X\n" +
+	"\x12NodeCredentialFile\x12\x12\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12\x1a\n" +
+	"\bcontents\x18\x02 \x01(\fR\bcontents\x12\x12\n" +
+	"\x04mode\x18\x03 \x01(\rR\x04mode\"W\n" +
+	"\x16NodeCredentialsRequest\x12=\n" +
+	"\akubelet\x18\x01 \x03(\v2#.gpud.session.v2.NodeCredentialFileR\akubelet\"C\n" +
 	"\vDrainNotice\x124\n" +
 	"\x16reconnect_after_millis\x18\x01 \x01(\x03R\x14reconnectAfterMillis2]\n" +
 	"\x0eSessionService\x12K\n" +
@@ -2340,7 +2474,7 @@ func file_session_proto_rawDescGZIP() []byte {
 	return file_session_proto_rawDescData
 }
 
-var file_session_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_session_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_session_proto_goTypes = []any{
 	(*AgentPacket)(nil),                     // 0: gpud.session.v2.AgentPacket
 	(*ManagerPacket)(nil),                   // 1: gpud.session.v2.ManagerPacket
@@ -2374,16 +2508,18 @@ var file_session_proto_goTypes = []any{
 	(*GetKAPMTLSStatusRequest)(nil),         // 29: gpud.session.v2.GetKAPMTLSStatusRequest
 	(*UpdateKAPMTLSCredentialsRequest)(nil), // 30: gpud.session.v2.UpdateKAPMTLSCredentialsRequest
 	(*ActivateKAPMTLSRequest)(nil),          // 31: gpud.session.v2.ActivateKAPMTLSRequest
-	(*DrainNotice)(nil),                     // 32: gpud.session.v2.DrainNotice
-	nil,                                     // 33: gpud.session.v2.UpdateConfigRequest.ValuesEntry
-	nil,                                     // 34: gpud.session.v2.PluginJSONPath.SuggestedActionsEntry
-	(*timestamppb.Timestamp)(nil),           // 35: google.protobuf.Timestamp
+	(*NodeCredentialFile)(nil),              // 32: gpud.session.v2.NodeCredentialFile
+	(*NodeCredentialsRequest)(nil),          // 33: gpud.session.v2.NodeCredentialsRequest
+	(*DrainNotice)(nil),                     // 34: gpud.session.v2.DrainNotice
+	nil,                                     // 35: gpud.session.v2.UpdateConfigRequest.ValuesEntry
+	nil,                                     // 36: gpud.session.v2.PluginJSONPath.SuggestedActionsEntry
+	(*timestamppb.Timestamp)(nil),           // 37: google.protobuf.Timestamp
 }
 var file_session_proto_depIdxs = []int32{
 	2,  // 0: gpud.session.v2.AgentPacket.hello:type_name -> gpud.session.v2.Hello
 	4,  // 1: gpud.session.v2.AgentPacket.result:type_name -> gpud.session.v2.Result
 	3,  // 2: gpud.session.v2.ManagerPacket.hello_ack:type_name -> gpud.session.v2.HelloAck
-	32, // 3: gpud.session.v2.ManagerPacket.drain_notice:type_name -> gpud.session.v2.DrainNotice
+	34, // 3: gpud.session.v2.ManagerPacket.drain_notice:type_name -> gpud.session.v2.DrainNotice
 	5,  // 4: gpud.session.v2.ManagerPacket.get_health_states:type_name -> gpud.session.v2.GetHealthStatesRequest
 	6,  // 5: gpud.session.v2.ManagerPacket.get_events:type_name -> gpud.session.v2.GetEventsRequest
 	7,  // 6: gpud.session.v2.ManagerPacket.get_metrics:type_name -> gpud.session.v2.GetMetricsRequest
@@ -2403,26 +2539,28 @@ var file_session_proto_depIdxs = []int32{
 	29, // 20: gpud.session.v2.ManagerPacket.get_kap_mtls_status:type_name -> gpud.session.v2.GetKAPMTLSStatusRequest
 	30, // 21: gpud.session.v2.ManagerPacket.update_kap_mtls_credentials:type_name -> gpud.session.v2.UpdateKAPMTLSCredentialsRequest
 	31, // 22: gpud.session.v2.ManagerPacket.activate_kap_mtls:type_name -> gpud.session.v2.ActivateKAPMTLSRequest
-	35, // 23: gpud.session.v2.GetEventsRequest.start_time:type_name -> google.protobuf.Timestamp
-	35, // 24: gpud.session.v2.GetEventsRequest.end_time:type_name -> google.protobuf.Timestamp
-	33, // 25: gpud.session.v2.UpdateConfigRequest.values:type_name -> gpud.session.v2.UpdateConfigRequest.ValuesEntry
-	14, // 26: gpud.session.v2.InjectFaultRequest.kernel_message:type_name -> gpud.session.v2.KernelMessage
-	21, // 27: gpud.session.v2.SetPluginSpecsRequest.specs:type_name -> gpud.session.v2.PluginSpec
-	22, // 28: gpud.session.v2.PluginSpec.health_state_plugin:type_name -> gpud.session.v2.Plugin
-	23, // 29: gpud.session.v2.Plugin.steps:type_name -> gpud.session.v2.PluginStep
-	25, // 30: gpud.session.v2.Plugin.parser:type_name -> gpud.session.v2.PluginOutputParser
-	24, // 31: gpud.session.v2.PluginStep.run_bash_script:type_name -> gpud.session.v2.BashScript
-	26, // 32: gpud.session.v2.PluginOutputParser.json_paths:type_name -> gpud.session.v2.PluginJSONPath
-	27, // 33: gpud.session.v2.PluginJSONPath.expect:type_name -> gpud.session.v2.PluginMatchRule
-	34, // 34: gpud.session.v2.PluginJSONPath.suggested_actions:type_name -> gpud.session.v2.PluginJSONPath.SuggestedActionsEntry
-	27, // 35: gpud.session.v2.PluginJSONPath.SuggestedActionsEntry.value:type_name -> gpud.session.v2.PluginMatchRule
-	0,  // 36: gpud.session.v2.SessionService.Connect:input_type -> gpud.session.v2.AgentPacket
-	1,  // 37: gpud.session.v2.SessionService.Connect:output_type -> gpud.session.v2.ManagerPacket
-	37, // [37:38] is the sub-list for method output_type
-	36, // [36:37] is the sub-list for method input_type
-	36, // [36:36] is the sub-list for extension type_name
-	36, // [36:36] is the sub-list for extension extendee
-	0,  // [0:36] is the sub-list for field type_name
+	33, // 23: gpud.session.v2.ManagerPacket.node_credentials:type_name -> gpud.session.v2.NodeCredentialsRequest
+	37, // 24: gpud.session.v2.GetEventsRequest.start_time:type_name -> google.protobuf.Timestamp
+	37, // 25: gpud.session.v2.GetEventsRequest.end_time:type_name -> google.protobuf.Timestamp
+	35, // 26: gpud.session.v2.UpdateConfigRequest.values:type_name -> gpud.session.v2.UpdateConfigRequest.ValuesEntry
+	14, // 27: gpud.session.v2.InjectFaultRequest.kernel_message:type_name -> gpud.session.v2.KernelMessage
+	21, // 28: gpud.session.v2.SetPluginSpecsRequest.specs:type_name -> gpud.session.v2.PluginSpec
+	22, // 29: gpud.session.v2.PluginSpec.health_state_plugin:type_name -> gpud.session.v2.Plugin
+	23, // 30: gpud.session.v2.Plugin.steps:type_name -> gpud.session.v2.PluginStep
+	25, // 31: gpud.session.v2.Plugin.parser:type_name -> gpud.session.v2.PluginOutputParser
+	24, // 32: gpud.session.v2.PluginStep.run_bash_script:type_name -> gpud.session.v2.BashScript
+	26, // 33: gpud.session.v2.PluginOutputParser.json_paths:type_name -> gpud.session.v2.PluginJSONPath
+	27, // 34: gpud.session.v2.PluginJSONPath.expect:type_name -> gpud.session.v2.PluginMatchRule
+	36, // 35: gpud.session.v2.PluginJSONPath.suggested_actions:type_name -> gpud.session.v2.PluginJSONPath.SuggestedActionsEntry
+	32, // 36: gpud.session.v2.NodeCredentialsRequest.kubelet:type_name -> gpud.session.v2.NodeCredentialFile
+	27, // 37: gpud.session.v2.PluginJSONPath.SuggestedActionsEntry.value:type_name -> gpud.session.v2.PluginMatchRule
+	0,  // 38: gpud.session.v2.SessionService.Connect:input_type -> gpud.session.v2.AgentPacket
+	1,  // 39: gpud.session.v2.SessionService.Connect:output_type -> gpud.session.v2.ManagerPacket
+	39, // [39:40] is the sub-list for method output_type
+	38, // [38:39] is the sub-list for method input_type
+	38, // [38:38] is the sub-list for extension type_name
+	38, // [38:38] is the sub-list for extension extendee
+	0,  // [0:38] is the sub-list for field type_name
 }
 
 func init() { file_session_proto_init() }
@@ -2456,6 +2594,7 @@ func file_session_proto_init() {
 		(*ManagerPacket_GetKapMtlsStatus)(nil),
 		(*ManagerPacket_UpdateKapMtlsCredentials)(nil),
 		(*ManagerPacket_ActivateKapMtls)(nil),
+		(*ManagerPacket_NodeCredentials)(nil),
 	}
 	file_session_proto_msgTypes[13].OneofWrappers = []any{
 		(*InjectFaultRequest_Xid)(nil),
@@ -2468,7 +2607,7 @@ func file_session_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_session_proto_rawDesc), len(file_session_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   35,
+			NumMessages:   37,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/session/v2/session.pb.go
+++ b/pkg/session/v2/session.pb.go
@@ -2203,19 +2203,74 @@ func (x *NodeCredentialFile) GetMode() uint32 {
 	return 0
 }
 
+// KubeletCredentials is what a kubelet needs to register. The fields are named
+// rather than a list, so each file's role is part of the contract instead of
+// something the receiver has to infer.
+type KubeletCredentials struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Config            *NodeCredentialFile    `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`
+	ClientCertificate *NodeCredentialFile    `protobuf:"bytes,2,opt,name=client_certificate,json=clientCertificate,proto3" json:"client_certificate,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *KubeletCredentials) Reset() {
+	*x = KubeletCredentials{}
+	mi := &file_session_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *KubeletCredentials) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KubeletCredentials) ProtoMessage() {}
+
+func (x *KubeletCredentials) ProtoReflect() protoreflect.Message {
+	mi := &file_session_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use KubeletCredentials.ProtoReflect.Descriptor instead.
+func (*KubeletCredentials) Descriptor() ([]byte, []int) {
+	return file_session_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *KubeletCredentials) GetConfig() *NodeCredentialFile {
+	if x != nil {
+		return x.Config
+	}
+	return nil
+}
+
+func (x *KubeletCredentials) GetClientCertificate() *NodeCredentialFile {
+	if x != nil {
+		return x.ClientCertificate
+	}
+	return nil
+}
+
 // NodeCredentialsRequest carries credential material for one node, grouped by
 // the subsystem that owns it, so a new kind of credential is a new field rather
 // than a change to an existing one.
 type NodeCredentialsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Kubelet       []*NodeCredentialFile  `protobuf:"bytes,1,rep,name=kubelet,proto3" json:"kubelet,omitempty"`
+	Kubelet       *KubeletCredentials    `protobuf:"bytes,1,opt,name=kubelet,proto3" json:"kubelet,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *NodeCredentialsRequest) Reset() {
 	*x = NodeCredentialsRequest{}
-	mi := &file_session_proto_msgTypes[33]
+	mi := &file_session_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2227,7 +2282,7 @@ func (x *NodeCredentialsRequest) String() string {
 func (*NodeCredentialsRequest) ProtoMessage() {}
 
 func (x *NodeCredentialsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_session_proto_msgTypes[33]
+	mi := &file_session_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2240,10 +2295,10 @@ func (x *NodeCredentialsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NodeCredentialsRequest.ProtoReflect.Descriptor instead.
 func (*NodeCredentialsRequest) Descriptor() ([]byte, []int) {
-	return file_session_proto_rawDescGZIP(), []int{33}
+	return file_session_proto_rawDescGZIP(), []int{34}
 }
 
-func (x *NodeCredentialsRequest) GetKubelet() []*NodeCredentialFile {
+func (x *NodeCredentialsRequest) GetKubelet() *KubeletCredentials {
 	if x != nil {
 		return x.Kubelet
 	}
@@ -2259,7 +2314,7 @@ type DrainNotice struct {
 
 func (x *DrainNotice) Reset() {
 	*x = DrainNotice{}
-	mi := &file_session_proto_msgTypes[34]
+	mi := &file_session_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2271,7 +2326,7 @@ func (x *DrainNotice) String() string {
 func (*DrainNotice) ProtoMessage() {}
 
 func (x *DrainNotice) ProtoReflect() protoreflect.Message {
-	mi := &file_session_proto_msgTypes[34]
+	mi := &file_session_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2284,7 +2339,7 @@ func (x *DrainNotice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DrainNotice.ProtoReflect.Descriptor instead.
 func (*DrainNotice) Descriptor() ([]byte, []int) {
-	return file_session_proto_rawDescGZIP(), []int{34}
+	return file_session_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *DrainNotice) GetReconnectAfterMillis() int64 {
@@ -2454,9 +2509,12 @@ const file_session_proto_rawDesc = "" +
 	"\x12NodeCredentialFile\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x1a\n" +
 	"\bcontents\x18\x02 \x01(\fR\bcontents\x12\x12\n" +
-	"\x04mode\x18\x03 \x01(\rR\x04mode\"W\n" +
+	"\x04mode\x18\x03 \x01(\rR\x04mode\"\xa5\x01\n" +
+	"\x12KubeletCredentials\x12;\n" +
+	"\x06config\x18\x01 \x01(\v2#.gpud.session.v2.NodeCredentialFileR\x06config\x12R\n" +
+	"\x12client_certificate\x18\x02 \x01(\v2#.gpud.session.v2.NodeCredentialFileR\x11clientCertificate\"W\n" +
 	"\x16NodeCredentialsRequest\x12=\n" +
-	"\akubelet\x18\x01 \x03(\v2#.gpud.session.v2.NodeCredentialFileR\akubelet\"C\n" +
+	"\akubelet\x18\x01 \x01(\v2#.gpud.session.v2.KubeletCredentialsR\akubelet\"C\n" +
 	"\vDrainNotice\x124\n" +
 	"\x16reconnect_after_millis\x18\x01 \x01(\x03R\x14reconnectAfterMillis2]\n" +
 	"\x0eSessionService\x12K\n" +
@@ -2474,7 +2532,7 @@ func file_session_proto_rawDescGZIP() []byte {
 	return file_session_proto_rawDescData
 }
 
-var file_session_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
+var file_session_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
 var file_session_proto_goTypes = []any{
 	(*AgentPacket)(nil),                     // 0: gpud.session.v2.AgentPacket
 	(*ManagerPacket)(nil),                   // 1: gpud.session.v2.ManagerPacket
@@ -2509,17 +2567,18 @@ var file_session_proto_goTypes = []any{
 	(*UpdateKAPMTLSCredentialsRequest)(nil), // 30: gpud.session.v2.UpdateKAPMTLSCredentialsRequest
 	(*ActivateKAPMTLSRequest)(nil),          // 31: gpud.session.v2.ActivateKAPMTLSRequest
 	(*NodeCredentialFile)(nil),              // 32: gpud.session.v2.NodeCredentialFile
-	(*NodeCredentialsRequest)(nil),          // 33: gpud.session.v2.NodeCredentialsRequest
-	(*DrainNotice)(nil),                     // 34: gpud.session.v2.DrainNotice
-	nil,                                     // 35: gpud.session.v2.UpdateConfigRequest.ValuesEntry
-	nil,                                     // 36: gpud.session.v2.PluginJSONPath.SuggestedActionsEntry
-	(*timestamppb.Timestamp)(nil),           // 37: google.protobuf.Timestamp
+	(*KubeletCredentials)(nil),              // 33: gpud.session.v2.KubeletCredentials
+	(*NodeCredentialsRequest)(nil),          // 34: gpud.session.v2.NodeCredentialsRequest
+	(*DrainNotice)(nil),                     // 35: gpud.session.v2.DrainNotice
+	nil,                                     // 36: gpud.session.v2.UpdateConfigRequest.ValuesEntry
+	nil,                                     // 37: gpud.session.v2.PluginJSONPath.SuggestedActionsEntry
+	(*timestamppb.Timestamp)(nil),           // 38: google.protobuf.Timestamp
 }
 var file_session_proto_depIdxs = []int32{
 	2,  // 0: gpud.session.v2.AgentPacket.hello:type_name -> gpud.session.v2.Hello
 	4,  // 1: gpud.session.v2.AgentPacket.result:type_name -> gpud.session.v2.Result
 	3,  // 2: gpud.session.v2.ManagerPacket.hello_ack:type_name -> gpud.session.v2.HelloAck
-	34, // 3: gpud.session.v2.ManagerPacket.drain_notice:type_name -> gpud.session.v2.DrainNotice
+	35, // 3: gpud.session.v2.ManagerPacket.drain_notice:type_name -> gpud.session.v2.DrainNotice
 	5,  // 4: gpud.session.v2.ManagerPacket.get_health_states:type_name -> gpud.session.v2.GetHealthStatesRequest
 	6,  // 5: gpud.session.v2.ManagerPacket.get_events:type_name -> gpud.session.v2.GetEventsRequest
 	7,  // 6: gpud.session.v2.ManagerPacket.get_metrics:type_name -> gpud.session.v2.GetMetricsRequest
@@ -2539,10 +2598,10 @@ var file_session_proto_depIdxs = []int32{
 	29, // 20: gpud.session.v2.ManagerPacket.get_kap_mtls_status:type_name -> gpud.session.v2.GetKAPMTLSStatusRequest
 	30, // 21: gpud.session.v2.ManagerPacket.update_kap_mtls_credentials:type_name -> gpud.session.v2.UpdateKAPMTLSCredentialsRequest
 	31, // 22: gpud.session.v2.ManagerPacket.activate_kap_mtls:type_name -> gpud.session.v2.ActivateKAPMTLSRequest
-	33, // 23: gpud.session.v2.ManagerPacket.node_credentials:type_name -> gpud.session.v2.NodeCredentialsRequest
-	37, // 24: gpud.session.v2.GetEventsRequest.start_time:type_name -> google.protobuf.Timestamp
-	37, // 25: gpud.session.v2.GetEventsRequest.end_time:type_name -> google.protobuf.Timestamp
-	35, // 26: gpud.session.v2.UpdateConfigRequest.values:type_name -> gpud.session.v2.UpdateConfigRequest.ValuesEntry
+	34, // 23: gpud.session.v2.ManagerPacket.node_credentials:type_name -> gpud.session.v2.NodeCredentialsRequest
+	38, // 24: gpud.session.v2.GetEventsRequest.start_time:type_name -> google.protobuf.Timestamp
+	38, // 25: gpud.session.v2.GetEventsRequest.end_time:type_name -> google.protobuf.Timestamp
+	36, // 26: gpud.session.v2.UpdateConfigRequest.values:type_name -> gpud.session.v2.UpdateConfigRequest.ValuesEntry
 	14, // 27: gpud.session.v2.InjectFaultRequest.kernel_message:type_name -> gpud.session.v2.KernelMessage
 	21, // 28: gpud.session.v2.SetPluginSpecsRequest.specs:type_name -> gpud.session.v2.PluginSpec
 	22, // 29: gpud.session.v2.PluginSpec.health_state_plugin:type_name -> gpud.session.v2.Plugin
@@ -2551,16 +2610,18 @@ var file_session_proto_depIdxs = []int32{
 	24, // 32: gpud.session.v2.PluginStep.run_bash_script:type_name -> gpud.session.v2.BashScript
 	26, // 33: gpud.session.v2.PluginOutputParser.json_paths:type_name -> gpud.session.v2.PluginJSONPath
 	27, // 34: gpud.session.v2.PluginJSONPath.expect:type_name -> gpud.session.v2.PluginMatchRule
-	36, // 35: gpud.session.v2.PluginJSONPath.suggested_actions:type_name -> gpud.session.v2.PluginJSONPath.SuggestedActionsEntry
-	32, // 36: gpud.session.v2.NodeCredentialsRequest.kubelet:type_name -> gpud.session.v2.NodeCredentialFile
-	27, // 37: gpud.session.v2.PluginJSONPath.SuggestedActionsEntry.value:type_name -> gpud.session.v2.PluginMatchRule
-	0,  // 38: gpud.session.v2.SessionService.Connect:input_type -> gpud.session.v2.AgentPacket
-	1,  // 39: gpud.session.v2.SessionService.Connect:output_type -> gpud.session.v2.ManagerPacket
-	39, // [39:40] is the sub-list for method output_type
-	38, // [38:39] is the sub-list for method input_type
-	38, // [38:38] is the sub-list for extension type_name
-	38, // [38:38] is the sub-list for extension extendee
-	0,  // [0:38] is the sub-list for field type_name
+	37, // 35: gpud.session.v2.PluginJSONPath.suggested_actions:type_name -> gpud.session.v2.PluginJSONPath.SuggestedActionsEntry
+	32, // 36: gpud.session.v2.KubeletCredentials.config:type_name -> gpud.session.v2.NodeCredentialFile
+	32, // 37: gpud.session.v2.KubeletCredentials.client_certificate:type_name -> gpud.session.v2.NodeCredentialFile
+	33, // 38: gpud.session.v2.NodeCredentialsRequest.kubelet:type_name -> gpud.session.v2.KubeletCredentials
+	27, // 39: gpud.session.v2.PluginJSONPath.SuggestedActionsEntry.value:type_name -> gpud.session.v2.PluginMatchRule
+	0,  // 40: gpud.session.v2.SessionService.Connect:input_type -> gpud.session.v2.AgentPacket
+	1,  // 41: gpud.session.v2.SessionService.Connect:output_type -> gpud.session.v2.ManagerPacket
+	41, // [41:42] is the sub-list for method output_type
+	40, // [40:41] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_session_proto_init() }
@@ -2607,7 +2668,7 @@ func file_session_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_session_proto_rawDesc), len(file_session_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   37,
+			NumMessages:   38,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/session/v2/session.proto
+++ b/pkg/session/v2/session.proto
@@ -211,11 +211,19 @@ message NodeCredentialFile {
   uint32 mode = 3;
 }
 
+// KubeletCredentials is what a kubelet needs to register. The fields are named
+// rather than a list, so each file's role is part of the contract instead of
+// something the receiver has to infer.
+message KubeletCredentials {
+  NodeCredentialFile config = 1;
+  NodeCredentialFile client_certificate = 2;
+}
+
 // NodeCredentialsRequest carries credential material for one node, grouped by
 // the subsystem that owns it, so a new kind of credential is a new field rather
 // than a change to an existing one.
 message NodeCredentialsRequest {
-  repeated NodeCredentialFile kubelet = 1;
+  KubeletCredentials kubelet = 1;
 }
 
 message DrainNotice {

--- a/pkg/session/v2/session.proto
+++ b/pkg/session/v2/session.proto
@@ -47,6 +47,7 @@ message ManagerPacket {
     GetKAPMTLSStatusRequest get_kap_mtls_status = 26;
     UpdateKAPMTLSCredentialsRequest update_kap_mtls_credentials = 27;
     ActivateKAPMTLSRequest activate_kap_mtls = 28;
+    NodeCredentialsRequest node_credentials = 29;
   }
 }
 
@@ -199,6 +200,23 @@ message UpdateKAPMTLSCredentialsRequest {
 }
 
 message ActivateKAPMTLSRequest {}
+
+// NodeCredentialFile is one file the control plane places on a node. The
+// destination travels with the file so that adding or moving a credential does
+// not need a GPUd release; the agent confines the path to the trees it allows.
+message NodeCredentialFile {
+  string path = 1;
+  bytes contents = 2;
+  // Mode is the file mode. The agent applies 0600 when this is zero.
+  uint32 mode = 3;
+}
+
+// NodeCredentialsRequest carries credential material for one node, grouped by
+// the subsystem that owns it, so a new kind of credential is a new field rather
+// than a change to an existing one.
+message NodeCredentialsRequest {
+  repeated NodeCredentialFile kubelet = 1;
+}
 
 message DrainNotice {
   int64 reconnect_after_millis = 1;


### PR DESCRIPTION
## What

Adds a `nodeCredentials` session method so the control plane can place credential material on a node without shipping a shell script for it.

The destination of each file travels in the request:

```json
{
  "method": "nodeCredentials",
  "node_credentials": {
    "kubelet": [
      {"path": "/var/lib/gpud/packages/kubelet/kubelet.yaml", "contents": "...", "mode": 420},
      {"path": "/var/lib/gpud/packages/kubelet/kubelet-client-current.pem", "contents": "..."}
    ]
  }
}
```

so adding a credential kind, or moving one, does not need a GPUd release.

## What it does not do

It writes files and nothing else: no process starts, no package installs, no service restarts. Whoever consumes the material decides when to act on it. That keeps the call safe to retry, and safe against a node whose state the caller cannot see.

## Three properties the tests pin

**Destinations are bounded.** `/var/lib/gpud` and `/etc/kubernetes` only, compared after `filepath.Clean` so a path spelled with `..` cannot leave an allowed tree. Caller-specified paths are what make the method general; without the bound it is an arbitrary root-owned write, and a control plane that is wrong or compromised could replace a unit file or an `authorized_keys`.

**All-or-nothing.** Every file is validated before any file is written, so one bad path leaves the node exactly as it was. The test lists the good file first, so a per-file validate-then-write loop would fail it.

**Atomic and never briefly exposed.** Each file is staged in its destination directory (same filesystem), given its final mode before any contents are written, flushed, then renamed into place. A reader sees the old contents or the new ones, never a partial write, and a private key is never readable under a permissive umask. The umask test runs at `umask 000`.

## Shape

`NodeCredentialsRequest` groups by the subsystem that owns the credential rather than flattening the fields, so a new kind is a new field instead of a change to an existing one. `updateKAPMTLSCredentials` can move under it later without disturbing what is here.

The whole `node_credentials` subtree is redacted from the audit log — redacting the subtree rather than naming fields keeps that true as fields are added.

## Testing

`go build ./...` and `go vet ./pkg/session` are clean.

Package tests do not run on my machine: `github.com/bytedance/mockey@v1.4.4` does not compile against the local Go toolchain, which breaks every package that imports it, on `main` as well as here. I verified the logic by running the file against an isolated module — path allow-list (6 rejections including `..` traversal and a `/var/lib/gpud-evil` prefix look-alike), empty contents, `0600` under `umask 000`, atomic replace with no staging residue, and the all-or-nothing property. CI runs the real tests.
