### PR TITLE
[LEP-6503] fix(helm/gpud): require startup probe with liveness

### DIFF
--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -553,8 +553,13 @@ spec:
               protocol: TCP
           {{- end }}
 
+          {{- if .Values.livenessProbe }}
+          {{- if not .Values.startupProbe }}
+          {{- fail "startupProbe is required when livenessProbe is enabled; gpud performs login and machine-info collection before /healthz starts" }}
+          {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
           # No readinessProbe is defined
           {{- with .Values.startupProbe }}
           # Gives slow control-plane login/machine-info time to finish before


### PR DESCRIPTION
## Summary

Prevent the chart from rendering the unsafe combination that caused GPUd startup to enter a restart loop: an immediate liveness probe with no startup probe.

GPUd performs control-plane login and machine-info collection before it opens the HTTPS `/healthz` listener. Without startup protection, kubelet can restart the process before initialization completes.

## Changes

- Fail Helm rendering when `livenessProbe` is enabled but `startupProbe` is omitted.
- Keep the existing five-minute default startup probe.
- Preserve intentional probe-free rendering when both `livenessProbe=null` and `startupProbe=null` are set.

## Evidence

### Kane failure before protection

- Pod: `gpud-h8jhr` on `gb-nvl-124-compute17`
- Image: `nvcr.io/nvstaging/lepton/gpud:0.13.0-rc.4`
- State: `CrashLoopBackOff`, 35 restarts
- Previous run: 2026-09-10T08:44:03Z to 2026-09-10T08:44:33Z
- Exit code: 143

### Kane recovery with startup protection

After the existing startup-probe patch, all three GPUd pods are ready with zero restarts:

```text
NAME         NODE                   READY   RESTARTS   STARTED
gpud-frvlc   gb-nvl-124-compute17   true    0          2026-09-10T08:54:18Z
gpud-gq9tp   gb-nvl-124-compute18   true    0          2026-09-10T08:54:18Z
gpud-r4f2g   dl20g11-0814           true    0          2026-09-10T08:54:59Z
```

## Validation

- `helm lint ./deployments/helm/gpud`
- Default `helm template gpud ./deployments/helm/gpud` includes the startup probe.
- `helm template gpud ./deployments/helm/gpud --set startupProbe=null` fails with an explicit error.
- `helm template gpud ./deployments/helm/gpud --set startupProbe=null --set livenessProbe=null` succeeds for deliberate probe-free deployments.
- `git diff --check`

Ref: LEP-6503