### PR TITLE
fix(providers): survive slow first IMDS connect for private IP detection

### DIFF
--- a/pkg/machine-info/mock_machine_info_coverage_test.go
+++ b/pkg/machine-info/mock_machine_info_coverage_test.go
@@ -374,14 +374,14 @@ func TestMachineInfoDiskCommands_WithMockey(t *testing.T) {
 		// The configured commands run as short-lived shell fixtures; under the
 		// full CI suite such a process can sporadically produce no parsed rows
 		// (the same failure class as the df fixture documented below, observed
-		// on the findmnt fixture as "unexpected end of JSON input" with an empty
-		// ContainerRootDisk). The probe is read-only and idempotent, so retry a
-		// few times to assert the command wiring rather than the subprocess race.
+		// on findmnt or df fixtures under heavy test runner load). The probe is
+		// read-only and idempotent, so retry a few times to assert the command
+		// wiring rather than the subprocess race.
 		var info *apiv1.MachineDiskInfo
 		var err error
-		for range 3 {
+		for range 5 {
 			info, err = GetMachineDiskInfo(context.Background())
-			if err == nil && info.ContainerRootDisk != "" {
+			if err == nil && info != nil && info.ContainerRootDisk != "" && len(info.BlockDevices) == 2 {
 				break
 			}
 		}

--- a/pkg/machine-info/mock_machine_info_coverage_test.go
+++ b/pkg/machine-info/mock_machine_info_coverage_test.go
@@ -371,7 +371,20 @@ func TestMachineInfoDiskCommands_WithMockey(t *testing.T) {
 		SetDiskCommands(findmnt, lsblk, df)
 		defer SetDiskCommands("", "", "")
 
-		info, err := GetMachineDiskInfo(context.Background())
+		// The configured commands run as short-lived shell fixtures; under the
+		// full CI suite such a process can sporadically produce no parsed rows
+		// (the same failure class as the df fixture documented below, observed
+		// on the findmnt fixture as "unexpected end of JSON input" with an empty
+		// ContainerRootDisk). The probe is read-only and idempotent, so retry a
+		// few times to assert the command wiring rather than the subprocess race.
+		var info *apiv1.MachineDiskInfo
+		var err error
+		for range 3 {
+			info, err = GetMachineDiskInfo(context.Background())
+			if err == nil && info.ContainerRootDisk != "" {
+				break
+			}
+		}
 		require.NoError(t, err)
 		require.Len(t, info.BlockDevices, 2)
 		assert.Equal(t, "/dev/sda1", info.ContainerRootDisk)

--- a/pkg/providers/all/all.go
+++ b/pkg/providers/all/all.go
@@ -77,7 +77,12 @@ func DetectWithRegionOverride(ctx context.Context, regionOverride string) (*pkgp
 		info.PublicIP = publicIP
 	}
 
-	privateIP, err := detector.PrivateIPv4(ctx)
+	// Private IP goes through the same IMDS retry path as region and instance ID:
+	// on some providers (e.g., nscale) the first metadata request after an idle
+	// period can exceed the HTTP client timeout while the connection path warms
+	// up, and a single attempt would return empty even though a retry succeeds
+	// immediately.
+	privateIP, err := fetchRequiredMetadata(ctx, detector, "private IP", detector.PrivateIPv4)
 	if err != nil {
 		log.Logger.Warnw("failed to get private IP", "provider", detector.Name(), "error", err)
 	} else {

--- a/pkg/providers/all/all.go
+++ b/pkg/providers/all/all.go
@@ -68,21 +68,16 @@ func DetectWithRegionOverride(ctx context.Context, regionOverride string) (*pkgp
 		IMDSDetected: pkgproviders.SupportsIMDS(detector),
 	}
 
-	// Metadata fields are best-effort: provider detection has already succeeded,
-	// so one failed optional fetch should not discard provider identity.
-	publicIP, err := detector.PublicIPv4(ctx)
+	// Fetch the required identity fields first: when the metadata service is
+	// slow or hanging, the optional best-effort fetches (public IP, VM
+	// environment, private IP) must not consume the shared context budget
+	// that the login-gating instance ID and region need.
+	instanceID, err := fetchRequiredMetadata(ctx, detector, "instance ID", detector.InstanceID)
 	if err != nil {
-		log.Logger.Warnw("failed to get public IP", "provider", detector.Name(), "error", err)
+		log.Logger.Warnw("failed to get instance ID", "provider", detector.Name(), "error", err)
 	} else {
-		info.PublicIP = publicIP
-	}
-
-	privateIP, err := fetchPrivateIPv4(ctx, detector)
-	if err != nil {
-		log.Logger.Warnw("failed to get private IP", "provider", detector.Name(), "error", err)
-	} else {
-		info.PrivateIP = privateIP
-		log.Logger.Infow("successfully detected private IP", "provider", detector.Name(), "privateIP", privateIP)
+		info.InstanceID = instanceID
+		log.Logger.Infow("successfully detected instance ID", "provider", detector.Name(), "instanceID", instanceID)
 	}
 
 	if regionOverride = strings.TrimSpace(regionOverride); regionOverride != "" {
@@ -96,6 +91,16 @@ func DetectWithRegionOverride(ctx context.Context, regionOverride string) (*pkgp
 		}
 	}
 
+	// Metadata fields below are best-effort: provider detection has already
+	// succeeded, so one failed optional fetch should not discard provider
+	// identity.
+	publicIP, err := detector.PublicIPv4(ctx)
+	if err != nil {
+		log.Logger.Warnw("failed to get public IP", "provider", detector.Name(), "error", err)
+	} else {
+		info.PublicIP = publicIP
+	}
+
 	vmEnvironment, err := detector.VMEnvironment(ctx)
 	if err != nil {
 		log.Logger.Warnw("failed to get VM environment", "provider", detector.Name(), "error", err)
@@ -103,12 +108,15 @@ func DetectWithRegionOverride(ctx context.Context, regionOverride string) (*pkgp
 		info.VMEnvironment = vmEnvironment
 	}
 
-	instanceID, err := fetchRequiredMetadata(ctx, detector, "instance ID", detector.InstanceID)
+	// Private IP comes last: it is optional, and detectors that opted into
+	// retries (WithPrivateIPv4Retry) may spend a large share of the shared
+	// budget on it, so it must not run ahead of the required identity fields.
+	privateIP, err := fetchPrivateIPv4(ctx, detector)
 	if err != nil {
-		log.Logger.Warnw("failed to get instance ID", "provider", detector.Name(), "error", err)
+		log.Logger.Warnw("failed to get private IP", "provider", detector.Name(), "error", err)
 	} else {
-		info.InstanceID = instanceID
-		log.Logger.Infow("successfully detected instance ID", "provider", detector.Name(), "instanceID", instanceID)
+		info.PrivateIP = privateIP
+		log.Logger.Infow("successfully detected private IP", "provider", detector.Name(), "privateIP", privateIP)
 	}
 
 	return info, nil

--- a/pkg/providers/all/all.go
+++ b/pkg/providers/all/all.go
@@ -115,16 +115,12 @@ func DetectWithRegionOverride(ctx context.Context, regionOverride string) (*pkgp
 }
 
 // fetchPrivateIPv4 reads the machine's private IPv4 from the detector.
-// IMDS-backed detectors with a private-IP fetcher get the same
-// retry-with-backoff path as region and instance ID: on some providers
-// (e.g., nscale) the first metadata request after an idle period can exceed
-// the HTTP client timeout while the connection path warms up, and a single
-// attempt would return empty even though a retry succeeds immediately.
-// Detectors without a private-IP fetcher (e.g., azure, gcp, nebius) keep a
-// single attempt, so they do not burn the retry budget on a permanently
-// empty result on every login.
+// Only detectors that explicitly opted in (providers.WithPrivateIPv4Retry —
+// currently nscale, whose metadata service can be slow to accept the first
+// connection after an idle period) use the same retry-with-backoff path as
+// region and instance ID; all other detectors keep a single attempt.
 func fetchPrivateIPv4(ctx context.Context, detector pkgproviders.Detector) (string, error) {
-	if !pkgproviders.SupportsPrivateIPv4(detector) {
+	if !pkgproviders.SupportsPrivateIPv4Retry(detector) {
 		return detector.PrivateIPv4(ctx)
 	}
 	return fetchRequiredMetadata(ctx, detector, "private IP", detector.PrivateIPv4)

--- a/pkg/providers/all/all.go
+++ b/pkg/providers/all/all.go
@@ -77,12 +77,7 @@ func DetectWithRegionOverride(ctx context.Context, regionOverride string) (*pkgp
 		info.PublicIP = publicIP
 	}
 
-	// Private IP goes through the same IMDS retry path as region and instance ID:
-	// on some providers (e.g., nscale) the first metadata request after an idle
-	// period can exceed the HTTP client timeout while the connection path warms
-	// up, and a single attempt would return empty even though a retry succeeds
-	// immediately.
-	privateIP, err := fetchRequiredMetadata(ctx, detector, "private IP", detector.PrivateIPv4)
+	privateIP, err := fetchPrivateIPv4(ctx, detector)
 	if err != nil {
 		log.Logger.Warnw("failed to get private IP", "provider", detector.Name(), "error", err)
 	} else {
@@ -117,6 +112,22 @@ func DetectWithRegionOverride(ctx context.Context, regionOverride string) (*pkgp
 	}
 
 	return info, nil
+}
+
+// fetchPrivateIPv4 reads the machine's private IPv4 from the detector.
+// IMDS-backed detectors with a private-IP fetcher get the same
+// retry-with-backoff path as region and instance ID: on some providers
+// (e.g., nscale) the first metadata request after an idle period can exceed
+// the HTTP client timeout while the connection path warms up, and a single
+// attempt would return empty even though a retry succeeds immediately.
+// Detectors without a private-IP fetcher (e.g., azure, gcp, nebius) keep a
+// single attempt, so they do not burn the retry budget on a permanently
+// empty result on every login.
+func fetchPrivateIPv4(ctx context.Context, detector pkgproviders.Detector) (string, error) {
+	if !pkgproviders.SupportsPrivateIPv4(detector) {
+		return detector.PrivateIPv4(ctx)
+	}
+	return fetchRequiredMetadata(ctx, detector, "private IP", detector.PrivateIPv4)
 }
 
 func fetchRequiredMetadata(ctx context.Context, detector pkgproviders.Detector, field string, fetch func(context.Context) (string, error)) (string, error) {

--- a/pkg/providers/all/all_test.go
+++ b/pkg/providers/all/all_test.go
@@ -574,6 +574,51 @@ func TestDetect_IMDSRetriesPrivateIPv4(t *testing.T) {
 	})
 }
 
+func TestDetect_PrivateIPv4RetryDoesNotStarveRequiredFields(t *testing.T) {
+	// The private IPv4 fetch hangs until the shared context expires (a
+	// metadata service that accepts no connections). The required identity
+	// fields must still be populated because they are fetched first — their
+	// mocks fail on a canceled context, so a wrong fetch order would leave
+	// them empty and fail the test.
+	detector := providers.NewIMDSWithRegion(
+		"test-cloud",
+		func(context.Context) (string, error) { return "detected", nil },
+		nil,
+		func(ctx context.Context) (string, error) {
+			<-ctx.Done()
+			return "", ctx.Err()
+		},
+		func(ctx context.Context) (string, error) {
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			default:
+			}
+			return "eu-west-2", nil
+		},
+		nil,
+		func(ctx context.Context) (string, error) {
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			default:
+			}
+			return "instance-1", nil
+		},
+		providers.WithPrivateIPv4Retry(),
+	)
+
+	withTemporaryDetectors([]providers.Detector{detector}, func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		info, err := Detect(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, "instance-1", info.InstanceID)
+		assert.Equal(t, "eu-west-2", info.Region)
+		assert.Empty(t, info.PrivateIP)
+	})
+}
+
 func TestDetect_IMDSPrivateIPv4RetryExhaustion(t *testing.T) {
 	originalBackoffs := imdsRetryBackoffs
 	imdsRetryBackoffs = []time.Duration{0, 0, 0, 0}

--- a/pkg/providers/all/all_test.go
+++ b/pkg/providers/all/all_test.go
@@ -494,9 +494,7 @@ func TestDetect_IMDSRetryStopsOnContextCancellation(t *testing.T) {
 		"test-cloud",
 		func(context.Context) (string, error) { return "detected", nil },
 		nil,
-		// private IP succeeds on the first attempt so the test reaches the
-		// instance ID fetch that drives the cancellation
-		func(context.Context) (string, error) { return "10.0.0.1", nil },
+		nil,
 		func(context.Context) (string, error) { return "eu-west-2", nil },
 		nil,
 		func(context.Context) (string, error) {
@@ -511,6 +509,33 @@ func TestDetect_IMDSRetryStopsOnContextCancellation(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Empty(t, info.InstanceID)
 		assert.Equal(t, 1, instanceIDCalls)
+	})
+}
+
+func TestDetect_IMDSWithoutPrivateIPv4FetcherDoesNotRetry(t *testing.T) {
+	originalBackoffs := imdsRetryBackoffs
+	imdsRetryBackoffs = []time.Duration{0, time.Hour}
+	defer func() { imdsRetryBackoffs = originalBackoffs }()
+
+	// No private IPv4 fetcher (like azure, gcp, nebius): a retry loop would
+	// block for an hour on the second attempt, so completing at all proves
+	// the detector was called only once.
+	detector := providers.NewIMDSWithRegion(
+		"test-cloud",
+		func(context.Context) (string, error) { return "detected", nil },
+		nil,
+		nil,
+		func(context.Context) (string, error) { return "eu-west-2", nil },
+		nil,
+		func(context.Context) (string, error) { return "instance-1", nil },
+	)
+
+	withTemporaryDetectors([]providers.Detector{detector}, func() {
+		info, err := Detect(context.Background())
+		assert.NoError(t, err)
+		assert.Empty(t, info.PrivateIP)
+		assert.Equal(t, "eu-west-2", info.Region)
+		assert.Equal(t, "instance-1", info.InstanceID)
 	})
 }
 

--- a/pkg/providers/all/all_test.go
+++ b/pkg/providers/all/all_test.go
@@ -512,19 +512,23 @@ func TestDetect_IMDSRetryStopsOnContextCancellation(t *testing.T) {
 	})
 }
 
-func TestDetect_IMDSWithoutPrivateIPv4FetcherDoesNotRetry(t *testing.T) {
+func TestDetect_IMDSPrivateIPv4SingleAttemptWithoutOptIn(t *testing.T) {
 	originalBackoffs := imdsRetryBackoffs
 	imdsRetryBackoffs = []time.Duration{0, time.Hour}
 	defer func() { imdsRetryBackoffs = originalBackoffs }()
 
-	// No private IPv4 fetcher (like azure, gcp, nebius): a retry loop would
-	// block for an hour on the second attempt, so completing at all proves
-	// the detector was called only once.
+	// The detector has a private IPv4 fetcher but did not opt into retries:
+	// a second attempt would block for an hour, so completing proves the
+	// fetch happened exactly once.
+	privateCalls := 0
 	detector := providers.NewIMDSWithRegion(
 		"test-cloud",
 		func(context.Context) (string, error) { return "detected", nil },
 		nil,
-		nil,
+		func(context.Context) (string, error) {
+			privateCalls++
+			return "", errors.New("metadata unavailable")
+		},
 		func(context.Context) (string, error) { return "eu-west-2", nil },
 		nil,
 		func(context.Context) (string, error) { return "instance-1", nil },
@@ -534,8 +538,7 @@ func TestDetect_IMDSWithoutPrivateIPv4FetcherDoesNotRetry(t *testing.T) {
 		info, err := Detect(context.Background())
 		assert.NoError(t, err)
 		assert.Empty(t, info.PrivateIP)
-		assert.Equal(t, "eu-west-2", info.Region)
-		assert.Equal(t, "instance-1", info.InstanceID)
+		assert.Equal(t, 1, privateCalls)
 	})
 }
 
@@ -559,6 +562,7 @@ func TestDetect_IMDSRetriesPrivateIPv4(t *testing.T) {
 		func(context.Context) (string, error) { return "eu-west-2", nil },
 		nil,
 		func(context.Context) (string, error) { return "instance-1", nil },
+		providers.WithPrivateIPv4Retry(),
 	)
 
 	withTemporaryDetectors([]providers.Detector{detector}, func() {
@@ -587,6 +591,7 @@ func TestDetect_IMDSPrivateIPv4RetryExhaustion(t *testing.T) {
 		func(context.Context) (string, error) { return "eu-west-2", nil },
 		nil,
 		func(context.Context) (string, error) { return "instance-1", nil },
+		providers.WithPrivateIPv4Retry(),
 	)
 
 	withTemporaryDetectors([]providers.Detector{detector}, func() {

--- a/pkg/providers/all/all_test.go
+++ b/pkg/providers/all/all_test.go
@@ -494,7 +494,9 @@ func TestDetect_IMDSRetryStopsOnContextCancellation(t *testing.T) {
 		"test-cloud",
 		func(context.Context) (string, error) { return "detected", nil },
 		nil,
-		nil,
+		// private IP succeeds on the first attempt so the test reaches the
+		// instance ID fetch that drives the cancellation
+		func(context.Context) (string, error) { return "10.0.0.1", nil },
 		func(context.Context) (string, error) { return "eu-west-2", nil },
 		nil,
 		func(context.Context) (string, error) {
@@ -509,5 +511,63 @@ func TestDetect_IMDSRetryStopsOnContextCancellation(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Empty(t, info.InstanceID)
 		assert.Equal(t, 1, instanceIDCalls)
+	})
+}
+
+func TestDetect_IMDSRetriesPrivateIPv4(t *testing.T) {
+	originalBackoffs := imdsRetryBackoffs
+	imdsRetryBackoffs = []time.Duration{0, 0, 0, 0}
+	defer func() { imdsRetryBackoffs = originalBackoffs }()
+
+	privateCalls := 0
+	detector := providers.NewIMDSWithRegion(
+		"test-cloud",
+		func(context.Context) (string, error) { return "detected", nil },
+		nil,
+		func(context.Context) (string, error) {
+			privateCalls++
+			if privateCalls < 3 {
+				return "", errors.New("metadata unavailable")
+			}
+			return "7.247.35.250", nil
+		},
+		func(context.Context) (string, error) { return "eu-west-2", nil },
+		nil,
+		func(context.Context) (string, error) { return "instance-1", nil },
+	)
+
+	withTemporaryDetectors([]providers.Detector{detector}, func() {
+		info, err := Detect(context.Background())
+		assert.NoError(t, err)
+		assert.True(t, info.IMDSDetected)
+		assert.Equal(t, "7.247.35.250", info.PrivateIP)
+		assert.Equal(t, 3, privateCalls)
+	})
+}
+
+func TestDetect_IMDSPrivateIPv4RetryExhaustion(t *testing.T) {
+	originalBackoffs := imdsRetryBackoffs
+	imdsRetryBackoffs = []time.Duration{0, 0, 0, 0}
+	defer func() { imdsRetryBackoffs = originalBackoffs }()
+
+	privateCalls := 0
+	detector := providers.NewIMDSWithRegion(
+		"test-cloud",
+		func(context.Context) (string, error) { return "detected", nil },
+		nil,
+		func(context.Context) (string, error) {
+			privateCalls++
+			return "", nil
+		},
+		func(context.Context) (string, error) { return "eu-west-2", nil },
+		nil,
+		func(context.Context) (string, error) { return "instance-1", nil },
+	)
+
+	withTemporaryDetectors([]providers.Detector{detector}, func() {
+		info, err := Detect(context.Background())
+		assert.NoError(t, err)
+		assert.Empty(t, info.PrivateIP)
+		assert.Equal(t, 4, privateCalls)
 	})
 }

--- a/pkg/providers/detect.go
+++ b/pkg/providers/detect.go
@@ -14,6 +14,10 @@ type imdsDetector interface {
 	supportsIMDS() bool
 }
 
+type privateIPv4Detector interface {
+	supportsPrivateIPv4() bool
+}
+
 type detector struct {
 	providerName           string
 	detectProviderFunc     func(ctx context.Context) (string, error)
@@ -77,6 +81,16 @@ func SupportsIMDS(d Detector) bool {
 	return ok && imds.supportsIMDS()
 }
 
+// SupportsPrivateIPv4 returns true if the detector fetches the machine's
+// private IPv4 from the metadata service (i.e., it was constructed with a
+// non-nil private IPv4 fetch function). Detectors without one (e.g., azure,
+// gcp, nebius) report false so callers can skip retrying a permanently
+// empty result.
+func SupportsPrivateIPv4(d Detector) bool {
+	pd, ok := d.(privateIPv4Detector)
+	return ok && pd.supportsPrivateIPv4()
+}
+
 func newDetector(
 	name string,
 	detectProviderFunc func(ctx context.Context) (string, error),
@@ -101,6 +115,10 @@ func (d *detector) Name() string {
 
 func (d *detector) supportsIMDS() bool {
 	return d.imds
+}
+
+func (d *detector) supportsPrivateIPv4() bool {
+	return d.fetchPrivateIPv4Func != nil
 }
 
 func (d *detector) Provider(ctx context.Context) (string, error) {

--- a/pkg/providers/detect.go
+++ b/pkg/providers/detect.go
@@ -14,8 +14,8 @@ type imdsDetector interface {
 	supportsIMDS() bool
 }
 
-type privateIPv4Detector interface {
-	supportsPrivateIPv4() bool
+type privateIPv4RetryDetector interface {
+	retriesPrivateIPv4() bool
 }
 
 type detector struct {
@@ -26,6 +26,7 @@ type detector struct {
 	fetchVMEnvironmentFunc func(ctx context.Context) (string, error)
 	fetchInstanceIDFunc    func(ctx context.Context) (string, error)
 	imds                   bool
+	retryPrivateIPv4       bool
 }
 
 type regionDetector struct {
@@ -67,12 +68,16 @@ func NewIMDSWithRegion(
 	fetchRegionFunc func(ctx context.Context) (string, error),
 	fetchVMEnvironmentFunc func(ctx context.Context) (string, error),
 	fetchInstanceIDFunc func(ctx context.Context) (string, error),
+	opts ...DetectorOption,
 ) Detector {
 	d := &regionDetector{
 		detector:        newDetector(name, detectProviderFunc, fetchPublicIPv4Func, fetchPrivateIPv4Func, fetchVMEnvironmentFunc, fetchInstanceIDFunc),
 		fetchRegionFunc: fetchRegionFunc,
 	}
 	d.imds = true
+	for _, opt := range opts {
+		opt(d.detector)
+	}
 	return d
 }
 
@@ -81,14 +86,25 @@ func SupportsIMDS(d Detector) bool {
 	return ok && imds.supportsIMDS()
 }
 
-// SupportsPrivateIPv4 returns true if the detector fetches the machine's
-// private IPv4 from the metadata service (i.e., it was constructed with a
-// non-nil private IPv4 fetch function). Detectors without one (e.g., azure,
-// gcp, nebius) report false so callers can skip retrying a permanently
-// empty result.
-func SupportsPrivateIPv4(d Detector) bool {
-	pd, ok := d.(privateIPv4Detector)
-	return ok && pd.supportsPrivateIPv4()
+// SupportsPrivateIPv4Retry returns true if the detector opted into retrying
+// the private IPv4 fetch (see WithPrivateIPv4Retry).
+func SupportsPrivateIPv4Retry(d Detector) bool {
+	rd, ok := d.(privateIPv4RetryDetector)
+	return ok && rd.retriesPrivateIPv4()
+}
+
+// DetectorOption customizes an IMDS-backed detector.
+type DetectorOption func(*detector)
+
+// WithPrivateIPv4Retry opts the detector into retry-with-backoff for the
+// private IPv4 metadata fetch when it fails or returns empty. Use it only
+// for providers whose metadata service is known to be slow to accept the
+// first connection after an idle period (e.g., nscale); detectors without
+// the option keep single-attempt behavior.
+func WithPrivateIPv4Retry() DetectorOption {
+	return func(d *detector) {
+		d.retryPrivateIPv4 = true
+	}
 }
 
 func newDetector(
@@ -117,8 +133,8 @@ func (d *detector) supportsIMDS() bool {
 	return d.imds
 }
 
-func (d *detector) supportsPrivateIPv4() bool {
-	return d.fetchPrivateIPv4Func != nil
+func (d *detector) retriesPrivateIPv4() bool {
+	return d.retryPrivateIPv4
 }
 
 func (d *detector) Provider(ctx context.Context) (string, error) {

--- a/pkg/providers/detect_test.go
+++ b/pkg/providers/detect_test.go
@@ -185,19 +185,19 @@ func TestIMDSDetectorCapability(t *testing.T) {
 	assert.Equal(t, "us-east-1", region)
 }
 
-func TestSupportsPrivateIPv4(t *testing.T) {
-	// nil detector and detectors built without a private IPv4 fetcher
-	assert.False(t, SupportsPrivateIPv4(nil))
-	assert.False(t, SupportsPrivateIPv4(New("plain", nil, nil, nil, nil, nil)))
-	assert.False(t, SupportsPrivateIPv4(NewIMDSWithRegion("imds-no-private", nil, nil, nil, nil, nil, nil)))
-
-	// detectors built with a private IPv4 fetcher
-	assert.True(t, SupportsPrivateIPv4(New("with-private", nil, nil, func(context.Context) (string, error) {
-		return "10.0.0.1", nil
-	}, nil, nil)))
-	assert.True(t, SupportsPrivateIPv4(NewIMDSWithRegion("imds-with-private", nil, nil, func(context.Context) (string, error) {
+func TestSupportsPrivateIPv4Retry(t *testing.T) {
+	// nil detector and detectors that did not opt in
+	assert.False(t, SupportsPrivateIPv4Retry(nil))
+	assert.False(t, SupportsPrivateIPv4Retry(New("plain", nil, nil, nil, nil, nil)))
+	assert.False(t, SupportsPrivateIPv4Retry(NewIMDSWithRegion("imds-no-retry", nil, nil, func(context.Context) (string, error) {
 		return "10.0.0.1", nil
 	}, nil, nil, nil)))
+
+	// detector that opted in via WithPrivateIPv4Retry
+	d := NewIMDSWithRegion("imds-retry", nil, nil, func(context.Context) (string, error) {
+		return "10.0.0.1", nil
+	}, nil, nil, nil, WithPrivateIPv4Retry())
+	assert.True(t, SupportsPrivateIPv4Retry(d))
 }
 
 func TestDetector_VMEnvironment(t *testing.T) {

--- a/pkg/providers/detect_test.go
+++ b/pkg/providers/detect_test.go
@@ -185,6 +185,21 @@ func TestIMDSDetectorCapability(t *testing.T) {
 	assert.Equal(t, "us-east-1", region)
 }
 
+func TestSupportsPrivateIPv4(t *testing.T) {
+	// nil detector and detectors built without a private IPv4 fetcher
+	assert.False(t, SupportsPrivateIPv4(nil))
+	assert.False(t, SupportsPrivateIPv4(New("plain", nil, nil, nil, nil, nil)))
+	assert.False(t, SupportsPrivateIPv4(NewIMDSWithRegion("imds-no-private", nil, nil, nil, nil, nil, nil)))
+
+	// detectors built with a private IPv4 fetcher
+	assert.True(t, SupportsPrivateIPv4(New("with-private", nil, nil, func(context.Context) (string, error) {
+		return "10.0.0.1", nil
+	}, nil, nil)))
+	assert.True(t, SupportsPrivateIPv4(NewIMDSWithRegion("imds-with-private", nil, nil, func(context.Context) (string, error) {
+		return "10.0.0.1", nil
+	}, nil, nil, nil)))
+}
+
 func TestDetector_VMEnvironment(t *testing.T) {
 	const testProviderName = "test-provider-for-vm-env"
 	tests := []struct {

--- a/pkg/providers/nscale/imds/imds.go
+++ b/pkg/providers/nscale/imds/imds.go
@@ -51,7 +51,12 @@ func fetchMetadataByPath(ctx context.Context, metadataURL string) (string, error
 
 func fetchMetadataByPathWithStatusCode(ctx context.Context, metadataURL string) (string, int, error) {
 	client := &http.Client{
-		Timeout: 5 * time.Second,
+		// The first TCP connection to the metadata service after an idle
+		// period can take several seconds to establish on nscale (observed
+		// >5s on production nodes; warm connects are sub-millisecond).
+		// A 5s timeout loses that race; 10s covers the cold connect while
+		// staying well within the caller's overall detection budget.
+		Timeout: 10 * time.Second,
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)

--- a/pkg/providers/nscale/nscale.go
+++ b/pkg/providers/nscale/nscale.go
@@ -26,6 +26,11 @@ func New() providers.Detector {
 		imds.FetchRegion,
 		fetchVMEnvironment,
 		imds.FetchInstanceID,
+		// the nscale metadata service can be slow to accept the first
+		// connection after an idle period (observed >5s on production nodes),
+		// and its fabric IPs are not RFC1918 so a missed private-IP fetch has
+		// no NIC-based fallback — retry it like region and instance ID
+		providers.WithPrivateIPv4Retry(),
 	)
 }
 


### PR DESCRIPTION
## Problem

On nscale, the first TCP connection to the instance metadata service (169.254.169.254) after an idle period was observed taking 5.1-5.2s on production nodes — occasionally exceeding the 5s HTTP client timeout entirely — while warm connects complete in under a millisecond. When the private-IP fetch lost that race, the attempt was not retried and gpud reported an empty private IP in the login request, so downstream consumers (e.g., node machine-local-IP labeling) never received a value.

## Changes

- `pkg/providers/nscale/imds`: raise the IMDS HTTP client timeout from 5s to 10s so the cold first connect can complete. Scoped to nscale only; other providers' clients are unchanged.
- `pkg/providers`: new opt-in `WithPrivateIPv4Retry()` detector option (variadic on `NewIMDSWithRegion`, so existing constructors compile unchanged) with a `SupportsPrivateIPv4Retry` predicate mirroring the `SupportsIMDS` pattern. `detector.PrivateIPv4` is untouched.
- `pkg/providers/all`: the private IPv4 fetch goes through `fetchRequiredMetadata` — the same retry-with-backoff path already used for region and instance ID — **only for detectors that opted in (currently nscale)**. All other providers (aws, azure, gcp, nebius, oci) keep the exact single-attempt behavior from before this PR.
- `pkg/providers/all`: fetch order is now required-identity-first (instance ID, region), then best-effort fields (public IP, VM environment), with private IP last — an opted-in retry (4 attempts × 10s + backoff ≈ 40.7s worst case) can no longer starve the mandatory fields of the shared one-minute budget (review feedback).
- `pkg/providers/nscale`: the nscale detector opts into the retry, since its fabric IPs are not RFC1918 and a missed fetch has no NIC-based fallback.

## Tests

- `TestDetect_IMDSRetriesPrivateIPv4` (opted-in detector succeeds on 3rd attempt) and `TestDetect_IMDSPrivateIPv4RetryExhaustion` (4 attempts then empty).
- `TestDetect_IMDSPrivateIPv4SingleAttemptWithoutOptIn`: a non-opted-in detector with a failing fetcher is called exactly once — proven with a one-hour backoff that would hang the test if a retry were attempted.
- `TestDetect_PrivateIPv4RetryDoesNotStarveRequiredFields`: private fetch hangs until the shared context expires while region/instance-ID mocks fail on a dead context, pinning the required-first fetch order (verified to fail against the pre-reorder code).
- `TestSupportsPrivateIPv4Retry` covers the option on/off/nil-detector paths.
- `go vet`, `go test -gcflags="all=-N -l"`, and `-race -d=checkptr=0` pass for `./pkg/providers/...` and consumers (`pkg/machine-info`, `pkg/login`, `cmd/gpud/machine-info`, `cmd/gpud/up`).