### PR TITLE
fix(package-controller): serialize package operations with credential rotation

### DIFF
--- a/pkg/gpud-manager/controllers/package_controller.go
+++ b/pkg/gpud-manager/controllers/package_controller.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/leptonai/gpud/pkg/gpud-manager/packages"
 	"github.com/leptonai/gpud/pkg/log"
+	"github.com/leptonai/gpud/pkg/packagelock"
 	"github.com/leptonai/gpud/pkg/process"
 )
 
@@ -118,78 +119,91 @@ func (c *PackageController) updateRunner(ctx context.Context) {
 			ticker.Reset(c.syncPeriod)
 		}
 		for _, pkg := range c.packageStatusSnapshot() {
-			c.RLock()
-			installed := pkg.IsInstalled || c.recoveredInstalled[pkg.Name]
-			scriptPath := pkg.ScriptPath
-			targetVersion := pkg.TargetVersion
-			c.RUnlock()
-			if !installed {
-				continue
-			}
-			var version string
-			err := runCommand(ctx, scriptPath, "version", &version)
-			if err != nil {
-				log.Logger.Errorf("[package controller]: %v unexpected version failure: %v", pkg.Name, err)
-				continue
-			}
-			if version == "" {
-				continue
-			}
-			c.Lock()
-			c.packageStatus[pkg.Name].CurrentVersion = version
-			c.Unlock()
+			c.updatePackage(ctx, pkg)
+		}
+	}
+}
 
-			var shouldSkipResult string
-			if err = runCommand(ctx, scriptPath, "shouldSkip", &shouldSkipResult); err == nil {
+func (c *PackageController) updatePackage(ctx context.Context, pkg *packages.PackageStatus) {
+	operationMu := packagelock.For(pkg.Name)
+	if !operationMu.TryLock() {
+		return
+	}
+	defer operationMu.Unlock()
+	if ctx.Err() != nil {
+		return
+	}
+
+	c.RLock()
+	installed := pkg.IsInstalled || c.recoveredInstalled[pkg.Name]
+	scriptPath := pkg.ScriptPath
+	targetVersion := pkg.TargetVersion
+	c.RUnlock()
+	if !installed {
+		return
+	}
+	var version string
+	err := runCommand(ctx, scriptPath, "version", &version)
+	if err != nil {
+		log.Logger.Errorf("[package controller]: %v unexpected version failure: %v", pkg.Name, err)
+		return
+	}
+	if version == "" {
+		return
+	}
+	c.Lock()
+	c.packageStatus[pkg.Name].CurrentVersion = version
+	c.Unlock()
+
+	var shouldSkipResult string
+	if err = runCommand(ctx, scriptPath, "shouldSkip", &shouldSkipResult); err == nil {
+		c.Lock()
+		c.packageStatus[pkg.Name].Skipped = true
+		c.Unlock()
+		log.Logger.Debugf("[package controller]: %v shouldSkip returned 0, skipping update", pkg.Name)
+		return
+	}
+
+	if version == targetVersion {
+		log.Logger.Debugf("[package controller]: %v version is %v (same as target, no-op)", pkg.Name, version)
+		return
+	}
+
+	log.Logger.Infof("[package controller]: %v version is %v, target is %v", pkg.Name, version, targetVersion)
+	var eta time.Duration
+	c.Lock()
+	c.packageStatus[pkg.Name].Installing = true
+	c.packageStatus[pkg.Name].Progress = 0
+	eta = c.packageStatus[pkg.Name].TotalTime
+	c.Unlock()
+	done := make(chan any)
+	go func() {
+		startTime := time.Now()
+		localTicker := time.NewTicker(2 * time.Second)
+		defer localTicker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-localTicker.C:
 				c.Lock()
-				c.packageStatus[pkg.Name].Skipped = true
-				c.Unlock()
-				log.Logger.Debugf("[package controller]: %v shouldSkip returned 0, skipping update", pkg.Name)
-				continue
-			}
-
-			if version == targetVersion {
-				log.Logger.Debugf("[package controller]: %v version is %v (same as target, no-op)", pkg.Name, version)
-				continue
-			}
-
-			log.Logger.Infof("[package controller]: %v version is %v, target is %v", pkg.Name, version, targetVersion)
-			var eta time.Duration
-			c.Lock()
-			c.packageStatus[pkg.Name].Installing = true
-			c.packageStatus[pkg.Name].Progress = 0
-			eta = c.packageStatus[pkg.Name].TotalTime
-			c.Unlock()
-			done := make(chan any)
-			go func() {
-				startTime := time.Now()
-				localTicker := time.NewTicker(2 * time.Second)
-				defer localTicker.Stop()
-				for {
-					select {
-					case <-done:
-						return
-					case <-localTicker.C:
-						c.Lock()
-						progress := int(time.Since(startTime).Seconds() / eta.Seconds() * 100)
-						if progress >= 100 {
-							progress = 98
-						}
-						c.packageStatus[pkg.Name].Progress = progress
-						c.Unlock()
-					}
+				progress := int(time.Since(startTime).Seconds() / eta.Seconds() * 100)
+				if progress >= 100 {
+					progress = 98
 				}
-			}()
-			err = runCommand(ctx, scriptPath, "upgrade", nil)
-			close(done)
-			c.Lock()
-			c.packageStatus[pkg.Name].Installing = false
-			c.packageStatus[pkg.Name].Progress = 100
-			c.Unlock()
-			if err != nil {
-				log.Logger.Errorf("[package controller]: %v unexpected upgrade failure: %v", pkg.Name, err)
+				c.packageStatus[pkg.Name].Progress = progress
+				c.Unlock()
 			}
 		}
+	}()
+	err = runCommand(ctx, scriptPath, "upgrade", nil)
+	close(done)
+	c.Lock()
+	c.packageStatus[pkg.Name].Installing = false
+	c.packageStatus[pkg.Name].Progress = 100
+	c.Unlock()
+	if err != nil {
+		log.Logger.Errorf("[package controller]: %v unexpected upgrade failure: %v", pkg.Name, err)
 	}
 }
 
