### PR TITLE
[LEP-6075] feat(helm): enable NVSentinel sink unix socket by default

### DIFF
--- a/deployments/helm/gpud/README.md
+++ b/deployments/helm/gpud/README.md
@@ -191,6 +191,37 @@ the containerd check behaves as before. On nodes that run neither containerd
 nor CRI-O, set `gpud.mountContainerd: false` and
 `gpud.containerdServiceActiveCommands: ""`.
 
+### NVSentinel Integration
+
+By default the chart enables GPUd's NVSentinel sink: GPUd serves the
+NVSentinel PlatformConnector gRPC API on a unix socket, and the node's
+NVSentinel platform-connector dials it to forward health events
+(Xid/SXid/InfiniBand), which GPUd components then deduplicate against their
+own detection:
+
+```yaml
+gpud:
+  nvsentinel:
+    enabled: true
+    socketPath: /var/run/nvsentinel/gpud.sock
+```
+
+GPUd only listens — it never dials NVSentinel — so nodes without NVSentinel
+are unaffected: the listener idles and components keep using their native
+detection (kmsg, NVML, ...). GPUd is simply ready whenever NVSentinel comes
+online. The socket's parent directory (`/var/run/nvsentinel`) is bind-mounted
+from the host with `DirectoryOrCreate`, which is what lets the
+platform-connector pod — it mounts the same host directory at its own
+`/var/run` — reach the socket at `/var/run/gpud.sock`. On nodes without
+NVSentinel this leaves only an empty host directory.
+
+Requires a gpud image with the LEP-6075 NVSentinel sink (v0.13.0+). On older
+images the unknown `--nvsentinel-endpoint` flag fails startup — set
+`gpud.nvsentinel.enabled: false` when pinning an older `image.tag`. As with
+the other startup flags, if `gpud.commandOverride` is set the default startup
+wrapper is bypassed, so include `--nvsentinel-endpoint` in the override when
+the sink is needed.
+
 ### Enabling or Disabling Components
 
 Set `gpud.components` (a list) to control which components run; it is rendered

--- a/deployments/helm/gpud/templates/daemonset.yaml
+++ b/deployments/helm/gpud/templates/daemonset.yaml
@@ -221,6 +221,20 @@ spec:
             path: /run/crio
             type: DirectoryOrCreate
         {{- end }}
