### PR TITLE
fix(package-controller): recover installed packages before dependency checks

### DIFF
--- a/pkg/gpud-manager/controllers/mock_package_controller_runner_test.go
+++ b/pkg/gpud-manager/controllers/mock_package_controller_runner_test.go
@@ -161,6 +161,7 @@ func TestInstallRunner_WithMockedRunCommand(t *testing.T) {
 			Name:           "dep",
 			IsInstalled:    true,
 			CurrentVersion: "2.0.0",
+			ScriptPath:     "/tmp/dep.sh",
 		}
 
 		controller.packageStatus["needs-missing-dep"] = &packages.PackageStatus{
@@ -175,19 +176,39 @@ func TestInstallRunner_WithMockedRunCommand(t *testing.T) {
 			ScriptPath: "/tmp/version.sh",
 			TotalTime:  200 * time.Millisecond,
 		}
+		controller.packageStatus["uninstalled-dep"] = &packages.PackageStatus{
+			Name:       "uninstalled-dep",
+			Dependency: [][]string{{"missing", "*"}},
+			ScriptPath: "/tmp/uninstalled-dep.sh",
+			TotalTime:  200 * time.Millisecond,
+		}
+		controller.packageStatus["needs-uninstalled-dep"] = &packages.PackageStatus{
+			Name:       "needs-uninstalled-dep",
+			Dependency: [][]string{{"uninstalled-dep", "*"}},
+			ScriptPath: "/tmp/needs-uninstalled-dep.sh",
+			TotalTime:  200 * time.Millisecond,
+		}
 		controller.packageStatus["skip"] = &packages.PackageStatus{
 			Name:       "skip",
 			ScriptPath: "/tmp/skip-install.sh",
 			TotalTime:  200 * time.Millisecond,
 		}
-		controller.packageStatus["installed"] = &packages.PackageStatus{
-			Name:       "installed",
-			ScriptPath: "/tmp/installed.sh",
+		controller.packageStatus["installed-with-missing-dep"] = &packages.PackageStatus{
+			Name:       "installed-with-missing-dep",
+			Dependency: [][]string{{"missing", "*"}},
+			ScriptPath: "/tmp/installed-with-missing-dep.sh",
 			TotalTime:  200 * time.Millisecond,
 		}
 		controller.packageStatus["install"] = &packages.PackageStatus{
 			Name:       "install",
+			Dependency: [][]string{{"dep", "2.0.0"}},
 			ScriptPath: "/tmp/install.sh",
+			TotalTime:  200 * time.Millisecond,
+		}
+		controller.packageStatus["installing"] = &packages.PackageStatus{
+			Name:       "installing",
+			Installing: true,
+			ScriptPath: "/tmp/installing.sh",
 			TotalTime:  200 * time.Millisecond,
 		}
 
@@ -195,19 +216,110 @@ func TestInstallRunner_WithMockedRunCommand(t *testing.T) {
 		startCalled := make(chan struct{}, 1)
 
 		var mockCalls atomic.Int64
+		var unexpectedCalls atomic.Int64
+		var installedProbeCalls atomic.Int64
+		var installedInstallCalls atomic.Int64
+		var installedStartCalls atomic.Int64
+		var missingProbeCalls atomic.Int64
+		var missingInstallCalls atomic.Int64
+		var missingStartCalls atomic.Int64
+		var oldVersionProbeCalls atomic.Int64
+		var oldVersionInstallCalls atomic.Int64
+		var oldVersionStartCalls atomic.Int64
+		var uninstalledDepProbeCalls atomic.Int64
+		var uninstalledDepInstallCalls atomic.Int64
+		var uninstalledDepStartCalls atomic.Int64
+		var dependentProbeCalls atomic.Int64
+		var dependentInstallCalls atomic.Int64
+		var dependentStartCalls atomic.Int64
+		var installingShouldSkipCalls atomic.Int64
+		var installingProbeCalls atomic.Int64
+		var installingInstallCalls atomic.Int64
+		var installingStartCalls atomic.Int64
 		mockey.Mock(runCommand).To(func(ctx context.Context, script, arg string, result *string) error {
 			mockCalls.Add(1)
 			switch filepath.Base(script) {
+			case "dep.sh":
+				switch arg {
+				case "shouldSkip":
+					return errors.New("no skip")
+				case "isInstalled":
+					return nil
+				}
+			case "missing.sh":
+				switch arg {
+				case "shouldSkip":
+					return errors.New("no skip")
+				case "isInstalled":
+					missingProbeCalls.Add(1)
+					return errors.New("not installed")
+				case "install":
+					missingInstallCalls.Add(1)
+					return nil
+				case "start":
+					missingStartCalls.Add(1)
+					return nil
+				}
+			case "version.sh":
+				switch arg {
+				case "shouldSkip":
+					return errors.New("no skip")
+				case "isInstalled":
+					oldVersionProbeCalls.Add(1)
+					return errors.New("not installed")
+				case "install":
+					oldVersionInstallCalls.Add(1)
+					return nil
+				case "start":
+					oldVersionStartCalls.Add(1)
+					return nil
+				}
+			case "uninstalled-dep.sh":
+				switch arg {
+				case "shouldSkip":
+					return errors.New("no skip")
+				case "isInstalled":
+					uninstalledDepProbeCalls.Add(1)
+					return errors.New("not installed")
+				case "install":
+					uninstalledDepInstallCalls.Add(1)
+					return nil
+				case "start":
+					uninstalledDepStartCalls.Add(1)
+					return nil
+				}
+			case "needs-uninstalled-dep.sh":
+				switch arg {
+				case "shouldSkip":
+					return errors.New("no skip")
+				case "isInstalled":
+					dependentProbeCalls.Add(1)
+					return errors.New("not installed")
+				case "install":
+					dependentInstallCalls.Add(1)
+					return nil
+				case "start":
+					dependentStartCalls.Add(1)
+					return nil
+				}
 			case "skip-install.sh":
 				if arg == "shouldSkip" {
 					return nil
 				}
-				return errors.New("unexpected")
-			case "installed.sh":
+			case "installed-with-missing-dep.sh":
 				if arg == "shouldSkip" {
 					return errors.New("no skip")
 				}
 				if arg == "isInstalled" {
+					installedProbeCalls.Add(1)
+					return nil
+				}
+				if arg == "install" {
+					installedInstallCalls.Add(1)
+					return nil
+				}
+				if arg == "start" {
+					installedStartCalls.Add(1)
 					return nil
 				}
 			case "install.sh":
@@ -231,8 +343,24 @@ func TestInstallRunner_WithMockedRunCommand(t *testing.T) {
 					}
 					return errors.New("start failed")
 				}
+			case "installing.sh":
+				switch arg {
+				case "shouldSkip":
+					installingShouldSkipCalls.Add(1)
+					return errors.New("no skip")
+				case "isInstalled":
+					installingProbeCalls.Add(1)
+					return nil
+				case "install":
+					installingInstallCalls.Add(1)
+					return nil
+				case "start":
+					installingStartCalls.Add(1)
+					return nil
+				}
 			}
-			return nil
+			unexpectedCalls.Add(1)
+			return errors.New("unexpected command")
 		}).Build()
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -262,7 +390,8 @@ func TestInstallRunner_WithMockedRunCommand(t *testing.T) {
 		require.Eventually(t, func() bool {
 			controller.RLock()
 			defer controller.RUnlock()
-			return controller.packageStatus["installed"].IsInstalled
+			installed := controller.packageStatus["installed-with-missing-dep"]
+			return installed.IsInstalled && installed.Progress == 100
 		}, 10*time.Second, 10*time.Millisecond)
 
 		require.Eventually(t, func() bool {
@@ -271,18 +400,50 @@ func TestInstallRunner_WithMockedRunCommand(t *testing.T) {
 			return controller.packageStatus["install"].Progress == 100
 		}, 10*time.Second, 10*time.Millisecond)
 
+		require.Eventually(t, func() bool {
+			return missingProbeCalls.Load() > 0 &&
+				oldVersionProbeCalls.Load() > 0 &&
+				uninstalledDepProbeCalls.Load() > 0 &&
+				dependentProbeCalls.Load() > 0 &&
+				installingShouldSkipCalls.Load() > 0
+		}, 10*time.Second, 10*time.Millisecond)
+
 		cancel()
 		// Ensure the runner goroutine has left the patched runCommand before
 		// PatchConvey unpatches it on scope exit (avoids a teardown data race).
 		waitMockQuiescent(t, &mockCalls)
 
 		controller.RLock()
-		missing := controller.packageStatus["needs-missing-dep"]
-		version := controller.packageStatus["needs-version-dep"]
+		missingInstalled := controller.packageStatus["needs-missing-dep"].IsInstalled
+		versionInstalled := controller.packageStatus["needs-version-dep"].IsInstalled
+		uninstalledDependencyInstalled := controller.packageStatus["uninstalled-dep"].IsInstalled
+		dependentInstalled := controller.packageStatus["needs-uninstalled-dep"].IsInstalled
 		controller.RUnlock()
 
-		assert.False(t, missing.IsInstalled)
-		assert.False(t, version.IsInstalled)
+		assert.False(t, missingInstalled)
+		assert.False(t, versionInstalled)
+		assert.False(t, uninstalledDependencyInstalled)
+		assert.False(t, dependentInstalled)
+		assert.Positive(t, installedProbeCalls.Load())
+		assert.Zero(t, installedInstallCalls.Load())
+		assert.Zero(t, installedStartCalls.Load())
+		assert.Zero(t, missingInstallCalls.Load())
+		assert.Zero(t, missingStartCalls.Load())
+		assert.Positive(t, missingProbeCalls.Load())
+		assert.Zero(t, oldVersionInstallCalls.Load())
+		assert.Zero(t, oldVersionStartCalls.Load())
+		assert.Positive(t, oldVersionProbeCalls.Load())
+		assert.Zero(t, uninstalledDepInstallCalls.Load())
+		assert.Zero(t, uninstalledDepStartCalls.Load())
+		assert.Positive(t, uninstalledDepProbeCalls.Load())
+		assert.Zero(t, dependentInstallCalls.Load())
+		assert.Zero(t, dependentStartCalls.Load())
+		assert.Positive(t, dependentProbeCalls.Load())
+		assert.Positive(t, installingShouldSkipCalls.Load())
+		assert.Zero(t, installingProbeCalls.Load())
+		assert.Zero(t, installingInstallCalls.Load())
+		assert.Zero(t, installingStartCalls.Load())
+		assert.Zero(t, unexpectedCalls.Load())
 	})
 }
 

--- a/pkg/gpud-manager/controllers/mock_package_controller_runner_test.go
+++ b/pkg/gpud-manager/controllers/mock_package_controller_runner_test.go
@@ -152,10 +152,63 @@ func TestUpdateRunner_WithMockedRunCommand(t *testing.T) {
 	})
 }
 