@@ -204,150 +218,171 @@ func (c *PackageController) installRunner(ctx context.Context) {
 			ticker.Reset(c.syncPeriod)
 		}
 		for _, pkg := range c.packageStatusSnapshot() {
-			c.RLock()
-			dependency := pkg.Dependency
-			scriptPath := pkg.ScriptPath
-			installing := pkg.Installing
-			installed := pkg.IsInstalled
-			recoveryProbed := c.recoveryProbed[pkg.Name]
-			c.RUnlock()
-
-			if installing {
-				log.Logger.Infof("[package controller]: %v installing...", pkg.Name)
-				continue
-			}
-
-			// Probe once before the dependency gate so a controller restart can
-			// recover packages that already exist on disk. Keep that state
-			// separate from IsInstalled: package dependencies only gate a fresh
-			// install, while an existing package must remain eligible for upgrade.
-			if !installed && !recoveryProbed {
-				c.Lock()
-				c.recoveryProbed[pkg.Name] = true
-				c.Unlock()
-
-				probeCtx, cancel := context.WithTimeout(ctx, c.recoveryProbeTimeout)
-				err := runCommand(probeCtx, scriptPath, "isInstalled", nil)
-				cancel()
-				if err == nil {
-					c.Lock()
-					c.recoveredInstalled[pkg.Name] = true
-					c.packageStatus[pkg.Name].Progress = 100
-					c.Unlock()
-					log.Logger.Debugw("[package controller] recovered existing installation", "name", pkg.Name)
-				} else if errors.Is(err, context.DeadlineExceeded) {
-					log.Logger.Warnw("[package controller] recovery probe timed out", "name", pkg.Name, "timeout", c.recoveryProbeTimeout)
-				}
-			}
-
-			var skipInstall bool
-			for _, dep := range dependency {
-				// Read the dependency's mutable fields under the read lock;
-				// updateRunner and the async install goroutine mutate them
-				// under the write lock.
-				c.RLock()
-				depPkg, depFound := c.packageStatus[dep[0]]
-				depInstalled := depFound && depPkg.IsInstalled
-				depVersion := ""
-				if depFound {
-					depVersion = depPkg.CurrentVersion
-				}
-				c.RUnlock()
-				if !depFound {
-					log.Logger.Infof("[package controller]: %v dependency %v not found, skipping", pkg.Name, dep[0])
-					skipInstall = true
-					break
-				}
-				if !depInstalled {
-					log.Logger.Infof("[package controller]: %v dependency %v not installed, skipping", pkg.Name, dep[0])
-					skipInstall = true
-					break
-				}
-				if dep[1] != "*" && (depVersion == "" || depVersion < dep[1]) {
-					log.Logger.Infof("[package controller]: %v dependency %v version %v does not meet required %v, skipping", pkg.Name, dep[0], depVersion, dep[1])
-					skipInstall = true
-					break
-				}
-			}
-			if skipInstall {
-				continue
-			}
-
-			c.RLock()
-			recovered := c.recoveredInstalled[pkg.Name]
-			c.RUnlock()
-			if recovered {
-				c.Lock()
-				c.packageStatus[pkg.Name].IsInstalled = true
-				c.Unlock()
-				continue
-			}
-
-			var shouldSkipResult string
-			if err := runCommand(ctx, scriptPath, "shouldSkip", &shouldSkipResult); err == nil {
-				c.Lock()
-				c.packageStatus[pkg.Name].Skipped = true
-				c.packageStatus[pkg.Name].Progress = 100
-				c.packageStatus[pkg.Name].IsInstalled = true
-				c.Unlock()
-				log.Logger.Debugf("[package controller]: %v shouldSkip returned 0, skipping install", pkg.Name)
-				continue
-			}
-
-			err := runCommand(ctx, scriptPath, "isInstalled", nil)
-			if err == nil {
-				c.Lock()
-				c.packageStatus[pkg.Name].Progress = 100
-				c.packageStatus[pkg.Name].IsInstalled = true
-				c.Unlock()
-				log.Logger.Debugw("[package controller] already installed", "name", pkg.Name)
-				continue
-			}
-
-			log.Logger.Warnw("[package controller] not installed, installing", "name", pkg.Name, "error", err)
-			go func() {
-				var eta time.Duration
-				c.Lock()
-				c.packageStatus[pkg.Name].Installing = true
-				c.packageStatus[pkg.Name].Progress = 0
-				eta = c.packageStatus[pkg.Name].TotalTime
-				c.Unlock()
-				done := make(chan any)
-				go func() {
-					startTime := time.Now()
-					localTicker := time.NewTicker(2 * time.Second)
-					defer localTicker.Stop()
-					for {
-						select {
-						case <-done:
-							return
-						case <-localTicker.C:
-							progress := int(time.Since(startTime).Seconds() / eta.Seconds() * 100)
-							if progress >= 100 {
-								progress = 98
-							}
-							c.Lock()
-							c.packageStatus[pkg.Name].Progress = progress
-							c.Unlock()
-						}
-					}
-				}()
-				err = runCommand(ctx, scriptPath, "install", nil)
-				close(done)
-				if err != nil {
-					log.Logger.Errorf("[package controller]: %v unexpected install failure: %v", pkg.Name, err)
-				} else {
-					if err = runCommand(ctx, scriptPath, "start", nil); err != nil {
-						log.Logger.Errorf("[package controller]: %v failed to start after installing: %v", pkg.Name, err)
-					}
-				}
-				c.Lock()
-				c.packageStatus[pkg.Name].Installing = false
-				c.packageStatus[pkg.Name].Progress = 100
-				c.Unlock()
-			}()
+			c.installPackage(ctx, pkg)
 		}
 	}