+
+        {{- if .Values.gpud.nvsentinel.enabled }}
+        # Host NVSentinel directory, shared with the NVSentinel
+        # platform-connector pod (which mounts the same host directory). gpud
+        # creates its PlatformConnector gRPC unix socket at
+        # gpud.nvsentinel.socketPath here; the connector dials it. Requires
+        # gpud v0.13.0+ (LEP-6075). DirectoryOrCreate so the pod starts on
+        # nodes without NVSentinel: gpud then idles on the socket and the
+        # connector, when it appears, finds and dials it.
+        - name: nvsentinel-run
+          hostPath:
+            path: {{ dir .Values.gpud.nvsentinel.socketPath }}
+            type: DirectoryOrCreate
+        {{- end }}
       {{- if .Values.extraVolumes }}
       {{- toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
@@ -430,6 +444,14 @@ spec:
 
               set -- "$@" --enable-auto-update={{ .Values.gpud.enableAutoUpdate }}
               set -- "$@" --auto-update-exit-code={{ .Values.gpud.autoUpdateExitCode }}
+
+              {{- if .Values.gpud.nvsentinel.enabled }}
+              # NVSentinel sink: serve the PlatformConnector gRPC API on this unix
+              # socket. This is a pure listener -- it never dials NVSentinel, so it
+              # is safe on nodes without NVSentinel and simply receives events
+              # whenever a platform-connector comes online and starts forwarding.
+              set -- "$@" --nvsentinel-endpoint="{{ .Values.gpud.nvsentinel.socketPath }}"
+              {{- end }}
 
               # Log the command for debugging, then exec to replace shell with gpud.
               # Keep the multi-line reboot script out of the startup log; gpud logs it
@@ -684,6 +706,13 @@ spec:
             # socket requires write access (same reason /run/containerd is rw).
             - name: host-run-crio
               mountPath: /run/crio
+            {{- end }}
+
+            {{- if .Values.gpud.nvsentinel.enabled }}
+            # Host NVSentinel directory shared with the platform-connector pod.
+            # Not read-only: gpud creates/removes its unix socket file here.
+            - name: nvsentinel-run
+              mountPath: {{ dir .Values.gpud.nvsentinel.socketPath }}
             {{- end }}
           {{- if .Values.extraVolumeMounts }}
           {{- toYaml .Values.extraVolumeMounts | nindent 12 }}

--- a/deployments/helm/gpud/values.yaml
+++ b/deployments/helm/gpud/values.yaml
@@ -232,6 +232,30 @@ gpud:
   # Set to false only if the node group uses a non-standard CRI-O socket path.
   mountCrio: true
 
+  # NVSentinel integration: gpud serves the NVSentinel PlatformConnector gRPC
+  # API on a local unix socket, and the node's NVSentinel platform-connector
+  # dials it to forward health events (Xid/SXid/InfiniBand). gpud only
+  # listens -- it never dials NVSentinel -- so a node without NVSentinel is
+  # unaffected: the listener idles and components keep using their native
+  # detection (kmsg, NVML, ...). Enabled by default so gpud is ready to
+  # receive events whenever NVSentinel comes online; events that arrive
+  # before components finish starting are queued, not dropped.
+  #
+  # Requires a gpud image with the LEP-6075 NVSentinel sink (v0.13.0+); on
+  # older images the unknown --nvsentinel-endpoint flag fails startup, so set
+  # enabled=false when pinning an older image.tag.
+  nvsentinel:
+    enabled: true
+    # The unix socket gpud serves (passed to --nvsentinel-endpoint). Its
+    # parent directory is bind-mounted from the host with DirectoryOrCreate,
+    # which is what lets the NVSentinel platform-connector pod -- it mounts
+    # the same host directory -- reach the socket. The default matches the
+    # stock NVSentinel DaemonSet contract: host /var/run/nvsentinel is
+    # mounted at the connector's /var/run, so it dials /var/run/gpud.sock.
+    # On nodes without NVSentinel the mount just creates an empty, unused
+    # /var/run/nvsentinel directory on the host.
+    socketPath: /var/run/nvsentinel/gpud.sock
+
   # Mount /dev/mem for deep hardware inspection and memory diagnostics (e.g., PCIe config space).
   # Defaults to false for maximum compatibility across platforms (addresses issue #1144).
   # Set to true if you need deep memory inspection and your environment supports /dev/mem.


### PR DESCRIPTION
## What

Enables the NVSentinel sink (LEP-6075, #1309) in the GPUd Helm chart by default, so every chart-deployed GPUd is ready to receive health events whenever a node's NVSentinel platform-connector comes online:

- `gpud.nvsentinel.enabled` (default `true`) appends `--nvsentinel-endpoint` to the `gpud run` args
- `gpud.nvsentinel.socketPath` (default `/var/run/nvsentinel/gpud.sock`) — the parent directory is bind-mounted from the host with `DirectoryOrCreate`, which is what lets the NVSentinel platform-connector pod (it mounts the same host directory at its own `/var/run`) reach the socket at `/var/run/gpud.sock`
- README section documenting the integration

## Why it is safe on nodes without NVSentinel

GPUd **only listens** — it never dials NVSentinel:

- The sink is a passive unix-socket gRPC server (`pkg/nvsentinel/source.go`); with no connector, it simply idles
- Components subscribe to the event source; with no events arriving, they behave exactly as before (native kmsg/NVML/IB detection)
- Events received before components finish starting are queued, not dropped; a full queue answers the RPC with `Unavailable` so the connector retries rather than losing events
- The hostPath is `DirectoryOrCreate`, so the pod starts normally on NVSentinel-less nodes (leaves only an empty `/var/run/nvsentinel` on the host)

## Compatibility note

The `--nvsentinel-endpoint` flag requires a gpud image with the LEP-6075 sink (v0.13.0+). On older pinned `image.tag` values the unknown flag fails startup — set `gpud.nvsentinel.enabled: false` there (documented in values.yaml and README).

## Testing

- `helm lint deployments/helm/gpud` — passes
- `helm template` (defaults) — renders `--nvsentinel-endpoint=/var/run/nvsentinel/gpud.sock`, the `nvsentinel-run` hostPath volume (`/var/run/nvsentinel`, `DirectoryOrCreate`), and its volumeMount; rendered YAML parses cleanly
- `helm template --set gpud.nvsentinel.enabled=false` — zero nvsentinel references rendered
- `helm template --set gpud.nvsentinel.socketPath=/custom/nvs/gpud.sock` — volume, mount, and flag all follow the overridden parent directory