### PR TITLE
[LEP-6173] feat(nvml): prefer pre-installed host driver, mount driver roots by default

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -207,6 +207,10 @@ sudo rm /etc/systemd/system/gpud.service
 					Hidden: true,
 					Usage:  "(optional) re-run login on start to fetch the current session token. Use only for BYOK deployments that supply a valid registration token on every start.",
 				},
+				&cli.BoolFlag{
+					Name:  "require-nvidia-driver",
+					Usage: "when login is configured, fail before registration if NVIDIA GPU hardware is present but the NVIDIA driver or NVML is unavailable",
+				},
 				&cli.StringFlag{
 					Name:   "token",
 					Hidden: true,

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -33,11 +33,49 @@ import (
 	pkgmachineinfo "github.com/leptonai/gpud/pkg/machine-info"
 	pkgmetadata "github.com/leptonai/gpud/pkg/metadata"
 	pkgnfschecker "github.com/leptonai/gpud/pkg/nfs-checker"
+	nvidianvml "github.com/leptonai/gpud/pkg/nvidia/nvml"
+	nvidiapci "github.com/leptonai/gpud/pkg/nvidia/pci"
 	gpudserver "github.com/leptonai/gpud/pkg/server"
 	pkgsqlite "github.com/leptonai/gpud/pkg/sqlite"
 	pkgsystemd "github.com/leptonai/gpud/pkg/systemd"
 	"github.com/leptonai/gpud/version"
 )
+
+var hasNVIDIAGPU = func() (bool, error) {
+	return nvidiapci.HasNVIDIAGPU(nvidiapci.DefaultSysfsPCIDevicesDir)
+}
+
+var newNVMLInstance = nvidianvml.New
+
+func requireNVIDIADriver() error {
+	hasGPU, err := hasNVIDIAGPU()
+	if err != nil {
+		return fmt.Errorf("failed to detect NVIDIA GPU devices: %w", err)
+	}
+	if !hasGPU {
+		return nil
+	}
+
+	instance, err := newNVMLInstance()
+	if err != nil {
+		return fmt.Errorf("NVIDIA GPU detected but the NVIDIA driver is not ready: %w", err)
+	}
+	defer func() {
+		if err := instance.Shutdown(); err != nil {
+			log.Logger.Debugw("failed to shut down pre-login NVML instance", "error", err)
+		}
+	}()
+
+	if !instance.NVMLExists() {
+		return fmt.Errorf("NVIDIA GPU detected but the NVIDIA NVML library is not loaded")
+	}
+	if err := instance.InitError(); err != nil {
+		return fmt.Errorf("NVIDIA GPU detected but the NVIDIA driver is not ready: %w", err)
+	}
+	return nil
+}
+
+var ensureNVIDIADriver = requireNVIDIADriver
 
 func Command(cliContext *cli.Context) error {
 	logLevel := cliContext.String("log-level")
@@ -90,6 +128,12 @@ func Command(cliContext *cli.Context) error {
 	shouldOverwriteMachineID := cliContext.Bool("machine-id-overwrite")
 	refreshSessionToken := cliContext.Bool("refresh-session-token")
 	controlPlaneLoginSucceeded := false
+
+	if cliContext.Bool("require-nvidia-driver") && (cliContext.IsSet("token") || controlPlaneLoginRegistrationToken != "") {
+		if err := ensureNVIDIADriver(); err != nil {
+			return err
+		}
+	}
 
 	// Note: login.Login() ALWAYS writes to the persistent state file (via dataDir),
 	// regardless of --db-in-memory flag. The login package doesn't know about in-memory mode.

--- a/cmd/gpud/run/mock_command_exec_test.go
+++ b/cmd/gpud/run/mock_command_exec_test.go
@@ -49,6 +49,7 @@ func newTestCLIContext(t *testing.T, values cliFlagValues) *cli.Context {
 	set.String("machine-id", "", "")
 	set.Bool("machine-id-overwrite", false, "")
 	set.Bool("refresh-session-token", false, "")
+	set.Bool("require-nvidia-driver", false, "")
 	set.String("listen-address", "", "")
 	set.Bool("pprof", false, "")
 	set.Duration("metrics-retention-period", 0, "")

--- a/cmd/gpud/run/require_nvidia_driver_test.go
+++ b/cmd/gpud/run/require_nvidia_driver_test.go
@@ -1,0 +1,183 @@
+//go:build linux
+
+package run
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	gpudmanager "github.com/leptonai/gpud/pkg/gpud-manager"
+	"github.com/leptonai/gpud/pkg/login"
+	nvidianvml "github.com/leptonai/gpud/pkg/nvidia/nvml"
+	nvidiapci "github.com/leptonai/gpud/pkg/nvidia/pci"
+)
+
+func stubNVIDIADriverRequirement(
+	t *testing.T,
+	hasGPU bool,
+	detectErr error,
+	instance nvidianvml.Instance,
+	nvmlErr error,
+) {
+	t.Helper()
+	originalHasGPU := hasNVIDIAGPU
+	originalNewNVML := newNVMLInstance
+	hasNVIDIAGPU = func() (bool, error) { return hasGPU, detectErr }
+	newNVMLInstance = func() (nvidianvml.Instance, error) { return instance, nvmlErr }
+	t.Cleanup(func() {
+		hasNVIDIAGPU = originalHasGPU
+		newNVMLInstance = originalNewNVML
+	})
+}
+
+func TestRequireNVIDIADriver(t *testing.T) {
+	t.Run("CPU-only node does not require NVML", func(t *testing.T) {
+		stubNVIDIADriverRequirement(t, false, nil, nil, errors.New("must not be called"))
+		require.NoError(t, requireNVIDIADriver())
+	})
+
+	t.Run("PCI detection failure is fatal", func(t *testing.T) {
+		stubNVIDIADriverRequirement(t, false, errors.New("sysfs unavailable"), nil, nil)
+		err := requireNVIDIADriver()
+		require.ErrorContains(t, err, "failed to detect NVIDIA GPU devices")
+	})
+
+	t.Run("GPU with missing NVML is rejected", func(t *testing.T) {
+		stubNVIDIADriverRequirement(t, true, nil, nvidianvml.NewNoOp(), nil)
+		err := requireNVIDIADriver()
+		require.ErrorContains(t, err, "NVML library is not loaded")
+	})
+
+	t.Run("GPU with NVML initialization error is rejected", func(t *testing.T) {
+		stubNVIDIADriverRequirement(t, true, nil, nil, errors.New("driver not ready"))
+		err := requireNVIDIADriver()
+		require.ErrorContains(t, err, "driver is not ready")
+	})
+
+	t.Run("GPU with working NVML is accepted", func(t *testing.T) {
+		stubNVIDIADriverRequirement(t, true, nil, &testNVMLInstance{exists: true}, nil)
+		require.NoError(t, requireNVIDIADriver())
+	})
+
+	t.Run("GPU with NVML device initialization error is rejected", func(t *testing.T) {
+		stubNVIDIADriverRequirement(t, true, nil, &testNVMLInstance{exists: true, initErr: errors.New("device enumeration failed")}, nil)
+		err := requireNVIDIADriver()
+		require.ErrorContains(t, err, "device enumeration failed")
+	})
+
+	t.Run("NVML shutdown error is non-fatal", func(t *testing.T) {
+		stubNVIDIADriverRequirement(t, true, nil, &testNVMLInstance{exists: true, shutdownErr: errors.New("shutdown failed")}, nil)
+		require.NoError(t, requireNVIDIADriver())
+	})
+}
+
+type testNVMLInstance struct {
+	nvidianvml.Instance
+	exists      bool
+	initErr     error
+	shutdownErr error
+}
+
+func (i *testNVMLInstance) NVMLExists() bool { return i.exists }
+func (i *testNVMLInstance) InitError() error { return i.initErr }
+func (i *testNVMLInstance) Shutdown() error  { return i.shutdownErr }
+
+func TestHasNVIDIAGPUReadsDefaultSysfs(t *testing.T) {
+	if _, err := os.Stat(nvidiapci.DefaultSysfsPCIDevicesDir); err != nil {
+		t.Skipf("sysfs PCI devices directory %q not available", nvidiapci.DefaultSysfsPCIDevicesDir)
+	}
+	_, err := hasNVIDIAGPU()
+	require.NoError(t, err)
+}
+
+func TestCommandRequireNVIDIADriverStopsBeforeLogin(t *testing.T) {
+	ctx := newTestCLIContext(t, cliFlagValues{
+		stringFlags: map[string]string{
+			"log-level": "info",
+			"data-dir":  t.TempDir(),
+			"token":     "registration-token",
+		},
+		boolFlags: map[string]bool{
+			"require-nvidia-driver": true,
+		},
+	})
+
+	mockey.PatchConvey("driver gate stops before login", t, func() {
+		loginCalled := false
+		mockey.Mock(ensureNVIDIADriver).Return(errors.New("NVIDIA NVML library is not loaded")).Build()
+		mockey.Mock(login.Login).To(func(context.Context, login.LoginConfig) error {
+			loginCalled = true
+			return nil
+		}).Build()
+
+		err := Command(ctx)
+		require.ErrorContains(t, err, "NVML library is not loaded")
+		assert.False(t, loginCalled)
+	})
+}
+
+func TestCommandRequireNVIDIADriverSkipsGateWithoutLogin(t *testing.T) {
+	ctx := newTestCLIContext(t, cliFlagValues{
+		stringFlags: map[string]string{
+			"log-level": "info",
+			"data-dir":  t.TempDir(),
+		},
+		boolFlags: map[string]bool{
+			"require-nvidia-driver": true,
+		},
+	})
+
+	mockey.PatchConvey("driver gate only applies to login", t, func() {
+		gateCalled := false
+		mockey.Mock(ensureNVIDIADriver).To(func() error {
+			gateCalled = true
+			return errors.New("must not be called")
+		}).Build()
+		mockey.Mock((*gpudmanager.Manager).Start).Return(errors.New("stop after login gate")).Build()
+
+		err := Command(ctx)
+		require.ErrorContains(t, err, "stop after login gate")
+		assert.False(t, gateCalled)
+	})
+}
+
+func TestCommandRequireNVIDIADriverGatePassesBeforeLogin(t *testing.T) {
+	ctx := newTestCLIContext(t, cliFlagValues{
+		stringFlags: map[string]string{
+			"log-level": "info",
+			"data-dir":  t.TempDir(),
+			"token":     "registration-token",
+		},
+		boolFlags: map[string]bool{
+			"require-nvidia-driver": true,
+		},
+	})
+
+	mockey.PatchConvey("driver gate passes and login proceeds", t, func() {
+		gateCalled := false
+		loginCalled := false
+		mockey.Mock(ensureNVIDIADriver).To(func() error {
+			gateCalled = true
+			return nil
+		}).Build()
+		mockey.Mock(login.Login).To(func(context.Context, login.LoginConfig) error {
+			loginCalled = true
+			return nil
+		}).Build()
+		mockey.Mock(recordLoginSuccessState).To(func(context.Context, string) error {
+			return nil
+		}).Build()
+		mockey.Mock((*gpudmanager.Manager).Start).Return(errors.New("stop after driver gate")).Build()
+
+		err := Command(ctx)
+		require.ErrorContains(t, err, "stop after driver gate")
+		assert.True(t, gateCalled)
+		assert.True(t, loginCalled)
+	})
+}

--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -161,12 +161,29 @@ spec:
 
         {{- if .Values.gpud.mountNVIDIADriverRoot }}
         # GPU Operator installs its driver libraries under this host path.
-        # On preinstalled-driver nodes this may be empty; gpud then preserves its
+        # gpud probes this well-known container path automatically when the
+        # mount is present -- no environment variable is needed because the
+        # path is fixed here and the mount is on by default. On
+        # preinstalled-driver nodes this may be empty; gpud then preserves its
         # normal system-library lookup.
         - name: host-nvidia-driver
           hostPath:
             path: /run/nvidia/driver
             type: DirectoryOrCreate
+        {{- end }}
+
+        {{- if .Values.gpud.mountHostRoot }}
+        # Host root filesystem, exposing pre-installed NVIDIA driver libraries
+        # under /host/usr/lib*. Same "host-root" pattern as the GPU Operator's
+        # DRA driver DaemonSet. gpud probes this well-known path automatically
+        # (before the driver root, so a pre-installed host driver wins),
+        # including the Operator's driver-ready contract at
+        # /host/run/nvidia/validations/driver-ready -- again with no
+        # environment variable, since the mount path is fixed.
+        - name: host-root
+          hostPath:
+            path: /
+            type: Directory
         {{- end }}
 
         {{- if .Values.gpud.mountContainerd }}
@@ -403,6 +420,10 @@ spec:
                 set -- "$@" --refresh-session-token
               fi
 
+              if [ "${GPUD_REQUIRE_NVIDIA_DRIVER:-}" = "true" ]; then
+                set -- "$@" --require-nvidia-driver
+              fi
+
               set -- "$@" --enable-auto-update={{ .Values.gpud.enableAutoUpdate }}
               set -- "$@" --auto-update-exit-code={{ .Values.gpud.autoUpdateExitCode }}
 
@@ -458,12 +479,6 @@ spec:
           env:
             - name: GPUD_NO_USAGE_STATS
               value: {{ not .Values.gpud.telemetry.enabled | quote }}
-            {{- if .Values.gpud.mountNVIDIADriverRoot }}
-            # Opt in to the GPU Operator driver-root fallback. Bare-metal/systemd
-            # runs do not receive this environment variable.
-            - name: GPUD_NVIDIA_DRIVER_ROOT
-              value: /run/nvidia/driver
-            {{- end }}
             {{- if .Values.gpud.tokenSecret.name }}
             # Session token sourced from an existing Secret (takes priority over a
             # token node label). Consumed by the startup script as $GPUD_TOKEN.
@@ -483,6 +498,12 @@ spec:
             # BYOK only: re-login on startup using the injected registration token.
             # Consumed as $GPUD_REFRESH_SESSION_TOKEN.
             - name: GPUD_REFRESH_SESSION_TOKEN
+              value: "true"
+            {{- end }}
+            {{- if .Values.gpud.requireNVIDIADriver }}
+            # BYOK: do not register NVIDIA GPU hardware until the driver and
+            # NVML are available. CPU-only nodes are unaffected.
+            - name: GPUD_REQUIRE_NVIDIA_DRIVER
               value: "true"
             {{- end }}
             {{- if .Values.gpud.rebootCommands }}
@@ -602,9 +623,22 @@ spec:
             {{- if .Values.gpud.mountNVIDIADriverRoot }}
             # GPU Operator-managed driver libraries. Read-only because gpud only
             # loads NVML and never modifies the driver installation.
+            # HostToContainer so an Operator driver (re)install that creates
+            # mounts under /run/nvidia/driver is visible without a pod restart.
             - name: host-nvidia-driver
               mountPath: /run/nvidia/driver
               readOnly: true
+              mountPropagation: HostToContainer
+            {{- end }}
+
+            {{- if .Values.gpud.mountHostRoot }}
+            # Pre-installed host driver libraries under /host/usr/lib*.
+            # Read-only; HostToContainer mirrors the GPU Operator's DRA driver
+            # DaemonSet so host driver changes propagate into the container.
+            - name: host-root
+              mountPath: /host
+              readOnly: true
+              mountPropagation: HostToContainer
             {{- end }}
 
             {{- if .Values.gpud.mountContainerd }}

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -74,6 +74,11 @@ gpud:
   # token on every start and needs to recover a stale session token.
   refreshSessionToken: false
 
+  # Refuse to register an NVIDIA GPU node until its driver and NVML are ready.
+  # CPU-only nodes continue normally. Enable this for BYOK, where administrators
+  # must install a working NVIDIA driver before the node joins Lepton.
+  requireNVIDIADriver: true
+
   # Enable auto update of gpud.
   enableAutoUpdate: false
 
@@ -159,12 +164,28 @@ gpud:
   containerdServiceActiveCommands: "nsenter --target 1 --mount -- systemctl is-active containerd"
 
   # Mount the GPU Operator's host driver installation at /run/nvidia/driver.
-  # The matching GPUD_NVIDIA_DRIVER_ROOT environment variable makes gpud use
-  # NVML from that tree when present. This is Helm/container-specific; systemd
-  # installations retain the standard system-library lookup.
-  # Enable this on GPU Operator clusters. It defaults to false so the chart does
-  # not create /run/nvidia/driver on nodes that use preinstalled drivers.
-  mountNVIDIADriverRoot: false
+  # gpud probes this well-known path automatically when the mount is present
+  # and loads NVML from that tree -- there is no environment variable for it
+  # because the chart fixes the mount path and the probe is existence-based.
+  # This is Helm/container-specific; systemd installations retain the standard
+  # system-library lookup.
+  # Defaults to true so GPU Operator clusters work out of the box, matching the
+  # Operator's own DRA driver DaemonSet (which also uses DirectoryOrCreate).
+  # On nodes with preinstalled drivers the hostPath may create an empty,
+  # unused /run/nvidia/driver directory; set to false to avoid that.
+  mountNVIDIADriverRoot: true
+
+  # Mount the host root filesystem read-only at /host so gpud can load NVML
+  # from a pre-installed host driver (host /usr/lib*). gpud probes this
+  # well-known path automatically and prefers the pre-installed host driver
+  # over the GPU Operator driver root when both are present, mirroring the
+  # Operator's own driver-validation order. The mount also exposes the
+  # Operator's driver-ready contract
+  # (/host/run/nvidia/validations/driver-ready), so a non-default Operator
+  # driver install directory is discovered without extra configuration.
+  # Without this mount, a containerized gpud cannot see the host's driver
+  # libraries.
+  mountHostRoot: true
 
   # Mount the host containerd directories so the containerd component can monitor
   # the node's containerd when gpud runs inside a container:

--- a/pkg/nvidia/nvml/lib/default_test.go
+++ b/pkg/nvidia/nvml/lib/default_test.go
@@ -16,7 +16,6 @@ func TestNewDefaultNoEnvVars(t *testing.T) {
 	require.NoError(t, os.Unsetenv(EnvInjectRemapedRowsPending))
 	require.NoError(t, os.Unsetenv(EnvInjectClockEventsHwSlowdown))
 	require.NoError(t, os.Unsetenv(EnvNVMLLibraryPath))
-	require.NoError(t, os.Unsetenv(EnvNVIDIADriverRoot))
 
 	// Create a new library instance
 	lib, err := New(WithInitReturn(nvml.SUCCESS))
@@ -102,5 +101,4 @@ func cleanupEnvVars() {
 	_ = os.Unsetenv(EnvInjectRemapedRowsPending)
 	_ = os.Unsetenv(EnvInjectClockEventsHwSlowdown)
 	_ = os.Unsetenv(EnvNVMLLibraryPath)
-	_ = os.Unsetenv(EnvNVIDIADriverRoot)
 }

--- a/pkg/nvidia/nvml/lib/options.go
+++ b/pkg/nvidia/nvml/lib/options.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	nvlibdevice "github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	nvinfo "github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
@@ -12,10 +13,25 @@ import (
 
 const (
 	// EnvNVMLLibraryPath explicitly selects the NVML shared library.
+	//
+	// This remains the only environment override for library selection.
+	// The two driver roots below are deliberately NOT configurable via
+	// environment variables: the gpud DaemonSet mounts them at these fixed,
+	// well-known paths by default (gpud.mountHostRoot and
+	// gpud.mountNVIDIADriverRoot), so an env var could only restate -- or
+	// disagree with -- the actual mount layout without adding flexibility.
 	EnvNVMLLibraryPath = "GPUD_NVML_LIBRARY_PATH"
-	// EnvNVIDIADriverRoot points at a containerized NVIDIA driver installation,
-	// such as the GPU Operator's /run/nvidia/driver tree.
-	EnvNVIDIADriverRoot = "GPUD_NVIDIA_DRIVER_ROOT"
+
+	// defaultHostRoot is the well-known container path where the gpud
+	// DaemonSet mounts the host root filesystem read-only, exposing a
+	// pre-installed host driver's libraries under "<root>/usr/lib...".
+	// It also exposes the GPU Operator's driver-ready validation contract,
+	// which gpud uses to discover a non-default driver install directory.
+	defaultHostRoot = "/host"
+
+	// defaultDriverRoot is the well-known container path where the gpud
+	// DaemonSet mounts the GPU Operator's driver installation tree.
+	defaultDriverRoot = "/run/nvidia/driver"
 )
 
 type Op struct {
@@ -53,27 +69,95 @@ func (op *Op) applyOpts(opts []OpOption) {
 }
 
 // resolveNVMLLibraryPath returns an explicitly configured library first, then
-// searches a configured driver root. With neither environment variable set it
-// returns empty, preserving go-nvml's standard system-library lookup.
+// probes the well-known driver roots that the gpud DaemonSet mounts by
+// default. It returns empty when no driver tree provides a library,
+// preserving go-nvml's standard system-library lookup.
+//
+// Every probe is existence-based, so on machines without these mounts (e.g.
+// bare-metal/systemd installations, where "/host" does not exist) resolution
+// falls through to the system lookup exactly as before.
 func resolveNVMLLibraryPath() string {
 	if libraryPath := os.Getenv(EnvNVMLLibraryPath); libraryPath != "" {
 		return libraryPath
 	}
+	return resolveFromDriverRoots(defaultHostRoot, defaultDriverRoot)
+}
 
-	driverRoot := os.Getenv(EnvNVIDIADriverRoot)
-	if driverRoot == "" {
-		return ""
+// resolveFromDriverRoots probes the host root and the GPU Operator driver
+// root for a usable NVML library. It takes the roots as parameters (rather
+// than reading the package constants) so tests can point the probes at
+// temporary directories.
+//
+// The probe order mirrors the GPU Operator's own driver-validation order: a
+// pre-installed host driver wins over the Operator-managed driver root when
+// both are present. Loading the host's own libnvidia-ml guarantees the
+// userspace library matches the loaded kernel module.
+func resolveFromDriverRoots(hostRoot, driverRoot string) string {
+	if libraryPath := probeNVMLLibrary(hostRoot); libraryPath != "" {
+		return libraryPath
 	}
 
+	// The GPU Operator records its validated driver root in the
+	// driver-ready contract; honor it to cover a non-default driver
+	// install directory (spec.hostPaths.driverInstallDir). The contract
+	// file lives on the host, so it is only readable through the host-root
+	// mount.
+	if libraryPath := probeDriverReadyContract(hostRoot); libraryPath != "" {
+		return libraryPath
+	}
+
+	return probeNVMLLibrary(driverRoot)
+}
+
+// probeNVMLLibrary returns the first existing NVML shared library under the
+// given root, covering the Debian/Ubuntu multiarch, RHEL lib64, and plain
+// usr/lib layouts. It returns empty when the root has no NVML library (e.g.,
+// the GPU Operator has not finished installing the driver yet).
+func probeNVMLLibrary(root string) string {
 	archLibraryDir := nvmlArchLibraryDir(runtime.GOARCH)
 	candidates := []string{
-		filepath.Join(driverRoot, "usr", "lib", archLibraryDir, "libnvidia-ml.so.1"),
-		filepath.Join(driverRoot, "usr", "lib64", "libnvidia-ml.so.1"),
-		filepath.Join(driverRoot, "usr", "lib", "libnvidia-ml.so.1"),
+		filepath.Join(root, "usr", "lib", archLibraryDir, "libnvidia-ml.so.1"),
+		filepath.Join(root, "usr", "lib64", "libnvidia-ml.so.1"),
+		filepath.Join(root, "usr", "lib", "libnvidia-ml.so.1"),
 	}
 	for _, candidate := range candidates {
 		if _, err := os.Stat(candidate); err == nil {
 			return candidate
+		}
+	}
+	return ""
+}
+
+// driverReadyContractPath is the GPU Operator's driver validation contract,
+// relative to the host root. The Operator's driver-validation step records
+// the selected NVIDIA_DRIVER_ROOT here after the driver validates, so it
+// reflects a non-default driver install directory
+// (spec.hostPaths.driverInstallDir).
+const driverReadyContractPath = "run/nvidia/validations/driver-ready"
+
+// probeDriverReadyContract reads the GPU Operator's driver-ready contract
+// under the given host root and probes the NVIDIA_DRIVER_ROOT it selects,
+// resolved under the same host root. It returns empty when the contract is
+// absent, unparseable, names a non-absolute path, or selects the host driver
+// ("/", already covered by the standard host-root probes). The contract's
+// DRIVER_ROOT_CTR_PATH is the DRA container's own mount path and does not
+// apply to gpud's mount layout.
+func probeDriverReadyContract(hostRoot string) string {
+	b, err := os.ReadFile(filepath.Join(hostRoot, driverReadyContractPath))
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		value, ok := strings.CutPrefix(strings.TrimSpace(line), "NVIDIA_DRIVER_ROOT=")
+		if !ok {
+			continue
+		}
+		value = strings.Trim(strings.TrimSpace(value), `"'`)
+		if value == "" || value == "/" || !filepath.IsAbs(value) {
+			continue
+		}
+		if libraryPath := probeNVMLLibrary(filepath.Join(hostRoot, value)); libraryPath != "" {
+			return libraryPath
 		}
 	}
 	return ""

--- a/pkg/nvidia/nvml/lib/options.go
+++ b/pkg/nvidia/nvml/lib/options.go
@@ -8,7 +8,10 @@ import (
 
 	nvlibdevice "github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	nvinfo "github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
+	nvdl "github.com/NVIDIA/go-nvml/pkg/dl"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+
+	"github.com/leptonai/gpud/pkg/log"
 )
 
 const (
@@ -63,6 +66,11 @@ func (op *Op) applyOpts(opts []OpOption) {
 		if libraryPath == "" {
 			op.nvmlLib = nvml.New()
 		} else {
+			// The companions must be loaded BEFORE the first NVML call
+			// (go-nvml dlopens libnvidia-ml lazily at nvml.New). See
+			// preloadNVMLCompanionLibraries for why resolving the library
+			// path alone is not sufficient inside a container.
+			preloadNVMLCompanionLibraries(libraryPath)
 			op.nvmlLib = nvml.New(nvml.WithLibraryPath(libraryPath))
 		}
 	}
@@ -161,6 +169,121 @@ func probeDriverReadyContract(hostRoot string) string {
 		}
 	}
 	return ""
+}
+
+// nvmlCompanionLibraryGlobs are the shared libraries that a driver-root
+// libnvidia-ml.so.1 needs at run time, expressed as globs against the
+// directory that libnvidia-ml.so.1 was resolved from.
+//
+// WHY these families: libnvidia-ml.so.1 dlopens libcuda.so.1 BY SONAME at
+// run time (confirmed by the SONAME strings embedded in the 580.x binary and
+// by runtime A/B tests on AKS A100 and NSCALE B200 nodes): when libcuda.so.1
+// cannot be found, every NVML query fails with NVML_ERROR_NOT_FOUND -- e.g.
+// "failed to get driver version: Not Found" -- even though libnvidia-ml
+// itself dlopened successfully. On 560+ driver trees, libcuda in turn loads
+// libnvidia-gpucomp.so.<version> for compute-related NVML queries, and NVML
+// uses libnvidia-cfg.so.1 for configuration queries. All three are therefore
+// preloaded whenever they exist alongside the resolved libnvidia-ml.
+//
+// WHY an explicit allowlist instead of LD_LIBRARY_PATH=<driver lib dir>: the
+// GPU Operator's driver tree bundles its OWN glibc in the same directory
+// (usr/lib/x86_64-linux-gnu/libc.so.6). Putting the whole directory on
+// LD_LIBRARY_PATH shadows the process glibc and crashes the gpud binary
+// itself ("libc.so.6: undefined symbol: __tunable_is_initialized, version
+// GLIBC_PRIVATE", observed on NSCALE driver 580.82.07). Preloading only the
+// NVIDIA companions by absolute path never touches libc/libpthread/libm: the
+// companions' own DT_NEEDED entries dedup against the glibc already loaded
+// in the gpud process.
+var nvmlCompanionLibraryGlobs = []string{
+	"libcuda.so*",
+	"libnvidia-cfg.so*",
+	"libnvidia-gpucomp.so*",
+}
+
+// findNVMLCompanionLibraries returns, for each companion family, the single
+// library file to preload from the directory of the resolved NVML library
+// path. It returns nil for a bare SONAME (e.g., "libnvidia-ml.so.1" with no
+// directory), because then resolution already defers to the system search
+// path, which also provides the companions.
+//
+// Kept separate from preloadNVMLCompanionLibraries so unit tests can assert
+// the selection without dlopening real driver libraries.
+func findNVMLCompanionLibraries(libraryPath string) []string {
+	dir := filepath.Dir(libraryPath)
+	if dir == "." || dir == "" {
+		return nil
+	}
+
+	var selected []string
+	for _, pattern := range nvmlCompanionLibraryGlobs {
+		// filepath.Glob returns sorted matches; a missing family is not an
+		// error (existence-based, mirroring the driver-root probes: older
+		// drivers ship no libnvidia-gpucomp, and that is fine).
+		matches, err := filepath.Glob(filepath.Join(dir, pattern))
+		if err != nil || len(matches) == 0 {
+			continue
+		}
+
+		// Prefer the SONAME symlink (e.g., "libcuda.so.1") over the dev
+		// symlink ("libcuda.so") and the versioned file
+		// ("libcuda.so.580.82.07"): the SONAME is the name libnvidia-ml
+		// looks up, and dlopening the symlink still registers the target's
+		// DT_SONAME, which is what makes the later by-SONAME lookup bind to
+		// this exact copy. libnvidia-gpucomp ships only as the versioned
+		// file, so "first sorted match" is the fallback.
+		pick := matches[0]
+		for _, m := range matches {
+			if strings.HasSuffix(m, ".so.1") {
+				pick = m
+				break
+			}
+		}
+		selected = append(selected, pick)
+	}
+	return selected
+}
+
+// preloadNVMLCompanionLibraries dlopens the NVML companion libraries from
+// the directory of the resolved NVML library path, and intentionally never
+// dlcloses them (they must stay loaded for the process lifetime, exactly
+// like libnvidia-ml itself).
+//
+// WHY this exists: the driver-root probes above fix WHERE libnvidia-ml.so.1
+// is found (a container that requests no GPU resources gets no toolkit
+// injection, so the driver tree mounted at /host or /run/nvidia/driver is
+// the only source), but an absolute-path dlopen of libnvidia-ml does NOT
+// make that tree's companion libraries discoverable -- libnvidia-ml looks
+// them up by bare SONAME through the standard search path, which does not
+// include the driver root. Preloading each companion by absolute path
+// registers its SONAME as already-loaded, so libnvidia-ml's later
+// dlopen("libcuda.so.1") binds to the copy from the SAME driver tree. That
+// keeps the whole NVML userspace stack version-consistent with each other
+// and with the kernel module, which is precisely the guarantee the
+// host-driver-first probe order is meant to provide.
+//
+// Without this, a no-injection BYOK container loaded libnvidia-ml from the
+// driver root but every NVML call returned NOT_FOUND, and
+// "gpud run --require-nvidia-driver" crash-looped nodes whose driver was
+// perfectly healthy (verified on AKS A100 nodes with a pre-installed host
+// driver via /host, and on NSCALE B200 nodes with the GPU Operator driver
+// via /run/nvidia/driver).
+func preloadNVMLCompanionLibraries(libraryPath string) {
+	companions := findNVMLCompanionLibraries(libraryPath)
+	if len(companions) == 0 {
+		return
+	}
+	for _, companion := range companions {
+		// Same flags go-nvml uses for libnvidia-ml itself
+		// (dl.RTLD_LAZY|dl.RTLD_GLOBAL). A dlopen failure here is logged but
+		// not fatal: companion loading must not change the existence-based
+		// contract of the probes -- if the driver tree is genuinely broken,
+		// the subsequent NVML calls surface that as before.
+		if err := nvdl.New(companion, nvdl.RTLD_LAZY|nvdl.RTLD_GLOBAL).Open(); err != nil {
+			log.Logger.Warnw("failed to preload NVML companion library", "library", companion, "error", err)
+			continue
+		}
+		log.Logger.Infow("preloaded NVML companion library from driver tree", "library", companion)
+	}
 }
 
 func nvmlArchLibraryDir(goarch string) string {

--- a/pkg/nvidia/nvml/lib/options_test.go
+++ b/pkg/nvidia/nvml/lib/options_test.go
@@ -31,40 +31,152 @@ func TestResolveNVMLLibraryPath(t *testing.T) {
 	cleanupEnvVars()
 	t.Cleanup(cleanupEnvVars)
 
-	// No container-specific configuration preserves go-nvml's default system
-	// lookup, which is the path used by systemd and other non-container runs.
+	// With no explicit override, resolution probes the well-known driver
+	// roots. Neither "/host" nor "/run/nvidia/driver" exists on a test
+	// machine, so the probes find nothing and go-nvml's default system
+	// lookup is preserved -- the same outcome bare-metal/systemd runs get.
 	assert.Empty(t, resolveNVMLLibraryPath())
 
+	// An explicit library path always wins over the driver-root probes.
 	explicit := "/custom/libnvidia-ml.so.1"
 	t.Setenv(EnvNVMLLibraryPath, explicit)
-	t.Setenv(EnvNVIDIADriverRoot, t.TempDir())
 	assert.Equal(t, explicit, resolveNVMLLibraryPath())
-
-	require.NoError(t, os.Unsetenv(EnvNVMLLibraryPath))
-	driverRoot := t.TempDir()
-	libraryPath := filepath.Join(driverRoot, "usr", "lib", nvmlArchLibraryDir(runtime.GOARCH), "libnvidia-ml.so.1")
-	require.NoError(t, os.MkdirAll(filepath.Dir(libraryPath), 0o755))
-	require.NoError(t, os.WriteFile(libraryPath, nil, 0o644))
-	t.Setenv(EnvNVIDIADriverRoot, driverRoot)
-	assert.Equal(t, libraryPath, resolveNVMLLibraryPath())
 }
 
-func TestResolveNVMLLibraryPathFallbacks(t *testing.T) {
-	cleanupEnvVars()
-	t.Cleanup(cleanupEnvVars)
-
+func TestResolveFromDriverRootsFallbacks(t *testing.T) {
 	driverRoot := t.TempDir()
-	t.Setenv(EnvNVIDIADriverRoot, driverRoot)
 
-	// A configured but empty driver root must retain the system-library fallback.
-	assert.Empty(t, resolveNVMLLibraryPath())
+	// A mounted but empty driver root (e.g. the GPU Operator has not
+	// finished installing the driver yet) must retain the system-library
+	// fallback.
+	assert.Empty(t, resolveFromDriverRoots(t.TempDir(), driverRoot))
 
 	// Exercise the common non-multiarch layout after the architecture-specific
 	// candidate is absent.
 	libraryPath := filepath.Join(driverRoot, "usr", "lib64", "libnvidia-ml.so.1")
 	require.NoError(t, os.MkdirAll(filepath.Dir(libraryPath), 0o755))
 	require.NoError(t, os.WriteFile(libraryPath, nil, 0o644))
-	assert.Equal(t, libraryPath, resolveNVMLLibraryPath())
+	assert.Equal(t, libraryPath, resolveFromDriverRoots(t.TempDir(), driverRoot))
+}
+
+// TestResolveFromDriverRootsHostRootPrecedence verifies that a pre-installed
+// host driver (host root mount) takes precedence over a GPU Operator-managed
+// driver root when both contain an NVML library, mirroring the GPU
+// Operator's driver-validation order.
+func TestResolveFromDriverRootsHostRootPrecedence(t *testing.T) {
+	cleanupEnvVars()
+	t.Cleanup(cleanupEnvVars)
+
+	writeLibrary := func(root string) string {
+		libraryPath := filepath.Join(root, "usr", "lib", nvmlArchLibraryDir(runtime.GOARCH), "libnvidia-ml.so.1")
+		require.NoError(t, os.MkdirAll(filepath.Dir(libraryPath), 0o755))
+		require.NoError(t, os.WriteFile(libraryPath, nil, 0o644))
+		return libraryPath
+	}
+
+	hostRoot := t.TempDir()
+	hostLibrary := writeLibrary(hostRoot)
+	driverRoot := t.TempDir()
+	driverLibrary := writeLibrary(driverRoot)
+
+	// Both present: the pre-installed host driver wins.
+	assert.Equal(t, hostLibrary, resolveFromDriverRoots(hostRoot, driverRoot))
+
+	// Host root without libraries falls through to the driver root.
+	require.NoError(t, os.Remove(hostLibrary))
+	assert.Equal(t, driverLibrary, resolveFromDriverRoots(hostRoot, driverRoot))
+
+	// Neither root provides a library: preserve the system-library fallback.
+	require.NoError(t, os.Remove(driverLibrary))
+	assert.Empty(t, resolveFromDriverRoots(hostRoot, driverRoot))
+
+	// An explicit library path still wins over both roots.
+	explicit := "/custom/libnvidia-ml.so.1"
+	t.Setenv(EnvNVMLLibraryPath, explicit)
+	assert.Equal(t, explicit, resolveNVMLLibraryPath())
+}
+
+// TestResolveFromDriverRootsHostRootOnly verifies host-root resolution when
+// the driver root mount is absent/empty.
+func TestResolveFromDriverRootsHostRootOnly(t *testing.T) {
+	hostRoot := t.TempDir()
+	libraryPath := filepath.Join(hostRoot, "usr", "lib64", "libnvidia-ml.so.1")
+	require.NoError(t, os.MkdirAll(filepath.Dir(libraryPath), 0o755))
+	require.NoError(t, os.WriteFile(libraryPath, nil, 0o644))
+
+	// The lib64 layout is found via the host root even with an empty driver root.
+	assert.Equal(t, libraryPath, resolveFromDriverRoots(hostRoot, t.TempDir()))
+}
+
+// TestProbeDriverReadyContract covers the GPU Operator driver-ready contract
+// discovery: missing contract, host-driver selection ("/"), rejected relative
+// paths, quoted values, and a custom driver install directory.
+func TestProbeDriverReadyContract(t *testing.T) {
+	// Missing contract file.
+	assert.Empty(t, probeDriverReadyContract(t.TempDir()))
+
+	writeContract := func(hostRoot, contents string) {
+		contractPath := filepath.Join(hostRoot, driverReadyContractPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(contractPath), 0o755))
+		require.NoError(t, os.WriteFile(contractPath, []byte(contents), 0o644))
+	}
+
+	hostRoot := t.TempDir()
+
+	// The contract selecting the host driver ("/") is covered by the
+	// standard host-root probes, so the contract probe returns empty.
+	writeContract(hostRoot, "NVIDIA_DRIVER_ROOT=/\n")
+	assert.Empty(t, probeDriverReadyContract(hostRoot))
+
+	// Relative paths are rejected.
+	writeContract(hostRoot, "NVIDIA_DRIVER_ROOT=run/nvidia/driver\n")
+	assert.Empty(t, probeDriverReadyContract(hostRoot))
+
+	// A custom install directory without the NVML library yields empty.
+	writeContract(hostRoot, "NVIDIA_DRIVER_ROOT=\"/opt/nvidia/driver\"\n")
+	assert.Empty(t, probeDriverReadyContract(hostRoot))
+
+	// A custom install directory with the NVML library resolves under the
+	// host root.
+	libraryPath := filepath.Join(hostRoot, "opt", "nvidia", "driver", "usr", "lib", nvmlArchLibraryDir(runtime.GOARCH), "libnvidia-ml.so.1")
+	require.NoError(t, os.MkdirAll(filepath.Dir(libraryPath), 0o755))
+	require.NoError(t, os.WriteFile(libraryPath, nil, 0o644))
+	assert.Equal(t, libraryPath, probeDriverReadyContract(hostRoot))
+}
+
+// TestResolveFromDriverRootsDriverReadyContract verifies the GPU Operator's
+// driver-ready contract is honored between the host-root and driver-root
+// probes: a pre-installed host driver still wins, the Operator-validated
+// custom install directory wins over the static driver root, and without the
+// contract the static driver root is used.
+func TestResolveFromDriverRootsDriverReadyContract(t *testing.T) {
+	hostRoot := t.TempDir()
+	contractPath := filepath.Join(hostRoot, driverReadyContractPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(contractPath), 0o755))
+	require.NoError(t, os.WriteFile(contractPath, []byte("NVIDIA_DRIVER_ROOT=/opt/nvidia/driver\nDRIVER_ROOT_CTR_PATH=/driver-root\n"), 0o644))
+	contractLibrary := filepath.Join(hostRoot, "opt", "nvidia", "driver", "usr", "lib64", "libnvidia-ml.so.1")
+	require.NoError(t, os.MkdirAll(filepath.Dir(contractLibrary), 0o755))
+	require.NoError(t, os.WriteFile(contractLibrary, nil, 0o644))
+
+	driverRoot := t.TempDir()
+	staticLibrary := filepath.Join(driverRoot, "usr", "lib", nvmlArchLibraryDir(runtime.GOARCH), "libnvidia-ml.so.1")
+	require.NoError(t, os.MkdirAll(filepath.Dir(staticLibrary), 0o755))
+	require.NoError(t, os.WriteFile(staticLibrary, nil, 0o644))
+
+	// A pre-installed host driver takes precedence over the contract.
+	hostLibrary := filepath.Join(hostRoot, "usr", "lib", nvmlArchLibraryDir(runtime.GOARCH), "libnvidia-ml.so.1")
+	require.NoError(t, os.MkdirAll(filepath.Dir(hostLibrary), 0o755))
+	require.NoError(t, os.WriteFile(hostLibrary, nil, 0o644))
+	assert.Equal(t, hostLibrary, resolveFromDriverRoots(hostRoot, driverRoot))
+	require.NoError(t, os.Remove(hostLibrary))
+
+	// The Operator-validated custom install directory wins over the static
+	// driver root.
+	assert.Equal(t, contractLibrary, resolveFromDriverRoots(hostRoot, driverRoot))
+
+	// Without the contract file, the static driver root is used.
+	require.NoError(t, os.Remove(contractPath))
+	assert.Equal(t, staticLibrary, resolveFromDriverRoots(hostRoot, driverRoot))
 }
 
 func TestNVMLArchLibraryDir(t *testing.T) {

--- a/pkg/nvidia/nvml/lib/options_test.go
+++ b/pkg/nvidia/nvml/lib/options_test.go
@@ -179,6 +179,74 @@ func TestResolveFromDriverRootsDriverReadyContract(t *testing.T) {
 	assert.Equal(t, staticLibrary, resolveFromDriverRoots(hostRoot, driverRoot))
 }
 
+// TestFindNVMLCompanionLibraries covers the companion-library selection that
+// preloadNVMLCompanionLibraries relies on: only the NVIDIA companions that
+// libnvidia-ml needs (libcuda, libnvidia-cfg, libnvidia-gpucomp) may be
+// selected from the resolved library's directory.
+//
+// The critical negative assertion is that libc.so.6 is NEVER selected: the
+// GPU Operator driver tree bundles its own glibc, and loading that copy (or
+// exposing the whole directory via LD_LIBRARY_PATH) crashes the host process
+// with "undefined symbol: __tunable_is_initialized, version GLIBC_PRIVATE".
+func TestFindNVMLCompanionLibraries(t *testing.T) {
+	writeFiles := func(dir string, names ...string) {
+		t.Helper()
+		for _, name := range names {
+			require.NoError(t, os.WriteFile(filepath.Join(dir, name), nil, 0o644))
+		}
+	}
+
+	// A bare SONAME (no directory) means the system lookup is in use, which
+	// also provides the companions -- nothing to preload.
+	assert.Nil(t, findNVMLCompanionLibraries("libnvidia-ml.so.1"))
+
+	// A nonexistent or empty driver tree provides nothing.
+	assert.Nil(t, findNVMLCompanionLibraries(filepath.Join(t.TempDir(), "does-not-exist", "libnvidia-ml.so.1")))
+	emptyDir := t.TempDir()
+	assert.Nil(t, findNVMLCompanionLibraries(filepath.Join(emptyDir, "libnvidia-ml.so.1")))
+
+	// Full 580.x driver tree: all three companion families are found, the
+	// SONAME symlinks are preferred for libcuda/libnvidia-cfg, the versioned
+	// file is used for libnvidia-gpucomp (the only name it ships under), and
+	// the bundled glibc is deliberately left out.
+	fullDir := t.TempDir()
+	writeFiles(fullDir,
+		"libnvidia-ml.so.1", "libnvidia-ml.so.580.82.07",
+		"libcuda.so", "libcuda.so.1", "libcuda.so.580.82.07",
+		"libnvidia-cfg.so", "libnvidia-cfg.so.1", "libnvidia-cfg.so.580.82.07",
+		"libnvidia-gpucomp.so.580.82.07",
+		"libc.so.6", "libpthread.so.0", "libm.so.6", // operator tree's bundled glibc: must never be preloaded
+	)
+	assert.Equal(t, []string{
+		filepath.Join(fullDir, "libcuda.so.1"),
+		filepath.Join(fullDir, "libnvidia-cfg.so.1"),
+		filepath.Join(fullDir, "libnvidia-gpucomp.so.580.82.07"),
+	}, findNVMLCompanionLibraries(filepath.Join(fullDir, "libnvidia-ml.so.1")))
+
+	// Older drivers ship no libnvidia-gpucomp: selection degrades to the
+	// families that exist.
+	olderDir := t.TempDir()
+	writeFiles(olderDir, "libcuda.so.1", "libcuda.so.535.154.05")
+	assert.Equal(t, []string{
+		filepath.Join(olderDir, "libcuda.so.1"),
+	}, findNVMLCompanionLibraries(filepath.Join(olderDir, "libnvidia-ml.so.1")))
+
+	// Without the SONAME symlink, the versioned file is still usable.
+	versionedOnlyDir := t.TempDir()
+	writeFiles(versionedOnlyDir, "libcuda.so.580.82.07")
+	assert.Equal(t, []string{
+		filepath.Join(versionedOnlyDir, "libcuda.so.580.82.07"),
+	}, findNVMLCompanionLibraries(filepath.Join(versionedOnlyDir, "libnvidia-ml.so.1")))
+}
+
+// TestPreloadNVMLCompanionLibrariesNoCompanions verifies that preloading is a
+// safe no-op when the resolved library has no companions (the unit-test
+// machine has no driver tree), so applyOpts behavior is unchanged there.
+func TestPreloadNVMLCompanionLibrariesNoCompanions(t *testing.T) {
+	preloadNVMLCompanionLibraries("libnvidia-ml.so.1")
+	preloadNVMLCompanionLibraries(filepath.Join(t.TempDir(), "libnvidia-ml.so.1"))
+}
+
 func TestNVMLArchLibraryDir(t *testing.T) {
 	tests := map[string]string{
 		"amd64":   "x86_64-linux-gnu",

--- a/pkg/nvidia/pci/detect_sysfs.go
+++ b/pkg/nvidia/pci/detect_sysfs.go
@@ -1,0 +1,38 @@
+package pci
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const DefaultSysfsPCIDevicesDir = "/sys/bus/pci/devices"
+
+// HasNVIDIAGPU reports whether sysfs contains an NVIDIA VGA or 3D controller.
+// PCI enumeration is available before the NVIDIA driver is installed.
+func HasNVIDIAGPU(sysfsDevicesDir string) (bool, error) {
+	entries, err := os.ReadDir(sysfsDevicesDir)
+	if err != nil {
+		return false, fmt.Errorf("failed to read sysfs PCI devices directory %q: %w", sysfsDevicesDir, err)
+	}
+
+	for _, entry := range entries {
+		deviceDir := filepath.Join(sysfsDevicesDir, entry.Name())
+		vendor, err := os.ReadFile(filepath.Join(deviceDir, "vendor"))
+		if err != nil || strings.TrimSpace(string(vendor)) != "0x10de" {
+			continue
+		}
+
+		class, err := os.ReadFile(filepath.Join(deviceDir, "class"))
+		if err != nil {
+			continue
+		}
+		classValue := strings.TrimSpace(string(class))
+		if strings.HasPrefix(classValue, "0x0300") || strings.HasPrefix(classValue, "0x0302") {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/nvidia/pci/detect_sysfs_test.go
+++ b/pkg/nvidia/pci/detect_sysfs_test.go
@@ -1,0 +1,86 @@
+package pci
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeSysfsPCIDevice(t *testing.T, root, address, vendor, class string) {
+	t.Helper()
+	dir := filepath.Join(root, address)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "vendor"), []byte(vendor+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "class"), []byte(class+"\n"), 0o644))
+}
+
+func TestHasNVIDIAGPU(t *testing.T) {
+	t.Run("NVIDIA 3D controller", func(t *testing.T) {
+		root := t.TempDir()
+		writeSysfsPCIDevice(t, root, "0000:19:00.0", "0x10de", "0x030200")
+
+		exists, err := HasNVIDIAGPU(root)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("NVIDIA VGA controller", func(t *testing.T) {
+		root := t.TempDir()
+		writeSysfsPCIDevice(t, root, "0000:01:00.0", "0x10de", "0x030000")
+
+		exists, err := HasNVIDIAGPU(root)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("ignores non-GPU NVIDIA device", func(t *testing.T) {
+		root := t.TempDir()
+		writeSysfsPCIDevice(t, root, "0000:02:00.0", "0x10de", "0x060400")
+
+		exists, err := HasNVIDIAGPU(root)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("ignores another vendor GPU", func(t *testing.T) {
+		root := t.TempDir()
+		writeSysfsPCIDevice(t, root, "0000:03:00.0", "0x1002", "0x030200")
+
+		exists, err := HasNVIDIAGPU(root)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("ignores NVIDIA device with unreadable vendor file", func(t *testing.T) {
+		root := t.TempDir()
+		dir := filepath.Join(root, "0000:04:00.0")
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		// a directory cannot be read as a file, forcing the vendor read error path
+		require.NoError(t, os.Mkdir(filepath.Join(dir, "vendor"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "class"), []byte("0x030000\n"), 0o644))
+
+		exists, err := HasNVIDIAGPU(root)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("ignores NVIDIA device with missing class file", func(t *testing.T) {
+		root := t.TempDir()
+		dir := filepath.Join(root, "0000:05:00.0")
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "vendor"), []byte("0x10de\n"), 0o644))
+
+		exists, err := HasNVIDIAGPU(root)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("missing sysfs", func(t *testing.T) {
+		exists, err := HasNVIDIAGPU(filepath.Join(t.TempDir(), "missing"))
+		assert.False(t, exists)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
c.f., https://github.com/leptonai/gpud/pull/1304
c.f., https://github.com/leptonai/gpud/pull/1311

Follow-up to #1304 (opt-in GPUD_NVIDIA_DRIVER_ROOT). Complementary to the NVML-free PCI product fallback in #1311, which covers the first-login driver-install race; this change restores full NVML monitoring once the driver exists, on both driver installation modes.

Library resolution order (pkg/nvidia/nvml/lib):
1. GPUD_NVML_LIBRARY_PATH (explicit, unchanged)
2. GPUD_NVIDIA_HOST_ROOT (new): host root fs mounted at /host, probing usr/lib/<arch>, usr/lib64, usr/lib -- a pre-installed host driver wins over the Operator driver root when both are present
3. GPUD_NVIDIA_DRIVER_ROOT (Operator-managed /run/nvidia/driver)
4. go-nvml default system lookup (unchanged when no env is set)

This mirrors the GPU Operator's DRA driver DaemonSet, which mounts /host and /driver-root and selects the pre-installed driver first at runtime.

Helm chart:
- gpud.mountHostRoot (new, default true): host root mounted read-only at /host with HostToContainer propagation, setting GPUD_NVIDIA_HOST_ROOT
- gpud.mountNVIDIADriverRoot: default flipped to true so GPU Operator clusters work out of the box; on preinstalled-driver nodes the DirectoryOrCreate hostPath may leave an empty, unused /run/nvidia/driver (set to false to avoid it)
- driver-root mount gains HostToContainer propagation so an Operator driver (re)install is visible without a pod restart

Backward compatible: with GPUD_NVIDIA_HOST_ROOT unset the resolution is identical to before.