+}
+
+func (c *PackageController) installPackage(ctx context.Context, pkg *packages.PackageStatus) {
+	operationMu := packagelock.For(pkg.Name)
+	if !operationMu.TryLock() {
+		return
+	}
+	// Transfer ownership only when the asynchronous install is launched.
+	async := false
+	defer func() {
+		if !async {
+			operationMu.Unlock()
+		}
+	}()
+	if ctx.Err() != nil {
+		return
+	}
+
+	c.RLock()
+	dependency := pkg.Dependency
+	scriptPath := pkg.ScriptPath
+	installing := pkg.Installing
+	installed := pkg.IsInstalled
+	recoveryProbed := c.recoveryProbed[pkg.Name]
+	c.RUnlock()
+
+	if installing {
+		log.Logger.Infof("[package controller]: %v installing...", pkg.Name)
+		return
+	}
+
+	// Probe once before the dependency gate so a controller restart can
+	// recover packages that already exist on disk. Keep that state
+	// separate from IsInstalled: package dependencies only gate a fresh
+	// install, while an existing package must remain eligible for upgrade.
+	if !installed && !recoveryProbed {
+		c.Lock()
+		c.recoveryProbed[pkg.Name] = true
+		c.Unlock()
+
+		probeCtx, cancel := context.WithTimeout(ctx, c.recoveryProbeTimeout)
+		err := runCommand(probeCtx, scriptPath, "isInstalled", nil)
+		cancel()
+		if err == nil {
+			c.Lock()
+			c.recoveredInstalled[pkg.Name] = true
+			c.packageStatus[pkg.Name].Progress = 100
+			c.Unlock()
+			log.Logger.Debugw("[package controller] recovered existing installation", "name", pkg.Name)
+		} else if errors.Is(err, context.DeadlineExceeded) {
+			log.Logger.Warnw("[package controller] recovery probe timed out", "name", pkg.Name, "timeout", c.recoveryProbeTimeout)
+		}
+	}
+
+	var skipInstall bool
+	for _, dep := range dependency {
+		// Read the dependency's mutable fields under the read lock;
+		// updateRunner and the async install goroutine mutate them
+		// under the write lock.
+		c.RLock()
+		depPkg, depFound := c.packageStatus[dep[0]]
+		depInstalled := depFound && depPkg.IsInstalled
+		depVersion := ""
+		if depFound {
+			depVersion = depPkg.CurrentVersion
+		}
+		c.RUnlock()
+		if !depFound {
+			log.Logger.Infof("[package controller]: %v dependency %v not found, skipping", pkg.Name, dep[0])
+			skipInstall = true
+			break
+		}
+		if !depInstalled {
+			log.Logger.Infof("[package controller]: %v dependency %v not installed, skipping", pkg.Name, dep[0])
+			skipInstall = true
+			break
+		}
+		if dep[1] != "*" && (depVersion == "" || depVersion < dep[1]) {
+			log.Logger.Infof("[package controller]: %v dependency %v version %v does not meet required %v, skipping", pkg.Name, dep[0], depVersion, dep[1])
+			skipInstall = true
+			break
+		}
+	}
+	if skipInstall {
+		return
+	}
+
+	c.RLock()
+	recovered := c.recoveredInstalled[pkg.Name]
+	c.RUnlock()
+	if recovered {
+		c.Lock()
+		c.packageStatus[pkg.Name].IsInstalled = true
+		c.Unlock()
+		return
+	}
+
+	var shouldSkipResult string
+	if err := runCommand(ctx, scriptPath, "shouldSkip", &shouldSkipResult); err == nil {
+		c.Lock()
+		c.packageStatus[pkg.Name].Skipped = true
+		c.packageStatus[pkg.Name].Progress = 100
+		c.packageStatus[pkg.Name].IsInstalled = true
+		c.Unlock()
+		log.Logger.Debugf("[package controller]: %v shouldSkip returned 0, skipping install", pkg.Name)
+		return
+	}
+
+	err := runCommand(ctx, scriptPath, "isInstalled", nil)
+	if err == nil {
+		c.Lock()
+		c.packageStatus[pkg.Name].Progress = 100
+		c.packageStatus[pkg.Name].IsInstalled = true
+		c.Unlock()
+		log.Logger.Debugw("[package controller] already installed", "name", pkg.Name)
+		return
+	}
+
+	log.Logger.Warnw("[package controller] not installed, installing", "name", pkg.Name, "error", err)
+	async = true
+	go func() {
+		defer operationMu.Unlock()
+		var eta time.Duration
+		c.Lock()
+		c.packageStatus[pkg.Name].Installing = true
+		c.packageStatus[pkg.Name].Progress = 0
+		eta = c.packageStatus[pkg.Name].TotalTime
+		c.Unlock()
+		done := make(chan any)
+		go func() {
+			startTime := time.Now()
+			localTicker := time.NewTicker(2 * time.Second)
+			defer localTicker.Stop()
+			for {
+				select {
+				case <-done:
+					return
+				case <-localTicker.C:
+					progress := int(time.Since(startTime).Seconds() / eta.Seconds() * 100)
+					if progress >= 100 {
+						progress = 98
+					}
+					c.Lock()
+					c.packageStatus[pkg.Name].Progress = progress
+					c.Unlock()
+				}
+			}
+		}()
+		err := runCommand(ctx, scriptPath, "install", nil)
+		close(done)
+		if err != nil {
+			log.Logger.Errorf("[package controller]: %v unexpected install failure: %v", pkg.Name, err)
+		} else {
+			if err = runCommand(ctx, scriptPath, "start", nil); err != nil {
+				log.Logger.Errorf("[package controller]: %v failed to start after installing: %v", pkg.Name, err)
+			}
+		}
+		c.Lock()
+		c.packageStatus[pkg.Name].Installing = false
+		c.packageStatus[pkg.Name].Progress = 100
+		c.Unlock()
+	}()
 }
 
 func (c *PackageController) deleteRunner(ctx context.Context) {
@@ -361,17 +396,30 @@ func (c *PackageController) deleteRunner(ctx context.Context) {
 			ticker.Reset(c.syncPeriod)
 		}
 		for _, pkg := range c.packageStatusSnapshot() {
-			c.RLock()
-			scriptPath := pkg.ScriptPath
-			c.RUnlock()
-			if err := runCommand(ctx, scriptPath, "needDelete", nil); err != nil {
-				continue
-			}
-			err := runCommand(ctx, scriptPath, "delete", nil)
-			if err != nil {
-				log.Logger.Infof("[package controller]: %v failed to delete: %v", pkg.Name, err)
-			}
+			c.deletePackage(ctx, pkg)
 		}
+	}
+}
+
+func (c *PackageController) deletePackage(ctx context.Context, pkg *packages.PackageStatus) {
+	operationMu := packagelock.For(pkg.Name)
+	if !operationMu.TryLock() {
+		return
+	}
+	defer operationMu.Unlock()
+	if ctx.Err() != nil {
+		return
+	}
+
+	c.RLock()
+	scriptPath := pkg.ScriptPath
+	c.RUnlock()
+	if err := runCommand(ctx, scriptPath, "needDelete", nil); err != nil {
+		return
+	}
+	err := runCommand(ctx, scriptPath, "delete", nil)
+	if err != nil {
+		log.Logger.Infof("[package controller]: %v failed to delete: %v", pkg.Name, err)
 	}
 }
 
