### PR TITLE
[LEP-6173] feat(run): require NVIDIA driver before registration

### DIFF
--- a/cmd/gpud/command/command.go
+++ b/cmd/gpud/command/command.go
@@ -207,6 +207,10 @@ sudo rm /etc/systemd/system/gpud.service
 					Hidden: true,
 					Usage:  "(optional) re-run login on start to fetch the current session token. Use only for BYOK deployments that supply a valid registration token on every start.",
 				},
+				&cli.BoolFlag{
+					Name:  "require-nvidia-driver",
+					Usage: "when login is configured, fail before registration if NVIDIA GPU hardware is present but the NVIDIA driver or NVML is unavailable",
+				},
 				&cli.StringFlag{
 					Name:   "token",
 					Hidden: true,

--- a/cmd/gpud/run/command.go
+++ b/cmd/gpud/run/command.go
@@ -33,11 +33,49 @@ import (
 	pkgmachineinfo "github.com/leptonai/gpud/pkg/machine-info"
 	pkgmetadata "github.com/leptonai/gpud/pkg/metadata"
 	pkgnfschecker "github.com/leptonai/gpud/pkg/nfs-checker"
+	nvidianvml "github.com/leptonai/gpud/pkg/nvidia/nvml"
+	nvidiapci "github.com/leptonai/gpud/pkg/nvidia/pci"
 	gpudserver "github.com/leptonai/gpud/pkg/server"
 	pkgsqlite "github.com/leptonai/gpud/pkg/sqlite"
 	pkgsystemd "github.com/leptonai/gpud/pkg/systemd"
 	"github.com/leptonai/gpud/version"
 )
+
+var hasNVIDIAGPU = func() (bool, error) {
+	return nvidiapci.HasNVIDIAGPU(nvidiapci.DefaultSysfsPCIDevicesDir)
+}
+
+var newNVMLInstance = nvidianvml.New
+
+func requireNVIDIADriver() error {
+	hasGPU, err := hasNVIDIAGPU()
+	if err != nil {
+		return fmt.Errorf("failed to detect NVIDIA GPU devices: %w", err)
+	}
+	if !hasGPU {
+		return nil
+	}
+
+	instance, err := newNVMLInstance()
+	if err != nil {
+		return fmt.Errorf("NVIDIA GPU detected but the NVIDIA driver is not ready: %w", err)
+	}
+	defer func() {
+		if err := instance.Shutdown(); err != nil {
+			log.Logger.Debugw("failed to shut down pre-login NVML instance", "error", err)
+		}
+	}()
+
+	if !instance.NVMLExists() {
+		return fmt.Errorf("NVIDIA GPU detected but the NVIDIA NVML library is not loaded")
+	}
+	if err := instance.InitError(); err != nil {
+		return fmt.Errorf("NVIDIA GPU detected but the NVIDIA driver is not ready: %w", err)
+	}
+	return nil
+}
+
+var ensureNVIDIADriver = requireNVIDIADriver
 
 func Command(cliContext *cli.Context) error {
 	logLevel := cliContext.String("log-level")
@@ -90,6 +128,12 @@ func Command(cliContext *cli.Context) error {
 	shouldOverwriteMachineID := cliContext.Bool("machine-id-overwrite")
 	refreshSessionToken := cliContext.Bool("refresh-session-token")
 	controlPlaneLoginSucceeded := false
+
+	if cliContext.Bool("require-nvidia-driver") && (cliContext.IsSet("token") || controlPlaneLoginRegistrationToken != "") {
+		if err := ensureNVIDIADriver(); err != nil {
+			return err
+		}
+	}
 
 	// Note: login.Login() ALWAYS writes to the persistent state file (via dataDir),
 	// regardless of --db-in-memory flag. The login package doesn't know about in-memory mode.

--- a/cmd/gpud/run/mock_command_exec_test.go
+++ b/cmd/gpud/run/mock_command_exec_test.go
@@ -49,6 +49,7 @@ func newTestCLIContext(t *testing.T, values cliFlagValues) *cli.Context {
 	set.String("machine-id", "", "")
 	set.Bool("machine-id-overwrite", false, "")
 	set.Bool("refresh-session-token", false, "")
+	set.Bool("require-nvidia-driver", false, "")
 	set.String("listen-address", "", "")
 	set.Bool("pprof", false, "")
 	set.Duration("metrics-retention-period", 0, "")

--- a/cmd/gpud/run/require_nvidia_driver_test.go
+++ b/cmd/gpud/run/require_nvidia_driver_test.go
@@ -1,0 +1,132 @@
+//go:build linux
+
+package run
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	gpudmanager "github.com/leptonai/gpud/pkg/gpud-manager"
+	"github.com/leptonai/gpud/pkg/login"
+	nvidianvml "github.com/leptonai/gpud/pkg/nvidia/nvml"
+)
+
+func stubNVIDIADriverRequirement(
+	t *testing.T,
+	hasGPU bool,
+	detectErr error,
+	instance nvidianvml.Instance,
+	nvmlErr error,
+) {
+	t.Helper()
+	originalHasGPU := hasNVIDIAGPU
+	originalNewNVML := newNVMLInstance
+	hasNVIDIAGPU = func() (bool, error) { return hasGPU, detectErr }
+	newNVMLInstance = func() (nvidianvml.Instance, error) { return instance, nvmlErr }
+	t.Cleanup(func() {
+		hasNVIDIAGPU = originalHasGPU
+		newNVMLInstance = originalNewNVML
+	})
+}
+
+func TestRequireNVIDIADriver(t *testing.T) {
+	t.Run("CPU-only node does not require NVML", func(t *testing.T) {
+		stubNVIDIADriverRequirement(t, false, nil, nil, errors.New("must not be called"))
+		require.NoError(t, requireNVIDIADriver())
+	})
+
+	t.Run("PCI detection failure is fatal", func(t *testing.T) {
+		stubNVIDIADriverRequirement(t, false, errors.New("sysfs unavailable"), nil, nil)
+		err := requireNVIDIADriver()
+		require.ErrorContains(t, err, "failed to detect NVIDIA GPU devices")
+	})
+
+	t.Run("GPU with missing NVML is rejected", func(t *testing.T) {
+		stubNVIDIADriverRequirement(t, true, nil, nvidianvml.NewNoOp(), nil)
+		err := requireNVIDIADriver()
+		require.ErrorContains(t, err, "NVML library is not loaded")
+	})
+
+	t.Run("GPU with NVML initialization error is rejected", func(t *testing.T) {
+		stubNVIDIADriverRequirement(t, true, nil, nil, errors.New("driver not ready"))
+		err := requireNVIDIADriver()
+		require.ErrorContains(t, err, "driver is not ready")
+	})
+
+	t.Run("GPU with working NVML is accepted", func(t *testing.T) {
+		stubNVIDIADriverRequirement(t, true, nil, &testNVMLInstance{exists: true}, nil)
+		require.NoError(t, requireNVIDIADriver())
+	})
+
+	t.Run("GPU with NVML device initialization error is rejected", func(t *testing.T) {
+		stubNVIDIADriverRequirement(t, true, nil, &testNVMLInstance{exists: true, initErr: errors.New("device enumeration failed")}, nil)
+		err := requireNVIDIADriver()
+		require.ErrorContains(t, err, "device enumeration failed")
+	})
+}
+
+type testNVMLInstance struct {
+	nvidianvml.Instance
+	exists  bool
+	initErr error
+}
+
+func (i *testNVMLInstance) NVMLExists() bool { return i.exists }
+func (i *testNVMLInstance) InitError() error { return i.initErr }
+func (i *testNVMLInstance) Shutdown() error  { return nil }
+
+func TestCommandRequireNVIDIADriverStopsBeforeLogin(t *testing.T) {
+	ctx := newTestCLIContext(t, cliFlagValues{
+		stringFlags: map[string]string{
+			"log-level": "info",
+			"data-dir":  t.TempDir(),
+			"token":     "registration-token",
+		},
+		boolFlags: map[string]bool{
+			"require-nvidia-driver": true,
+		},
+	})
+
+	mockey.PatchConvey("driver gate stops before login", t, func() {
+		loginCalled := false
+		mockey.Mock(ensureNVIDIADriver).Return(errors.New("NVIDIA NVML library is not loaded")).Build()
+		mockey.Mock(login.Login).To(func(context.Context, login.LoginConfig) error {
+			loginCalled = true
+			return nil
+		}).Build()
+
+		err := Command(ctx)
+		require.ErrorContains(t, err, "NVML library is not loaded")
+		assert.False(t, loginCalled)
+	})
+}
+
+func TestCommandRequireNVIDIADriverSkipsGateWithoutLogin(t *testing.T) {
+	ctx := newTestCLIContext(t, cliFlagValues{
+		stringFlags: map[string]string{
+			"log-level": "info",
+			"data-dir":  t.TempDir(),
+		},
+		boolFlags: map[string]bool{
+			"require-nvidia-driver": true,
+		},
+	})
+
+	mockey.PatchConvey("driver gate only applies to login", t, func() {
+		gateCalled := false
+		mockey.Mock(ensureNVIDIADriver).To(func() error {
+			gateCalled = true
+			return errors.New("must not be called")
+		}).Build()
+		mockey.Mock((*gpudmanager.Manager).Start).Return(errors.New("stop after login gate")).Build()
+
+		err := Command(ctx)
+		require.ErrorContains(t, err, "stop after login gate")
+		assert.False(t, gateCalled)
+	})
+}

--- a/cmd/gpud/run/require_nvidia_driver_test.go
+++ b/cmd/gpud/run/require_nvidia_driver_test.go
@@ -5,6 +5,7 @@ package run
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/bytedance/mockey"
@@ -14,6 +15,7 @@ import (
 	gpudmanager "github.com/leptonai/gpud/pkg/gpud-manager"
 	"github.com/leptonai/gpud/pkg/login"
 	nvidianvml "github.com/leptonai/gpud/pkg/nvidia/nvml"
+	nvidiapci "github.com/leptonai/gpud/pkg/nvidia/pci"
 )
 
 func stubNVIDIADriverRequirement(
@@ -68,17 +70,31 @@ func TestRequireNVIDIADriver(t *testing.T) {
 		err := requireNVIDIADriver()
 		require.ErrorContains(t, err, "device enumeration failed")
 	})
+
+	t.Run("NVML shutdown error is non-fatal", func(t *testing.T) {
+		stubNVIDIADriverRequirement(t, true, nil, &testNVMLInstance{exists: true, shutdownErr: errors.New("shutdown failed")}, nil)
+		require.NoError(t, requireNVIDIADriver())
+	})
 }
 
 type testNVMLInstance struct {
 	nvidianvml.Instance
-	exists  bool
-	initErr error
+	exists      bool
+	initErr     error
+	shutdownErr error
 }
 
 func (i *testNVMLInstance) NVMLExists() bool { return i.exists }
 func (i *testNVMLInstance) InitError() error { return i.initErr }
-func (i *testNVMLInstance) Shutdown() error  { return nil }
+func (i *testNVMLInstance) Shutdown() error  { return i.shutdownErr }
+
+func TestHasNVIDIAGPUReadsDefaultSysfs(t *testing.T) {
+	if _, err := os.Stat(nvidiapci.DefaultSysfsPCIDevicesDir); err != nil {
+		t.Skipf("sysfs PCI devices directory %q not available", nvidiapci.DefaultSysfsPCIDevicesDir)
+	}
+	_, err := hasNVIDIAGPU()
+	require.NoError(t, err)
+}
 
 func TestCommandRequireNVIDIADriverStopsBeforeLogin(t *testing.T) {
 	ctx := newTestCLIContext(t, cliFlagValues{
@@ -128,5 +144,40 @@ func TestCommandRequireNVIDIADriverSkipsGateWithoutLogin(t *testing.T) {
 		err := Command(ctx)
 		require.ErrorContains(t, err, "stop after login gate")
 		assert.False(t, gateCalled)
+	})
+}
+
+func TestCommandRequireNVIDIADriverGatePassesBeforeLogin(t *testing.T) {
+	ctx := newTestCLIContext(t, cliFlagValues{
+		stringFlags: map[string]string{
+			"log-level": "info",
+			"data-dir":  t.TempDir(),
+			"token":     "registration-token",
+		},
+		boolFlags: map[string]bool{
+			"require-nvidia-driver": true,
+		},
+	})
+
+	mockey.PatchConvey("driver gate passes and login proceeds", t, func() {
+		gateCalled := false
+		loginCalled := false
+		mockey.Mock(ensureNVIDIADriver).To(func() error {
+			gateCalled = true
+			return nil
+		}).Build()
+		mockey.Mock(login.Login).To(func(context.Context, login.LoginConfig) error {
+			loginCalled = true
+			return nil
+		}).Build()
+		mockey.Mock(recordLoginSuccessState).To(func(context.Context, string) error {
+			return nil
+		}).Build()
+		mockey.Mock((*gpudmanager.Manager).Start).Return(errors.New("stop after driver gate")).Build()
+
+		err := Command(ctx)
+		require.ErrorContains(t, err, "stop after driver gate")
+		assert.True(t, gateCalled)
+		assert.True(t, loginCalled)
 	})
 }

--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -420,6 +420,10 @@ spec:
                 set -- "$@" --refresh-session-token
               fi
 
+              if [ "${GPUD_REQUIRE_NVIDIA_DRIVER:-}" = "true" ]; then
+                set -- "$@" --require-nvidia-driver
+              fi
+
               set -- "$@" --enable-auto-update={{ .Values.gpud.enableAutoUpdate }}
               set -- "$@" --auto-update-exit-code={{ .Values.gpud.autoUpdateExitCode }}
 
@@ -494,6 +498,12 @@ spec:
             # BYOK only: re-login on startup using the injected registration token.
             # Consumed as $GPUD_REFRESH_SESSION_TOKEN.
             - name: GPUD_REFRESH_SESSION_TOKEN
+              value: "true"
+            {{- end }}
+            {{- if .Values.gpud.requireNVIDIADriver }}
+            # BYOK: do not register NVIDIA GPU hardware until the driver and
+            # NVML are available. CPU-only nodes are unaffected.
+            - name: GPUD_REQUIRE_NVIDIA_DRIVER
               value: "true"
             {{- end }}
             {{- if .Values.gpud.rebootCommands }}

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -74,6 +74,11 @@ gpud:
   # token on every start and needs to recover a stale session token.
   refreshSessionToken: false
 
+  # Refuse to register an NVIDIA GPU node until its driver and NVML are ready.
+  # CPU-only nodes continue normally. Enable this for BYOK, where administrators
+  # must install a working NVIDIA driver before the node joins Lepton.
+  requireNVIDIADriver: true
+
   # Enable auto update of gpud.
   enableAutoUpdate: false
 

--- a/pkg/nvidia/pci/detect_sysfs.go
+++ b/pkg/nvidia/pci/detect_sysfs.go
@@ -1,0 +1,38 @@
+package pci
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const DefaultSysfsPCIDevicesDir = "/sys/bus/pci/devices"
+
+// HasNVIDIAGPU reports whether sysfs contains an NVIDIA VGA or 3D controller.
+// PCI enumeration is available before the NVIDIA driver is installed.
+func HasNVIDIAGPU(sysfsDevicesDir string) (bool, error) {
+	entries, err := os.ReadDir(sysfsDevicesDir)
+	if err != nil {
+		return false, fmt.Errorf("failed to read sysfs PCI devices directory %q: %w", sysfsDevicesDir, err)
+	}
+
+	for _, entry := range entries {
+		deviceDir := filepath.Join(sysfsDevicesDir, entry.Name())
+		vendor, err := os.ReadFile(filepath.Join(deviceDir, "vendor"))
+		if err != nil || strings.TrimSpace(string(vendor)) != "0x10de" {
+			continue
+		}
+
+		class, err := os.ReadFile(filepath.Join(deviceDir, "class"))
+		if err != nil {
+			continue
+		}
+		classValue := strings.TrimSpace(string(class))
+		if strings.HasPrefix(classValue, "0x0300") || strings.HasPrefix(classValue, "0x0302") {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/nvidia/pci/detect_sysfs_test.go
+++ b/pkg/nvidia/pci/detect_sysfs_test.go
@@ -54,6 +54,30 @@ func TestHasNVIDIAGPU(t *testing.T) {
 		assert.False(t, exists)
 	})
 
+	t.Run("ignores NVIDIA device with unreadable vendor file", func(t *testing.T) {
+		root := t.TempDir()
+		dir := filepath.Join(root, "0000:04:00.0")
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		// a directory cannot be read as a file, forcing the vendor read error path
+		require.NoError(t, os.Mkdir(filepath.Join(dir, "vendor"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "class"), []byte("0x030000\n"), 0o644))
+
+		exists, err := HasNVIDIAGPU(root)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("ignores NVIDIA device with missing class file", func(t *testing.T) {
+		root := t.TempDir()
+		dir := filepath.Join(root, "0000:05:00.0")
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "vendor"), []byte("0x10de\n"), 0o644))
+
+		exists, err := HasNVIDIAGPU(root)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
 	t.Run("missing sysfs", func(t *testing.T) {
 		exists, err := HasNVIDIAGPU(filepath.Join(t.TempDir(), "missing"))
 		assert.False(t, exists)

--- a/pkg/nvidia/pci/detect_sysfs_test.go
+++ b/pkg/nvidia/pci/detect_sysfs_test.go
@@ -1,0 +1,62 @@
+package pci
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeSysfsPCIDevice(t *testing.T, root, address, vendor, class string) {
+	t.Helper()
+	dir := filepath.Join(root, address)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "vendor"), []byte(vendor+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "class"), []byte(class+"\n"), 0o644))
+}
+
+func TestHasNVIDIAGPU(t *testing.T) {
+	t.Run("NVIDIA 3D controller", func(t *testing.T) {
+		root := t.TempDir()
+		writeSysfsPCIDevice(t, root, "0000:19:00.0", "0x10de", "0x030200")
+
+		exists, err := HasNVIDIAGPU(root)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("NVIDIA VGA controller", func(t *testing.T) {
+		root := t.TempDir()
+		writeSysfsPCIDevice(t, root, "0000:01:00.0", "0x10de", "0x030000")
+
+		exists, err := HasNVIDIAGPU(root)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("ignores non-GPU NVIDIA device", func(t *testing.T) {
+		root := t.TempDir()
+		writeSysfsPCIDevice(t, root, "0000:02:00.0", "0x10de", "0x060400")
+
+		exists, err := HasNVIDIAGPU(root)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("ignores another vendor GPU", func(t *testing.T) {
+		root := t.TempDir()
+		writeSysfsPCIDevice(t, root, "0000:03:00.0", "0x1002", "0x030200")
+
+		exists, err := HasNVIDIAGPU(root)
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("missing sysfs", func(t *testing.T) {
+		exists, err := HasNVIDIAGPU(filepath.Join(t.TempDir(), "missing"))
+		assert.False(t, exists)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

Add `gpud run --require-nvidia-driver` to prevent an NVIDIA GPU node from registering before its driver and NVML are ready.

The check runs immediately before `login.Login`:

- NVIDIA VGA/3D controller present in PCI sysfs + NVML unavailable or broken: fail before registration
- no NVIDIA GPU hardware: continue normally, preserving CPU-only node support
- working NVML: continue with the existing login flow
- no login configured: skip the gate

The Helm chart enables this prerequisite by default for the BYOK DaemonSet. Kubernetes restarts the pod until the driver is ready, so an empty GPU product cannot reach Lepton's one-shot accelerator-type population flow.

## Dependency

This PR targets the branch for #1314 rather than `main`. The driver-root mounts and runtime library resolution from #1314 are required for the check to eventually succeed on GPU Operator-managed nodes.

Once #1314 merges, this PR can be retargeted to `main`. Together they supersede the PCI product-name fallback in #1311.

## Verification

- `go test -race -gcflags="all=-N -l" ./pkg/nvidia/pci ./cmd/gpud/run ./cmd/gpud/command`
- `go vet ./pkg/nvidia/pci ./cmd/gpud/run ./cmd/gpud/command`
- `helm lint deployments/helm/gpud`
- `helm template` verified with the gate enabled and disabled

Refs LEP-6173
