### PR TITLE
[LEP-6503][LEP-6504] fix(helm/gpud): persistence checks on GPU Operator nodes

### DIFF
--- a/components/accelerator/nvidia/persistence-mode/component.go
+++ b/components/accelerator/nvidia/persistence-mode/component.go
@@ -47,9 +47,10 @@ type component struct {
 	nvmlInstance           nvidianvml.Instance
 	getPersistenceModeFunc func(uuid string, dev device.Device) (PersistenceMode, error)
 
-	// queryEffectivePersistenceModesFunc queries nvidia-smi's current per-GPU
-	// persistence state when the raw NVML API reports disabled.
-	queryEffectivePersistenceModesFunc func(context.Context) (map[string]bool, error)
+	// daemonPersistenceModesFunc returns GPU minor numbers currently held open
+	// by nvidia-persistenced when raw NVML reports disabled.
+	daemonPersistenceModesFunc func(string) (map[int]bool, error)
+	procRoot                   string
 
 	eventBucket eventstore.Bucket
 
@@ -66,9 +67,10 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		getTimeNowFunc: func() time.Time {
 			return time.Now().UTC()
 		},
-		nvmlInstance:                       gpudInstance.NVMLInstance,
-		getPersistenceModeFunc:             GetPersistenceMode,
-		queryEffectivePersistenceModesFunc: queryEffectivePersistenceModes,
+		nvmlInstance:               gpudInstance.NVMLInstance,
+		getPersistenceModeFunc:     GetPersistenceMode,
+		daemonPersistenceModesFunc: daemonPersistenceModes,
+		procRoot:                   "/proc",
 	}
 
 	if gpudInstance.EventStore != nil {
@@ -227,40 +229,35 @@ func (c *component) Check() components.CheckResult {
 	}
 
 	// Effective persistence fallback (LEP-6504): on daemon-managed platforms,
-	// nvmlDeviceGetPersistenceMode can report DISABLED while nvidia-smi reports
-	// Enabled for the same GPU. Query nvidia-smi once, only when needed, because
-	// NVIDIA documents that it reads the daemon's current per-GPU RPC state.
-	var effectiveModes map[string]bool
-	var effectiveModesErr error
-	effectiveModesChecked := false
+	// nvmlDeviceGetPersistenceMode can report DISABLED while the persistence
+	// daemon actively holds that GPU open. Inspect the daemon's file descriptors
+	// once, only when needed, and match the open /dev/nvidiaN handle to the
+	// device's NVML minor number.
+	var daemonModes map[int]bool
+	var daemonModesErr error
+	daemonModesChecked := false
 	for i := range cr.PersistenceModes {
 		pm := &cr.PersistenceModes[i]
-		if !pm.Supported || pm.Enabled {
+		if !pm.Supported || pm.Enabled || pm.minorNumber < 0 {
 			continue
 		}
-		if !effectiveModesChecked && c.queryEffectivePersistenceModesFunc != nil {
-			effectiveModes, effectiveModesErr = c.queryEffectivePersistenceModesFunc(c.ctx)
-			effectiveModesChecked = true
-			if effectiveModesErr != nil {
-				log.Logger.Warnw("failed to query effective persistence mode with nvidia-smi; retaining NVML result", "error", effectiveModesErr)
+		if !daemonModesChecked && c.daemonPersistenceModesFunc != nil {
+			daemonModes, daemonModesErr = c.daemonPersistenceModesFunc(c.procRoot)
+			daemonModesChecked = true
+			if daemonModesErr != nil {
+				log.Logger.Debugw("failed to inspect nvidia-persistenced device handles; retaining NVML result", "error", daemonModesErr)
 			}
 		}
-		if c.queryEffectivePersistenceModesFunc == nil {
+		if c.daemonPersistenceModesFunc == nil || daemonModesErr != nil {
 			continue
 		}
-		if effectiveModesErr != nil {
-			continue
-		}
-		if effectiveEnabled, ok := effectiveModes[pm.UUID]; ok {
+		if daemonModes[pm.minorNumber] {
 			rawEnabled := pm.Enabled
 			pm.NVMLReportedEnabled = &rawEnabled
-			pm.Enabled = effectiveEnabled
-			pm.EffectiveStateSource = "nvidia-smi"
-			log.Logger.Infow("verified effective persistence mode with nvidia-smi",
-				"uuid", pm.UUID, "busID", pm.BusID, "effectiveEnabled", effectiveEnabled)
-		} else {
-			log.Logger.Warnw("nvidia-smi persistence query did not return the NVML device; retaining NVML result",
-				"uuid", pm.UUID, "busID", pm.BusID)
+			pm.Enabled = true
+			pm.EffectiveStateSource = "nvidia-persistenced"
+			log.Logger.Infow("verified daemon-managed persistence from open GPU device handle",
+				"uuid", pm.UUID, "busID", pm.BusID, "minorNumber", pm.minorNumber)
 		}
 	}
 
@@ -311,14 +308,14 @@ func (c *component) Check() components.CheckResult {
 	} else {
 		cr.health = apiv1.HealthStateTypeHealthy
 		cr.reason = fmt.Sprintf("all %d GPU(s) were checked, no persistence mode issue found", len(devs))
-		nvidiaSMICount := 0
+		daemonManagedCount := 0
 		for _, pm := range cr.PersistenceModes {
-			if pm.EffectiveStateSource == "nvidia-smi" && pm.Enabled {
-				nvidiaSMICount++
+			if pm.EffectiveStateSource == "nvidia-persistenced" && pm.Enabled {
+				daemonManagedCount++
 			}
 		}
-		if nvidiaSMICount > 0 {
-			cr.reason = fmt.Sprintf("%s (%d GPU(s) verified enabled via nvidia-smi)", cr.reason, nvidiaSMICount)
+		if daemonManagedCount > 0 {
+			cr.reason = fmt.Sprintf("%s (%d GPU(s) verified via nvidia-persistenced)", cr.reason, daemonManagedCount)
 		}
 	}
 

--- a/components/accelerator/nvidia/persistence-mode/component.go
+++ b/components/accelerator/nvidia/persistence-mode/component.go
@@ -47,6 +47,10 @@ type component struct {
 	nvmlInstance           nvidianvml.Instance
 	getPersistenceModeFunc func(uuid string, dev device.Device) (PersistenceMode, error)
 
+	// queryEffectivePersistenceModesFunc queries nvidia-smi's current per-GPU
+	// persistence state when the raw NVML API reports disabled.
+	queryEffectivePersistenceModesFunc func(context.Context) (map[string]bool, error)
+
 	eventBucket eventstore.Bucket
 
 	lastMu          sync.RWMutex
@@ -62,8 +66,9 @@ func New(gpudInstance *components.GPUdInstance) (components.Component, error) {
 		getTimeNowFunc: func() time.Time {
 			return time.Now().UTC()
 		},
-		nvmlInstance:           gpudInstance.NVMLInstance,
-		getPersistenceModeFunc: GetPersistenceMode,
+		nvmlInstance:                       gpudInstance.NVMLInstance,
+		getPersistenceModeFunc:             GetPersistenceMode,
+		queryEffectivePersistenceModesFunc: queryEffectivePersistenceModes,
 	}
 
 	if gpudInstance.EventStore != nil {
@@ -221,6 +226,44 @@ func (c *component) Check() components.CheckResult {
 		cr.PersistenceModes = append(cr.PersistenceModes, persistenceMode)
 	}
 
+	// Effective persistence fallback (LEP-6504): on daemon-managed platforms,
+	// nvmlDeviceGetPersistenceMode can report DISABLED while nvidia-smi reports
+	// Enabled for the same GPU. Query nvidia-smi once, only when needed, because
+	// NVIDIA documents that it reads the daemon's current per-GPU RPC state.
+	var effectiveModes map[string]bool
+	var effectiveModesErr error
+	effectiveModesChecked := false
+	for i := range cr.PersistenceModes {
+		pm := &cr.PersistenceModes[i]
+		if !pm.Supported || pm.Enabled {
+			continue
+		}
+		if !effectiveModesChecked && c.queryEffectivePersistenceModesFunc != nil {
+			effectiveModes, effectiveModesErr = c.queryEffectivePersistenceModesFunc(c.ctx)
+			effectiveModesChecked = true
+			if effectiveModesErr != nil {
+				log.Logger.Warnw("failed to query effective persistence mode with nvidia-smi; retaining NVML result", "error", effectiveModesErr)
+			}
+		}
+		if c.queryEffectivePersistenceModesFunc == nil {
+			continue
+		}
+		if effectiveModesErr != nil {
+			continue
+		}
+		if effectiveEnabled, ok := effectiveModes[pm.UUID]; ok {
+			rawEnabled := pm.Enabled
+			pm.NVMLReportedEnabled = &rawEnabled
+			pm.Enabled = effectiveEnabled
+			pm.EffectiveStateSource = "nvidia-smi"
+			log.Logger.Infow("verified effective persistence mode with nvidia-smi",
+				"uuid", pm.UUID, "busID", pm.BusID, "effectiveEnabled", effectiveEnabled)
+		} else {
+			log.Logger.Warnw("nvidia-smi persistence query did not return the NVML device; retaining NVML result",
+				"uuid", pm.UUID, "busID", pm.BusID)
+		}
+	}
+
 	notEnabled := []string{}
 	for _, pm := range cr.PersistenceModes {
 		if pm.Supported && !pm.Enabled {
@@ -268,6 +311,15 @@ func (c *component) Check() components.CheckResult {
 	} else {
 		cr.health = apiv1.HealthStateTypeHealthy
 		cr.reason = fmt.Sprintf("all %d GPU(s) were checked, no persistence mode issue found", len(devs))
+		nvidiaSMICount := 0
+		for _, pm := range cr.PersistenceModes {
+			if pm.EffectiveStateSource == "nvidia-smi" && pm.Enabled {
+				nvidiaSMICount++
+			}
+		}
+		if nvidiaSMICount > 0 {
+			cr.reason = fmt.Sprintf("%s (%d GPU(s) verified enabled via nvidia-smi)", cr.reason, nvidiaSMICount)
+		}
 	}
 
 	return cr

--- a/components/accelerator/nvidia/persistence-mode/component_test.go
+++ b/components/accelerator/nvidia/persistence-mode/component_test.go
@@ -255,6 +255,99 @@ func TestCheck_Success(t *testing.T) {
 	assert.Equal(t, persistenceMode, data.PersistenceModes[0])
 }
 
+func TestCheck_NvidiaSMIReportsEffectivePersistenceEnabled(t *testing.T) {
+	ctx := context.Background()
+	uuid := "gpu-uuid-daemon-managed"
+	mockDev := testutil.NewMockDevice(&mock.Device{}, "test-arch", "test-brand", "test-cuda", "0000:01:00.0")
+
+	c := mustComponent(t, mockComponent(ctx,
+		func() map[string]device.Device { return map[string]device.Device{uuid: mockDev} },
+		func(_ string, _ device.Device) (PersistenceMode, error) {
+			return PersistenceMode{UUID: uuid, BusID: "0000:01:00.0", Supported: true, Enabled: false}, nil
+		},
+	))
+	c.queryEffectivePersistenceModesFunc = func(context.Context) (map[string]bool, error) {
+		return map[string]bool{uuid: true}, nil
+	}
+
+	result := c.Check().(*checkResult)
+	require.Len(t, result.PersistenceModes, 1)
+	assert.Equal(t, apiv1.HealthStateTypeHealthy, result.health)
+	assert.Contains(t, result.reason, "1 GPU(s) verified enabled via nvidia-smi")
+	assert.True(t, result.PersistenceModes[0].Enabled)
+	assert.Equal(t, "nvidia-smi", result.PersistenceModes[0].EffectiveStateSource)
+	require.NotNil(t, result.PersistenceModes[0].NVMLReportedEnabled)
+	assert.False(t, *result.PersistenceModes[0].NVMLReportedEnabled)
+	states := result.HealthStates()
+	assert.Contains(t, states[0].ExtraInfo["data"], `"nvml_reported_enabled":false`)
+	assert.Contains(t, states[0].ExtraInfo["data"], `"effective_state_source":"nvidia-smi"`)
+}
+
+func TestCheck_NvidiaSMIReportsEffectivePersistenceDisabled(t *testing.T) {
+	ctx := context.Background()
+	uuid := "gpu-uuid-daemon-disabled"
+	mockDev := testutil.NewMockDevice(&mock.Device{}, "test-arch", "test-brand", "test-cuda", "0000:01:00.0")
+
+	c := mustComponent(t, mockComponent(ctx,
+		func() map[string]device.Device { return map[string]device.Device{uuid: mockDev} },
+		func(_ string, _ device.Device) (PersistenceMode, error) {
+			return PersistenceMode{UUID: uuid, BusID: "0000:01:00.0", Supported: true, Enabled: false}, nil
+		},
+	))
+	c.queryEffectivePersistenceModesFunc = func(context.Context) (map[string]bool, error) {
+		return map[string]bool{uuid: false}, nil
+	}
+
+	result := c.Check().(*checkResult)
+	require.Len(t, result.PersistenceModes, 1)
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, result.health)
+	assert.False(t, result.PersistenceModes[0].Enabled)
+	assert.Equal(t, "nvidia-smi", result.PersistenceModes[0].EffectiveStateSource)
+}
+
+func TestCheck_NvidiaSMIFallbackFailureRetainsNVMLResult(t *testing.T) {
+	ctx := context.Background()
+	uuid := "gpu-uuid-zombie-daemon"
+	mockDev := testutil.NewMockDevice(&mock.Device{}, "test-arch", "test-brand", "test-cuda", "0000:01:00.0")
+
+	c := mustComponent(t, mockComponent(ctx,
+		func() map[string]device.Device { return map[string]device.Device{uuid: mockDev} },
+		func(_ string, _ device.Device) (PersistenceMode, error) {
+			return PersistenceMode{UUID: uuid, BusID: "0000:01:00.0", Supported: true, Enabled: false}, nil
+		},
+	))
+	c.queryEffectivePersistenceModesFunc = func(context.Context) (map[string]bool, error) {
+		return nil, errors.New("nvidia-smi failed")
+	}
+
+	result := c.Check().(*checkResult)
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, result.health)
+	assert.False(t, result.PersistenceModes[0].Enabled)
+	assert.Empty(t, result.PersistenceModes[0].EffectiveStateSource)
+	assert.Nil(t, result.PersistenceModes[0].NVMLReportedEnabled)
+}
+
+func TestCheck_NvidiaSMIFallbackMissingUUIDRetainsNVMLResult(t *testing.T) {
+	ctx := context.Background()
+	uuid := "gpu-uuid-missing-from-smi"
+	mockDev := testutil.NewMockDevice(&mock.Device{}, "test-arch", "test-brand", "test-cuda", "0000:01:00.0")
+
+	c := mustComponent(t, mockComponent(ctx,
+		func() map[string]device.Device { return map[string]device.Device{uuid: mockDev} },
+		func(_ string, _ device.Device) (PersistenceMode, error) {
+			return PersistenceMode{UUID: uuid, BusID: "0000:01:00.0", Supported: true, Enabled: false}, nil
+		},
+	))
+	c.queryEffectivePersistenceModesFunc = func(context.Context) (map[string]bool, error) {
+		return map[string]bool{"different-gpu": true}, nil
+	}
+
+	result := c.Check().(*checkResult)
+	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, result.health)
+	assert.False(t, result.PersistenceModes[0].Enabled)
+	assert.Empty(t, result.PersistenceModes[0].EffectiveStateSource)
+}
+
 func TestCheck_PersistenceModeError(t *testing.T) {
 	ctx := context.Background()
 

--- a/components/accelerator/nvidia/persistence-mode/component_test.go
+++ b/components/accelerator/nvidia/persistence-mode/component_test.go
@@ -255,7 +255,7 @@ func TestCheck_Success(t *testing.T) {
 	assert.Equal(t, persistenceMode, data.PersistenceModes[0])
 }
 
-func TestCheck_NvidiaSMIReportsEffectivePersistenceEnabled(t *testing.T) {
+func TestCheck_PersistenceDaemonHoldsDeviceOpen(t *testing.T) {
 	ctx := context.Background()
 	uuid := "gpu-uuid-daemon-managed"
 	mockDev := testutil.NewMockDevice(&mock.Device{}, "test-arch", "test-brand", "test-cuda", "0000:01:00.0")
@@ -266,24 +266,27 @@ func TestCheck_NvidiaSMIReportsEffectivePersistenceEnabled(t *testing.T) {
 			return PersistenceMode{UUID: uuid, BusID: "0000:01:00.0", Supported: true, Enabled: false}, nil
 		},
 	))
-	c.queryEffectivePersistenceModesFunc = func(context.Context) (map[string]bool, error) {
-		return map[string]bool{uuid: true}, nil
+	c.getPersistenceModeFunc = func(_ string, _ device.Device) (PersistenceMode, error) {
+		return PersistenceMode{UUID: uuid, BusID: "0000:01:00.0", Supported: true, Enabled: false, minorNumber: 3}, nil
+	}
+	c.daemonPersistenceModesFunc = func(string) (map[int]bool, error) {
+		return map[int]bool{3: true}, nil
 	}
 
 	result := c.Check().(*checkResult)
 	require.Len(t, result.PersistenceModes, 1)
 	assert.Equal(t, apiv1.HealthStateTypeHealthy, result.health)
-	assert.Contains(t, result.reason, "1 GPU(s) verified enabled via nvidia-smi")
+	assert.Contains(t, result.reason, "1 GPU(s) verified via nvidia-persistenced")
 	assert.True(t, result.PersistenceModes[0].Enabled)
-	assert.Equal(t, "nvidia-smi", result.PersistenceModes[0].EffectiveStateSource)
+	assert.Equal(t, "nvidia-persistenced", result.PersistenceModes[0].EffectiveStateSource)
 	require.NotNil(t, result.PersistenceModes[0].NVMLReportedEnabled)
 	assert.False(t, *result.PersistenceModes[0].NVMLReportedEnabled)
 	states := result.HealthStates()
 	assert.Contains(t, states[0].ExtraInfo["data"], `"nvml_reported_enabled":false`)
-	assert.Contains(t, states[0].ExtraInfo["data"], `"effective_state_source":"nvidia-smi"`)
+	assert.Contains(t, states[0].ExtraInfo["data"], `"effective_state_source":"nvidia-persistenced"`)
 }
 
-func TestCheck_NvidiaSMIReportsEffectivePersistenceDisabled(t *testing.T) {
+func TestCheck_PersistenceDaemonDoesNotHoldDeviceOpen(t *testing.T) {
 	ctx := context.Background()
 	uuid := "gpu-uuid-daemon-disabled"
 	mockDev := testutil.NewMockDevice(&mock.Device{}, "test-arch", "test-brand", "test-cuda", "0000:01:00.0")
@@ -294,18 +297,21 @@ func TestCheck_NvidiaSMIReportsEffectivePersistenceDisabled(t *testing.T) {
 			return PersistenceMode{UUID: uuid, BusID: "0000:01:00.0", Supported: true, Enabled: false}, nil
 		},
 	))
-	c.queryEffectivePersistenceModesFunc = func(context.Context) (map[string]bool, error) {
-		return map[string]bool{uuid: false}, nil
+	c.getPersistenceModeFunc = func(_ string, _ device.Device) (PersistenceMode, error) {
+		return PersistenceMode{UUID: uuid, BusID: "0000:01:00.0", Supported: true, Enabled: false, minorNumber: 3}, nil
+	}
+	c.daemonPersistenceModesFunc = func(string) (map[int]bool, error) {
+		return map[int]bool{}, nil
 	}
 
 	result := c.Check().(*checkResult)
 	require.Len(t, result.PersistenceModes, 1)
 	assert.Equal(t, apiv1.HealthStateTypeUnhealthy, result.health)
 	assert.False(t, result.PersistenceModes[0].Enabled)
-	assert.Equal(t, "nvidia-smi", result.PersistenceModes[0].EffectiveStateSource)
+	assert.Empty(t, result.PersistenceModes[0].EffectiveStateSource)
 }
 
-func TestCheck_NvidiaSMIFallbackFailureRetainsNVMLResult(t *testing.T) {
+func TestCheck_PersistenceDaemonInspectionFailureRetainsNVMLResult(t *testing.T) {
 	ctx := context.Background()
 	uuid := "gpu-uuid-zombie-daemon"
 	mockDev := testutil.NewMockDevice(&mock.Device{}, "test-arch", "test-brand", "test-cuda", "0000:01:00.0")
@@ -316,8 +322,11 @@ func TestCheck_NvidiaSMIFallbackFailureRetainsNVMLResult(t *testing.T) {
 			return PersistenceMode{UUID: uuid, BusID: "0000:01:00.0", Supported: true, Enabled: false}, nil
 		},
 	))
-	c.queryEffectivePersistenceModesFunc = func(context.Context) (map[string]bool, error) {
-		return nil, errors.New("nvidia-smi failed")
+	c.getPersistenceModeFunc = func(_ string, _ device.Device) (PersistenceMode, error) {
+		return PersistenceMode{UUID: uuid, BusID: "0000:01:00.0", Supported: true, Enabled: false, minorNumber: 3}, nil
+	}
+	c.daemonPersistenceModesFunc = func(string) (map[int]bool, error) {
+		return nil, errors.New("proc inspection failed")
 	}
 
 	result := c.Check().(*checkResult)
@@ -327,9 +336,9 @@ func TestCheck_NvidiaSMIFallbackFailureRetainsNVMLResult(t *testing.T) {
 	assert.Nil(t, result.PersistenceModes[0].NVMLReportedEnabled)
 }
 
-func TestCheck_NvidiaSMIFallbackMissingUUIDRetainsNVMLResult(t *testing.T) {
+func TestCheck_UnknownMinorNumberRetainsNVMLResult(t *testing.T) {
 	ctx := context.Background()
-	uuid := "gpu-uuid-missing-from-smi"
+	uuid := "gpu-uuid-unknown-minor"
 	mockDev := testutil.NewMockDevice(&mock.Device{}, "test-arch", "test-brand", "test-cuda", "0000:01:00.0")
 
 	c := mustComponent(t, mockComponent(ctx,
@@ -338,8 +347,11 @@ func TestCheck_NvidiaSMIFallbackMissingUUIDRetainsNVMLResult(t *testing.T) {
 			return PersistenceMode{UUID: uuid, BusID: "0000:01:00.0", Supported: true, Enabled: false}, nil
 		},
 	))
-	c.queryEffectivePersistenceModesFunc = func(context.Context) (map[string]bool, error) {
-		return map[string]bool{"different-gpu": true}, nil
+	c.getPersistenceModeFunc = func(_ string, _ device.Device) (PersistenceMode, error) {
+		return PersistenceMode{UUID: uuid, BusID: "0000:01:00.0", Supported: true, Enabled: false, minorNumber: -1}, nil
+	}
+	c.daemonPersistenceModesFunc = func(string) (map[int]bool, error) {
+		return map[int]bool{3: true}, nil
 	}
 
 	result := c.Check().(*checkResult)

--- a/components/accelerator/nvidia/persistence-mode/persistence_mode.go
+++ b/components/accelerator/nvidia/persistence-mode/persistence_mode.go
@@ -1,10 +1,18 @@
 package persistencemode
 
 import (
+	"context"
+	"encoding/csv"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
+	"github.com/leptonai/gpud/pkg/nvidia/driverroot"
 	nvmlerrors "github.com/leptonai/gpud/pkg/nvidia/errors"
 	"github.com/leptonai/gpud/pkg/nvidia/nvml/device"
 )
@@ -22,14 +30,23 @@ import (
 // NVIDIA Persistence Daemon provides a more robust implementation of persistence mode on Linux.
 // ref. https://docs.nvidia.com/deploy/driver-persistence/index.html#usage
 //
-// To enable persistence mode, we need to check if "nvidia-persistenced" is running.
-// Or run "nvidia-smi -pm 1" to enable persistence mode.
+// nvidia-smi transparently uses nvidia-persistenced's per-GPU RPC interface
+// when the daemon is running, and otherwise falls back to legacy persistence.
 type PersistenceMode struct {
-	UUID    string `json:"uuid"`
-	BusID   string `json:"bus_id"`
-	Enabled bool   `json:"enabled"`
+	UUID  string `json:"uuid"`
+	BusID string `json:"bus_id"`
+	// Enabled is the effective persistence state. It normally comes directly
+	// from NVML; on daemon-managed systems where NVML reports disabled, gpud
+	// verifies the state through nvidia-smi's per-GPU daemon RPC query.
+	Enabled bool `json:"enabled"`
 	// Supported is true if the persistence mode is supported by the device.
 	Supported bool `json:"supported"`
+	// NVMLReportedEnabled preserves the raw nvmlDeviceGetPersistenceMode
+	// result when nvidia-smi was needed to determine the effective state.
+	NVMLReportedEnabled *bool `json:"nvml_reported_enabled,omitempty"`
+	// EffectiveStateSource is "nvidia-smi" when Enabled was verified through
+	// the persistence daemon RPC rather than taken directly from NVML.
+	EffectiveStateSource string `json:"effective_state_source,omitempty"`
 }
 
 // GetPersistenceMode returns the persistence mode for a device.
@@ -59,4 +76,75 @@ func GetPersistenceMode(uuid string, dev device.Device) (PersistenceMode, error)
 	mode.Enabled = pm == nvml.FEATURE_ENABLED
 
 	return mode, nil
+}
+
+// queryEffectivePersistenceModes asks nvidia-smi for the effective per-GPU
+// state. NVIDIA documents that nvidia-smi uses nvidia-persistenced's RPC
+// interface when the daemon is running, so this observes runtime per-device
+// changes that cannot be inferred from the daemon process or its startup argv.
+//
+// The driver-root chroot path is required for GPU Operator installations:
+// nvidia-smi and its matching libraries live inside that root. Bare-metal
+// installations use nvidia-smi from PATH.
+func queryEffectivePersistenceModes(ctx context.Context) (map[string]bool, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	args := []string{"--query-gpu=uuid,persistence_mode", "--format=csv,noheader,nounits"}
+	var lastErr error
+	for _, root := range driverroot.Existing() {
+		executable := filepath.Join(root, "usr", "bin", "nvidia-smi")
+		if st, err := os.Stat(executable); err != nil || !st.Mode().IsRegular() || st.Mode().Perm()&0o111 == 0 {
+			continue
+		}
+		out, err := runPersistenceModeQuery(queryCtx, "chroot", root, "/usr/bin/nvidia-smi", args[0], args[1])
+		if err != nil {
+			lastErr = fmt.Errorf("failed to query persistence mode with %s: %w", executable, err)
+			continue
+		}
+		return parsePersistenceModeCSV(out)
+	}
+
+	executable, err := exec.LookPath("nvidia-smi")
+	if err == nil {
+		out, runErr := runPersistenceModeQuery(queryCtx, executable, args...)
+		if runErr == nil {
+			return parsePersistenceModeCSV(out)
+		}
+		lastErr = fmt.Errorf("failed to query persistence mode with %s: %w", executable, runErr)
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, fmt.Errorf("nvidia-smi not found in PATH or NVIDIA driver roots")
+}
+
+func runPersistenceModeQuery(ctx context.Context, executable string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, executable, args...).Output()
+}
+
+func parsePersistenceModeCSV(data []byte) (map[string]bool, error) {
+	records, err := csv.NewReader(strings.NewReader(string(data))).ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse nvidia-smi persistence output: %w", err)
+	}
+	if len(records) == 0 {
+		return nil, fmt.Errorf("nvidia-smi returned no persistence mode rows")
+	}
+	states := make(map[string]bool, len(records))
+	for _, record := range records {
+		if len(record) != 2 {
+			return nil, fmt.Errorf("unexpected nvidia-smi persistence row with %d fields", len(record))
+		}
+		uuid := strings.TrimSpace(record[0])
+		state := strings.ToLower(strings.TrimSpace(record[1]))
+		if uuid == "" || (state != "enabled" && state != "disabled") {
+			return nil, fmt.Errorf("unexpected nvidia-smi persistence row %q", record)
+		}
+		if _, exists := states[uuid]; exists {
+			return nil, fmt.Errorf("duplicate nvidia-smi persistence row for GPU %q", uuid)
+		}
+		states[uuid] = state == "enabled"
+	}
+	return states, nil
 }

--- a/components/accelerator/nvidia/persistence-mode/persistence_mode.go
+++ b/components/accelerator/nvidia/persistence-mode/persistence_mode.go
@@ -1,18 +1,14 @@
 package persistencemode
 
 import (
-	"context"
-	"encoding/csv"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
-	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
-	"github.com/leptonai/gpud/pkg/nvidia/driverroot"
 	nvmlerrors "github.com/leptonai/gpud/pkg/nvidia/errors"
 	"github.com/leptonai/gpud/pkg/nvidia/nvml/device"
 )
@@ -37,16 +33,17 @@ type PersistenceMode struct {
 	BusID string `json:"bus_id"`
 	// Enabled is the effective persistence state. It normally comes directly
 	// from NVML; on daemon-managed systems where NVML reports disabled, gpud
-	// verifies the state through nvidia-smi's per-GPU daemon RPC query.
+	// verifies that nvidia-persistenced holds the GPU device open.
 	Enabled bool `json:"enabled"`
 	// Supported is true if the persistence mode is supported by the device.
 	Supported bool `json:"supported"`
 	// NVMLReportedEnabled preserves the raw nvmlDeviceGetPersistenceMode
-	// result when nvidia-smi was needed to determine the effective state.
+	// result when daemon device handles determined the effective state.
 	NVMLReportedEnabled *bool `json:"nvml_reported_enabled,omitempty"`
-	// EffectiveStateSource is "nvidia-smi" when Enabled was verified through
-	// the persistence daemon RPC rather than taken directly from NVML.
+	// EffectiveStateSource is "nvidia-persistenced" when Enabled was verified
+	// from the daemon's open GPU device handles rather than taken from NVML.
 	EffectiveStateSource string `json:"effective_state_source,omitempty"`
+	minorNumber          int
 }
 
 // GetPersistenceMode returns the persistence mode for a device.
@@ -55,6 +52,12 @@ func GetPersistenceMode(uuid string, dev device.Device) (PersistenceMode, error)
 		UUID:      uuid,
 		BusID:     dev.PCIBusID(),
 		Supported: true,
+	}
+	minorNumber, ret := dev.GetMinorNumber()
+	if ret == nvml.SUCCESS {
+		mode.minorNumber = minorNumber
+	} else {
+		mode.minorNumber = -1
 	}
 
 	// ref. https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html#group__nvmlDeviceQueries_1g1224ad7b15d7407bebfff034ec094c6b
@@ -78,73 +81,54 @@ func GetPersistenceMode(uuid string, dev device.Device) (PersistenceMode, error)
 	return mode, nil
 }
 
-// queryEffectivePersistenceModes asks nvidia-smi for the effective per-GPU
-// state. NVIDIA documents that nvidia-smi uses nvidia-persistenced's RPC
-// interface when the daemon is running, so this observes runtime per-device
-// changes that cannot be inferred from the daemon process or its startup argv.
-//
-// The driver-root chroot path is required for GPU Operator installations:
-// nvidia-smi and its matching libraries live inside that root. Bare-metal
-// installations use nvidia-smi from PATH.
-func queryEffectivePersistenceModes(ctx context.Context) (map[string]bool, error) {
-	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	args := []string{"--query-gpu=uuid,persistence_mode", "--format=csv,noheader,nounits"}
-	var lastErr error
-	for _, root := range driverroot.Existing() {
-		executable := filepath.Join(root, "usr", "bin", "nvidia-smi")
-		if st, err := os.Stat(executable); err != nil || !st.Mode().IsRegular() || st.Mode().Perm()&0o111 == 0 {
-			continue
-		}
-		out, err := runPersistenceModeQuery(queryCtx, "chroot", root, "/usr/bin/nvidia-smi", args[0], args[1])
-		if err != nil {
-			lastErr = fmt.Errorf("failed to query persistence mode with %s: %w", executable, err)
-			continue
-		}
-		return parsePersistenceModeCSV(out)
-	}
-
-	executable, err := exec.LookPath("nvidia-smi")
-	if err == nil {
-		out, runErr := runPersistenceModeQuery(queryCtx, executable, args...)
-		if runErr == nil {
-			return parsePersistenceModeCSV(out)
-		}
-		lastErr = fmt.Errorf("failed to query persistence mode with %s: %w", executable, runErr)
-	}
-	if lastErr != nil {
-		return nil, lastErr
-	}
-	return nil, fmt.Errorf("nvidia-smi not found in PATH or NVIDIA driver roots")
-}
-
-func runPersistenceModeQuery(ctx context.Context, executable string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, executable, args...).Output()
-}
-
-func parsePersistenceModeCSV(data []byte) (map[string]bool, error) {
-	records, err := csv.NewReader(strings.NewReader(string(data))).ReadAll()
+// daemonPersistenceModes returns the GPU minor numbers that a live
+// nvidia-persistenced process currently holds open. NVIDIA's daemon
+// implementation opens a GPU device when persistence is enabled and closes
+// it when disabled; those handles are the mechanism that keeps driver state
+// loaded. Reading them from proc therefore observes current per-GPU state
+// without executing nvidia-smi or inferring state from startup arguments.
+func daemonPersistenceModes(procRoot string) (map[int]bool, error) {
+	entries, err := os.ReadDir(procRoot)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse nvidia-smi persistence output: %w", err)
+		return nil, err
 	}
-	if len(records) == 0 {
-		return nil, fmt.Errorf("nvidia-smi returned no persistence mode rows")
+	modes := make(map[int]bool)
+	foundDaemon := false
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := strconv.Atoi(entry.Name()); err != nil {
+			continue
+		}
+		pidRoot := filepath.Join(procRoot, entry.Name())
+		cmdline, err := os.ReadFile(filepath.Join(pidRoot, "cmdline"))
+		if err != nil || filepath.Base(strings.SplitN(string(cmdline), "\x00", 2)[0]) != "nvidia-persistenced" {
+			continue
+		}
+		foundDaemon = true
+		fds, err := os.ReadDir(filepath.Join(pidRoot, "fd"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read nvidia-persistenced file descriptors for pid %s: %w", entry.Name(), err)
+		}
+		for _, fd := range fds {
+			target, err := os.Readlink(filepath.Join(pidRoot, "fd", fd.Name()))
+			if err != nil {
+				return nil, fmt.Errorf("failed to read nvidia-persistenced file descriptor %s for pid %s: %w", fd.Name(), entry.Name(), err)
+			}
+			target = strings.TrimSuffix(target, " (deleted)")
+			if !strings.HasPrefix(target, "/dev/nvidia") {
+				continue
+			}
+			name := filepath.Base(target)
+			minor, err := strconv.Atoi(strings.TrimPrefix(name, "nvidia"))
+			if err == nil && name == "nvidia"+strconv.Itoa(minor) {
+				modes[minor] = true
+			}
+		}
 	}
-	states := make(map[string]bool, len(records))
-	for _, record := range records {
-		if len(record) != 2 {
-			return nil, fmt.Errorf("unexpected nvidia-smi persistence row with %d fields", len(record))
-		}
-		uuid := strings.TrimSpace(record[0])
-		state := strings.ToLower(strings.TrimSpace(record[1]))
-		if uuid == "" || (state != "enabled" && state != "disabled") {
-			return nil, fmt.Errorf("unexpected nvidia-smi persistence row %q", record)
-		}
-		if _, exists := states[uuid]; exists {
-			return nil, fmt.Errorf("duplicate nvidia-smi persistence row for GPU %q", uuid)
-		}
-		states[uuid] = state == "enabled"
+	if foundDaemon {
+		return modes, nil
 	}
-	return states, nil
+	return nil, fmt.Errorf("nvidia-persistenced process not found")
 }

--- a/components/accelerator/nvidia/persistence-mode/persistence_mode_test.go
+++ b/components/accelerator/nvidia/persistence-mode/persistence_mode_test.go
@@ -1,8 +1,9 @@
 package persistencemode
 
 import (
-	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
@@ -13,32 +14,43 @@ import (
 	"github.com/leptonai/gpud/pkg/nvidia/nvml/testutil"
 )
 
-func TestParsePersistenceModeCSV(t *testing.T) {
-	states, err := parsePersistenceModeCSV([]byte("GPU-1, Enabled\nGPU-2, Disabled\n"))
+func TestDaemonPersistenceModes(t *testing.T) {
+	procRoot := t.TempDir()
+	firstPIDRoot := filepath.Join(procRoot, "122")
+	require.NoError(t, os.MkdirAll(filepath.Join(firstPIDRoot, "fd"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(firstPIDRoot, "cmdline"), []byte("nvidia-persistenced\x00"), 0o644))
+	require.NoError(t, os.Symlink("/dev/nvidia2", filepath.Join(firstPIDRoot, "fd", "3")))
+
+	pidRoot := filepath.Join(procRoot, "123")
+	require.NoError(t, os.MkdirAll(filepath.Join(pidRoot, "fd"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pidRoot, "cmdline"), []byte("/usr/bin/nvidia-persistenced\x00--persistence-mode\x00"), 0o644))
+	require.NoError(t, os.Symlink("/dev/nvidia0", filepath.Join(pidRoot, "fd", "3")))
+	require.NoError(t, os.Symlink("/dev/nvidia3", filepath.Join(pidRoot, "fd", "4")))
+	require.NoError(t, os.Symlink("/dev/nvidiactl", filepath.Join(pidRoot, "fd", "5")))
+	require.NoError(t, os.Symlink("/tmp/nvidia4", filepath.Join(pidRoot, "fd", "6")))
+
+	modes, err := daemonPersistenceModes(procRoot)
 	require.NoError(t, err)
-	assert.Equal(t, map[string]bool{"GPU-1": true, "GPU-2": false}, states)
+	assert.Equal(t, map[int]bool{0: true, 2: true, 3: true}, modes)
 }
 
-func TestParsePersistenceModeCSVErrors(t *testing.T) {
-	tests := map[string]string{
-		"empty":            "",
-		"missing field":    "GPU-1\n",
-		"unexpected state": "GPU-1, N/A\n",
-		"empty UUID":       ", Enabled\n",
-		"duplicate UUID":   "GPU-1, Enabled\nGPU-1, Disabled\n",
-	}
-	for name, input := range tests {
-		t.Run(name, func(t *testing.T) {
-			_, err := parsePersistenceModeCSV([]byte(input))
-			require.Error(t, err)
-		})
-	}
-}
+func TestDaemonPersistenceModesErrors(t *testing.T) {
+	_, err := daemonPersistenceModes(filepath.Join(t.TempDir(), "missing"))
+	require.Error(t, err)
 
-func TestRunPersistenceModeQueryHonorsCancellation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	_, err := runPersistenceModeQuery(ctx, "sh", "-c", "sleep 60")
+	procRoot := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(procRoot, "456"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(procRoot, "456", "cmdline"), []byte("unrelated\x00"), 0o644))
+	_, err = daemonPersistenceModes(procRoot)
+	require.Error(t, err)
+
+	partialRoot := t.TempDir()
+	partialPIDRoot := filepath.Join(partialRoot, "789")
+	require.NoError(t, os.MkdirAll(filepath.Join(partialPIDRoot, "fd"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(partialPIDRoot, "cmdline"), []byte("nvidia-persistenced\x00"), 0o644))
+	// Verify that a missing fd directory makes the entire snapshot indeterminate.
+	require.NoError(t, os.Remove(filepath.Join(partialPIDRoot, "fd")))
+	_, err = daemonPersistenceModes(partialRoot)
 	require.Error(t, err)
 }
 

--- a/components/accelerator/nvidia/persistence-mode/persistence_mode_test.go
+++ b/components/accelerator/nvidia/persistence-mode/persistence_mode_test.go
@@ -1,15 +1,46 @@
 package persistencemode
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	nvmlerrors "github.com/leptonai/gpud/pkg/nvidia/errors"
 	"github.com/leptonai/gpud/pkg/nvidia/nvml/testutil"
 )
+
+func TestParsePersistenceModeCSV(t *testing.T) {
+	states, err := parsePersistenceModeCSV([]byte("GPU-1, Enabled\nGPU-2, Disabled\n"))
+	require.NoError(t, err)
+	assert.Equal(t, map[string]bool{"GPU-1": true, "GPU-2": false}, states)
+}
+
+func TestParsePersistenceModeCSVErrors(t *testing.T) {
+	tests := map[string]string{
+		"empty":            "",
+		"missing field":    "GPU-1\n",
+		"unexpected state": "GPU-1, N/A\n",
+		"empty UUID":       ", Enabled\n",
+		"duplicate UUID":   "GPU-1, Enabled\nGPU-1, Disabled\n",
+	}
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := parsePersistenceModeCSV([]byte(input))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestRunPersistenceModeQueryHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := runPersistenceModeQuery(ctx, "sh", "-c", "sleep 60")
+	require.Error(t, err)
+}
 
 func TestGetPersistenceMode(t *testing.T) {
 	testCases := []struct {

--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -556,6 +556,13 @@ spec:
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           # No readinessProbe is defined
+          {{- with .Values.startupProbe }}
+          # Gives slow control-plane login/machine-info time to finish before
+          # the liveness probe starts (liveness stays off until the first
+          # successful startup probe). Set startupProbe: null to disable.
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.resources }}
           # Omitted entirely when values sets "resources: null", so the
           # DaemonSet consumes none of the node's allocatable resources.

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -304,6 +304,31 @@ livenessProbe:
     scheme: HTTPS
 # No readinessProbe is defined
 
+# Startup probe. gpud performs control-plane login (when a token is
+# configured) and machine-info collection BEFORE it opens its HTTPS listener.
+# Cloud-provider metadata detection can consume full per-provider timeout
+# budgets when IMDS (169.254.169.254) is silently dropped, pushing startup
+# past the ~30s liveness budget (periodSeconds 10 x failureThreshold 3) and
+# into a kill/restart loop. A startup probe disables the liveness probe until
+# the first successful check (Kubernetes semantics), giving gpud up to
+# roughly failureThreshold x periodSeconds (default ~300s) to finish login
+# and boot.
+# The probe uses the fixed gpud listener port below. If gpud.listenAddress is
+# changed from :15132, update both livenessProbe.httpGet.port and
+# startupProbe.httpGet.port to match. To replace httpGet with exec, tcpSocket,
+# or grpc, set startupProbe.httpGet: null as part of the same values override;
+# Helm otherwise deep-merges the new handler with this default httpGet map,
+# and Kubernetes rejects a probe with more than one handler.
+# Set to null to disable.
+startupProbe:
+  httpGet:
+    path: /healthz
+    port: 15132
+    scheme: HTTPS
+  periodSeconds: 10
+  failureThreshold: 30
+  timeoutSeconds: 5
+
 updateStrategy:
   rollingUpdate:
     # This MUST be an integer for a DaemonSet. It cannot be a percentage.

--- a/pkg/nvidia/nvml/lib/options.go
+++ b/pkg/nvidia/nvml/lib/options.go
@@ -131,19 +131,22 @@ func probeNVMLLibrary(root string) string {
 	return ""
 }
 
-// nvmlCompanionLibraryGlobs are the shared libraries that a driver-root
-// libnvidia-ml.so.1 needs at run time, expressed as globs against the
-// directory that libnvidia-ml.so.1 was resolved from.
+// nvmlCompanionLibraries are the shared libraries that a driver-root
+// libnvidia-ml.so.1 needs at run time, matched as globs against the
+// directory that libnvidia-ml.so.1 was resolved from (with stat-based
+// fallbacks for directories whose listing is broken).
 //
 // WHY these families: libnvidia-ml.so.1 dlopens libcuda.so.1 BY SONAME at
 // run time (confirmed by the SONAME strings embedded in the 580.x binary and
 // by runtime A/B tests on AKS A100 and NSCALE B200 nodes): when libcuda.so.1
-// cannot be found, every NVML query fails with NVML_ERROR_NOT_FOUND -- e.g.
-// "failed to get driver version: Not Found" -- even though libnvidia-ml
-// itself dlopened successfully. On 560+ driver trees, libcuda in turn loads
-// libnvidia-gpucomp.so.<version> for compute-related NVML queries, and NVML
-// uses libnvidia-cfg.so.1 for configuration queries. All three are therefore
-// preloaded whenever they exist alongside the resolved libnvidia-ml.
+// cannot be found, NVML queries that need it fail with NVML_ERROR_NOT_FOUND
+// -- e.g. "failed to get CUDA driver version: Not Found" -- even though
+// libnvidia-ml itself dlopened successfully and libcuda-independent queries
+// like SystemGetDriverVersion still work. On 560+ driver trees, libcuda in
+// turn loads libnvidia-gpucomp.so.<version> for compute-related NVML
+// queries, and NVML uses libnvidia-cfg.so.1 for configuration queries. All
+// three are therefore preloaded whenever they exist alongside the resolved
+// libnvidia-ml.
 //
 // WHY an explicit allowlist instead of LD_LIBRARY_PATH=<driver lib dir>: the
 // GPU Operator's driver tree bundles its OWN glibc in the same directory
@@ -154,10 +157,33 @@ func probeNVMLLibrary(root string) string {
 // NVIDIA companions by absolute path never touches libc/libpthread/libm: the
 // companions' own DT_NEEDED entries dedup against the glibc already loaded
 // in the gpud process.
-var nvmlCompanionLibraryGlobs = []string{
-	"libcuda.so*",
-	"libnvidia-cfg.so*",
-	"libnvidia-gpucomp.so*",
+
+// nvmlCompanionLibrary describes one NVML companion library family to
+// preload from the driver tree.
+type nvmlCompanionLibrary struct {
+	// glob matches the family in the directory of the resolved libnvidia-ml
+	// (preferred path; covers versioned files).
+	glob string
+	// sonames are the stable names probed with os.Stat when the glob matches
+	// nothing. filepath.Glob reads the directory, so it silently returns no
+	// matches when the directory LISTING is broken even though the files
+	// exist and open fine -- observed on a BYOK node where the GPU Operator
+	// driver root (/run/nvidia/driver) was a stale driver-container rootfs:
+	// "ls" showed an empty directory while stat/open of libcuda.so.1 worked.
+	// Missing the libcuda companion makes every NVML query that needs it fail
+	// with NVML_ERROR_NOT_FOUND, so the fallback must not rely on readdir.
+	sonames []string
+	// versionedPrefix, when non-empty, names a library that ships only as a
+	// versioned file (e.g. libnvidia-gpucomp); the probed name is derived
+	// from the resolved libnvidia-ml version
+	// (libnvidia-ml.so.<ver> -> "<versionedPrefix><ver>").
+	versionedPrefix string
+}
+
+var nvmlCompanionLibraries = []nvmlCompanionLibrary{
+	{glob: "libcuda.so*", sonames: []string{"libcuda.so.1", "libcuda.so"}},
+	{glob: "libnvidia-cfg.so*", sonames: []string{"libnvidia-cfg.so.1", "libnvidia-cfg.so"}},
+	{glob: "libnvidia-gpucomp.so*", versionedPrefix: "libnvidia-gpucomp.so."},
 }
 
 // findNVMLCompanionLibraries returns, for each companion family, the single
@@ -175,32 +201,77 @@ func findNVMLCompanionLibraries(libraryPath string) []string {
 	}
 
 	var selected []string
-	for _, pattern := range nvmlCompanionLibraryGlobs {
+	for _, family := range nvmlCompanionLibraries {
 		// filepath.Glob returns sorted matches; a missing family is not an
 		// error (existence-based, mirroring the driver-root probes: older
 		// drivers ship no libnvidia-gpucomp, and that is fine).
-		matches, err := filepath.Glob(filepath.Join(dir, pattern))
-		if err != nil || len(matches) == 0 {
+		matches, err := filepath.Glob(filepath.Join(dir, family.glob))
+		if err == nil && len(matches) > 0 {
+			// Prefer the SONAME symlink (e.g., "libcuda.so.1") over the dev
+			// symlink ("libcuda.so") and the versioned file
+			// ("libcuda.so.580.82.07"): the SONAME is the name libnvidia-ml
+			// looks up, and dlopening the symlink still registers the target's
+			// DT_SONAME, which is what makes the later by-SONAME lookup bind to
+			// this exact copy. libnvidia-gpucomp ships only as the versioned
+			// file, so "first sorted match" is the fallback.
+			pick := matches[0]
+			for _, m := range matches {
+				if strings.HasSuffix(m, ".so.1") {
+					pick = m
+					break
+				}
+			}
+			selected = append(selected, pick)
 			continue
 		}
 
-		// Prefer the SONAME symlink (e.g., "libcuda.so.1") over the dev
-		// symlink ("libcuda.so") and the versioned file
-		// ("libcuda.so.580.82.07"): the SONAME is the name libnvidia-ml
-		// looks up, and dlopening the symlink still registers the target's
-		// DT_SONAME, which is what makes the later by-SONAME lookup bind to
-		// this exact copy. libnvidia-gpucomp ships only as the versioned
-		// file, so "first sorted match" is the fallback.
-		pick := matches[0]
-		for _, m := range matches {
-			if strings.HasSuffix(m, ".so.1") {
-				pick = m
-				break
-			}
+		// The glob found nothing. Fall back to probing the family's stable
+		// names with os.Stat: directory reads can fail or return empty on a
+		// stale/corrupt driver-root mount while plain lookups still work.
+		if pick := probeCompanionLibrary(dir, family, libraryPath); pick != "" {
+			selected = append(selected, pick)
 		}
-		selected = append(selected, pick)
 	}
 	return selected
+}
+
+// probeCompanionLibrary finds a companion library by stat-ing its stable
+// names (or its version-derived name) instead of reading the directory. It
+// returns empty when no candidate exists.
+func probeCompanionLibrary(dir string, family nvmlCompanionLibrary, libraryPath string) string {
+	candidates := family.sonames
+	if family.versionedPrefix != "" {
+		if version := nvmlLibraryVersion(libraryPath); version != "" {
+			candidates = []string{family.versionedPrefix + version}
+		}
+	}
+	for _, name := range candidates {
+		candidate := filepath.Join(dir, name)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// nvmlLibraryVersion extracts the driver version suffix from the NVML
+// library path, following the SONAME symlink when present:
+// "libnvidia-ml.so.1" -> "libnvidia-ml.so.580.82.07" -> "580.82.07".
+// It returns empty when no versioned name can be determined.
+func nvmlLibraryVersion(libraryPath string) string {
+	const prefix = "libnvidia-ml.so."
+
+	resolvedPath, err := filepath.EvalSymlinks(libraryPath)
+	if err != nil {
+		resolvedPath = libraryPath
+	}
+	name := filepath.Base(resolvedPath)
+	if strings.HasPrefix(name, prefix) {
+		if version := strings.TrimPrefix(name, prefix); version != "" && version != "1" {
+			return version
+		}
+	}
+	return ""
 }
 
 // preloadNVMLCompanionLibraries dlopens the NVML companion libraries from

--- a/pkg/nvidia/nvml/lib/options_test.go
+++ b/pkg/nvidia/nvml/lib/options_test.go
@@ -9,6 +9,7 @@ import (
 	nvinfo "github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+	"github.com/bytedance/mockey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -249,6 +250,79 @@ func TestFindNVMLCompanionLibraries(t *testing.T) {
 func TestPreloadNVMLCompanionLibrariesNoCompanions(t *testing.T) {
 	preloadNVMLCompanionLibraries("libnvidia-ml.so.1")
 	preloadNVMLCompanionLibraries(filepath.Join(t.TempDir(), "libnvidia-ml.so.1"))
+}
+
+// TestFindNVMLCompanionLibrariesBrokenDirectoryListing covers the stale GPU
+// Operator driver-root case: the directory LISTING returns nothing (broken
+// readdir on a leftover driver-container overlay) while file lookups still
+// work. The stat-based fallback must still find the companions.
+func TestFindNVMLCompanionLibrariesBrokenDirectoryListing(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(name string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), nil, 0o644))
+	}
+	writeFile("libnvidia-ml.so.580.126.20")
+	require.NoError(t, os.Symlink("libnvidia-ml.so.580.126.20", filepath.Join(dir, "libnvidia-ml.so.1")))
+	writeFile("libcuda.so.580.126.20")
+	require.NoError(t, os.Symlink("libcuda.so.580.126.20", filepath.Join(dir, "libcuda.so.1")))
+	writeFile("libnvidia-cfg.so.580.126.20")
+	require.NoError(t, os.Symlink("libnvidia-cfg.so.580.126.20", filepath.Join(dir, "libnvidia-cfg.so.1")))
+	writeFile("libnvidia-gpucomp.so.580.126.20")
+
+	mockey.PatchConvey("directory listing returns nothing but lookups work", t, func() {
+		mockey.Mock(filepath.Glob).To(func(pattern string) ([]string, error) {
+			return nil, nil
+		}).Build()
+
+		assert.Equal(t, []string{
+			filepath.Join(dir, "libcuda.so.1"),
+			filepath.Join(dir, "libnvidia-cfg.so.1"),
+			filepath.Join(dir, "libnvidia-gpucomp.so.580.126.20"),
+		}, findNVMLCompanionLibraries(filepath.Join(dir, "libnvidia-ml.so.1")))
+	})
+}
+
+func TestProbeCompanionLibrary(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "libcuda.so.1"), nil, 0o644))
+
+	// SONAME probe finds the library
+	assert.Equal(t, filepath.Join(dir, "libcuda.so.1"),
+		probeCompanionLibrary(dir, nvmlCompanionLibrary{sonames: []string{"libcuda.so.1", "libcuda.so"}}, ""))
+
+	// missing library returns empty
+	assert.Empty(t, probeCompanionLibrary(dir, nvmlCompanionLibrary{sonames: []string{"libnvidia-cfg.so.1"}}, ""))
+
+	// versioned family with an underivable version returns empty
+	assert.Empty(t, probeCompanionLibrary(dir, nvmlCompanionLibrary{versionedPrefix: "libnvidia-gpucomp.so."}, filepath.Join(dir, "libnvidia-ml.so.1")))
+}
+
+func TestNVMLLibraryVersion(t *testing.T) {
+	dir := t.TempDir()
+
+	// versioned filename directly
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "libnvidia-ml.so.580.126.20"), nil, 0o644))
+	assert.Equal(t, "580.126.20", nvmlLibraryVersion(filepath.Join(dir, "libnvidia-ml.so.580.126.20")))
+
+	// SONAME symlink to a versioned file
+	require.NoError(t, os.Symlink("libnvidia-ml.so.580.126.20", filepath.Join(dir, "libnvidia-ml.so.1")))
+	assert.Equal(t, "580.126.20", nvmlLibraryVersion(filepath.Join(dir, "libnvidia-ml.so.1")))
+
+	// absolute symlink to a versioned file
+	absDir := t.TempDir()
+	absTarget := filepath.Join(absDir, "libnvidia-ml.so.580.126.20")
+	require.NoError(t, os.WriteFile(absTarget, nil, 0o644))
+	require.NoError(t, os.Symlink(absTarget, filepath.Join(absDir, "libnvidia-ml.so.1")))
+	assert.Equal(t, "580.126.20", nvmlLibraryVersion(filepath.Join(absDir, "libnvidia-ml.so.1")))
+
+	// bare SONAME file (no version) yields nothing
+	plainDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(plainDir, "libnvidia-ml.so.1"), nil, 0o644))
+	assert.Equal(t, "", nvmlLibraryVersion(filepath.Join(plainDir, "libnvidia-ml.so.1")))
+
+	// nonexistent path yields nothing
+	assert.Equal(t, "", nvmlLibraryVersion(filepath.Join(plainDir, "does-not-exist.so.1")))
 }
 
 func TestNVMLArchLibraryDir(t *testing.T) {


### PR DESCRIPTION
# [LEP-6503][LEP-6504] Fix BYOK startup and persistence checks on GPU Operator nodes

## Summary

This fixes three failures observed after upgrading the Nightly BYOK cluster to `gpud` `0.13.0-rc.2`:

- `[LEP-6503]` Slow pre-server login could exhaust the liveness budget and restart `gpud` forever.
- `[LEP-6503]` A stale GPU Operator driver-root overlay could expose NVIDIA libraries by exact path while returning an empty directory listing. `gpud` found `libnvidia-ml.so.1`, missed its companion libraries, and failed the CUDA version query with `NVML_ERROR_NOT_FOUND`.
- `[LEP-6504]` On GB200 with driver `595.91.07`, `nvmlDeviceGetPersistenceMode` returned `SUCCESS` with mode `0` even though `nvidia-persistenced` held all four GPU devices open and persistence was effective.

The fixes are narrow and do not add an `nvidia-smi` dependency:

- Add a configurable Kubernetes startup probe. Liveness remains unchanged and starts only after startup succeeds.
- Keep the existing allowlisted NVIDIA companion preload, but add exact-path probes when directory enumeration returns no matches.
- When raw NVML reports persistence disabled, inspect the running persistence daemon's open `/dev/nvidiaN` handles and match them to NVML device minor numbers.

## Root Cause

### `[LEP-6503]` Startup restart loop

`gpud run --refresh-session-token` performs control-plane login and machine-info collection before opening its HTTPS listener. On affected GB200 nodes, blocked IMDS calls consumed approximately 30 seconds:

```text
nscale: 10s
azure:  10s
oci:     5s
other providers + ASN/login: several seconds
```

The `0.13.0-rc.2` chart started liveness checks immediately:

```yaml
livenessProbe:
  httpGet:
    path: /healthz
    port: 15132
    scheme: HTTPS
  periodSeconds: 10
  failureThreshold: 3
  timeoutSeconds: 1
```

The third failure arrived as login completed, so kubelet killed the process before port `15132` opened. The observed pods restarted 21 and 56 times. Setting `livenessProbe.initialDelaySeconds=120` stopped the loop, confirming that the process needed startup grace rather than a different liveness policy.

### `[LEP-6503]` Driver-root companion discovery

Node `ipp2-0290` had a separate deterministic crash loop:

```text
failed to create nvml instance: failed to get driver version: Not Found
```

Its stale GPU Operator overlay had inconsistent directory semantics:

```text
ls /run/nvidia/driver/usr/lib/x86_64-linux-gnu
# total 0

stat /run/nvidia/driver/usr/lib/x86_64-linux-gnu/libcuda.so.1
# succeeds
```

The existing loader found `libnvidia-ml.so.1` by exact `os.Stat`, then used `filepath.Glob` to find companions. The empty `readdir` result made glob return no matches, so `libcuda.so.1` was not preloaded. A direct `go-nvml` probe reproduced the split behavior:

```text
nvmlInit_v2                    -> SUCCESS
nvmlSystemGetDriverVersion     -> SUCCESS (580.126.20)
nvmlSystemGetCudaDriverVersion -> NVML_ERROR_NOT_FOUND
```

The fix keeps the existing probe order and preload allowlist. It adds direct `os.Stat` fallbacks for `libcuda.so.1`, `libnvidia-cfg.so.1`, and version-matched `libnvidia-gpucomp.so.<driver-version>`. It does not use `LD_LIBRARY_PATH`, which would expose the driver root's bundled glibc and crash `gpud` with a `GLIBC_PRIVATE` symbol error.

### `[LEP-6504]` Daemon-managed persistence

On `gb-nvl-124-compute17`, persistence mode was the only unhealthy gpud component:

```text
all 4 GPU(s) disabled persistence mode
```

For those same four GPUs:

- Direct `nvmlDeviceGetPersistenceMode` returned `SUCCESS`, mode `0`.
- `nvidia-persistenced --persistence-mode` was running.
- The daemon process held `/dev/nvidia0` through `/dev/nvidia3` open.
- `nvidia-smi` independently reported `Enabled` for every matching UUID during investigation, but the implementation does not invoke or depend on it.

NVIDIA's persistence daemon source provides the decisive invariant: enabling a GPU calls `nvCfgOpenPciDevice`; disabling it calls `nvCfgCloseDevice`; current per-GPU mode is tracked by those handles. Process presence or startup arguments are insufficient because the daemon remains alive when devices are disabled and RPC can change individual GPUs after startup.

## Changes

### `[LEP-6503]` Helm startup probe

- Add an HTTPS startup probe for `/healthz` on port `15132`.
- Default budget: approximately five minutes (`periodSeconds: 10`, `failureThreshold: 30`, `timeoutSeconds: 5`).
- Keep the existing liveness probe unchanged.
- Allow `startupProbe: null` to disable the probe.
- Document Helm deep-merge behavior for alternate handlers and listener/probe port coupling.

### `[LEP-6503]` NVML companion fallback

- Keep glob-based selection for normal driver roots.
- If globbing returns no entries, probe stable companion SONAMEs directly.
- Derive `libnvidia-gpucomp`'s version from the fully resolved NVML symlink.
- Keep the allowlist limited to NVIDIA companions; never add the driver directory to `LD_LIBRARY_PATH`.

### `[LEP-6504]` Dependency-free persistence fallback

- Run only when NVML reports a supported GPU as disabled.
- Capture each NVML device's minor number.
- Inspect all live `nvidia-persistenced` processes and aggregate open `/dev/nvidiaN` handles.
- Treat a GPU as daemon-managed only when its exact minor number is held open.
- Preserve the raw NVML result as `nvml_reported_enabled`; identify the effective source as `nvidia-persistenced`.
- Fail closed: missing daemon, unreadable/incomplete FD snapshots, or unavailable minor numbers retain the NVML-disabled state and warning event.
- Do not execute host binaries and do not depend on `nvidia-smi`.

## Validation

### Live BYOK validation

- Patched NVML probe on `ipp2-0290` preloaded all companions despite empty directory listings and completed full instance creation:

```text
NVMLExists=true driver=580.126.20 cuda=13.0 product=NVIDIA-A10 devices=1
```

- On arm64 GB200, the live `nvidia-persistenced` process held all four target devices open:

```text
/dev/nvidia0
/dev/nvidia1
/dev/nvidia2
/dev/nvidia3
```

- NVIDIA's daemon implementation confirms that these open handles are the mechanism used for enabled persistence mode.

### Automated validation

- `go test -race ./components/accelerator/nvidia/persistence-mode/... ./pkg/nvidia/nvml/...`
- `go vet ./components/accelerator/nvidia/persistence-mode/... ./pkg/nvidia/nvml/...`
- `go test ./... -run '^$'`
- `helm lint deployments/helm/gpud`
- Default Helm render contains the startup probe.
- `--set startupProbe=null` omits it.
- `git diff --check`

## References

- NVBug 6737605 / LEP-6503
- NVBug 6737677 / LEP-6504
- NVIDIA persistence daemon implementation: https://github.com/NVIDIA/nvidia-persistenced/blob/main/nvidia-persistenced.c
- NVIDIA Driver Persistence: https://docs.nvidia.com/deploy/driver-persistence/persistence-daemon.html
- Kubernetes probes: https://kubernetes.io/docs/concepts/workloads/pods/liveness-readiness-startup-probes/
