### PR TITLE
[LEP-6152] fix(machine-info): align GPU identifiers with MachineGPUInfo

### DIFF
--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -286,24 +286,6 @@ type MachineInfo struct {
 	// Uptime represents when the machine up
 	Uptime metav1.Time `json:"uptime,omitempty"`
 
-	// ClusterUUID is the GPU fabric cluster UUID ("Cluster UUID" in nvidia-smi -q).
-	// All nodes in one NVLink fabric, for example one NVIDIA GB200 NVL72 rack,
-	// report the same value. NVIDIA uses it to group nodes by fabric domain.
-	// Collected with the NVML fabric state API. Empty when the node is not in
-	// an NVLink fabric.
-	ClusterUUID string `json:"clusterUUID,omitempty"`
-	// CliqueID is the GPU fabric clique ID ("Clique Id" in nvidia-smi -q).
-	// It identifies the clique of the node inside the NVLink fabric. NVIDIA
-	// uses it to place and isolate workloads on multi-node NVLink systems.
-	// Collected with the NVML fabric state API. Zero when the node is not in
-	// an NVLink fabric.
-	CliqueID uint32 `json:"cliqueID,omitempty"`
-	// ChassisSerial is the serial number of the chassis that contains the GPUs
-	// as reported by NVML platform info. Support and operations teams use it to
-	// find the physical hardware for repair or replacement.
-	// Empty when the platform does not report a chassis serial number.
-	ChassisSerial string `json:"chassisSerial,omitempty"`
-
 	// CPUInfo is the CPU info of the machine.
 	CPUInfo *MachineCPUInfo `json:"cpuInfo,omitempty"`
 	// MemoryInfo is the memory info of the machine.
@@ -343,14 +325,16 @@ func (i *MachineInfo) RenderTable(wr io.Writer) {
 		table.Append([]string{"GPU Memory", i.GPUInfo.Memory})
 	}
 
-	if i.ClusterUUID != "" {
-		table.Append([]string{"GPU Fabric Cluster UUID", i.ClusterUUID})
-	}
-	if i.CliqueID != 0 {
-		table.Append([]string{"GPU Fabric Clique ID", fmt.Sprintf("%d", i.CliqueID)})
-	}
-	if i.ChassisSerial != "" {
-		table.Append([]string{"Chassis Serial", i.ChassisSerial})
+	if i.GPUInfo != nil {
+		if i.GPUInfo.ClusterUUID != "" {
+			table.Append([]string{"GPU Fabric Cluster UUID", i.GPUInfo.ClusterUUID})
+		}
+		if i.GPUInfo.CliqueID != nil {
+			table.Append([]string{"GPU Fabric Clique ID", fmt.Sprintf("%d", *i.GPUInfo.CliqueID)})
+		}
+		if i.GPUInfo.ChassisSerial != "" {
+			table.Append([]string{"Chassis Serial", i.GPUInfo.ChassisSerial})
+		}
 	}
 
 	if i.NICInfo != nil {
@@ -399,6 +383,22 @@ type MachineGPUInfo struct {
 	Architecture string `json:"architecture,omitempty"`
 
 	Memory string `json:"memory,omitempty"`
+
+	// ClusterUUID is the GPU fabric cluster UUID ("Cluster UUID" in nvidia-smi -q).
+	// All nodes in one NVLink fabric, for example one NVIDIA GB200 NVL72 rack,
+	// report the same value. NVIDIA uses it to group nodes by fabric domain.
+	// Collected with the NVML fabric state API. Empty when the node is not in
+	// an NVLink fabric.
+	ClusterUUID string `json:"clusterUUID,omitempty"`
+	// CliqueID is the GPU fabric clique ID ("Clique Id" in nvidia-smi -q).
+	// It identifies the clique of the node inside the NVLink fabric. A pointer
+	// preserves clique 0 as a reported value while nil means not reported.
+	CliqueID *uint32 `json:"cliqueID,omitempty"`
+	// ChassisSerial is the serial number of the chassis that contains the GPUs
+	// as reported by NVML platform info. Support and operations teams use it to
+	// find the physical hardware for repair or replacement.
+	// Empty when the platform does not report a chassis serial number.
+	ChassisSerial string `json:"chassisSerial,omitempty"`
 
 	// GPUs is the GPU info of the machine.
 	GPUs []MachineGPUInstance `json:"gpus,omitempty"`

--- a/api/v1/types_test.go
+++ b/api/v1/types_test.go
@@ -2,7 +2,12 @@ package v1
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 )
 
 func TestEventTypeFromString(t *testing.T) {
@@ -96,6 +101,35 @@ func TestSuggestedActions_DescribeActions(t *testing.T) {
 	}
 }
 
+func TestMachineInfo_GPUIdentifierJSONShape(t *testing.T) {
+	cliqueZero := uint32(0)
+	info := MachineInfo{
+		GPUInfo: &MachineGPUInfo{
+			ClusterUUID:   "12345678-1234-1234-1234-1234567890ab",
+			CliqueID:      &cliqueZero,
+			ChassisSerial: "3136434J5234567",
+		},
+	}
+
+	raw, err := json.Marshal(info)
+	require.NoError(t, err)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.NotContains(t, got, "clusterUUID")
+	assert.NotContains(t, got, "cliqueID")
+	assert.NotContains(t, got, "chassisSerial")
+	gpuInfo, ok := got["gpuInfo"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "12345678-1234-1234-1234-1234567890ab", gpuInfo["clusterUUID"])
+	assert.Equal(t, float64(0), gpuInfo["cliqueID"])
+	assert.Equal(t, "3136434J5234567", gpuInfo["chassisSerial"])
+
+	info.GPUInfo.CliqueID = nil
+	raw, err = json.Marshal(info)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "cliqueID")
+}
+
 func TestMachineInfo_RenderTable(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -144,10 +178,12 @@ func TestMachineInfo_RenderTable(t *testing.T) {
 		{
 			name: "Machine info with GPU fabric identifiers and chassis serial",
 			machineInfo: MachineInfo{
-				GPUdVersion:   "1.0.0",
-				ClusterUUID:   "12345678-1234-1234-1234-1234567890ab",
-				CliqueID:      42,
-				ChassisSerial: "3136434J5234567",
+				GPUdVersion: "1.0.0",
+				GPUInfo: &MachineGPUInfo{
+					ClusterUUID:   "12345678-1234-1234-1234-1234567890ab",
+					CliqueID:      ptr.To(uint32(42)),
+					ChassisSerial: "3136434J5234567",
+				},
 			},
 			wantContains: []string{
 				"GPUd Version", "1.0.0",

--- a/cmd/gpud/machine-info/mock_command_test.go
+++ b/cmd/gpud/machine-info/mock_command_test.go
@@ -483,9 +483,15 @@ func TestCommand_JSONOutput(t *testing.T) {
 			return mockNVML, nil
 		}).Build()
 
+		cliqueZero := uint32(0)
 		mockey.Mock(pkgmachineinfo.GetMachineInfo).To(func(nvmlInstance nvidianvml.Instance) (*apiv1.MachineInfo, error) {
 			return &apiv1.MachineInfo{
 				MachineID: "test-machine-id",
+				GPUInfo: &apiv1.MachineGPUInfo{
+					ClusterUUID:   "12345678-1234-1234-1234-1234567890ab",
+					CliqueID:      &cliqueZero,
+					ChassisSerial: "3136434J5234567",
+				},
 			}, nil
 		}).Build()
 
@@ -517,6 +523,14 @@ func TestCommand_JSONOutput(t *testing.T) {
 		var out map[string]any
 		require.NoError(t, json.Unmarshal([]byte(stdout), &out))
 		assert.Equal(t, "", out["machine_id"])
+		machineInfoOut, ok := out["machine_info"].(map[string]any)
+		require.True(t, ok)
+		gpuInfoOut, ok := machineInfoOut["gpuInfo"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "12345678-1234-1234-1234-1234567890ab", gpuInfoOut["clusterUUID"])
+		assert.Equal(t, float64(0), gpuInfoOut["cliqueID"])
+		assert.Equal(t, "3136434J5234567", gpuInfoOut["chassisSerial"])
+		assert.NotContains(t, machineInfoOut, "clusterUUID")
 
 		providerOut, ok := out["provider"].(map[string]any)
 		require.True(t, ok)

--- a/pkg/machine-info/gossip_request_test.go
+++ b/pkg/machine-info/gossip_request_test.go
@@ -1,11 +1,13 @@
 package machineinfo
 
 import (
+	"encoding/json"
 	"errors"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	apiv1 "github.com/leptonai/gpud/api/v1"
 	"github.com/leptonai/gpud/pkg/log"
@@ -67,6 +69,33 @@ func TestCreateGossipRequest(t *testing.T) {
 }
 
 // TestCreateGossipRequestMocked tests the createGossipRequest function with mocked dependencies
+func TestGossipRequestGPUIdentifierWireShape(t *testing.T) {
+	cliqueZero := uint32(0)
+	req := apiv1.GossipRequest{
+		MachineID: "machine-1",
+		MachineInfo: &apiv1.MachineInfo{
+			GPUInfo: &apiv1.MachineGPUInfo{
+				ClusterUUID:   "12345678-1234-1234-1234-1234567890ab",
+				CliqueID:      &cliqueZero,
+				ChassisSerial: "3136434J5234567",
+			},
+		},
+	}
+
+	raw, err := json.Marshal(req)
+	require.NoError(t, err)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	machineInfo, ok := got["machineInfo"].(map[string]any)
+	require.True(t, ok)
+	gpuInfo, ok := machineInfo["gpuInfo"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "12345678-1234-1234-1234-1234567890ab", gpuInfo["clusterUUID"])
+	assert.Equal(t, float64(0), gpuInfo["cliqueID"])
+	assert.Equal(t, "3136434J5234567", gpuInfo["chassisSerial"])
+	assert.NotContains(t, machineInfo, "clusterUUID")
+}
+
 func TestCreateGossipRequestMocked(t *testing.T) {
 	// Setup
 	machineID := "test-machine-id"

--- a/pkg/machine-info/machine_info.go
+++ b/pkg/machine-info/machine_info.go
@@ -98,12 +98,13 @@ func GetMachineInfo(nvmlInstance nvidianvml.Instance) (*apiv1.MachineInfo, error
 		return nil, fmt.Errorf("failed to get machine gpu info: %w", err)
 	}
 
-	// The control plane records these values in the Machine CR status, so
-	// that operators can see the fabric domain and the clique of each node.
-	// Only NVLink fabric systems (e.g., NVIDIA GB200 NVL72) report them;
-	// they stay empty on other platforms.
-	info.ClusterUUID, info.CliqueID = getGPUFabricIdentifiers(nvmlInstance)
-	info.ChassisSerial = getGPUChassisSerial(nvmlInstance)
+	// The control plane records these values next to the other GPU properties in
+	// Machine.Status.MachineInfo.GPUInfo. Keep the producer wire shape aligned
+	// with that CRD shape so gpud-manager can unmarshal and persist them.
+	if info.GPUInfo != nil {
+		info.GPUInfo.ClusterUUID, info.GPUInfo.CliqueID = getGPUFabricIdentifiers(nvmlInstance)
+		info.GPUInfo.ChassisSerial = getGPUChassisSerial(nvmlInstance)
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
@@ -454,16 +455,17 @@ func GetSystemResourceGPUCount(nvmlInstance nvidianvml.Instance) (string, error)
 // these identifiers, so the first device with a readable fabric state is
 // sufficient. Fabric state telemetry is not supported on all platforms; in
 // that case this function returns empty values and does not fail.
-func getGPUFabricIdentifiers(nvmlInstance nvidianvml.Instance) (string, uint32) {
+func getGPUFabricIdentifiers(nvmlInstance nvidianvml.Instance) (string, *uint32) {
 	for uuid, dev := range nvmlInstance.Devices() {
 		fabricState, err := dev.GetFabricState()
 		if err != nil {
 			log.Logger.Debugw("failed to get GPU fabric state for machine info", "uuid", uuid, "error", err)
 			continue
 		}
-		return fabricState.ClusterUUID, fabricState.CliqueID
+		cliqueID := fabricState.CliqueID
+		return fabricState.ClusterUUID, &cliqueID
 	}
-	return "", 0
+	return "", nil
 }
 
 // getGPUChassisSerial returns the chassis serial reported by NVML platform

--- a/pkg/machine-info/machine_info_fabric_test.go
+++ b/pkg/machine-info/machine_info_fabric_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shirou/gopsutil/v4/mem"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 
 	nvidiamemory "github.com/leptonai/gpud/components/accelerator/nvidia/memory"
 	pkghost "github.com/leptonai/gpud/pkg/host"
@@ -58,7 +59,7 @@ func TestGetGPUFabricIdentifiers(t *testing.T) {
 
 		clusterUUID, cliqueID := getGPUFabricIdentifiers(nvmlInstance)
 		assert.Equal(t, "cluster-uuid-123", clusterUUID)
-		assert.Equal(t, uint32(42), cliqueID)
+		assert.Equal(t, ptr.To(uint32(42)), cliqueID)
 	})
 
 	t.Run("skips devices with fabric state errors", func(t *testing.T) {
@@ -79,7 +80,7 @@ func TestGetGPUFabricIdentifiers(t *testing.T) {
 
 		clusterUUID, cliqueID := getGPUFabricIdentifiers(nvmlInstance)
 		assert.Equal(t, "cluster-uuid-456", clusterUUID)
-		assert.Equal(t, uint32(7), cliqueID)
+		assert.Equal(t, ptr.To(uint32(7)), cliqueID)
 	})
 
 	t.Run("returns empty values when no device supports fabric state", func(t *testing.T) {
@@ -90,7 +91,7 @@ func TestGetGPUFabricIdentifiers(t *testing.T) {
 
 		clusterUUID, cliqueID := getGPUFabricIdentifiers(nvmlInstance)
 		assert.Empty(t, clusterUUID)
-		assert.Zero(t, cliqueID)
+		assert.Nil(t, cliqueID)
 	})
 
 	t.Run("returns empty values without devices", func(t *testing.T) {
@@ -100,7 +101,7 @@ func TestGetGPUFabricIdentifiers(t *testing.T) {
 
 		clusterUUID, cliqueID := getGPUFabricIdentifiers(nvmlInstance)
 		assert.Empty(t, clusterUUID)
-		assert.Zero(t, cliqueID)
+		assert.Nil(t, cliqueID)
 	})
 }
 
@@ -142,9 +143,10 @@ func TestGetMachineInfo_GPUFabricIdentifiers(t *testing.T) {
 		info, err := GetMachineInfo(nvmlInstance)
 		require.NoError(t, err)
 		require.NotNil(t, info)
-		assert.Equal(t, "cluster-uuid-123", info.ClusterUUID)
-		assert.Equal(t, uint32(42), info.CliqueID)
-		assert.Equal(t, "3136434J5234567", info.ChassisSerial)
+		require.NotNil(t, info.GPUInfo)
+		assert.Equal(t, "cluster-uuid-123", info.GPUInfo.ClusterUUID)
+		assert.Equal(t, ptr.To(uint32(42)), info.GPUInfo.CliqueID)
+		assert.Equal(t, "3136434J5234567", info.GPUInfo.ChassisSerial)
 	})
 
 	mockey.PatchConvey("GetMachineInfo tolerates NVML platform info failure", t, func() {
@@ -175,8 +177,9 @@ func TestGetMachineInfo_GPUFabricIdentifiers(t *testing.T) {
 		info, err := GetMachineInfo(nvmlInstance)
 		require.NoError(t, err)
 		require.NotNil(t, info)
-		assert.Empty(t, info.ClusterUUID)
-		assert.Zero(t, info.CliqueID)
-		assert.Empty(t, info.ChassisSerial)
+		require.NotNil(t, info.GPUInfo)
+		assert.Empty(t, info.GPUInfo.ClusterUUID)
+		assert.Nil(t, info.GPUInfo.CliqueID)
+		assert.Empty(t, info.GPUInfo.ChassisSerial)
 	})
 }

--- a/pkg/server/mock_server_test.go
+++ b/pkg/server/mock_server_test.go
@@ -982,12 +982,18 @@ func TestHandleAdminPackagesStatus_Error(t *testing.T) {
 // TestMachineInfo_WithMockedGetMachineInfo tests machineInfo with a successful mocked GetMachineInfo.
 func TestMachineInfo_WithMockedGetMachineInfo(t *testing.T) {
 	mockey.PatchConvey("machineInfo returns mocked machine info", t, func() {
+		cliqueZero := uint32(0)
 		expectedInfo := &apiv1.MachineInfo{
 			GPUdVersion:     "test-version",
 			KernelVersion:   "5.4.0-test",
 			OSImage:         "TestOS",
 			Hostname:        "test-host",
 			OperatingSystem: "linux",
+			GPUInfo: &apiv1.MachineGPUInfo{
+				ClusterUUID:   "12345678-1234-1234-1234-1234567890ab",
+				CliqueID:      &cliqueZero,
+				ChassisSerial: "3136434J5234567",
+			},
 		}
 
 		mockey.Mock(pkgmachineinfo.GetMachineInfo).To(func(nvmlInstance nvidianvml.Instance) (*apiv1.MachineInfo, error) {
@@ -1014,6 +1020,10 @@ func TestMachineInfo_WithMockedGetMachineInfo(t *testing.T) {
 		assert.Equal(t, "TestOS", resp.OSImage)
 		assert.Equal(t, "test-host", resp.Hostname)
 		assert.Equal(t, "linux", resp.OperatingSystem)
+		require.NotNil(t, resp.GPUInfo)
+		assert.Equal(t, "12345678-1234-1234-1234-1234567890ab", resp.GPUInfo.ClusterUUID)
+		assert.Equal(t, uint32(0), *resp.GPUInfo.CliqueID)
+		assert.Equal(t, "3136434J5234567", resp.GPUInfo.ChassisSerial)
 	})
 }
 


### PR DESCRIPTION
Move ClusterUUID, CliqueID, and ChassisSerial into the nested gpuInfo JSON object consumed by lepton main. Preserve an explicitly reported clique ID of zero with a pointer, while nil remains unreported. Keep the plain machine-info rows unchanged and pin CLI, HTTP, gossip, and JSON contracts with tests.