+func TestUpdateRunner_UpgradesRecoveredPackageWithoutInstallDependencies(t *testing.T) {
+	mockey.PatchConvey("update runner upgrades a recovered package without install dependencies", t, func() {
+		controller := NewPackageController(make(chan packages.PackageInfo))
+		controller.syncPeriod = 10 * time.Millisecond
+		controller.packageStatus["kubelet"] = &packages.PackageStatus{
+			Name:          "kubelet",
+			TargetVersion: "2.0.0",
+			ScriptPath:    "/tmp/kubelet.sh",
+			Dependency:    [][]string{{"missing-install-dependency", "*"}},
+			TotalTime:     200 * time.Millisecond,
+		}
+		controller.recoveredInstalled["kubelet"] = true
+
+		upgradeCalled := make(chan struct{}, 1)
+		var mockCalls atomic.Int64
+		mockey.Mock(runCommand).To(func(ctx context.Context, script, arg string, result *string) error {
+			mockCalls.Add(1)
+			switch arg {
+			case "version":
+				*result = "1.0.0"
+				return nil
+			case "shouldSkip":
+				return errors.New("no skip")
+			case "upgrade":
+				select {
+				case upgradeCalled <- struct{}{}:
+				default:
+				}
+				return nil
+			default:
+				return errors.New("unexpected command")
+			}
+		}).Build()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go controller.updateRunner(ctx)
+
+		select {
+		case <-upgradeCalled:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for recovered package upgrade")
+		}
+		cancel()
+		waitMockQuiescent(t, &mockCalls)
+
+		controller.RLock()
+		progress := controller.packageStatus["kubelet"].Progress
+		controller.RUnlock()
+		assert.Equal(t, 100, progress)
+	})
+}
+
 func TestInstallRunner_WithMockedRunCommand(t *testing.T) {
 	mockey.PatchConvey("install runner handles deps/skip/install paths", t, func() {
 		controller := NewPackageController(make(chan packages.PackageInfo))
 		controller.syncPeriod = 10 * time.Millisecond
+		controller.recoveryProbeTimeout = 100 * time.Millisecond
 
 		controller.packageStatus["dep"] = &packages.PackageStatus{
 			Name:           "dep",
@@ -182,10 +235,10 @@ func TestInstallRunner_WithMockedRunCommand(t *testing.T) {
 			ScriptPath: "/tmp/uninstalled-dep.sh",
 			TotalTime:  200 * time.Millisecond,
 		}
-		controller.packageStatus["needs-uninstalled-dep"] = &packages.PackageStatus{
-			Name:       "needs-uninstalled-dep",
-			Dependency: [][]string{{"uninstalled-dep", "*"}},
-			ScriptPath: "/tmp/needs-uninstalled-dep.sh",
+		controller.packageStatus["needs-recovered-dep"] = &packages.PackageStatus{
+			Name:       "needs-recovered-dep",
+			Dependency: [][]string{{"installed-with-missing-dep", "*"}},
+			ScriptPath: "/tmp/needs-recovered-dep.sh",
 			TotalTime:  200 * time.Millisecond,
 		}
 		controller.packageStatus["skip"] = &packages.PackageStatus{
@@ -229,9 +282,9 @@ func TestInstallRunner_WithMockedRunCommand(t *testing.T) {
 		var uninstalledDepProbeCalls atomic.Int64
 		var uninstalledDepInstallCalls atomic.Int64
 		var uninstalledDepStartCalls atomic.Int64
-		var dependentProbeCalls atomic.Int64
-		var dependentInstallCalls atomic.Int64
-		var dependentStartCalls atomic.Int64
+		var recoveredDependentProbeCalls atomic.Int64
+		var recoveredDependentInstallCalls atomic.Int64
+		var recoveredDependentStartCalls atomic.Int64
 		var installingShouldSkipCalls atomic.Int64
 		var installingProbeCalls atomic.Int64
 		var installingInstallCalls atomic.Int64
@@ -288,23 +341,26 @@ func TestInstallRunner_WithMockedRunCommand(t *testing.T) {
 					uninstalledDepStartCalls.Add(1)
 					return nil
 				}
-			case "needs-uninstalled-dep.sh":
+			case "needs-recovered-dep.sh":
 				switch arg {
 				case "shouldSkip":
 					return errors.New("no skip")
 				case "isInstalled":
-					dependentProbeCalls.Add(1)
+					recoveredDependentProbeCalls.Add(1)
 					return errors.New("not installed")
 				case "install":
-					dependentInstallCalls.Add(1)
+					recoveredDependentInstallCalls.Add(1)
 					return nil
 				case "start":
-					dependentStartCalls.Add(1)
+					recoveredDependentStartCalls.Add(1)
 					return nil
 				}
 			case "skip-install.sh":
-				if arg == "shouldSkip" {
+				switch arg {
+				case "shouldSkip":
 					return nil
+				case "isInstalled":
+					return errors.New("not installed")
 				}
 			case "installed-with-missing-dep.sh":
 				if arg == "shouldSkip" {
@@ -388,10 +444,16 @@ func TestInstallRunner_WithMockedRunCommand(t *testing.T) {
 		}, 10*time.Second, 10*time.Millisecond)
 
 		require.Eventually(t, func() bool {
-			controller.RLock()
-			defer controller.RUnlock()
-			installed := controller.packageStatus["installed-with-missing-dep"]
-			return installed.IsInstalled && installed.Progress == 100
+			statuses, err := controller.Status(context.Background())
+			if err != nil {
+				return false
+			}
+			for _, status := range statuses {
+				if status.Name == "installed-with-missing-dep" {
+					return status.IsInstalled && status.Progress == 100
+				}
+			}
+			return false
 		}, 10*time.Second, 10*time.Millisecond)
 
 		require.Eventually(t, func() bool {
@@ -401,11 +463,10 @@ func TestInstallRunner_WithMockedRunCommand(t *testing.T) {
 		}, 10*time.Second, 10*time.Millisecond)
 
 		require.Eventually(t, func() bool {
-			return missingProbeCalls.Load() > 0 &&
-				oldVersionProbeCalls.Load() > 0 &&
-				uninstalledDepProbeCalls.Load() > 0 &&
-				dependentProbeCalls.Load() > 0 &&
-				installingShouldSkipCalls.Load() > 0
+			return missingProbeCalls.Load() == 1 &&
+				oldVersionProbeCalls.Load() == 1 &&
+				uninstalledDepProbeCalls.Load() == 1 &&
+				recoveredDependentProbeCalls.Load() == 1
 		}, 10*time.Second, 10*time.Millisecond)
 
 		cancel()
@@ -417,33 +478,145 @@ func TestInstallRunner_WithMockedRunCommand(t *testing.T) {
 		missingInstalled := controller.packageStatus["needs-missing-dep"].IsInstalled
 		versionInstalled := controller.packageStatus["needs-version-dep"].IsInstalled
 		uninstalledDependencyInstalled := controller.packageStatus["uninstalled-dep"].IsInstalled
-		dependentInstalled := controller.packageStatus["needs-uninstalled-dep"].IsInstalled
+		recoveredDependentInstalled := controller.packageStatus["needs-recovered-dep"].IsInstalled
+		recoveredInstalled := controller.packageStatus["installed-with-missing-dep"].IsInstalled
 		controller.RUnlock()
 
 		assert.False(t, missingInstalled)
 		assert.False(t, versionInstalled)
 		assert.False(t, uninstalledDependencyInstalled)
-		assert.False(t, dependentInstalled)
-		assert.Positive(t, installedProbeCalls.Load())
+		assert.False(t, recoveredDependentInstalled)
+		assert.False(t, recoveredInstalled)
+		assert.EqualValues(t, 1, installedProbeCalls.Load())
 		assert.Zero(t, installedInstallCalls.Load())
 		assert.Zero(t, installedStartCalls.Load())
 		assert.Zero(t, missingInstallCalls.Load())
 		assert.Zero(t, missingStartCalls.Load())
-		assert.Positive(t, missingProbeCalls.Load())
+		assert.EqualValues(t, 1, missingProbeCalls.Load())
 		assert.Zero(t, oldVersionInstallCalls.Load())
 		assert.Zero(t, oldVersionStartCalls.Load())
-		assert.Positive(t, oldVersionProbeCalls.Load())
+		assert.EqualValues(t, 1, oldVersionProbeCalls.Load())
 		assert.Zero(t, uninstalledDepInstallCalls.Load())
 		assert.Zero(t, uninstalledDepStartCalls.Load())
-		assert.Positive(t, uninstalledDepProbeCalls.Load())
-		assert.Zero(t, dependentInstallCalls.Load())
-		assert.Zero(t, dependentStartCalls.Load())
-		assert.Positive(t, dependentProbeCalls.Load())
-		assert.Positive(t, installingShouldSkipCalls.Load())
+		assert.EqualValues(t, 1, uninstalledDepProbeCalls.Load())
+		assert.Zero(t, recoveredDependentInstallCalls.Load())
+		assert.Zero(t, recoveredDependentStartCalls.Load())
+		assert.EqualValues(t, 1, recoveredDependentProbeCalls.Load())
+		assert.Zero(t, installingShouldSkipCalls.Load())
 		assert.Zero(t, installingProbeCalls.Load())
 		assert.Zero(t, installingInstallCalls.Load())
 		assert.Zero(t, installingStartCalls.Load())
 		assert.Zero(t, unexpectedCalls.Load())
+	})
+}
+
+func TestInstallRunner_RecoveryProbeTimeoutDoesNotBlockFollowingPackage(t *testing.T) {
+	mockey.PatchConvey("a timed out recovery probe does not block later packages", t, func() {
+		controller := NewPackageController(make(chan packages.PackageInfo))
+		controller.syncPeriod = 10 * time.Millisecond
+		controller.recoveryProbeTimeout = 50 * time.Millisecond
+		controller.packageStatus["blocked"] = &packages.PackageStatus{
+			Name:       "blocked",
+			Dependency: [][]string{{"missing", "*"}},
+			ScriptPath: "/tmp/blocked.sh",
+			TotalTime:  200 * time.Millisecond,
+		}
+
+		probeStarted := make(chan struct{}, 1)
+		installCalled := make(chan struct{}, 1)
+		var mockCalls atomic.Int64
+		var blockedProbeCalls atomic.Int64
+		var installComplete atomic.Bool
+		mockey.Mock(runCommand).To(func(ctx context.Context, script, arg string, result *string) error {
+			mockCalls.Add(1)
+			switch filepath.Base(script) {
+			case "blocked.sh":
+				if arg != "isInstalled" {
+					return errors.New("unexpected blocked command")
+				}
+				blockedProbeCalls.Add(1)
+				select {
+				case probeStarted <- struct{}{}:
+				default:
+				}
+				<-ctx.Done()
+				return ctx.Err()
+			case "installable.sh":
+				switch arg {
+				case "isInstalled":
+					if installComplete.Load() {
+						return nil
+					}
+					return errors.New("not installed")
+				case "shouldSkip":
+					return errors.New("no skip")
+				case "install":
+					installComplete.Store(true)
+					select {
+					case installCalled <- struct{}{}:
+					default:
+					}
+					return nil
+				case "start":
+					return nil
+				}
+			}
+			return errors.New("unexpected command")
+		}).Build()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go controller.installRunner(ctx)
+
+		select {
+		case <-probeStarted:
+		case <-time.After(5 * time.Second):
+			cancel()
+			t.Fatal("timed out waiting for blocked recovery probe")
+		}
+
+		controller.Lock()
+		controller.packageStatus["installable"] = &packages.PackageStatus{
+			Name:       "installable",
+			ScriptPath: "/tmp/installable.sh",
+			TotalTime:  200 * time.Millisecond,
+		}
+		controller.Unlock()
+
+		select {
+		case <-installCalled:
+		case <-time.After(time.Second):
+			cancel()
+			t.Fatal("timed out recovery probe blocked the following package")
+		}
+
+		cancel()
+		waitMockQuiescent(t, &mockCalls)
+		assert.EqualValues(t, 1, blockedProbeCalls.Load())
+	})
+}
+
+func TestStatusRunner_DoesNotRestartRecoveryOnlyPackage(t *testing.T) {
+	mockey.PatchConvey("status runner ignores recovery-only packages", t, func() {
+		controller := NewPackageController(make(chan packages.PackageInfo))
+		controller.syncPeriod = 10 * time.Millisecond
+		controller.packageStatus["recovered"] = &packages.PackageStatus{
+			Name:       "recovered",
+			ScriptPath: "/tmp/recovered.sh",
+		}
+		controller.recoveredInstalled["recovered"] = true
+
+		var mockCalls atomic.Int64
+		mockey.Mock(runCommand).To(func(ctx context.Context, script, arg string, result *string) error {
+			mockCalls.Add(1)
+			return errors.New("unexpected command")
+		}).Build()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go controller.statusRunner(ctx)
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+		waitMockQuiescent(t, &mockCalls)
+		assert.Zero(t, mockCalls.Load())
 	})
 }
 

--- a/pkg/gpud-manager/controllers/mock_package_controller_runner_test.go
+++ b/pkg/gpud-manager/controllers/mock_package_controller_runner_test.go
@@ -595,28 +595,62 @@ func TestInstallRunner_RecoveryProbeTimeoutDoesNotBlockFollowingPackage(t *testi
 	})
 }
 
-func TestStatusRunner_DoesNotRestartRecoveryOnlyPackage(t *testing.T) {
-	mockey.PatchConvey("status runner ignores recovery-only packages", t, func() {
+func TestStatusRunner_ChecksRecoveryOnlyPackageWithoutRestart(t *testing.T) {
+	mockey.PatchConvey("status runner checks recovery-only packages without restarting them", t, func() {
 		controller := NewPackageController(make(chan packages.PackageInfo))
 		controller.syncPeriod = 10 * time.Millisecond
-		controller.packageStatus["recovered"] = &packages.PackageStatus{
-			Name:       "recovered",
-			ScriptPath: "/tmp/recovered.sh",
+		controller.packageStatus["recovered-ok"] = &packages.PackageStatus{
+			Name:       "recovered-ok",
+			ScriptPath: "/tmp/recovered-ok.sh",
 		}
-		controller.recoveredInstalled["recovered"] = true
+		controller.recoveredInstalled["recovered-ok"] = true
+		controller.packageStatus["recovered-failed"] = &packages.PackageStatus{
+			Name:       "recovered-failed",
+			ScriptPath: "/tmp/recovered-failed.sh",
+		}
+		controller.recoveredInstalled["recovered-failed"] = true
 
 		var mockCalls atomic.Int64
+		var okStatusCalls atomic.Int64
+		var failedStatusCalls atomic.Int64
+		var restartCalls atomic.Int64
 		mockey.Mock(runCommand).To(func(ctx context.Context, script, arg string, result *string) error {
 			mockCalls.Add(1)
+			switch arg {
+			case "shouldSkip":
+				return errors.New("no skip")
+			case "status":
+				switch filepath.Base(script) {
+				case "recovered-ok.sh":
+					okStatusCalls.Add(1)
+					return nil
+				case "recovered-failed.sh":
+					failedStatusCalls.Add(1)
+					return errors.New("status failed")
+				}
+			case "stop", "start":
+				restartCalls.Add(1)
+				return nil
+			}
 			return errors.New("unexpected command")
 		}).Build()
 
 		ctx, cancel := context.WithCancel(context.Background())
 		go controller.statusRunner(ctx)
-		time.Sleep(50 * time.Millisecond)
+		require.Eventually(t, func() bool {
+			controller.RLock()
+			defer controller.RUnlock()
+			return controller.packageStatus["recovered-ok"].Status && failedStatusCalls.Load() > 0
+		}, 5*time.Second, 10*time.Millisecond)
 		cancel()
 		waitMockQuiescent(t, &mockCalls)
-		assert.Zero(t, mockCalls.Load())
+		assert.Positive(t, okStatusCalls.Load())
+		assert.Positive(t, failedStatusCalls.Load())
+		assert.Zero(t, restartCalls.Load())
+		controller.RLock()
+		defer controller.RUnlock()
+		assert.True(t, controller.packageStatus["recovered-ok"].Status)
+		assert.False(t, controller.packageStatus["recovered-failed"].Status)
 	})
 }
 

--- a/pkg/gpud-manager/controllers/package_controller.go
+++ b/pkg/gpud-manager/controllers/package_controller.go
@@ -198,38 +198,6 @@ func (c *PackageController) installRunner(ctx context.Context) {
 			dependency := pkg.Dependency
 			scriptPath := pkg.ScriptPath
 			c.RUnlock()
-			var skipCheck bool
-			for _, dep := range dependency {
-				// Read the dependency's mutable fields under the read lock;
-				// updateRunner and the async install goroutine mutate them
-				// under the write lock.
-				c.RLock()
-				depPkg, depFound := c.packageStatus[dep[0]]
-				depInstalled := depFound && depPkg.IsInstalled
-				depVersion := ""
-				if depFound {
-					depVersion = depPkg.CurrentVersion
-				}
-				c.RUnlock()
-				if !depFound {
-					log.Logger.Infof("[package controller]: %v dependency %v not found, skipping", pkg.Name, dep[0])
-					skipCheck = true
-					break
-				}
-				if !depInstalled {
-					log.Logger.Infof("[package controller]: %v dependency %v not installed, skipping", pkg.Name, dep[0])
-					skipCheck = true
-					break
-				}
-				if dep[1] != "*" && (depVersion == "" || depVersion < dep[1]) {
-					log.Logger.Infof("[package controller]: %v dependency %v version %v does not meet required %v, skipping", pkg.Name, dep[0], depVersion, dep[1])
-					skipCheck = true
-					break
-				}
-			}
-			if skipCheck {
-				continue
-			}
 
 			var shouldSkipResult string
 			if err := runCommand(ctx, scriptPath, "shouldSkip", &shouldSkipResult); err == nil {
@@ -258,6 +226,39 @@ func (c *PackageController) installRunner(ctx context.Context) {
 				c.packageStatus[pkg.Name].IsInstalled = true
 				c.Unlock()
 				log.Logger.Debugw("[package controller] already installed", "name", pkg.Name)
+				continue
+			}
+
+			var skipInstall bool
+			for _, dep := range dependency {
+				// Read the dependency's mutable fields under the read lock;
+				// updateRunner and the async install goroutine mutate them
+				// under the write lock.
+				c.RLock()
+				depPkg, depFound := c.packageStatus[dep[0]]
+				depInstalled := depFound && depPkg.IsInstalled
+				depVersion := ""
+				if depFound {
+					depVersion = depPkg.CurrentVersion
+				}
+				c.RUnlock()
+				if !depFound {
+					log.Logger.Infof("[package controller]: %v dependency %v not found, skipping", pkg.Name, dep[0])
+					skipInstall = true
+					break
+				}
+				if !depInstalled {
+					log.Logger.Infof("[package controller]: %v dependency %v not installed, skipping", pkg.Name, dep[0])
+					skipInstall = true
+					break
+				}
+				if dep[1] != "*" && (depVersion == "" || depVersion < dep[1]) {
+					log.Logger.Infof("[package controller]: %v dependency %v version %v does not meet required %v, skipping", pkg.Name, dep[0], depVersion, dep[1])
+					skipInstall = true
+					break
+				}
+			}
+			if skipInstall {
 				continue
 			}
 

--- a/pkg/gpud-manager/controllers/package_controller.go
+++ b/pkg/gpud-manager/controllers/package_controller.go
@@ -388,9 +388,10 @@ func (c *PackageController) statusRunner(ctx context.Context) {
 		for _, pkg := range c.packageStatusSnapshot() {
 			c.RLock()
 			installed := pkg.IsInstalled
+			recovered := c.recoveredInstalled[pkg.Name]
 			scriptPath := pkg.ScriptPath
 			c.RUnlock()
-			if !installed {
+			if !installed && !recovered {
 				continue
 			}
 
@@ -410,6 +411,14 @@ func (c *PackageController) statusRunner(ctx context.Context) {
 				c.packageStatus[pkg.Name].Status = true
 				c.Unlock()
 				log.Logger.Debugf("[package controller]: %v status ok", pkg.Name)
+				continue
+			}
+			// Recovery establishes that the package exists on disk, but its
+			// dependencies have not passed the install gate. Report the package's
+			// actual health without restarting it until normal installed state is
+			// established, avoiding a restart loop when a dependency is unavailable.
+			if recovered && !installed {
+				log.Logger.Warnw("[package controller] recovered package status not ok; skipping restart", "name", pkg.Name, "error", err)
 				continue
 			}
 			log.Logger.Errorf("[package controller]: %v status not ok, restarting", pkg.Name)

--- a/pkg/gpud-manager/controllers/package_controller.go
+++ b/pkg/gpud-manager/controllers/package_controller.go
@@ -17,17 +17,23 @@ import (
 )
 
 type PackageController struct {
-	fileWatcher   chan packages.PackageInfo
-	packageStatus map[string]*packages.PackageStatus
-	syncPeriod    time.Duration
+	fileWatcher          chan packages.PackageInfo
+	packageStatus        map[string]*packages.PackageStatus
+	recoveryProbed       map[string]bool
+	recoveredInstalled   map[string]bool
+	syncPeriod           time.Duration
+	recoveryProbeTimeout time.Duration
 	sync.RWMutex
 }
 
 func NewPackageController(watcher chan packages.PackageInfo) *PackageController {
 	r := &PackageController{
-		fileWatcher:   watcher,
-		packageStatus: make(map[string]*packages.PackageStatus),
-		syncPeriod:    3 * time.Second,
+		fileWatcher:          watcher,
+		packageStatus:        make(map[string]*packages.PackageStatus),
+		recoveryProbed:       make(map[string]bool),
+		recoveredInstalled:   make(map[string]bool),
+		syncPeriod:           3 * time.Second,
+		recoveryProbeTimeout: 10 * time.Second,
 	}
 	return r
 }
@@ -36,8 +42,12 @@ func (c *PackageController) Status(ctx context.Context) ([]packages.PackageStatu
 	c.RLock()
 	defer c.RUnlock()
 	var ret []packages.PackageStatus
-	for _, pkg := range c.packageStatus {
-		ret = append(ret, *pkg)
+	for name, pkg := range c.packageStatus {
+		status := *pkg
+		// A recovered installation is real state on disk, but it does not
+		// satisfy dependency gates until the dependencies have been validated.
+		status.IsInstalled = status.IsInstalled || c.recoveredInstalled[name]
+		ret = append(ret, status)
 	}
 	sort.Sort(packages.PackageStatuses(ret))
 	return ret, nil
@@ -109,7 +119,7 @@ func (c *PackageController) updateRunner(ctx context.Context) {
 		}
 		for _, pkg := range c.packageStatusSnapshot() {
 			c.RLock()
-			installed := pkg.IsInstalled
+			installed := pkg.IsInstalled || c.recoveredInstalled[pkg.Name]
 			scriptPath := pkg.ScriptPath
 			targetVersion := pkg.TargetVersion
 			c.RUnlock()
@@ -197,36 +207,37 @@ func (c *PackageController) installRunner(ctx context.Context) {
 			c.RLock()
 			dependency := pkg.Dependency
 			scriptPath := pkg.ScriptPath
-			c.RUnlock()
-
-			var shouldSkipResult string
-			if err := runCommand(ctx, scriptPath, "shouldSkip", &shouldSkipResult); err == nil {
-				c.Lock()
-				c.packageStatus[pkg.Name].Skipped = true
-				c.packageStatus[pkg.Name].Progress = 100
-				c.packageStatus[pkg.Name].IsInstalled = true
-				c.Unlock()
-				log.Logger.Debugf("[package controller]: %v shouldSkip returned 0, skipping install", pkg.Name)
-				continue
-			}
-
-			c.RLock()
 			installing := pkg.Installing
+			installed := pkg.IsInstalled
+			recoveryProbed := c.recoveryProbed[pkg.Name]
 			c.RUnlock()
+
 			if installing {
 				log.Logger.Infof("[package controller]: %v installing...", pkg.Name)
 				continue
 			}
 
-			// if installing, then skip
-			err := runCommand(ctx, scriptPath, "isInstalled", nil)
-			if err == nil {
+			// Probe once before the dependency gate so a controller restart can
+			// recover packages that already exist on disk. Keep that state
+			// separate from IsInstalled: package dependencies only gate a fresh
+			// install, while an existing package must remain eligible for upgrade.
+			if !installed && !recoveryProbed {
 				c.Lock()
-				c.packageStatus[pkg.Name].Progress = 100
-				c.packageStatus[pkg.Name].IsInstalled = true
+				c.recoveryProbed[pkg.Name] = true
 				c.Unlock()
-				log.Logger.Debugw("[package controller] already installed", "name", pkg.Name)
-				continue
+
+				probeCtx, cancel := context.WithTimeout(ctx, c.recoveryProbeTimeout)
+				err := runCommand(probeCtx, scriptPath, "isInstalled", nil)
+				cancel()
+				if err == nil {
+					c.Lock()
+					c.recoveredInstalled[pkg.Name] = true
+					c.packageStatus[pkg.Name].Progress = 100
+					c.Unlock()
+					log.Logger.Debugw("[package controller] recovered existing installation", "name", pkg.Name)
+				} else if errors.Is(err, context.DeadlineExceeded) {
+					log.Logger.Warnw("[package controller] recovery probe timed out", "name", pkg.Name, "timeout", c.recoveryProbeTimeout)
+				}
 			}
 
 			var skipInstall bool
@@ -259,6 +270,37 @@ func (c *PackageController) installRunner(ctx context.Context) {
 				}
 			}
 			if skipInstall {
+				continue
+			}
+
+			c.RLock()
+			recovered := c.recoveredInstalled[pkg.Name]
+			c.RUnlock()
+			if recovered {
+				c.Lock()
+				c.packageStatus[pkg.Name].IsInstalled = true
+				c.Unlock()
+				continue
+			}
+
+			var shouldSkipResult string
+			if err := runCommand(ctx, scriptPath, "shouldSkip", &shouldSkipResult); err == nil {
+				c.Lock()
+				c.packageStatus[pkg.Name].Skipped = true
+				c.packageStatus[pkg.Name].Progress = 100
+				c.packageStatus[pkg.Name].IsInstalled = true
+				c.Unlock()
+				log.Logger.Debugf("[package controller]: %v shouldSkip returned 0, skipping install", pkg.Name)
+				continue
+			}
+
+			err := runCommand(ctx, scriptPath, "isInstalled", nil)
+			if err == nil {
+				c.Lock()
+				c.packageStatus[pkg.Name].Progress = 100
+				c.packageStatus[pkg.Name].IsInstalled = true
+				c.Unlock()
+				log.Logger.Debugw("[package controller] already installed", "name", pkg.Name)
 				continue
 			}
 


### PR DESCRIPTION
## Summary

- detect packages that are already installed before validating dependencies needed for a fresh install
- preserve dependency gates for missing, uninstalled, or version-incompatible dependencies
- cover restart recovery, dependency boundaries, and concurrent-install guards

## Why

Package controller state is rebuilt in memory when GPUd starts. Previously, a newly declared but unavailable dependency prevented `isInstalled` from running, so an existing package could remain `Unknown` and become ineligible for updates after a restart.

## Testing

- `GOFLAGS=-mod=mod GOTOOLCHAIN=go1.25.12 go test ./pkg/gpud-manager/controllers -run TestInstallRunner_WithMockedRunCommand -count=100 -shuffle=on`
- `GOFLAGS=-mod=mod GOTOOLCHAIN=go1.25.12 go test -race ./pkg/gpud-manager/controllers -run TestInstallRunner_WithMockedRunCommand -count=20 -shuffle=on`
- `GOFLAGS=-mod=mod GOTOOLCHAIN=go1.25.12 go test ./pkg/gpud-manager/controllers -count=5 -shuffle=on`
- `GOFLAGS=-mod=mod GOTOOLCHAIN=go1.25.12 go test -race ./pkg/gpud-manager/controllers -count=1`
- `GOFLAGS=-mod=mod GOTOOLCHAIN=go1.25.12 go build ./...`
- custom `golangci-lint v2.7.2`: 0 issues for `./pkg/gpud-manager/controllers/...`