@@ -386,54 +434,67 @@ func (c *PackageController) statusRunner(ctx context.Context) {
 			ticker.Reset(c.syncPeriod)
 		}
 		for _, pkg := range c.packageStatusSnapshot() {
-			c.RLock()
-			installed := pkg.IsInstalled
-			recovered := c.recoveredInstalled[pkg.Name]
-			scriptPath := pkg.ScriptPath
-			c.RUnlock()
-			if !installed && !recovered {
-				continue
-			}
-
-			var shouldSkipResult string
-			if err := runCommand(ctx, scriptPath, "shouldSkip", &shouldSkipResult); err == nil {
-				c.Lock()
-				c.packageStatus[pkg.Name].Skipped = true
-				c.packageStatus[pkg.Name].Status = true
-				c.Unlock()
-				log.Logger.Debugf("[package controller]: %v shouldSkip returned 0, setting status to true", pkg.Name)
-				continue
-			}
-
-			err := runCommand(ctx, scriptPath, "status", nil)
-			if err == nil {
-				c.Lock()
-				c.packageStatus[pkg.Name].Status = true
-				c.Unlock()
-				log.Logger.Debugf("[package controller]: %v status ok", pkg.Name)
-				continue
-			}
-			// Recovery establishes that the package exists on disk, but its
-			// dependencies have not passed the install gate. Report the package's
-			// actual health without restarting it until normal installed state is
-			// established, avoiding a restart loop when a dependency is unavailable.
-			if recovered && !installed {
-				log.Logger.Warnw("[package controller] recovered package status not ok; skipping restart", "name", pkg.Name, "error", err)
-				continue
-			}
-			log.Logger.Errorf("[package controller]: %v status not ok, restarting", pkg.Name)
-			// Use the scriptPath snapshot taken under the read lock above:
-			// reconcileLoop can update pkg.ScriptPath concurrently under the
-			// write lock, so reading the field here without the lock is a
-			// data race.
-			if err = runCommand(ctx, scriptPath, "stop", nil); err != nil {
-				log.Logger.Errorf("[package controller]: %v unexpected stop failure: %v", pkg.Name, err)
-				continue
-			}
-			if err = runCommand(ctx, scriptPath, "start", nil); err != nil {
-				log.Logger.Errorf("[package controller]: %v unexpected start failure: %v", pkg.Name, err)
-			}
+			c.statusPackage(ctx, pkg)
 		}
+	}
+}
+
+func (c *PackageController) statusPackage(ctx context.Context, pkg *packages.PackageStatus) {
+	operationMu := packagelock.For(pkg.Name)
+	if !operationMu.TryLock() {
+		return
+	}
+	defer operationMu.Unlock()
+	if ctx.Err() != nil {
+		return
+	}
+
+	c.RLock()
+	installed := pkg.IsInstalled
+	recovered := c.recoveredInstalled[pkg.Name]
+	scriptPath := pkg.ScriptPath
+	c.RUnlock()
+	if !installed && !recovered {
+		return
+	}
+
+	var shouldSkipResult string
+	if err := runCommand(ctx, scriptPath, "shouldSkip", &shouldSkipResult); err == nil {
+		c.Lock()
+		c.packageStatus[pkg.Name].Skipped = true
+		c.packageStatus[pkg.Name].Status = true
+		c.Unlock()
+		log.Logger.Debugf("[package controller]: %v shouldSkip returned 0, setting status to true", pkg.Name)
+		return
+	}
+
+	err := runCommand(ctx, scriptPath, "status", nil)
+	if err == nil {
+		c.Lock()
+		c.packageStatus[pkg.Name].Status = true
+		c.Unlock()
+		log.Logger.Debugf("[package controller]: %v status ok", pkg.Name)
+		return
+	}
+	// Recovery establishes that the package exists on disk, but its
+	// dependencies have not passed the install gate. Report the package's
+	// actual health without restarting it until normal installed state is
+	// established, avoiding a restart loop when a dependency is unavailable.
+	if recovered && !installed {
+		log.Logger.Warnw("[package controller] recovered package status not ok; skipping restart", "name", pkg.Name, "error", err)
+		return
+	}
+	log.Logger.Errorf("[package controller]: %v status not ok, restarting", pkg.Name)
+	// Use the scriptPath snapshot taken under the read lock above:
+	// reconcileLoop can update pkg.ScriptPath concurrently under the
+	// write lock, so reading the field here without the lock is a
+	// data race.
+	if err = runCommand(ctx, scriptPath, "stop", nil); err != nil {
+		log.Logger.Errorf("[package controller]: %v unexpected stop failure: %v", pkg.Name, err)
+		return
+	}
+	if err = runCommand(ctx, scriptPath, "start", nil); err != nil {
+		log.Logger.Errorf("[package controller]: %v unexpected start failure: %v", pkg.Name, err)
 	}
 }
 

--- a/pkg/gpud-manager/controllers/package_operation_cancellation_test.go
+++ b/pkg/gpud-manager/controllers/package_operation_cancellation_test.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leptonai/gpud/pkg/gpud-manager/packages"
+	"github.com/leptonai/gpud/pkg/packagelock"
+)
+
+func TestCanceledPackageOperationsDoNotExecuteCommands(t *testing.T) {
+	mockey.PatchConvey("canceled work is a no-op and does not retain ownership", t, func() {
+		c := NewPackageController(nil)
+		pkg := &packages.PackageStatus{Name: t.Name(), IsInstalled: true}
+		c.packageStatus[pkg.Name] = pkg
+		var calls atomic.Int64
+		mockey.Mock(runCommand).To(func(context.Context, string, string, *string) error {
+			calls.Add(1)
+			return nil
+		}).Build()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		for _, operation := range []func(context.Context, *packages.PackageStatus){
+			c.statusPackage, c.installPackage, c.updatePackage, c.deletePackage,
+		} {
+			operation(ctx, pkg)
+			mu := packagelock.For(pkg.Name)
+			require.True(t, mu.TryLock(), "canceled operation retained ownership")
+			mu.Unlock()
+		}
+		assert.Zero(t, calls.Load())
+		c.statusPackage(context.Background(), pkg)
+		assert.Positive(t, calls.Load(), "subsequent live work must execute")
+	})
+}
+
+func TestCanceledAsyncPackageInstallCanRetry(t *testing.T) {
+	mockey.PatchConvey("canceling an active installation permits a fresh retry", t, func() {
+		c := NewPackageController(nil)
+		pkg := &packages.PackageStatus{Name: t.Name(), TotalTime: time.Second}
+		c.packageStatus[pkg.Name] = pkg
+		var installs, starts atomic.Int64
+		entered := make(chan struct{})
+		mockey.Mock(runCommand).To(func(ctx context.Context, script, arg string, result *string) error {
+			switch arg {
+			case "install":
+				if installs.Add(1) == 1 {
+					close(entered)
+					<-ctx.Done()
+					return ctx.Err()
+				}
+				return nil
+			case "start":
+				starts.Add(1)
+				return nil
+			default:
+				return errors.New("not installed")
+			}
+		}).Build()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		c.installPackage(ctx, pkg)
+		select {
+		case <-entered:
+		case <-time.After(5 * time.Second):
+			t.Fatal("installation never started")
+		}
+		cancel()
+		mu := packagelock.For(pkg.Name)
+		waitReleased := func() {
+			t.Helper()
+			require.Eventually(t, func() bool {
+				if !mu.TryLock() {
+					return false
+				}
+				defer mu.Unlock()
+				c.RLock()
+				defer c.RUnlock()
+				return !pkg.Installing
+			}, 5*time.Second, time.Millisecond)
+		}
+		waitReleased()
+		assert.Zero(t, starts.Load(), "canceled installation must not start the package")
+		c.installPackage(context.Background(), pkg)
+		waitReleased()
+		assert.EqualValues(t, 2, installs.Load())
+		assert.EqualValues(t, 1, starts.Load())
+	})
+}

--- a/pkg/gpud-manager/controllers/package_operation_lock_test.go
+++ b/pkg/gpud-manager/controllers/package_operation_lock_test.go
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leptonai/gpud/pkg/gpud-manager/packages"
+	"github.com/leptonai/gpud/pkg/kapmtls"
+	"github.com/leptonai/gpud/pkg/packagelock"
+)
+
+func TestPackageOperationsSkipBusyPackage(t *testing.T) {
+	mockey.PatchConvey("a rotation excludes every lifecycle operation without blocking other packages", t, func() {
+		c := NewPackageController(nil)
+		pkg := &packages.PackageStatus{Name: kapmtls.PackageName, IsInstalled: true}
+		other := &packages.PackageStatus{Name: t.Name(), IsInstalled: true}
+		c.packageStatus[pkg.Name] = pkg
+		c.packageStatus[other.Name] = other
+		var calls int
+		mockey.Mock(runCommand).To(func(context.Context, string, string, *string) error {
+			calls++
+			return nil
+		}).Build()
+		mu := packagelock.For(kapmtls.PackageName)
+		mu.Lock()
+		defer mu.Unlock()
+		for _, operation := range []func(context.Context, *packages.PackageStatus){
+			c.statusPackage, c.installPackage, c.updatePackage, c.deletePackage,
+		} {
+			operation(context.Background(), pkg)
+		}
+		assert.Zero(t, calls)
+		c.statusPackage(context.Background(), other)
+		assert.Positive(t, calls)
+	})
+}
+
+func TestPackageStatusRecoveryIsAtomic(t *testing.T) {
+	for _, failedCommand := range []string{"", "stop", "start"} {
+		t.Run("failure-"+failedCommand, func(t *testing.T) {
+			mockey.PatchConvey("status and recovery share one operation lock, including errors", t, func() {
+				c := NewPackageController(nil)
+				pkg := &packages.PackageStatus{Name: t.Name(), IsInstalled: true}
+				c.packageStatus[pkg.Name] = pkg
+				mu := packagelock.For(pkg.Name)
+				var calls []string
+				mockey.Mock(runCommand).To(func(ctx context.Context, script, arg string, result *string) error {
+					calls = append(calls, arg)
+					if mu.TryLock() {
+						mu.Unlock()
+						t.Error("operation mutex released before recovery completed")
+					}
+					// Commands must not run with the controller state mutex held.
+					_, err := c.Status(ctx)
+					assert.NoError(t, err)
+					if arg == "shouldSkip" || arg == "status" || arg == failedCommand {
+						return errors.New("command failed")
+					}
+					return nil
+				}).Build()
+				c.statusPackage(context.Background(), pkg)
+				want := []string{"shouldSkip", "status", "stop", "start"}
+				if failedCommand == "stop" {
+					want = want[:3]
+				}
+				assert.Equal(t, want, calls)
+				require.True(t, mu.TryLock(), "operation lock leaked on completion")
+				mu.Unlock()
+			})
+		})
+	}
+}
+
+func TestPackageInstallRetainsAsyncLock(t *testing.T) {
+	for _, failInstall := range []bool{false, true} {
+		name := "success"
+		if failInstall {
+			name = "failure"
+		}
+		t.Run(name, func(t *testing.T) {
+			mockey.PatchConvey("async installation owns the lock until install and start finish", t, func() {
+				c := NewPackageController(nil)
+				pkg := &packages.PackageStatus{Name: t.Name(), TotalTime: time.Second}
+				c.packageStatus[pkg.Name] = pkg
+				entered := make(chan struct{})
+				release := make(chan struct{})
+				var installs, starts atomic.Int64
+				mockey.Mock(runCommand).To(func(ctx context.Context, script, arg string, result *string) error {
+					switch arg {
+					case "install":
+						installs.Add(1)
+						close(entered)
+						<-release
+						if failInstall {
+							return errors.New("install failed")
+						}
+						return nil
+					case "start":
+						starts.Add(1)
+						mu := packagelock.For(pkg.Name)
+						if mu.TryLock() {
+							mu.Unlock()
+							t.Error("lock released before post-install start")
+						}
+						return nil
+					default:
+						return errors.New("not installed")
+					}
+				}).Build()
+				c.installPackage(context.Background(), pkg)
+				<-entered
+				c.installPackage(context.Background(), pkg)
+				c.statusPackage(context.Background(), pkg)
+				c.deletePackage(context.Background(), pkg)
+				c.updatePackage(context.Background(), pkg)
+				assert.EqualValues(t, 1, installs.Load())
+				close(release)
+				mu := packagelock.For(pkg.Name)
+				require.Eventually(t, func() bool {
+					if !mu.TryLock() {
+						return false
+					}
+					defer mu.Unlock()
+					c.RLock()
+					defer c.RUnlock()
+					return !pkg.Installing && pkg.Progress == 100
+				}, 5*time.Second, time.Millisecond)
+				if failInstall {
+					assert.Zero(t, starts.Load())
+				} else {
+					assert.EqualValues(t, 1, starts.Load())
+				}
+			})
+		})
+	}
+}

--- a/pkg/kapmtls/manager.go
+++ b/pkg/kapmtls/manager.go
@@ -24,9 +24,13 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/leptonai/gpud/pkg/packagelock"
 )
 
 const (
+	PackageName = "kap-mtls-agent"
+
 	DefaultAgentBinaryPath = "/usr/local/bin/kaproxy-mtls-agent"
 	DefaultAgentUnitPath   = "/etc/systemd/system/kaproxy-mtls-agent.service"
 
@@ -111,8 +115,6 @@ type Manager struct {
 	updateMu   *sync.Mutex
 }
 
-var stateDirectoryLocks sync.Map
-
 func NewManager(paths Paths) *Manager {
 	return &Manager{
 		paths:      paths,
@@ -120,19 +122,16 @@ func NewManager(paths Paths) *Manager {
 		httpClient: &http.Client{Timeout: readyTimeout},
 		readyURL:   AgentReadyURL,
 		now:        time.Now,
-		updateMu:   lockForStateDirectory(paths.StateDir),
+		updateMu:   packagelock.For(PackageName),
 	}
-}
-
-func lockForStateDirectory(stateDir string) *sync.Mutex {
-	key := filepath.Clean(stateDir)
-	lock, _ := stateDirectoryLocks.LoadOrStore(key, &sync.Mutex{})
-	return lock.(*sync.Mutex)
 }
 
 func (m *Manager) Status(ctx context.Context, machineID string) (*Status, error) {
 	m.updateMu.Lock()
 	defer m.updateMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	credentials, err := m.inspectCredentials(machineID)
 	if err != nil {
@@ -176,6 +175,9 @@ func (m *Manager) Status(ctx context.Context, machineID string) (*Status, error)
 func (m *Manager) UpdateCredentials(ctx context.Context, machineID string, credentials Credentials) error {
 	m.updateMu.Lock()
 	defer m.updateMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	if !m.agentInstalled() {
 		return fmt.Errorf("KAP mTLS agent is not installed")
@@ -212,6 +214,9 @@ func (m *Manager) UpdateCredentials(ctx context.Context, machineID string, crede
 func (m *Manager) Activate(ctx context.Context) error {
 	m.updateMu.Lock()
 	defer m.updateMu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	if !m.agentInstalled() {
 		return fmt.Errorf("KAP mTLS agent is not installed")

--- a/pkg/kapmtls/operation_lock_test.go
+++ b/pkg/kapmtls/operation_lock_test.go
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kapmtls
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leptonai/gpud/pkg/packagelock"
+)
+
+type operationLockRunner func(context.Context, string, ...string) ([]byte, error)
+
+func (r operationLockRunner) Run(ctx context.Context, command string, args ...string) ([]byte, error) {
+	return r(ctx, command, args...)
+}
+
+func assertPackageLocked(t *testing.T) {
+	t.Helper()
+	mu := packagelock.For(PackageName)
+	if mu.TryLock() {
+		mu.Unlock()
+		t.Error("KAP operation does not hold the managed package lock")
+	}
+}
+
+func TestCredentialRotationHoldsPackageLockThroughReadinessAndRollback(t *testing.T) {
+	for _, failRestart := range []bool{false, true} {
+		name := "ready"
+		if failRestart {
+			name = "rollback"
+		}
+		t.Run(name, func(t *testing.T) {
+			manager, runner, paths := newTestManager(t)
+			require.NoError(t, manager.UpdateCredentials(context.Background(), "machine-1", newTestCredentials(t, "worker-1", "machine-1", 1)))
+			previous, err := manager.currentReleaseID()
+			require.NoError(t, err)
+			restarts := 0
+			manager.runner = operationLockRunner(func(ctx context.Context, command string, args ...string) ([]byte, error) {
+				assertPackageLocked(t)
+				if args[0] == "restart" {
+					restarts++
+					if failRestart && restarts == 1 {
+						return nil, errors.New("restart failed")
+					}
+					if failRestart {
+						current, readErr := manager.currentReleaseID()
+						assert.NoError(t, readErr)
+						assert.Equal(t, previous, current)
+						assert.NoError(t, ctx.Err(), "rollback has its own uncanceled context")
+					}
+				}
+				return runner.Run(ctx, command, args...)
+			})
+			ready := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assertPackageLocked(t)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer ready.Close()
+			manager.readyURL = ready.URL
+			err = manager.UpdateCredentials(context.Background(), "machine-1", newTestCredentials(t, "worker-1", "machine-1", 2))
+			if failRestart {
+				require.ErrorContains(t, err, "restart failed")
+				assert.Equal(t, 2, restarts)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, 1, restarts)
+				entries, readErr := os.ReadDir(filepath.Join(paths.StateDir, ReleasesDirectoryName))
+				require.NoError(t, readErr)
+				assert.Len(t, entries, 1)
+			}
+			mu := packagelock.For(PackageName)
+			require.True(t, mu.TryLock(), "operation lock leaked")
+			mu.Unlock()
+		})
+	}
+}
+
+func TestManagerOperationsSharePackageLockAndHonorCancellation(t *testing.T) {
+	manager, runner, paths := newTestManager(t)
+	other := NewManager(DefaultPaths(t.TempDir()))
+	require.Same(t, packagelock.For("kap-mtls-agent"), manager.updateMu)
+	require.Same(t, manager.updateMu, other.updateMu, "systemd service operations share a lock even across state directories")
+	credentials := newTestCredentials(t, "worker-1", "machine-1", 1)
+	operations := []func(context.Context) error{
+		func(ctx context.Context) error { return manager.UpdateCredentials(ctx, "machine-1", credentials) },
+		manager.Activate,
+		func(ctx context.Context) error {
+			_, err := manager.Status(ctx, "machine-1")
+			return err
+		},
+	}
+	for _, operation := range operations {
+		manager.updateMu.Lock()
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() { done <- operation(ctx) }()
+		cancel()
+		manager.updateMu.Unlock()
+		require.ErrorIs(t, <-done, context.Canceled)
+	}
+	assert.Empty(t, runner.calls)
+	_, err := os.Lstat(filepath.Join(paths.StateDir, CurrentSymlinkName))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/pkg/packagelock/lock.go
+++ b/pkg/packagelock/lock.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package packagelock serializes in-process operations on managed packages.
+package packagelock
+
+import "sync"
+
+var locks sync.Map
+
+// For returns the process-wide operation mutex for a package name.
+// Entries are retained so all callers always share the same mutex.
+func For(name string) *sync.Mutex {
+	lock, _ := locks.LoadOrStore(name, &sync.Mutex{})
+	return lock.(*sync.Mutex)
+}

--- a/pkg/packagelock/lock_test.go
+++ b/pkg/packagelock/lock_test.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package packagelock
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestForSharesMutexByPackage(t *testing.T) {
+	mu := For(t.Name())
+	mu.Lock()
+	defer mu.Unlock()
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			other := For(t.Name())
+			if other.TryLock() {
+				other.Unlock()
+				t.Error("same package acquired a second operation lock")
+			}
+		}()
+	}
+	wg.Wait()
+	other := For(t.Name() + "-other")
+	require.True(t, other.TryLock())
+	other.Unlock()
+}


### PR DESCRIPTION
KAP certificate rotation restarts `kaproxy-mtls-agent` while gpud's package watchdog independently checks and restarts the same service. During a planned drain, the watchdog can cancel the credential manager's restart, causing rollback to the old certificate and repeated renewal failures.

Share a small process-local mutex per package name. Controller runners skip busy packages and hold the mutex across each complete check/action sequence, including asynchronous installation. KAP uses the same mutex through credential activation, readiness, and rollback. The controller has no KAP-specific branches; other packages remain eligible for checking while KAP is busy.

This is a gpud-only change: existing node scripts and control-plane APIs remain compatible. The lock coordinates operations within gpud; external systemctl commands and detached script children are outside its scope.

### Validation

- Full `go build ./...` and `GOTOOLCHAIN=go1.25.12 go vet ./...` passed.
- `GOTOOLCHAIN=go1.25.12 go test -short -race -gcflags='all=-N -l -d=checkptr=0' ./pkg/packagelock ./pkg/kapmtls ./pkg/gpud-manager/controllers` passed, including existing recovery tests. New controller/KAP concurrency tests also passed 20 race repetitions.
- Independent architecture, concurrency review, behavioral testing, and requirement coverage audit performed before opening.
- Local lint could not start because the installed golangci-lint lacks the repository's `nilaway` plugin; CI must run the custom linter.
- No live-node E2E has been run for this change.
